### PR TITLE
feat(car-library): shard-local provenance refs (-39.6% size)

### DIFF
--- a/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
+++ b/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
@@ -12,16 +12,17 @@ from vibesensor.adapters.persistence.vehicle_configurations import (
 )
 
 
-def _load_sample_shards(count: int) -> list[tuple[Path, list[dict[str, object]]]]:
-    shards: list[tuple[Path, list[dict[str, object]]]] = []
+def _load_sample_shards(count: int) -> list[tuple[Path, dict[str, object]]]:
+    shards: list[tuple[Path, dict[str, object]]] = []
     for shard_path in sorted(_VEHICLE_CONFIG_DATA_DIR.rglob("*.json")):
         payload = json.loads(shard_path.read_text(encoding="utf-8"))
-        assert isinstance(payload, list)
-        assert all(isinstance(row, dict) for row in payload)
+        assert isinstance(payload, dict)
+        assert "configurations" in payload
+        assert isinstance(payload["configurations"], list)
         shards.append(
             (
                 shard_path.relative_to(_VEHICLE_CONFIG_DATA_DIR),
-                cast(list[dict[str, object]], payload),
+                cast(dict[str, object], payload),
             )
         )
         if len(shards) == count:
@@ -32,18 +33,22 @@ def _load_sample_shards(count: int) -> list[tuple[Path, list[dict[str, object]]]
 def _write_shard(
     root: Path,
     relative_path: Path,
-    rows: list[dict[str, object]],
+    shard: dict[str, object],
 ) -> None:
     shard_path = root / relative_path
     shard_path.parent.mkdir(parents=True, exist_ok=True)
-    shard_path.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+    shard_path.write_text(json.dumps(shard, indent=2) + "\n", encoding="utf-8")
 
 
 def test_load_vehicle_configurations_reads_multiple_shards(tmp_path: Path) -> None:
     sample_shards = _load_sample_shards(2)
-    expected_ids = {str(row["id"]) for _, rows in sample_shards for row in rows}
-    for relative_path, rows in sample_shards:
-        _write_shard(tmp_path, relative_path, rows)
+    expected_ids = {
+        str(row["id"])
+        for _, shard in sample_shards
+        for row in cast(list[dict[str, object]], shard["configurations"])
+    }
+    for relative_path, shard in sample_shards:
+        _write_shard(tmp_path, relative_path, shard)
 
     with patch(
         "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
@@ -57,10 +62,10 @@ def test_load_vehicle_configurations_reads_multiple_shards(tmp_path: Path) -> No
 def test_load_vehicle_configurations_fails_closed_for_duplicate_ids_across_shards(
     tmp_path: Path,
 ) -> None:
-    relative_path, rows = _load_sample_shards(1)[0]
-    duplicate_row = copy.deepcopy(rows[0])
-    _write_shard(tmp_path, relative_path, [duplicate_row])
-    _write_shard(tmp_path, Path("duplicate") / relative_path.name, [duplicate_row])
+    relative_path, shard = _load_sample_shards(1)[0]
+    duplicate = copy.deepcopy(shard)
+    _write_shard(tmp_path, relative_path, duplicate)
+    _write_shard(tmp_path, Path("duplicate") / relative_path.name, duplicate)
 
     with patch(
         "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
@@ -70,8 +75,8 @@ def test_load_vehicle_configurations_fails_closed_for_duplicate_ids_across_shard
 
 
 def test_load_vehicle_configurations_fails_closed_for_invalid_shard(tmp_path: Path) -> None:
-    relative_path, rows = _load_sample_shards(1)[0]
-    _write_shard(tmp_path, relative_path, rows)
+    relative_path, shard = _load_sample_shards(1)[0]
+    _write_shard(tmp_path, relative_path, shard)
     bad_path = tmp_path / "broken" / "bad.json"
     bad_path.parent.mkdir(parents=True, exist_ok=True)
     bad_path.write_text("{not valid json", encoding="utf-8")
@@ -86,15 +91,101 @@ def test_load_vehicle_configurations_fails_closed_for_invalid_shard(tmp_path: Pa
 def test_load_vehicle_configurations_fails_closed_when_required_evidence_refs_are_missing(
     tmp_path: Path,
 ) -> None:
-    relative_path, rows = _load_sample_shards(1)[0]
-    bad_payload = copy.deepcopy(rows)
-    bad_drivetrain = cast(dict[str, object], bad_payload[0]["drivetrain"])
-    bad_payload[0]["drivetrain"] = {
+    relative_path, shard = _load_sample_shards(1)[0]
+    bad_payload = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], bad_payload["configurations"])
+    bad_drivetrain = cast(dict[str, object], rows[0]["drivetrain"])
+    rows[0]["drivetrain"] = {
         "value": bad_drivetrain["value"],
         "confidence": "official_exact",
         "notes": "Broken test payload without evidence refs.",
     }
     _write_shard(tmp_path, relative_path, bad_payload)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        assert load_vehicle_configurations() == []
+
+
+def test_load_vehicle_configurations_expands_notes_and_evidence_refs(tmp_path: Path) -> None:
+    """Loader must inline shard-local notes_ref and evidence_refs_ref values."""
+
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    drivetrain = cast(dict[str, object], rows[0]["drivetrain"])
+
+    notes_text = "test-only inline ref expansion notes"
+    evidence_list = [
+        "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
+    ]
+    fixture.setdefault("definitions", {})
+    defs = cast(dict[str, object], fixture["definitions"])
+    defs["notes"] = {**cast(dict[str, str], defs.get("notes", {})), "test_note_ref": notes_text}
+    defs["evidence_ref_sets"] = {
+        **cast(dict[str, list[str]], defs.get("evidence_ref_sets", {})),
+        "test_evidence_ref": evidence_list,
+    }
+    drivetrain.pop("notes", None)
+    drivetrain.pop("evidence_refs", None)
+    drivetrain["notes_ref"] = "test_note_ref"
+    drivetrain["evidence_refs_ref"] = "test_evidence_ref"
+
+    _write_shard(tmp_path, relative_path, fixture)
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        loaded = load_vehicle_configurations()
+
+    target = next(config for config in loaded if config.id == rows[0]["id"])
+    assert target.drivetrain_metadata.notes == notes_text
+    assert target.drivetrain_metadata.evidence_refs == tuple(evidence_list)
+
+
+def test_load_vehicle_configurations_fails_closed_for_unknown_notes_ref(tmp_path: Path) -> None:
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    drivetrain = cast(dict[str, object], rows[0]["drivetrain"])
+    drivetrain.pop("notes", None)
+    drivetrain["notes_ref"] = "does_not_exist"
+    _write_shard(tmp_path, relative_path, fixture)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        assert load_vehicle_configurations() == []
+
+
+def test_load_vehicle_configurations_fails_closed_for_unknown_evidence_refs_ref(
+    tmp_path: Path,
+) -> None:
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    drivetrain = cast(dict[str, object], rows[0]["drivetrain"])
+    drivetrain.pop("evidence_refs", None)
+    drivetrain["evidence_refs_ref"] = "does_not_exist"
+    _write_shard(tmp_path, relative_path, fixture)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        assert load_vehicle_configurations() == []
+
+
+def test_load_vehicle_configurations_rejects_legacy_array_shard(tmp_path: Path) -> None:
+    """Bare array shards are no longer accepted; canonical shape is the shard object."""
+
+    relative_path, shard = _load_sample_shards(1)[0]
+    legacy_path = tmp_path / relative_path
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(json.dumps(shard["configurations"], indent=2) + "\n", encoding="utf-8")
 
     with patch(
         "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",

--- a/apps/server/vibesensor/adapters/persistence/vehicle_configurations.py
+++ b/apps/server/vibesensor/adapters/persistence/vehicle_configurations.py
@@ -38,6 +38,14 @@ __all__ = [
 _VEHICLE_CONFIG_DATA_DIR = resolve_static_data_file("vehicle_configurations")
 _STRICT_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
 
+_NOTES_REF_KEY = "notes_ref"
+_NOTE_REF_KEY = "note_ref"
+_EVIDENCE_REFS_REF_KEY = "evidence_refs_ref"
+_DEFINITIONS_KEY = "definitions"
+_CONFIGURATIONS_KEY = "configurations"
+_DEFINITIONS_NOTES_KEY = "notes"
+_DEFINITIONS_EVIDENCE_KEY = "evidence_ref_sets"
+
 
 class VehicleFieldMetadataRow(TypedDict):
     confidence: VehicleFieldConfidence
@@ -272,6 +280,98 @@ def _relative_shard_path(shard_path: Path) -> Path:
         return shard_path
 
 
+class _ShardRefError(ValueError):
+    """Raised when a shard contains an unknown or malformed provenance ref."""
+
+
+def _resolve_shard_refs(
+    payload: Any,
+    notes_defs: dict[str, str],
+    evidence_defs: dict[str, list[str]],
+) -> Any:
+    if isinstance(payload, dict):
+        resolved: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key == _NOTES_REF_KEY:
+                if not isinstance(value, str) or value not in notes_defs:
+                    raise _ShardRefError(f"unknown notes_ref {value!r}")
+                if "notes" in payload or "notes" in resolved:
+                    raise _ShardRefError("notes_ref conflicts with inline notes")
+                resolved["notes"] = notes_defs[value]
+            elif key == _NOTE_REF_KEY:
+                if not isinstance(value, str) or value not in notes_defs:
+                    raise _ShardRefError(f"unknown note_ref {value!r}")
+                if "note" in payload or "note" in resolved:
+                    raise _ShardRefError("note_ref conflicts with inline note")
+                resolved["note"] = notes_defs[value]
+            elif key == _EVIDENCE_REFS_REF_KEY:
+                if not isinstance(value, str) or value not in evidence_defs:
+                    raise _ShardRefError(f"unknown evidence_refs_ref {value!r}")
+                if "evidence_refs" in payload or "evidence_refs" in resolved:
+                    raise _ShardRefError("evidence_refs_ref conflicts with inline evidence_refs")
+                resolved["evidence_refs"] = list(evidence_defs[value])
+            else:
+                resolved[key] = _resolve_shard_refs(value, notes_defs, evidence_defs)
+        return resolved
+    if isinstance(payload, list):
+        return [_resolve_shard_refs(item, notes_defs, evidence_defs) for item in payload]
+    return payload
+
+
+def _validate_definitions(raw_definitions: Any) -> tuple[dict[str, str], dict[str, list[str]]]:
+    if not isinstance(raw_definitions, dict):
+        raise _ShardRefError("definitions must be an object")
+    allowed = {_DEFINITIONS_NOTES_KEY, _DEFINITIONS_EVIDENCE_KEY}
+    extra_keys = set(raw_definitions.keys()) - allowed
+    if extra_keys:
+        raise _ShardRefError(f"unsupported definitions keys: {sorted(extra_keys)}")
+
+    raw_notes = raw_definitions.get(_DEFINITIONS_NOTES_KEY, {})
+    if not isinstance(raw_notes, dict):
+        raise _ShardRefError("definitions.notes must be an object")
+    notes_defs: dict[str, str] = {}
+    for key, value in raw_notes.items():
+        if not isinstance(key, str) or not key:
+            raise _ShardRefError(f"invalid notes key {key!r}")
+        if not isinstance(value, str):
+            raise _ShardRefError(f"definitions.notes[{key}] must be a string")
+        notes_defs[key] = value
+
+    raw_evidence = raw_definitions.get(_DEFINITIONS_EVIDENCE_KEY, {})
+    if not isinstance(raw_evidence, dict):
+        raise _ShardRefError("definitions.evidence_ref_sets must be an object")
+    evidence_defs: dict[str, list[str]] = {}
+    for key, value in raw_evidence.items():
+        if not isinstance(key, str) or not key:
+            raise _ShardRefError(f"invalid evidence_ref_sets key {key!r}")
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            raise _ShardRefError(f"definitions.evidence_ref_sets[{key}] must be a list of strings")
+        evidence_defs[key] = list(value)
+
+    return notes_defs, evidence_defs
+
+
+def _expand_shard_payload(data: Any) -> list[dict[str, Any]]:
+    """Expand a shard payload into a plain list of vehicle configuration row dicts."""
+
+    if not isinstance(data, dict):
+        raise _ShardRefError(
+            "shard root must be an object with 'configurations' (and optional 'definitions')"
+        )
+    extra_keys = set(data.keys()) - {_DEFINITIONS_KEY, _CONFIGURATIONS_KEY}
+    if extra_keys:
+        raise _ShardRefError(f"unsupported shard keys: {sorted(extra_keys)}")
+
+    notes_defs, evidence_defs = _validate_definitions(data.get(_DEFINITIONS_KEY, {}))
+
+    raw_configs = data.get(_CONFIGURATIONS_KEY)
+    if not isinstance(raw_configs, list):
+        raise _ShardRefError("shard 'configurations' must be a list")
+
+    expanded = _resolve_shard_refs(raw_configs, notes_defs, evidence_defs)
+    return cast(list[dict[str, Any]], expanded)
+
+
 def _load_vehicle_configuration_rows() -> list[VehicleConfigurationRow]:
     if not _VEHICLE_CONFIG_DATA_DIR.is_dir():
         LOGGER.warning(
@@ -294,15 +394,18 @@ def _load_vehicle_configuration_rows() -> list[VehicleConfigurationRow]:
             )
             return []
 
-        if not isinstance(data, list):
+        try:
+            expanded = _expand_shard_payload(data)
+        except _ShardRefError as exc:
             LOGGER.warning(
-                "Exact vehicle configuration shard %s must contain a JSON array",
+                "Exact vehicle configuration shard %s has invalid provenance refs: %s",
                 _relative_shard_path(shard_path),
+                exc,
             )
             return []
 
         try:
-            shard_rows = _VEHICLE_CONFIGURATION_ADAPTER.validate_python(data)
+            shard_rows = _VEHICLE_CONFIGURATION_ADAPTER.validate_python(expanded)
         except ValidationError as exc:
             LOGGER.warning(
                 "Exact vehicle configuration shard %s failed validation: %s",

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a1/8X.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a1/8X.json
@@ -1,811 +1,640 @@
-[
-  {
-    "id": "audi-8x-1-0-tfsi-eu-2011-5-speed-manu-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "8X",
-    "body_code": "8X",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A1 (8X, 2011-2018)",
-    "variant_name": "1.0 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
+      "n3": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
+      "n4": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429.",
+      "n6": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "legacy_research_sources:0cd20821c4bc",
         "secondary_technical_sources:a1-8x-wikipedia",
         "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-      "code": "5-SPEED-MANU",
-      "name": "5-speed manual",
-      "evidence_refs": [
-        "legacy_research_sources:0cd20821c4bc",
-        "secondary_technical_sources:a1-8x-wikipedia",
-        "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "value": 0.854,
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "value": 3.652,
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014",
-          "legacy_research_sources:0cd20821c4bc"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked exact official Audi launch and facelift sources. Official Audi material places the 1.0 TFSI only in the spring-2015 facelift window, while facelift brochures confirm the 1.0 TFSI 5-speed manual FWD state and a lower 15-inch baseline wheel package. This represented 2011 manual row therefore remains a contradicted advisory placeholder rather than a validated launch-era exact state.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014",
-          "legacy_research_sources:0cd20821c4bc"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 1.0 TFSI facelift-era exact ratio and final-drive capture",
-        "reason": "The recovered official facelift sources close the 1.0 TFSI manual existence, FWD applicability, and lower baseline tyre package, but this pass did not safely capture a directly quotable official ratio/final-drive table for the exact manual state.",
-        "evidence_refs": [
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      },
-      {
-        "item": "Audi A1 1.0 TFSI placeholder replacement for the contradicted 2011 row",
-        "reason": "Official Audi launch and facelift material shows that 1.0 TFSI belongs to the spring-2015 refresh window rather than the 2011 launch window, but this pass did not split the stored placeholder into exact 2015+ manual rows.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8x-1-0-tfsi-eu-2011-dct7-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "8X",
-    "body_code": "8X",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A1 (8X, 2011-2018)",
-    "variant_name": "1.0 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-      "value": "FWD",
-      "evidence_refs": [
-        "legacy_research_sources:0cd20821c4bc",
-        "secondary_technical_sources:a1-8x-wikipedia",
-        "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
-        "legacy_research_sources:0cd20821c4bc",
-        "secondary_technical_sources:a1-8x-wikipedia",
-        "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "value": 0.68,
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "value": 3.786,
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014",
-          "legacy_research_sources:0cd20821c4bc"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.0 TFSI three-cylinder petrol engine (CHZB 999cc) was introduced with the November 2014 facelift, on sale from spring 2015 (Audi MediaCenter press release: 'first three-cylinder gasoline engine in the history of Audi'). No 1.0 TFSI variant existed at the 2010 launch or in any 2011-2014 production year. The repo row's production_start_year=2011 with 1.0 TFSI engine_code is a non-existent combination. Drivetrain, transmission, ratios, and tires downgraded to no_confidence with safety gates set to require manual confirmation. Authoritative replacement would be a 2015-start row.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked exact official Audi launch and facelift sources. Official Audi material again places the 1.0 TFSI only in the spring-2015 facelift window, while facelift brochures confirm the 1.0 TFSI 7-speed S tronic FWD state and a lower 15-inch baseline wheel package. This represented 2011 S tronic row therefore remains a contradicted advisory placeholder rather than a validated launch-era exact state.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014",
-          "legacy_research_sources:0cd20821c4bc"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 1.0 TFSI S tronic facelift-era exact ratio and final-drive capture",
-        "reason": "The recovered official facelift sources close the 1.0 TFSI S tronic existence, FWD applicability, and lower baseline tyre package, but this pass did not safely capture a directly quotable official ratio/final-drive table for the exact S tronic state.",
-        "evidence_refs": [
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      },
-      {
-        "item": "Audi A1 1.0 TFSI S tronic placeholder replacement for the contradicted 2011 row",
-        "reason": "Official Audi launch and facelift material shows that 1.0 TFSI belongs to the spring-2015 refresh window rather than the 2011 launch window, but this pass did not split the stored placeholder into exact 2015+ S tronic rows.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:cfd6a6b47886",
-          "legacy_research_sources:092a3f271f19"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8x-1-4-tfsi-eu-2011-5-speed-manu-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "8X",
-    "body_code": "8X",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A1 (8X, 2011-2018)",
-    "variant_name": "1.4 TFSI",
-    "engine_code": "1.4L",
-    "engine_name": "1.4L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
+      ],
+      "e2": [
+        "legacy_research_sources:1497d4e055e8",
+        "legacy_research_sources:493533bb041f",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b"
+      ],
+      "e3": [
         "legacy_research_sources:d3ced68412f8",
         "secondary_technical_sources:a1-8x-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
-      "code": "5-SPEED-MANU",
-      "name": "5-speed manual",
-      "evidence_refs": [
+      ],
+      "e4": [
+        "secondary_technical_sources:a1-8x-wikipedia",
+        "secondary_technical_sources:audi-mediacenter-a1-1-0-tfsi-launch-2014",
+        "legacy_research_sources:0cd20821c4bc"
+      ],
+      "e5": [
+        "legacy_research_sources:0cd20821c4bc",
+        "legacy_research_sources:cfd6a6b47886",
+        "legacy_research_sources:092a3f271f19"
+      ],
+      "e6": [
+        "legacy_research_sources:d36a12aece1e"
+      ],
+      "e7": [
+        "legacy_research_sources:cfd6a6b47886",
+        "legacy_research_sources:092a3f271f19"
+      ],
+      "e8": [
+        "secondary_technical_sources:a1-8x-wikipedia",
+        "legacy_research_sources:d3ced68412f8"
+      ],
+      "e9": [
+        "legacy_research_sources:0cd20821c4bc",
         "legacy_research_sources:d3ced68412f8",
+        "legacy_research_sources:cfd6a6b47886"
+      ],
+      "e10": [
+        "legacy_research_sources:d36a12aece1e",
         "secondary_technical_sources:a1-8x-wikipedia"
+      ],
+      "e11": [
+        "legacy_research_sources:d36a12aece1e",
+        "legacy_research_sources:5709c957ea25",
+        "legacy_research_sources:cfd6a6b47886"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
-        "value": 0.854,
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
-        "value": 3.652,
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "legacy_research_sources:d3ced68412f8"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A1 8X 1.4 TFSI 122 PS engine was offered exclusively with a 6-speed manual or 7-speed S tronic (DQ200); a 5-speed manual was NEVER paired with the 1.4 TFSI engine. Audi UK official tech sheet (legacy_research_sources:d3ced68412f8, Status Sep 2011) lists 6-speed manual ratios I 3.615 / II 1.955 / III 1.281 / IV 0.973 / V 0.778 / VI 0.646, R 3.182, FD 3.625 - no 5-speed variant was ever produced for this engine. The 5-speed manual was paired only with the lower-output 1.2 TFSI 86 PS. Drivetrain, transmission, ratios, and tires downgraded to no_confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked exact official Audi launch and facelift sources. Official Audi launch-era 1.4 TFSI 122 PS technical data and later facelift brochures both show a 6-speed manual rather than a 5-speed, so this represented 2011 5-speed row remains a contradicted advisory placeholder rather than a validated exact state.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:d3ced68412f8",
-          "legacy_research_sources:cfd6a6b47886"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a1-8x-wikipedia",
-          "legacy_research_sources:d3ced68412f8"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8",
-          "secondary_technical_sources:a1-8x-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 1.4 TFSI exact 6-speed-manual row split by power and era",
-        "reason": "Official Audi launch and facelift sources both point to a 6-speed manual, but the stored broad 1.4 TFSI manual placeholder still collapses launch 122 PS and later facelift states into one non-exact row.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:d3ced68412f8",
-          "legacy_research_sources:cfd6a6b47886"
-        ]
-      },
-      {
-        "item": "Audi A1 1.4 TFSI manual exact ratio and final-drive capture",
-        "reason": "The recovered official launch technical-sheet URL is strong gearbox-family evidence, but this pass did not safely capture a directly quotable ratio/final-drive table for repo upgrade.",
-        "evidence_refs": [
-          "legacy_research_sources:d3ced68412f8"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-8x-1-4-tfsi-eu-2011-dct7-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "8X",
-    "body_code": "8X",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A1 (8X, 2011-2018)",
-    "variant_name": "1.4 TFSI",
-    "engine_code": "1.4L",
-    "engine_name": "1.4L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429.",
-      "value": "FWD",
-      "evidence_refs": [
-        "legacy_research_sources:d36a12aece1e",
-        "secondary_technical_sources:a1-8x-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
-        "legacy_research_sources:d36a12aece1e",
-        "secondary_technical_sources:a1-8x-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429.",
-        "value": 0.653,
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e"
-        ]
+  "configurations": [
+    {
+      "id": "audi-8x-1-0-tfsi-eu-2011-5-speed-manu-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "8X",
+      "body_code": "8X",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A1 (8X, 2011-2018)",
+      "variant_name": "1.0 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
       },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429. Encodes DQ200 sub-trans 1 (gears 1-4 + reverse 4.500) output ratio.",
-        "value": 4.8,
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e"
-        ]
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "5-SPEED-MANU",
+        "name": "5-speed manual",
+        "evidence_refs_ref": "e1"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          3.5,
-          2.087,
-          1.343,
-          0.933,
-          0.974,
-          0.778,
-          0.653
-        ],
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:1497d4e055e8",
-          "legacy_research_sources:493533bb041f",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.854,
+          "evidence_refs_ref": "e1"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.652,
+          "evidence_refs_ref": "e1"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 45.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked exact official Audi launch and facelift sources. Official Audi material places the 1.0 TFSI only in the spring-2015 facelift window, while facelift brochures confirm the 1.0 TFSI 5-speed manual FWD state and a lower 15-inch baseline wheel package. This represented 2011 manual row therefore remains a contradicted advisory placeholder rather than a validated launch-era exact state.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
+          "note_ref": "n4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1497d4e055e8",
-            "legacy_research_sources:493533bb041f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 1.0 TFSI facelift-era exact ratio and final-drive capture",
+          "reason": "The recovered official facelift sources close the 1.0 TFSI manual existence, FWD applicability, and lower baseline tyre package, but this pass did not safely capture a directly quotable official ratio/final-drive table for the exact manual state.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi A1 1.0 TFSI placeholder replacement for the contradicted 2011 row",
+          "reason": "Official Audi launch and facelift material shows that 1.0 TFSI belongs to the spring-2015 refresh window rather than the 2011 launch window, but this pass did not split the stored placeholder into exact 2015+ manual rows.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Checked official Audi launch and facelift sources. Official launch-period 1.4 TFSI technical sheets already show separate 122 PS S tronic and 185 PS S tronic states, and later facelift brochures add further 1.4 TFSI S tronic variants. This single represented 2011 DCT row therefore remains a mixed-power, mixed-era advisory placeholder rather than one exact production-safe configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:0cd20821c4bc",
-          "legacy_research_sources:d36a12aece1e",
-          "legacy_research_sources:5709c957ea25",
-          "legacy_research_sources:cfd6a6b47886"
+    {
+      "id": "audi-8x-1-0-tfsi-eu-2011-dct7-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "8X",
+      "body_code": "8X",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A1 (8X, 2011-2018)",
+      "variant_name": "1.0 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.68,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.786,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.988",
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e"
-        ]
+      "verification_notes": [
+        {
+          "note": "Checked exact official Audi launch and facelift sources. Official Audi material again places the 1.0 TFSI only in the spring-2015 facelift window, while facelift brochures confirm the 1.0 TFSI 7-speed S tronic FWD state and a lower 15-inch baseline wheel package. This represented 2011 S tronic row therefore remains a contradicted advisory placeholder rather than a validated launch-era exact state.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 1.0 TFSI S tronic facelift-era exact ratio and final-drive capture",
+          "reason": "The recovered official facelift sources close the 1.0 TFSI S tronic existence, FWD applicability, and lower baseline tyre package, but this pass did not safely capture a directly quotable official ratio/final-drive table for the exact S tronic state.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi A1 1.0 TFSI S tronic placeholder replacement for the contradicted 2011 row",
+          "reason": "Official Audi launch and facelift material shows that 1.0 TFSI belongs to the spring-2015 refresh window rather than the 2011 launch window, but this pass did not split the stored placeholder into exact 2015+ S tronic rows.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 1.4 TFSI S tronic exact power-era split",
-        "reason": "Official Audi launch material already shows separate 122 PS and 185 PS S tronic states, and later facelift material adds more 1.4 TFSI S tronic variants, so this single broad row still merges multiple exact configurations.",
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e",
-          "legacy_research_sources:5709c957ea25",
-          "legacy_research_sources:cfd6a6b47886"
+    },
+    {
+      "id": "audi-8x-1-4-tfsi-eu-2011-5-speed-manu-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "8X",
+      "body_code": "8X",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A1 (8X, 2011-2018)",
+      "variant_name": "1.4 TFSI",
+      "engine_code": "1.4L",
+      "engine_name": "1.4L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "5-SPEED-MANU",
+        "name": "5-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.854,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.652,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "item": "Audi A1 1.4 TFSI S tronic exact ratio and final-drive capture",
-        "reason": "The recovered official launch and facelift sources close gearbox-family existence, but they do not support a single production-safe ratio/final-drive mapping for this mixed-power placeholder row.",
-        "evidence_refs": [
-          "legacy_research_sources:d36a12aece1e",
-          "legacy_research_sources:5709c957ea25",
-          "legacy_research_sources:cfd6a6b47886"
-        ]
+      "verification_notes": [
+        {
+          "note": "Checked exact official Audi launch and facelift sources. Official Audi launch-era 1.4 TFSI 122 PS technical data and later facelift brochures both show a 6-speed manual rather than a 5-speed, so this represented 2011 5-speed row remains a contradicted advisory placeholder rather than a validated exact state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 1.4 TFSI exact 6-speed-manual row split by power and era",
+          "reason": "Official Audi launch and facelift sources both point to a 6-speed manual, but the stored broad 1.4 TFSI manual placeholder still collapses launch 122 PS and later facelift states into one non-exact row.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi A1 1.4 TFSI manual exact ratio and final-drive capture",
+          "reason": "The recovered official launch technical-sheet URL is strong gearbox-family evidence, but this pass did not safely capture a directly quotable ratio/final-drive table for repo upgrade.",
+          "evidence_refs": [
+            "legacy_research_sources:d3ced68412f8"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-8x-1-4-tfsi-eu-2011-dct7-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "8X",
+      "body_code": "8X",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A1 (8X, 2011-2018)",
+      "variant_name": "1.4 TFSI",
+      "engine_code": "1.4L",
+      "engine_name": "1.4L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n5",
+        "value": "FWD",
+        "evidence_refs_ref": "e10"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e10"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n5",
+          "value": 0.653,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes": "Sonnet redo research (2026-04 v2): Audi UK 1.4 TFSI 122 PS S tronic technical data sheet (legacy_research_sources:d36a12aece1e, Status Sep 2011) confirms 7-speed S tronic DQ200 with full gear set [3.500, 2.087, 1.343, 0.933, 0.974, 0.778, 0.653], reverse 3.988, and DQ200's characteristic split final drive: 4.800 for sub-trans 1 (gears 1-4 + reverse 4.500) and 3.429 for sub-trans 2 (gears 5-7). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd / low-gear) ratio, final_drive_rear encodes sub-trans 2 (high-gear) ratio (NOT a physical rear axle on FWD). Production start 2010 (UK Q4 2010 launch); the repo's 2011 reflects MY2011 convention. Top gear was wrongly recorded as 0.680 (placeholder) - corrected to 0.653 (7th gear). FD 3.786 placeholder superseded by split 4.800/3.429. Encodes DQ200 sub-trans 1 (gears 1-4 + reverse 4.500) output ratio.",
+          "value": 4.8,
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            3.5,
+            2.087,
+            1.343,
+            0.933,
+            0.974,
+            0.778,
+            0.653
+          ],
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official Audi launch and facelift sources. Official launch-period 1.4 TFSI technical sheets already show separate 122 PS S tronic and 185 PS S tronic states, and later facelift brochures add further 1.4 TFSI S tronic variants. This single represented 2011 DCT row therefore remains a mixed-power, mixed-era advisory placeholder rather than one exact production-safe configuration.",
+          "evidence_refs": [
+            "legacy_research_sources:0cd20821c4bc",
+            "legacy_research_sources:d36a12aece1e",
+            "legacy_research_sources:5709c957ea25",
+            "legacy_research_sources:cfd6a6b47886"
+          ]
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note": "Reverse gear ratio (research note): 3.988",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 1.4 TFSI S tronic exact power-era split",
+          "reason": "Official Audi launch material already shows separate 122 PS and 185 PS S tronic states, and later facelift material adds more 1.4 TFSI S tronic variants, so this single broad row still merges multiple exact configurations.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Audi A1 1.4 TFSI S tronic exact ratio and final-drive capture",
+          "reason": "The recovered official launch and facelift sources close gearbox-family existence, but they do not support a single production-safe ratio/final-drive mapping for this mixed-power placeholder row.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a1/GB.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a1/GB.json
@@ -1,1037 +1,868 @@
-[
-  {
-    "id": "audi-gb-25-tfsi-eu-2019-mt6-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "25 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n3": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
+      "n4": "DQ200 7-speed S tronic top gear (7th)."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:e0f98b630da4",
+        "legacy_research_sources:f72d096965c6"
+      ],
+      "e2": [
         "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
       ],
-      "notes": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
+        "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
+        "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
+        "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
         "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
       ],
-      "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 25 TFSI manual: 5-speed manual gearbox (NOT 6-speed). Forward gear ratios 3.769/1.955/1.281/0.881/0.673; reverse 3.182; final drive 3.933.",
-      "code": "MT5",
-      "name": "5-speed manual"
-    },
-    "ratios": {
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "Audi eTD 25 TFSI manual forward gear ratios.",
-        "value": [
-          3.769,
-          1.955,
-          1.281,
-          0.881,
-          0.673
-        ]
-      },
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "5-speed manual top gear (5th).",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB MQB A0 FWD: single-axle final drive 3.933 (no rear axle).",
-        "value": 3.933
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB 25 TFSI manual basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
-        "front": {
-          "width_mm": 185.0,
-          "aspect_pct": 65.0,
-          "rim_in": 15.0
-        },
-        "default_axle_for_speed": "front"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 25 TFSI manual placeholder. The 06/20/2018 launch release supports manual availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 25 TFSI sheet closes a later exact 5-speed manual state with 0.673 top gear, 3.933 final drive, and 185/65 R15 tires. Those late official values contradict the inherited MT6, 0.840, 3.462, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Transmission marketing correction: Canonical row labeled MT6 was incorrect; eTD confirms 5-speed manual."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 Sportback 25 TFSI manual applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact manual state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row manual gearbox count, top gear, final drive, and tire applicability",
-        "reason": "The checked late official 25 TFSI manual sheet documents a 5-speed gearbox with 0.673 top gear, 3.933 final drive, and 185/65 R15 tires rather than the inherited MT6, 0.840, 3.462, and 215/45 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-manual-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-gb-25-tfsi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2021,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "25 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e9": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
         "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
       ],
-      "notes": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
+      "e10": [
+        "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release"
       ],
-      "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 25 TFSI S tronic. Forward gear ratios 3.765/2.273/1.531/1.133/1.176/0.956/0.795; reverse 4.169; DQ200 sub-transmission final drives 4.438 (odd gears 1/3/5/7) and 3.227 (even gears 2/4/6).",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)"
-    },
-    "ratios": {
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi eTD 25 TFSI S tronic forward gear ratios.",
-        "value": [
-          3.765,
-          2.273,
-          1.531,
-          1.133,
-          1.176,
-          0.956,
-          0.795
-        ]
-      },
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 7-speed S tronic top gear (7th).",
-        "value": 0.795
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.438. Note: this is a DCT sub-transmission ratio, NOT a front-axle ratio (the A1 GB is FWD-only, single front axle).",
-        "value": 4.438
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB 25 TFSI S tronic basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
-        "front": {
-          "width_mm": 185.0,
-          "aspect_pct": 65.0,
-          "rim_in": 15.0
-        },
-        "default_axle_for_speed": "front"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 25 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 25 TFSI S tronic sheet closes a later exact state with 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 Sportback 25 TFSI S tronic applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
-        "reason": "The checked late official 25 TFSI S tronic sheet documents 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-25-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "A1 25 TFSI S tronic was added in MY2021; pre-2021 production span is unsupported",
-        "reason": "Audi MediaCenter A1 Sportback model-page snapshots from March 2019 and June 2020 do not list the 25 TFSI S tronic motorization (1077). The variant first appears in the October 2021 archived snapshot, indicating a MY2021 introduction. The repo's 2019 production_start_year was therefore wrong and has been corrected to 2021.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-gb-30-tfsi-eu-2019-mt6-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e11": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
         "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
       ],
-      "notes": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
+      "e12": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
+        "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page"
       ],
-      "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 30 TFSI manual: 6-speed manual gearbox.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "6-speed manual top gear (6th) per the late Germany-program 2026 eTD.",
-        "value": 0.554
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB MQB A0 FWD: single-axle final drive 4.353 per the late 2026 eTD (different gearing pair from the earlier 2022-12 eTD).",
-        "value": 4.353
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB 30 TFSI manual basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
-        "front": {
-          "width_mm": 185.0,
-          "aspect_pct": 65.0,
-          "rim_in": 15.0
-        },
-        "default_axle_for_speed": "front"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 30 TFSI manual placeholder. The 06/20/2018 launch release supports manual availability for non-top engines at Europe launch, and the checked 02/03/2026 Germany-program 30 TFSI sheet closes a later exact 6-speed manual state with 0.554 top gear, 4.353 final drive, and 185/65 R15 tires. Those late official values contradict the inherited 0.840, 3.462, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 Sportback 30 TFSI manual applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact manual state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row manual top gear, final drive, and tire applicability",
-        "reason": "The checked late official 30 TFSI manual sheet documents 0.554 top gear, 4.353 final drive, and 185/65 R15 tires rather than the inherited 0.840, 3.462, and 215/45 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "30 TFSI MT6 mid-life ratio refresh and 85→81 kW power re-rating",
-        "reason": "An earlier 2022-12 Audi MediaCenter eTD for the same motorization (443) listed forward gear ratios 3.769/1.947/1.281/0.973/0.778/0.642, top gear 0.642, and final drive 4.056. The late 2026 eTD currently cited records top gear 0.554 and final drive 4.353, indicating a mid-life gearbox/final-drive refresh. The launch (Jan 2019) press kit also rated the 30 TFSI at 85 kW (116 PS) before the 2021+ 81 kW (110 PS) WLTP re-rating. The broad 2019-2024 row collapses both states into one mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-gb-30-tfsi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e13": [
+        "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
         "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
       ],
-      "notes": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-      ],
-      "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 30 TFSI S tronic. Forward gear ratios 3.765/2.273/1.531/1.133/1.176/0.956/0.795; reverse 4.169; DQ200 sub-transmission final drives 4.438 (odd gears) / 3.227 (even gears) — same DQ200 calibration as the 25 TFSI S tronic.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)"
-    },
-    "ratios": {
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi eTD 30 TFSI S tronic forward gear ratios; identical to 25 TFSI S tronic (shared DQ200 tune).",
-        "value": [
-          3.765,
-          2.273,
-          1.531,
-          1.133,
-          1.176,
-          0.956,
-          0.795
-        ]
-      },
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 7-speed S tronic top gear (7th).",
-        "value": 0.795
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.438. NOT a front-axle ratio; the A1 GB is FWD-only.",
-        "value": 4.438
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi A1 GB 30 TFSI S tronic basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
-        "front": {
-          "width_mm": 185.0,
-          "aspect_pct": 65.0,
-          "rim_in": 15.0
-        },
-        "default_axle_for_speed": "front"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
+      "e14": [
+        "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
+        "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 30 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 30 TFSI S tronic sheet closes a later exact state with 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 Sportback 30 TFSI S tronic applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
-        "reason": "The checked late official 30 TFSI S tronic sheet documents 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-30-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "30 TFSI launch power 85 kW re-rated to 81 kW from MY2021",
-        "reason": "The Jan 2019 Audi A1 Sportback press kit rated the 30 TFSI at 85 kW (116 PS); the 2021+ Audi MediaCenter eTDs rate the same engine at 81 kW (110 PS). The broad 2019-2024 row covers both states.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-gb-35-tfsi-eu-2019-mt6-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
+  "configurations": [
+    {
+      "id": "audi-gb-25-tfsi-eu-2019-mt6-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "25 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n3",
+        "value": "FWD"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 25 TFSI manual: 5-speed manual gearbox (NOT 6-speed). Forward gear ratios 3.769/1.955/1.281/0.881/0.673; reverse 3.182; final drive 3.933.",
+        "code": "MT5",
+        "name": "5-speed manual"
+      },
+      "ratios": {
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Audi eTD 25 TFSI manual forward gear ratios.",
+          "value": [
+            3.769,
+            1.955,
+            1.281,
+            0.881,
+            0.673
+          ]
+        },
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "5-speed manual top gear (5th).",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Audi A1 GB MQB A0 FWD: single-axle final drive 3.933 (no rear axle).",
+          "value": 3.933
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Audi A1 GB 25 TFSI manual basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
+          "front": {
+            "width_mm": 185.0,
+            "aspect_pct": 65.0,
+            "rim_in": 15.0
+          },
+          "default_axle_for_speed": "front"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 25 TFSI manual placeholder. The 06/20/2018 launch release supports manual availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 25 TFSI sheet closes a later exact 5-speed manual state with 0.673 top gear, 3.933 final drive, and 185/65 R15 tires. Those late official values contradict the inherited MT6, 0.840, 3.462, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n2"
+        },
+        {
+          "note": "Transmission marketing correction: Canonical row labeled MT6 was incorrect; eTD confirms 5-speed manual."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 Sportback 25 TFSI manual applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact manual state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Represented-row manual gearbox count, top gear, final drive, and tire applicability",
+          "reason": "The checked late official 25 TFSI manual sheet documents a 5-speed gearbox with 0.673 top gear, 3.933 final drive, and 185/65 R15 tires rather than the inherited MT6, 0.840, 3.462, and 215/45 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:e0f98b630da4",
-          "legacy_research_sources:f72d096965c6"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "audi-gb-25-tfsi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2021,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "25 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "value": "FWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 25 TFSI S tronic. Forward gear ratios 3.765/2.273/1.531/1.133/1.176/0.956/0.795; reverse 4.169; DQ200 sub-transmission final drives 4.438 (odd gears 1/3/5/7) and 3.227 (even gears 2/4/6).",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)"
+      },
+      "ratios": {
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Audi eTD 25 TFSI S tronic forward gear ratios.",
+          "value": [
+            3.765,
+            2.273,
+            1.531,
+            1.133,
+            1.176,
+            0.956,
+            0.795
+          ]
+        },
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n4",
+          "value": 0.795
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.438. Note: this is a DCT sub-transmission ratio, NOT a front-axle ratio (the A1 GB is FWD-only, single front axle).",
+          "value": 4.438
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Audi A1 GB 25 TFSI S tronic basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
+          "front": {
+            "width_mm": 185.0,
+            "aspect_pct": 65.0,
+            "rim_in": 15.0
+          },
+          "default_axle_for_speed": "front"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 25 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 25 TFSI S tronic sheet closes a later exact state with 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 Sportback 25 TFSI S tronic applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
+          "reason": "The checked late official 25 TFSI S tronic sheet documents 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "A1 25 TFSI S tronic was added in MY2021; pre-2021 production span is unsupported",
+          "reason": "Audi MediaCenter A1 Sportback model-page snapshots from March 2019 and June 2020 do not list the 25 TFSI S tronic motorization (1077). The variant first appears in the October 2021 archived snapshot, indicating a MY2021 introduction. The repo's 2019 production_start_year was therefore wrong and has been corrected to 2021.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-gb-30-tfsi-eu-2019-mt6-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 30 TFSI manual: 6-speed manual gearbox.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "6-speed manual top gear (6th) per the late Germany-program 2026 eTD.",
+          "value": 0.554
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Audi A1 GB MQB A0 FWD: single-axle final drive 4.353 per the late 2026 eTD (different gearing pair from the earlier 2022-12 eTD).",
+          "value": 4.353
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Audi A1 GB 30 TFSI manual basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
+          "front": {
+            "width_mm": 185.0,
+            "aspect_pct": 65.0,
+            "rim_in": 15.0
+          },
+          "default_axle_for_speed": "front"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 30 TFSI manual placeholder. The 06/20/2018 launch release supports manual availability for non-top engines at Europe launch, and the checked 02/03/2026 Germany-program 30 TFSI sheet closes a later exact 6-speed manual state with 0.554 top gear, 4.353 final drive, and 185/65 R15 tires. Those late official values contradict the inherited 0.840, 3.462, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 Sportback 30 TFSI manual applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact manual state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Represented-row manual top gear, final drive, and tire applicability",
+          "reason": "The checked late official 30 TFSI manual sheet documents 0.554 top gear, 4.353 final drive, and 185/65 R15 tires rather than the inherited 0.840, 3.462, and 215/45 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "30 TFSI MT6 mid-life ratio refresh and 85→81 kW power re-rating",
+          "reason": "An earlier 2022-12 Audi MediaCenter eTD for the same motorization (443) listed forward gear ratios 3.769/1.947/1.281/0.973/0.778/0.642, top gear 0.642, and final drive 4.056. The late 2026 eTD currently cited records top gear 0.554 and final drive 4.353, indicating a mid-life gearbox/final-drive refresh. The launch (Jan 2019) press kit also rated the 30 TFSI at 85 kW (116 PS) before the 2021+ 81 kW (110 PS) WLTP re-rating. The broad 2019-2024 row collapses both states into one mapping.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-gb-30-tfsi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 30 TFSI S tronic. Forward gear ratios 3.765/2.273/1.531/1.133/1.176/0.956/0.795; reverse 4.169; DQ200 sub-transmission final drives 4.438 (odd gears) / 3.227 (even gears) — same DQ200 calibration as the 25 TFSI S tronic.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)"
+      },
+      "ratios": {
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Audi eTD 30 TFSI S tronic forward gear ratios; identical to 25 TFSI S tronic (shared DQ200 tune).",
+          "value": [
+            3.765,
+            2.273,
+            1.531,
+            1.133,
+            1.176,
+            0.956,
+            0.795
+          ]
+        },
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n4",
+          "value": 0.795
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.438. NOT a front-axle ratio; the A1 GB is FWD-only.",
+          "value": 4.438
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Audi A1 GB 30 TFSI S tronic basic tire per official eTD. Audi MediaCenter Germany-program eTD lists basic tire/wheel as 185/65 R15 on 5.5 J × 15 steel.",
+          "front": {
+            "width_mm": 185.0,
+            "aspect_pct": 65.0,
+            "rim_in": 15.0
+          },
+          "default_axle_for_speed": "front"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 30 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, but the checked 02/03/2026 Germany-program 30 TFSI S tronic sheet closes a later exact state with 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 Sportback 30 TFSI S tronic applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
+          "reason": "The checked late official 30 TFSI S tronic sheet documents 0.795 top gear, split final drives 4.438 / 3.227, and 185/65 R15 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "30 TFSI launch power 85 kW re-rated to 81 kW from MY2021",
+          "reason": "The Jan 2019 Audi A1 Sportback press kit rated the 30 TFSI at 85 kW (116 PS); the 2021+ Audi MediaCenter eTDs rate the same engine at 81 kW (110 PS). The broad 2019-2024 row covers both states.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-gb-35-tfsi-eu-2019-mt6-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 45.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 35 TFSI manual placeholder. The 06/20/2018 launch release says non-top engines could launch with manual or 7-speed S tronic transmissions, but the current Audi MediaCenter A1 Sportback model page and the checked 02/03/2026 exact technical-data set expose only a 35 TFSI S tronic late-program sheet. No checked official source closes a 35 TFSI manual ratio or tire package, so the inherited MT6, 0.840, 3.462, and 215/45 R17 carryover values remain unsupported and production JSON stays unchanged.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 35 TFSI manual placeholder. The 06/20/2018 launch release says non-top engines could launch with manual or 7-speed S tronic transmissions, but the current Audi MediaCenter A1 Sportback model page and the checked 02/03/2026 exact technical-data set expose only a 35 TFSI S tronic late-program sheet. No checked official source closes a 35 TFSI manual ratio or tire package, so the inherited MT6, 0.840, 3.462, and 215/45 R17 carryover values remain unsupported and production JSON stays unchanged.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A1 Sportback 35 TFSI manual applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked official chain leaves room for an early manual launch-era state, but the current official model page and recovered late exact sheets expose only 35 TFSI S tronic. No checked official manual technical-data sheet was recovered for the represented 35 TFSI row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row manual gearbox, top gear, final drive, and tire applicability",
-        "reason": "Because no checked official 35 TFSI manual technical-data sheet was recovered, the inherited MT6, 0.840, 3.462, and 215/45 R17 values remain unsupported broad-row carryover data rather than an exact manual mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "A1 GB 35 TFSI 6-speed manual is a phantom configuration; never offered for sale",
-        "reason": "Audi MediaCenter A1 Sportback model-page snapshots from March 2019, June 2020, October 2021, and October 2022 list 35 TFSI only as a 7-speed S tronic motorization (810); no 35 TFSI manual motorization was ever published. Only the pre-launch Jan 2019 press kit (with 'subject to change without notice' caveat) mentioned a manual variant for the 35 TFSI. The Audi MediaCenter 'until 2026' model hub also lists the 35 TFSI only as S tronic.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-gb-35-tfsi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "GB",
-    "body_code": "GB",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "A1 (GB, 2019-2024)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
       ],
-      "notes": " Audi A1 GB (second-generation MQB A0 platform) is FWD only; no quattro variant exists.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-      ],
-      "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 35 TFSI S tronic (110 kW 1.5 TFSI COD). Forward gear ratios 3.500/2.087/1.343/0.933/0.974/0.788/0.653; reverse 3.722; DQ200 sub-transmission final drives 4.800 (odd) / 3.429 (even) — different gearing pair from the 1.0 TFSI S tronic variants.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)"
-    },
-    "ratios": {
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi eTD 35 TFSI S tronic forward gear ratios; tuned for the 1.5 TFSI COD engine and distinct from the 1.0 TFSI S tronic ratios.",
-        "value": [
-          3.5,
-          2.087,
-          1.343,
-          0.933,
-          0.974,
-          0.788,
-          0.653
-        ]
-      },
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 7-speed S tronic top gear (7th) for the 35 TFSI.",
-        "value": 0.653
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.800. NOT a front-axle ratio; the A1 GB is FWD-only.",
-        "value": 4.8
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ],
-        "notes": "Audi MediaCenter Germany-program eTD lists basic tire/wheel for the 35 TFSI as 195/55 R16 on 6.5 J × 16 cast aluminum (different basic tire from the 1.0 TFSI variants).",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "front"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "item": "Exact Audi A1 Sportback 35 TFSI manual applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked official chain leaves room for an early manual launch-era state, but the current official model page and recovered late exact sheets expose only 35 TFSI S tronic. No checked official manual technical-data sheet was recovered for the represented 35 TFSI row.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
+          "item": "Represented-row manual gearbox, top gear, final drive, and tire applicability",
+          "reason": "Because no checked official 35 TFSI manual technical-data sheet was recovered, the inherited MT6, 0.840, 3.462, and 215/45 R17 values remain unsupported broad-row carryover data rather than an exact manual mapping.",
+          "evidence_refs_ref": "e14"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:e0f98b630da4",
-            "legacy_research_sources:f72d096965c6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "item": "A1 GB 35 TFSI 6-speed manual is a phantom configuration; never offered for sale",
+          "reason": "Audi MediaCenter A1 Sportback model-page snapshots from March 2019, June 2020, October 2021, and October 2022 list 35 TFSI only as a 7-speed S tronic motorization (810); no 35 TFSI manual motorization was ever published. Only the pre-launch Jan 2019 press kit (with 'subject to change without notice' caveat) mentioned a manual variant for the 35 TFSI. The Audi MediaCenter 'until 2026' model hub also lists the 35 TFSI only as S tronic.",
+          "evidence_refs_ref": "e10"
         }
-      ]
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 35 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, while the current Audi MediaCenter model page and the checked 02/03/2026 35 TFSI S tronic sheet close a later exact state with 0.653 top gear, split final drives 4.800 / 3.429, and 195/55 R16 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-2018-launch-release",
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
+    {
+      "id": "audi-gb-35-tfsi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "GB",
+      "body_code": "GB",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "A1 (GB, 2019-2024)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "Confirmed by Audi MediaCenter Germany-program eTD for the A1 Sportback 35 TFSI S tronic (110 kW 1.5 TFSI COD). Forward gear ratios 3.500/2.087/1.343/0.933/0.974/0.788/0.653; reverse 3.722; DQ200 sub-transmission final drives 4.800 (odd) / 3.429 (even) — different gearing pair from the 1.0 TFSI S tronic variants.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)"
+      },
+      "ratios": {
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Audi eTD 35 TFSI S tronic forward gear ratios; tuned for the 1.5 TFSI COD engine and distinct from the 1.0 TFSI S tronic ratios.",
+          "value": [
+            3.5,
+            2.087,
+            1.343,
+            0.933,
+            0.974,
+            0.788,
+            0.653
+          ]
+        },
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "DQ200 7-speed S tronic top gear (7th) for the 35 TFSI.",
+          "value": 0.653
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "DQ200 sub-transmission final drive for odd gears (1/3/5/7) is 4.800. NOT a front-axle ratio; the A1 GB is FWD-only.",
+          "value": 4.8
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Audi MediaCenter Germany-program eTD lists basic tire/wheel for the 35 TFSI as 195/55 R16 on 6.5 J × 16 cast aluminum (different basic tire from the 1.0 TFSI variants).",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "front"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific Audi MediaCenter evidence for the broad A1 Sportback 35 TFSI S tronic placeholder. The 06/20/2018 launch release supports 7-speed S tronic availability for non-top engines at Europe launch, while the current Audi MediaCenter model page and the checked 02/03/2026 35 TFSI S tronic sheet close a later exact state with 0.653 top gear, split final drives 4.800 / 3.429, and 195/55 R16 tires. Those late official values contradict the inherited 0.680, 3.786, and 215/45 R17 carryover values, so production JSON remains unchanged and the broad EU 2019-2024 row stays split-sensitive rather than exact.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A1 Sportback 35 TFSI S tronic applicability across the represented EU 2019-2024 row span",
+          "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
+          "reason": "The checked late official 35 TFSI S tronic sheet documents 0.653 top gear, split final drives 4.800 / 3.429, and 195/55 R16 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A1 Sportback 35 TFSI S tronic applicability across the represented EU 2019-2024 row span",
-        "reason": "The checked 2026 Germany-program technical-data sheet proves a later exact S tronic state, but this pass did not recover an official year-by-year source chain proving the full represented EU 2019-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-sportback-until-2026-model-page",
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row S tronic top gear, split final-drive, and tire applicability",
-        "reason": "The checked late official 35 TFSI S tronic sheet documents 0.653 top gear, split final drives 4.800 / 3.429, and 195/55 R16 tires rather than the inherited 0.680, single 3.786 final drive, and 215/45 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:gb-a1-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8V.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8V.json
@@ -1,2218 +1,1711 @@
-[
-  {
-    "id": "audi-8v-1-6-tdi-eu-2013-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "1.6 TDI",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 1.6 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia 8V powertrain section confirm FWD MQ350 6MT for 1.6 TDI. Production_start_year 2013 retained per Audi MediaCenter 1.6 TDI ultra press release (Sedan availability mid-2014; first deliveries entering MY2013 model designation). Carfolio reputable_secondary ratios: top 0.59 / FD 3.39 / tire baseline 205/55 R16. Repo placeholder 0.84/3.462/225/45-17 contradicted by every saved exact page.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n3": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
+      "n4": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
+      "n6": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
+      "n7": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n8": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n9": "Audi A3 8V Saloon 1.6 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia 8V powertrain section confirm FWD MQ350 6MT for 1.6 TDI. Production_start_year 2013 retained per Audi MediaCenter 1.6 TDI ultra press release (Sedan availability mid-2014; first deliveries entering MY2013 model designation). Carfolio reputable_secondary ratios: top 0.59 / FD 3.39 / tire baseline 205/55 R16. Repo placeholder 0.84/3.462/225/45-17 contradicted by every saved exact page.",
+      "n10": "Audi A3 8V Saloon 1.6 TDI 7-speed S tronic FWD. CRITICAL CORRECTION: transmission name was '7-speed S tronic (DQ381)' which is wrong. 1.6 TDI peak torque (~250 Nm at 110 PS) sits at the DQ200 limit, not the DQ381 wet-clutch range. ADAC catalogue lists this entry as 'S tronic (7-Gang)' = DQ200; Wikipedia A3 8V section explicitly lists DQ200 for 1.6 TDI. Corrected to DQ200. Ratios from Carfolio reputable_secondary: top 0.64 / FD 3.43; tire baseline 205/55 R16.",
+      "n11": "Audi A3 8V Saloon 2.0 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia confirm FWD MQ350 6MT for 2.0 TDI 150 PS variant. No exact Saloon ratio page recovered for the 2.0 TDI manual; ratios remain no_confidence pending official 8V technical-data PDF. Tire baseline 205/55 R16 from auto-data exact secondary; 225/45 R17 was UK Sport-trim option, not universal default.",
+      "n12": "Audi A3 8V Saloon 2.0 TDI S tronic FWD. CRITICAL: transmission was labeled DQ381 uniformly, but for 2013-2016 production this engine used the 6-speed DQ250 (FWD-6F variant), with DQ381 (7-speed wet) introduced from MY2017 European market per Wikipedia S_tronic article and ADAC catalogue (no '7-Gang' label on pre-facelift 2.0 TDI S tronic entries). Repo holds the broad 2013-2020 row; transmission code retained as DCT7 family with name 'S tronic (DQ250 6-speed pre-2017, DQ381 7-speed from 2017)' to capture the era-split. Carfolio exact 2016 Sedan page shows 6-speed automatic top 0.62 / FD 3.33 - applied as reputable_secondary (representative of the dominant pre-2017 production span). Tire baseline 205/55 R16.",
+      "n13": "Audi A3 8V Saloon 2.0 TDI quattro 6-speed manual AWD. Auto-data exact secondary supports a 2.0 TDI 150 PS quattro 6-speed manual variant for 2016-2018 (likely Sportback/Saloon). UK MY2018 price list lists the 2.0 TDI quattro only with S tronic, suggesting this manual variant was a non-UK market configuration. Carfolio adjacent (non-Saloon) page: top 0.72 / FD 3.10 - applied as reputable_secondary but flagged as adjacent-only. Tire baseline 205/55 R16.",
+      "n14": "Audi A3 8V Saloon 2.0 TDI quattro S tronic AWD. CRITICAL: era-split transmission. 2013-2016 used DQ250-6A (6-speed wet AWD); 2017-2020 used DQ381-7A (7-speed wet AWD with Haldex). UK MY2018 price list naming '7-speed S tronic' is consistent with the post-2017 DQ381-7A. Carfolio exact 2016 Saloon page: 6-speed top 0.62 / FD 3.33 - representative of pre-2017 dominant span. Tire baseline 205/55 R16.",
+      "n15": "Audi A3 8V Saloon 30 TFSI (1.0 TFSI 116 PS, 3-cyl) 6-speed manual FWD. CRITICAL DATE FIX: the 1.0 TFSI engine and the 30 TFSI badge were introduced with the November 2016 8V facelift, NOT at 2013 launch (no 1.0 TFSI appears in pre-facelift ADAC catalogue entries; Wikipedia A3 8V powertrain section lists 1.0 TFSI as a facelift addition). production_start_year corrected 2013 -> 2016. Transmission: MQ200 6-speed manual (within MQ200 torque range). Carfolio exact Saloon page: top 0.64 / FD 4.06; tire baseline 205/55 R16.",
+      "n16": "Audi A3 8V Saloon 30 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2016 (1.0 TFSI / 30 TFSI badge introduced with 8V facelift). Transmission code corrected from DQ381 -> DQ200: 1.0 TFSI 116 PS peak torque ~200 Nm sits well within DQ200 250 Nm dry-clutch limit; ADAC catalogue lists the entry as 'S tronic (7-Gang)' = DQ200; Wikipedia confirms. Carfolio exact Saloon page: top 0.80 / FD 4.44 (DQ200 typical low-gear sub-trans 1 ratio); tire baseline 205/55 R16.",
+      "n17": "Audi A3 8V Saloon 35 TFSI (1.5 TFSI evo 150 PS) 6-speed manual FWD. CRITICAL DATE FIX: the 1.5 TFSI evo engine and 35 TFSI badge appeared in the 8V lineup from 2017 (Wikipedia A3 8V section: 1.5 TFSI introduced as facelift evolution; ADAC catalogue has no pre-2017 1.5 TFSI entry). 2013 start was wrong; corrected to 2017. Transmission: MQ250 6-speed manual. Carfolio exact Saloon page: top 0.73 / FD 3.65; tire baseline 205/55 R16.",
+      "n18": "Audi A3 8V Saloon 35 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2017. Transmission code corrected from DQ381 -> DQ200: 1.5 TFSI evo peak torque 250 Nm sits at the DQ200 dry-clutch ceiling (multiple VW-group 1.5 TFSI applications use DQ200 in this exact configuration). ADAC '7-Gang' label and Wikipedia A3 8V powertrain entry corroborate. Carfolio exact Saloon page: top 0.65 / FD 4.80 (DQ200 sub-trans 1 ratio); tire baseline 205/55 R16.",
+      "n19": "Audi A3 8V Saloon 40 TFSI quattro (2.0 TFSI 190 PS) S tronic AWD. CRITICAL: this row merges two production eras. 2013-2016: 1.8 TFSI quattro 180 PS with DQ250-6A 6-speed wet AWD (auto-data 2013 page). 2016-2018: 2.0 TFSI quattro 190 PS / 40 TFSI badge with same DQ250-6A then DQ381-7A from 2017. UK MY2018 price list lists the 2.0 TFSI quattro only with S tronic. Carfolio adjacent 2.0 TFSI quattro S tronic page (non-Saloon labeled but same powertrain): top 0.64 / FD 3.13 - applied as reputable_secondary representative of the 2.0 TFSI quattro DQ381-7A 7-speed era. Tire baseline 205/55 R16.",
+      "n20": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
+      "n21": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n22": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n23": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250 6-speed pre-2017 ratio.",
+      "n24": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250-6A pre-2017 ratio.",
+      "n25": "Sonnet redo (2026-04 v2): Haldex AWD rear ratio mirrors front in published specs.",
+      "n26": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data with High confidence, but the recovered public official timing anchors still limit the reliable sedan badge-era scope to the late 8V window rather than a clean 2013 start."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:9f75939b3958"
+      ],
+      "e2": [
+        "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
+        "secondary_technical_sources:a3-8v-adac-catalogue"
+      ],
+      "e3": [
         "secondary_technical_sources:a3-8v-adac-catalogue",
         "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 1.6 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia 8V powertrain section confirm FWD MQ350 6MT for 1.6 TDI. Production_start_year 2013 retained per Audi MediaCenter 1.6 TDI ultra press release (Sedan availability mid-2014; first deliveries entering MY2013 model designation). Carfolio reputable_secondary ratios: top 0.59 / FD 3.39 / tire baseline 205/55 R16. Repo placeholder 0.84/3.462/225/45-17 contradicted by every saved exact page.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
+      ],
+      "e4": [
         "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.59,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 3.39,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 1.6 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia 8V powertrain section confirm FWD MQ350 6MT for 1.6 TDI. Production_start_year 2013 retained per Audi MediaCenter 1.6 TDI ultra press release (Sedan availability mid-2014; first deliveries entering MY2013 model designation). Carfolio reputable_secondary ratios: top 0.59 / FD 3.39 / tire baseline 205/55 R16. Repo placeholder 0.84/3.462/225/45-17 contradicted by every saved exact page.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 05/2014 ultra release states that the A3 1.6 TDI ultra had been available on the three-door and Sportback since 2013 while the Sedan version would only arrive 'in future'. The recovered exact sedan-specific manual evidence in this run is later only: a 2016-2018 facelift 1.6 TDI manual sedan with front-wheel drive and 205/55 R16 baseline tires. That makes the broad 2013-2020 sedan row overbroad and leaves the inherited 225/45 R17 default unsupported for the exact sedan state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 1.6 TDI exact EU start-year applicability",
-        "reason": "Official Audi MediaCenter 05/2014 ultra release contradicts a clean 2013 Sedan start for the 1.6 TDI row, and the recovered exact sedan-specific manual evidence only begins in 2016.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 1.6 TDI exact manual ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific manual evidence is limited to a later 2016-2018 state with 205/55 R16 baseline tires, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 1.6 TDI body and timing splits",
-        "reason": "The recovered evidence shows that body style and timing materially change whether the 1.6 TDI sedan state exists at all, but the current broad row does not represent those splits explicitly.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-1-6-tdi-eu-2013-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "1.6 TDI",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 1.6 TDI 7-speed S tronic FWD. CRITICAL CORRECTION: transmission name was '7-speed S tronic (DQ381)' which is wrong. 1.6 TDI peak torque (~250 Nm at 110 PS) sits at the DQ200 limit, not the DQ381 wet-clutch range. ADAC catalogue lists this entry as 'S tronic (7-Gang)' = DQ200; Wikipedia A3 8V section explicitly lists DQ200 for 1.6 TDI. Corrected to DQ200. Ratios from Carfolio reputable_secondary: top 0.64 / FD 3.43; tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 1.6 TDI 7-speed S tronic FWD. CRITICAL CORRECTION: transmission name was '7-speed S tronic (DQ381)' which is wrong. 1.6 TDI peak torque (~250 Nm at 110 PS) sits at the DQ200 limit, not the DQ381 wet-clutch range. ADAC catalogue lists this entry as 'S tronic (7-Gang)' = DQ200; Wikipedia A3 8V section explicitly lists DQ200 for 1.6 TDI. Corrected to DQ200. Ratios from Carfolio reputable_secondary: top 0.64 / FD 3.43; tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
+        "secondary_technical_sources:audi-a3-8v-wikipedia",
+        "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
+      ],
+      "e5": [
+        "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
+        "secondary_technical_sources:s-tronic-dsg-wikipedia"
+      ],
+      "e6": [
+        "legacy_research_sources:be16a3c42d91",
+        "legacy_research_sources:bf27b4d53ea2",
+        "legacy_research_sources:c038c5e64fb3",
+        "legacy_research_sources:c149d6f750c4",
+        "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
+        "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
+        "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e7": [
+        "secondary_technical_sources:a3-8v-adac-catalogue"
+      ],
+      "e8": [
+        "legacy_research_sources:be16a3c42d91",
+        "legacy_research_sources:bf27b4d53ea2",
+        "secondary_technical_sources:a3-8v-sedan-2-0-tdi-mt6-autodata"
+      ],
+      "e9": [
+        "legacy_research_sources:be16a3c42d91",
+        "legacy_research_sources:bf27b4d53ea2",
+        "secondary_technical_sources:a3-8v-sedan-2-0-tdi-dct7-autodata"
+      ],
+      "e10": [
+        "legacy_research_sources:be16a3c42d91",
+        "legacy_research_sources:bf27b4d53ea2",
+        "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-mt6-autodata"
+      ],
+      "e11": [
+        "legacy_research_sources:be16a3c42d91",
+        "legacy_research_sources:bf27b4d53ea2",
+        "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-dct7-autodata"
+      ],
+      "e12": [
+        "legacy_research_sources:c038c5e64fb3",
+        "legacy_research_sources:c149d6f750c4",
+        "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
+        "secondary_technical_sources:a3-8v-sedan-30-tfsi-mt6-autodata"
+      ],
+      "e13": [
+        "legacy_research_sources:c038c5e64fb3",
+        "legacy_research_sources:c149d6f750c4",
+        "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
+        "secondary_technical_sources:a3-8v-sedan-30-tfsi-dct7-autodata"
+      ],
+      "e14": [
+        "legacy_research_sources:c038c5e64fb3",
+        "legacy_research_sources:c149d6f750c4",
+        "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
+        "legacy_research_sources:c695158c5f25",
+        "secondary_technical_sources:a3-8v-sedan-35-tfsi-mt6-autodata"
+      ],
+      "e15": [
+        "legacy_research_sources:c038c5e64fb3",
+        "legacy_research_sources:c149d6f750c4",
+        "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
+        "legacy_research_sources:c695158c5f25",
+        "secondary_technical_sources:a3-8v-sedan-35-tfsi-dct7-autodata"
+      ],
+      "e16": [
+        "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
+        "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
+      ],
+      "e17": [
         "secondary_technical_sources:a3-8v-adac-catalogue",
         "secondary_technical_sources:audi-a3-8v-wikipedia",
         "secondary_technical_sources:s-tronic-dsg-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 3.43,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 1.6 TDI 7-speed S tronic FWD. CRITICAL CORRECTION: transmission name was '7-speed S tronic (DQ381)' which is wrong. 1.6 TDI peak torque (~250 Nm at 110 PS) sits at the DQ200 limit, not the DQ381 wet-clutch range. ADAC catalogue lists this entry as 'S tronic (7-Gang)' = DQ200; Wikipedia A3 8V section explicitly lists DQ200 for 1.6 TDI. Corrected to DQ200. Ratios from Carfolio reputable_secondary: top 0.64 / FD 3.43; tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 05/2014 ultra release states that the A3 1.6 TDI ultra had been available on the three-door and Sportback since 2013 while the Sedan version would only arrive 'in future'. The recovered exact sedan-specific S tronic evidence in this run is later only: a 2016-2018 facelift 1.6 TDI S tronic sedan with front-wheel drive and 205/55 R16 baseline tires. That makes the broad 2013-2020 sedan row overbroad and leaves the inherited 225/45 R17 default unsupported for the exact sedan automatic state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 1.6 TDI exact EU start-year applicability",
-        "reason": "Official Audi MediaCenter 05/2014 ultra release contradicts a clean 2013 Sedan start for the 1.6 TDI S tronic row, and the recovered exact sedan-specific automatic evidence only begins in 2016.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 1.6 TDI exact automatic ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific S tronic evidence is limited to a later 2016-2018 state with 205/55 R16 baseline tires, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 1.6 TDI body and timing splits",
-        "reason": "The recovered evidence shows that body style and timing materially change whether the 1.6 TDI sedan state exists at all, but the current broad row does not represent those splits explicitly.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
-          "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-2-0-tdi-eu-2013-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia confirm FWD MQ350 6MT for 2.0 TDI 150 PS variant. No exact Saloon ratio page recovered for the 2.0 TDI manual; ratios remain no_confidence pending official 8V technical-data PDF. Tire baseline 205/55 R16 from auto-data exact secondary; 225/45 R17 was UK Sport-trim option, not universal default.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia confirm FWD MQ350 6MT for 2.0 TDI 150 PS variant. No exact Saloon ratio page recovered for the 2.0 TDI manual; ratios remain no_confidence pending official 8V technical-data PDF. Tire baseline 205/55 R16 from auto-data exact secondary; 225/45 R17 was UK Sport-trim option, not universal default.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact Saloon source for 2.0 TDI MT6 ratio. Repo placeholder 0.84 was a family_default carryover.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact Saloon source for 2.0 TDI MT6 final drive. Repo placeholder 3.462 was a family_default carryover.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 2.0 TDI 6-speed manual FWD (MQ350). ADAC catalogue + Wikipedia confirm FWD MQ350 6MT for 2.0 TDI 150 PS variant. No exact Saloon ratio page recovered for the 2.0 TDI manual; ratios remain no_confidence pending official 8V technical-data PDF. Tire baseline 205/55 R16 from auto-data exact secondary; 225/45 R17 was UK Sport-trim option, not universal default.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI 150 hp manual state, that means the broad 2013-2020 row still spans unrecovered early years and inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 2.0 TDI exact EU start-year applicability",
-        "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered manual sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 2.0 TDI exact manual ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific 2.0 TDI manual evidence is limited to the facelift-era 2016-2018 slice with a 205/55 R16 baseline, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 2.0 TDI facelift-era splits",
-        "reason": "The recovered evidence places the sedan-specific 2.0 TDI manual state in the facelift-era program only, but the current broad row does not represent that later-only scope explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-2-0-tdi-eu-2013-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI S tronic FWD. CRITICAL: transmission was labeled DQ381 uniformly, but for 2013-2016 production this engine used the 6-speed DQ250 (FWD-6F variant), with DQ381 (7-speed wet) introduced from MY2017 European market per Wikipedia S_tronic article and ADAC catalogue (no '7-Gang' label on pre-facelift 2.0 TDI S tronic entries). Repo holds the broad 2013-2020 row; transmission code retained as DCT7 family with name 'S tronic (DQ250 6-speed pre-2017, DQ381 7-speed from 2017)' to capture the era-split. Carfolio exact 2016 Sedan page shows 6-speed automatic top 0.62 / FD 3.33 - applied as reputable_secondary (representative of the dominant pre-2017 production span). Tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI S tronic FWD. CRITICAL: transmission was labeled DQ381 uniformly, but for 2013-2016 production this engine used the 6-speed DQ250 (FWD-6F variant), with DQ381 (7-speed wet) introduced from MY2017 European market per Wikipedia S_tronic article and ADAC catalogue (no '7-Gang' label on pre-facelift 2.0 TDI S tronic entries). Repo holds the broad 2013-2020 row; transmission code retained as DCT7 family with name 'S tronic (DQ250 6-speed pre-2017, DQ381 7-speed from 2017)' to capture the era-split. Carfolio exact 2016 Sedan page shows 6-speed automatic top 0.62 / FD 3.33 - applied as reputable_secondary (representative of the dominant pre-2017 production span). Tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "S tronic (DQ250 6-speed 2013-2016 / DQ381 7-speed 2017-2020)",
-      "evidence_refs": [
+      ],
+      "e18": [
+        "audi_mediacenter_sources:8v-a3-ultra-2014-press-release",
+        "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
+      ],
+      "e19": [
         "secondary_technical_sources:a3-8v-adac-catalogue",
         "secondary_technical_sources:audi-a3-8v-wikipedia",
         "secondary_technical_sources:s-tronic-dsg-wikipedia",
         "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250 6-speed pre-2017 ratio.",
-        "value": 0.62,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250 6-speed pre-2017 ratio.",
-        "value": 3.33,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 2.0 TDI S tronic FWD. CRITICAL: transmission was labeled DQ381 uniformly, but for 2013-2016 production this engine used the 6-speed DQ250 (FWD-6F variant), with DQ381 (7-speed wet) introduced from MY2017 European market per Wikipedia S_tronic article and ADAC catalogue (no '7-Gang' label on pre-facelift 2.0 TDI S tronic entries). Repo holds the broad 2013-2020 row; transmission code retained as DCT7 family with name 'S tronic (DQ250 6-speed pre-2017, DQ381 7-speed from 2017)' to capture the era-split. Carfolio exact 2016 Sedan page shows 6-speed automatic top 0.62 / FD 3.33 - applied as reputable_secondary (representative of the dominant pre-2017 production span). Tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI 150 hp S tronic state, that means the broad 2013-2020 row remains too wide and still inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 2.0 TDI exact EU start-year applicability",
-        "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered S tronic sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 2.0 TDI exact automatic ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific 2.0 TDI S tronic evidence is limited to the facelift-era 2016-2018 slice with a 205/55 R16 baseline, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 2.0 TDI facelift-era splits",
-        "reason": "The recovered evidence places the sedan-specific 2.0 TDI S tronic state in the facelift-era program only, but the current broad row does not represent that later-only scope explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-2-0-tdi-quattro-eu-2013-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI quattro 6-speed manual AWD. Auto-data exact secondary supports a 2.0 TDI 150 PS quattro 6-speed manual variant for 2016-2018 (likely Sportback/Saloon). UK MY2018 price list lists the 2.0 TDI quattro only with S tronic, suggesting this manual variant was a non-UK market configuration. Carfolio adjacent (non-Saloon) page: top 0.72 / FD 3.10 - applied as reputable_secondary but flagged as adjacent-only. Tire baseline 205/55 R16.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI quattro 6-speed manual AWD. Auto-data exact secondary supports a 2.0 TDI 150 PS quattro 6-speed manual variant for 2016-2018 (likely Sportback/Saloon). UK MY2018 price list lists the 2.0 TDI quattro only with S tronic, suggesting this manual variant was a non-UK market configuration. Carfolio adjacent (non-Saloon) page: top 0.72 / FD 3.10 - applied as reputable_secondary but flagged as adjacent-only. Tire baseline 205/55 R16.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent (non-Saloon) Carfolio 2.0 TDI quattro page; Saloon-exact value not found.",
-        "value": 0.72,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent (non-Saloon) Carfolio page; Saloon-exact value not found.",
-        "value": 3.1,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): Haldex AWD - rear axle drive ratio mirrors front in published consumer specs. Reputable_secondary via Carfolio adjacent page.",
-        "value": 3.1,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 2.0 TDI quattro 6-speed manual AWD. Auto-data exact secondary supports a 2.0 TDI 150 PS quattro 6-speed manual variant for 2016-2018 (likely Sportback/Saloon). UK MY2018 price list lists the 2.0 TDI quattro only with S tronic, suggesting this manual variant was a non-UK market configuration. Carfolio adjacent (non-Saloon) page: top 0.72 / FD 3.10 - applied as reputable_secondary but flagged as adjacent-only. Tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI quattro 150 hp manual state, that means the broad 2013-2020 row still spans unrecovered early years and inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 2.0 TDI quattro exact EU start-year applicability",
-        "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered AWD manual sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 2.0 TDI quattro exact manual ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific AWD manual evidence is limited to the facelift-era 2016-2018 150 hp slice with a 205/55 R16 baseline, so this pass does not prove one production-safe manual package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 2.0 TDI quattro facelift-era splits",
-        "reason": "The recovered evidence places the AWD manual sedan state in the facelift-era program only, but the current broad row does not represent that later-only scope or its separate power-state split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-2-0-tdi-quattro-eu-2013-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI quattro S tronic AWD. CRITICAL: era-split transmission. 2013-2016 used DQ250-6A (6-speed wet AWD); 2017-2020 used DQ381-7A (7-speed wet AWD with Haldex). UK MY2018 price list naming '7-speed S tronic' is consistent with the post-2017 DQ381-7A. Carfolio exact 2016 Saloon page: 6-speed top 0.62 / FD 3.33 - representative of pre-2017 dominant span. Tire baseline 205/55 R16.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 2.0 TDI quattro S tronic AWD. CRITICAL: era-split transmission. 2013-2016 used DQ250-6A (6-speed wet AWD); 2017-2020 used DQ381-7A (7-speed wet AWD with Haldex). UK MY2018 price list naming '7-speed S tronic' is consistent with the post-2017 DQ381-7A. Carfolio exact 2016 Saloon page: 6-speed top 0.62 / FD 3.33 - representative of pre-2017 dominant span. Tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "S tronic (DQ250-6A 2013-2016 / DQ381-7A 2017-2020)",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:s-tronic-dsg-wikipedia",
+      ],
+      "e20": [
         "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250-6A pre-2017 ratio.",
-        "value": 0.62,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Reflects DQ250-6A pre-2017 ratio.",
-        "value": 3.33,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): Haldex AWD rear ratio mirrors front in published specs.",
-        "value": 3.33,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 2.0 TDI quattro S tronic AWD. CRITICAL: era-split transmission. 2013-2016 used DQ250-6A (6-speed wet AWD); 2017-2020 used DQ381-7A (7-speed wet AWD with Haldex). UK MY2018 price list naming '7-speed S tronic' is consistent with the post-2017 DQ381-7A. Carfolio exact 2016 Saloon page: 6-speed top 0.62 / FD 3.33 - representative of pre-2017 dominant span. Tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI quattro 184 hp S tronic state, that means the broad 2013-2020 row remains too wide and still hides the recovered 150 hp manual versus 184 hp automatic AWD split.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 2.0 TDI quattro exact EU start-year applicability",
-        "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered AWD automatic sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 2.0 TDI quattro exact automatic ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific AWD automatic evidence is limited to the facelift-era 2016-2018 184 hp slice with a 205/55 R16 baseline, so this pass does not prove one production-safe automatic package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 2.0 TDI quattro facelift-era splits",
-        "reason": "The recovered evidence places the AWD automatic sedan state in the facelift-era program only and shows that it is a different exact power-state slice from the AWD manual row, but the current broad row does not represent that split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-8v-30-tfsi-eu-2013-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 30 TFSI (1.0 TFSI 116 PS, 3-cyl) 6-speed manual FWD. CRITICAL DATE FIX: the 1.0 TFSI engine and the 30 TFSI badge were introduced with the November 2016 8V facelift, NOT at 2013 launch (no 1.0 TFSI appears in pre-facelift ADAC catalogue entries; Wikipedia A3 8V powertrain section lists 1.0 TFSI as a facelift addition). production_start_year corrected 2013 -> 2016. Transmission: MQ200 6-speed manual (within MQ200 torque range). Carfolio exact Saloon page: top 0.64 / FD 4.06; tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 30 TFSI (1.0 TFSI 116 PS, 3-cyl) 6-speed manual FWD. CRITICAL DATE FIX: the 1.0 TFSI engine and the 30 TFSI badge were introduced with the November 2016 8V facelift, NOT at 2013 launch (no 1.0 TFSI appears in pre-facelift ADAC catalogue entries; Wikipedia A3 8V powertrain section lists 1.0 TFSI as a facelift addition). production_start_year corrected 2013 -> 2016. Transmission: MQ200 6-speed manual (within MQ200 torque range). Carfolio exact Saloon page: top 0.64 / FD 4.06; tire baseline 205/55 R16.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "audi-8v-1-6-tdi-eu-2013-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "1.6 TDI",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
+        "notes_ref": "n9",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 4.06,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 30 TFSI (1.0 TFSI 116 PS, 3-cyl) 6-speed manual FWD. CRITICAL DATE FIX: the 1.0 TFSI engine and the 30 TFSI badge were introduced with the November 2016 8V facelift, NOT at 2013 launch (no 1.0 TFSI appears in pre-facelift ADAC catalogue entries; Wikipedia A3 8V powertrain section lists 1.0 TFSI as a facelift addition). production_start_year corrected 2013 -> 2016. Transmission: MQ200 6-speed manual (within MQ200 torque range). Carfolio exact Saloon page: top 0.64 / FD 4.06; tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n9",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.59,
+          "evidence_refs_ref": "e2"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.39,
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New public official badge-era anchors now show that 30 TFSI belongs to the late 8V program, not to a clean 2013 row start: the recovered UK brochure explicitly says '2018 Model Year / Edition 2.2 01/18' and the Germany brochure is dated November 2018. Combined with exact sedan-specific secondary evidence for the 2018-March 2020 30 TFSI manual state, the broad row remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan slice.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-mt6-autodata"
-        ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 30 TFSI exact EU start-year applicability",
-        "reason": "Recovered public official badge-era anchors start in 2018 and the exact recovered sedan-specific 30 TFSI manual slice begins in 2018 as well, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 30 TFSI exact manual ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific manual evidence is limited to the late 2018-2020 naming-era state with 205/55 R16 baseline tires, and the official brochure anchors only confirm the badge-era timing window, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 30 TFSI naming-era splits",
-        "reason": "The recovered official brochure timing anchors and exact secondary evidence place the 30 TFSI sedan manual state only in the late facelift naming era, but the current broad row does not represent that late-only naming split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-30-tfsi-eu-2013-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 30 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2016 (1.0 TFSI / 30 TFSI badge introduced with 8V facelift). Transmission code corrected from DQ381 -> DQ200: 1.0 TFSI 116 PS peak torque ~200 Nm sits well within DQ200 250 Nm dry-clutch limit; ADAC catalogue lists the entry as 'S tronic (7-Gang)' = DQ200; Wikipedia confirms. Carfolio exact Saloon page: top 0.80 / FD 4.44 (DQ200 typical low-gear sub-trans 1 ratio); tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 30 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2016 (1.0 TFSI / 30 TFSI badge introduced with 8V facelift). Transmission code corrected from DQ381 -> DQ200: 1.0 TFSI 116 PS peak torque ~200 Nm sits well within DQ200 250 Nm dry-clutch limit; ADAC catalogue lists the entry as 'S tronic (7-Gang)' = DQ200; Wikipedia confirms. Carfolio exact Saloon page: top 0.80 / FD 4.44 (DQ200 typical low-gear sub-trans 1 ratio); tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:s-tronic-dsg-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.8,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. DQ200 sub-trans 1 final drive (gears 1-4 + reverse).",
-        "value": 4.44,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 30 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2016 (1.0 TFSI / 30 TFSI badge introduced with 8V facelift). Transmission code corrected from DQ381 -> DQ200: 1.0 TFSI 116 PS peak torque ~200 Nm sits well within DQ200 250 Nm dry-clutch limit; ADAC catalogue lists the entry as 'S tronic (7-Gang)' = DQ200; Wikipedia confirms. Carfolio exact Saloon page: top 0.80 / FD 4.44 (DQ200 typical low-gear sub-trans 1 ratio); tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n9",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 05/2014 ultra release states that the A3 1.6 TDI ultra had been available on the three-door and Sportback since 2013 while the Sedan version would only arrive 'in future'. The recovered exact sedan-specific manual evidence in this run is later only: a 2016-2018 facelift 1.6 TDI manual sedan with front-wheel drive and 205/55 R16 baseline tires. That makes the broad 2013-2020 sedan row overbroad and leaves the inherited 225/45 R17 default unsupported for the exact sedan state.",
+          "evidence_refs_ref": "e16"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n20"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New public official badge-era anchors now show that 30 TFSI belongs to the late 8V program, not to a clean 2013 row start: the recovered UK brochure explicitly says '2018 Model Year / Edition 2.2 01/18' and the Germany brochure is dated November 2018. Combined with exact sedan-specific secondary evidence for the 2018-March 2020 30 TFSI S tronic state, the broad row remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan automatic slice.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 30 TFSI exact EU start-year applicability",
-        "reason": "Recovered public official badge-era anchors start in 2018 and the exact recovered sedan-specific 30 TFSI S tronic slice begins in 2018 as well, so this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 30 TFSI exact automatic ratio and tire mapping across the represented row",
-        "reason": "Recovered exact sedan-specific S tronic evidence is limited to the late 2018-2020 naming-era state with 205/55 R16 baseline tires, and the official brochure anchors only confirm the badge-era timing window, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 30 TFSI naming-era splits",
-        "reason": "The recovered official brochure timing anchors and exact secondary evidence place the 30 TFSI sedan automatic state only in the late facelift naming era, but the current broad row does not represent that late-only naming split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-30-tfsi-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-35-tfsi-eu-2013-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2017,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 35 TFSI (1.5 TFSI evo 150 PS) 6-speed manual FWD. CRITICAL DATE FIX: the 1.5 TFSI evo engine and 35 TFSI badge appeared in the 8V lineup from 2017 (Wikipedia A3 8V section: 1.5 TFSI introduced as facelift evolution; ADAC catalogue has no pre-2017 1.5 TFSI entry). 2013 start was wrong; corrected to 2017. Transmission: MQ250 6-speed manual. Carfolio exact Saloon page: top 0.73 / FD 3.65; tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 35 TFSI (1.5 TFSI evo 150 PS) 6-speed manual FWD. CRITICAL DATE FIX: the 1.5 TFSI evo engine and 35 TFSI badge appeared in the 8V lineup from 2017 (Wikipedia A3 8V section: 1.5 TFSI introduced as facelift evolution; ADAC catalogue has no pre-2017 1.5 TFSI entry). 2013 start was wrong; corrected to 2017. Transmission: MQ250 6-speed manual. Carfolio exact Saloon page: top 0.73 / FD 3.65; tire baseline 205/55 R16.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.73,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 3.65,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 35 TFSI (1.5 TFSI evo 150 PS) 6-speed manual FWD. CRITICAL DATE FIX: the 1.5 TFSI evo engine and 35 TFSI badge appeared in the 8V lineup from 2017 (Wikipedia A3 8V section: 1.5 TFSI introduced as facelift evolution; ADAC catalogue has no pre-2017 1.5 TFSI entry). 2013 start was wrong; corrected to 2017. Transmission: MQ250 6-speed manual. Carfolio exact Saloon page: top 0.73 / FD 3.65; tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "item": "Audi A3 Sedan 1.6 TDI exact EU start-year applicability",
+          "reason": "Official Audi MediaCenter 05/2014 ultra release contradicts a clean 2013 Sedan start for the 1.6 TDI row, and the recovered exact sedan-specific manual evidence only begins in 2016.",
+          "evidence_refs_ref": "e16"
         },
         {
-          "confidence": "family_default",
+          "item": "Audi A3 Sedan 1.6 TDI exact manual ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific manual evidence is limited to a later 2016-2018 state with 205/55 R16 baseline tires, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
           "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
+            "secondary_technical_sources:a3-8v-sedan-1-6-tdi-mt6-autodata"
+          ]
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "item": "Schema-safe representation of exact 8V 1.6 TDI body and timing splits",
+          "reason": "The recovered evidence shows that body style and timing materially change whether the 1.6 TDI sedan state exists at all, but the current broad row does not represent those splits explicitly.",
+          "evidence_refs_ref": "e16"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Recovered public badge-era anchors show the 35 TFSI naming window belongs to late 8V, not to a clean 2013 row start: the UK 2018 model-year saloon price-list mirror and Germany November 2018 brochure anchor the public badge-era timing, while exact sedan-specific secondary evidence covers the 2018-2020 35 TFSI manual state. The official Spain 03/2020 new-A3 sedan technical-data PDF is successor-generation 8Y evidence, so it is retained only as negative cross-generation context and must not support this 8V row. The broad 2013-2020 row therefore remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan slice.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-mt6-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data with High confidence, but the recovered public official timing anchors still limit the reliable sedan badge-era scope to the late 8V window rather than a clean 2013 start."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 35 TFSI exact EU start-year applicability",
-        "reason": "Recovered public badge-era anchors start in 2018 and the matching secondary sedan slice is 2018-2020, while the official Spain 03/2020 sheet is successor-generation 8Y negative context rather than 8V support; this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 35 TFSI exact manual ratio and tire mapping across the represented row",
-        "reason": "The recovered exact late-8V sedan evidence remains limited to the badge-era 2018-2020 slice with 205/55 R16 baseline tires, and the 03/2020 official Spain sheet is 8Y/new-A3 material rather than 8V evidence, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 35 TFSI badge-era splits",
-        "reason": "The recovered official-origin and secondary evidence places the 35 TFSI sedan manual state only in the late badge-era window, and the public official 03/2020 sheet belongs to the successor 8Y sedan, but the current broad row does not represent that later-only naming split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-35-tfsi-eu-2013-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2017,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 35 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2017. Transmission code corrected from DQ381 -> DQ200: 1.5 TFSI evo peak torque 250 Nm sits at the DQ200 dry-clutch ceiling (multiple VW-group 1.5 TFSI applications use DQ200 in this exact configuration). ADAC '7-Gang' label and Wikipedia A3 8V powertrain entry corroborate. Carfolio exact Saloon page: top 0.65 / FD 4.80 (DQ200 sub-trans 1 ratio); tire baseline 205/55 R16.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 35 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2017. Transmission code corrected from DQ381 -> DQ200: 1.5 TFSI evo peak torque 250 Nm sits at the DQ200 dry-clutch ceiling (multiple VW-group 1.5 TFSI applications use DQ200 in this exact configuration). ADAC '7-Gang' label and Wikipedia A3 8V powertrain entry corroborate. Carfolio exact Saloon page: top 0.65 / FD 4.80 (DQ200 sub-trans 1 ratio); tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:s-tronic-dsg-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table.",
-        "value": 0.65,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. DQ200 sub-trans 1 final drive.",
-        "value": 4.8,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ]
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-8v-1-6-tdi-eu-2013-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "1.6 TDI",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 35 TFSI 7-speed S tronic FWD. Date fix: 2013 -> 2017. Transmission code corrected from DQ381 -> DQ200: 1.5 TFSI evo peak torque 250 Nm sits at the DQ200 dry-clutch ceiling (multiple VW-group 1.5 TFSI applications use DQ200 in this exact configuration). ADAC '7-Gang' label and Wikipedia A3 8V powertrain entry corroborate. Carfolio exact Saloon page: top 0.65 / FD 4.80 (DQ200 sub-trans 1 ratio); tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n10",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n10",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e17"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e2"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2026 Limousine manual + MHEV S tronic states) with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.43,
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Recovered public badge-era anchors show the 35 TFSI naming window belongs to late 8V, not to a clean 2013 row start: the UK 2018 model-year saloon price-list mirror and Germany November 2018 brochure anchor the public badge-era timing, while exact sedan-specific secondary evidence covers the 2018-2020 35 TFSI S tronic state. The official Spain 03/2020 new-A3 sedan technical-data PDF is successor-generation 8Y evidence, so it is retained only as negative cross-generation context and must not support this 8V row. The broad 2013-2020 row therefore remains too ambiguous on late non-MHEV versus MHEV automatic identity and its inherited tire/ratio package is unsupported.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-dct7-autodata"
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data with High confidence, but the recovered public official timing anchors still limit the reliable sedan badge-era scope to the late 8V window rather than a clean 2013 start."
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 05/2014 ultra release states that the A3 1.6 TDI ultra had been available on the three-door and Sportback since 2013 while the Sedan version would only arrive 'in future'. The recovered exact sedan-specific S tronic evidence in this run is later only: a 2016-2018 facelift 1.6 TDI S tronic sedan with front-wheel drive and 205/55 R16 baseline tires. That makes the broad 2013-2020 sedan row overbroad and leaves the inherited 225/45 R17 default unsupported for the exact sedan automatic state.",
+          "evidence_refs_ref": "e18"
+        },
+        {
+          "note_ref": "n20"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 1.6 TDI exact EU start-year applicability",
+          "reason": "Official Audi MediaCenter 05/2014 ultra release contradicts a clean 2013 Sedan start for the 1.6 TDI S tronic row, and the recovered exact sedan-specific automatic evidence only begins in 2016.",
+          "evidence_refs_ref": "e18"
+        },
+        {
+          "item": "Audi A3 Sedan 1.6 TDI exact automatic ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific S tronic evidence is limited to a later 2016-2018 state with 205/55 R16 baseline tires, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs": [
+            "secondary_technical_sources:a3-8v-sedan-1-6-tdi-dct7-autodata"
+          ]
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 1.6 TDI body and timing splits",
+          "reason": "The recovered evidence shows that body style and timing materially change whether the 1.6 TDI sedan state exists at all, but the current broad row does not represent those splits explicitly.",
+          "evidence_refs_ref": "e18"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 35 TFSI exact EU start-year applicability",
-        "reason": "Recovered public badge-era anchors start in 2018 and the matching secondary sedan slice is 2018-2020, while the official Spain 03/2020 sheet is successor-generation 8Y negative context rather than 8V support; this pass does not support the row's inherited 2013 start year.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-dct7-autodata"
+    },
+    {
+      "id": "audi-8v-2-0-tdi-eu-2013-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n11",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n11",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact Saloon source for 2.0 TDI MT6 ratio. Repo placeholder 0.84 was a family_default carryover.",
+          "value": 0.84,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact Saloon source for 2.0 TDI MT6 final drive. Repo placeholder 3.462 was a family_default carryover.",
+          "value": 3.462,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "item": "Audi A3 Sedan 35 TFSI exact automatic ratio and tire mapping across the represented row",
-        "reason": "The recovered exact late-8V sedan evidence remains limited to the badge-era 2018-2020 slice, and the 03/2020 official Spain sheet is 8Y/new-A3 material rather than 8V evidence, so this pass does not prove one production-safe automatic package across the full 2013-2020 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V 35 TFSI badge-era splits",
-        "reason": "The recovered official-origin and secondary evidence places the 35 TFSI sedan automatic state only in the late badge-era window, and the public official 03/2020 sheet belongs to the successor 8Y sedan, but the current broad row does not represent that later-only naming and powertrain split explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "legacy_research_sources:c695158c5f25",
-          "secondary_technical_sources:a3-8v-sedan-35-tfsi-dct7-autodata"
-        ]
+      "verification_notes": [
+        {
+          "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI 150 hp manual state, that means the broad 2013-2020 row still spans unrecovered early years and inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n7"
+        },
+        {
+          "note_ref": "n21",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n22",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 2.0 TDI exact EU start-year applicability",
+          "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered manual sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Audi A3 Sedan 2.0 TDI exact manual ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific 2.0 TDI manual evidence is limited to the facelift-era 2016-2018 slice with a 205/55 R16 baseline, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 2.0 TDI facelift-era splits",
+          "reason": "The recovered evidence places the sedan-specific 2.0 TDI manual state in the facelift-era program only, but the current broad row does not represent that later-only scope explicitly.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-40-tfsi-quattro-eu-2013-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "40 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-      ]
     },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-      ]
+    {
+      "id": "audi-8v-2-0-tdi-eu-2013-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "code": "DCT7",
+        "name": "S tronic (DQ250 6-speed 2013-2016 / DQ381 7-speed 2017-2020)",
+        "evidence_refs_ref": "e19"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n23",
+          "value": 0.62,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n23",
+          "value": 3.33,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n12",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI 150 hp S tronic state, that means the broad 2013-2020 row remains too wide and still inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 2.0 TDI exact EU start-year applicability",
+          "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered S tronic sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi A3 Sedan 2.0 TDI exact automatic ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific 2.0 TDI S tronic evidence is limited to the facelift-era 2016-2018 slice with a 205/55 R16 baseline, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 2.0 TDI facelift-era splits",
+          "reason": "The recovered evidence places the sedan-specific 2.0 TDI S tronic state in the facelift-era program only, but the current broad row does not represent that later-only scope explicitly.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "ratios": {
-      "top_gear_ratio": {
+    {
+      "id": "audi-8v-2-0-tdi-quattro-eu-2013-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n13",
+        "value": "AWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n13",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent (non-Saloon) Carfolio 2.0 TDI quattro page; Saloon-exact value not found.",
+          "value": 0.72,
+          "evidence_refs_ref": "e20"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent (non-Saloon) Carfolio page; Saloon-exact value not found.",
+          "value": 3.1,
+          "evidence_refs_ref": "e20"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo (2026-04 v2): Haldex AWD - rear axle drive ratio mirrors front in published consumer specs. Reputable_secondary via Carfolio adjacent page.",
+          "value": 3.1,
+          "evidence_refs_ref": "e20"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n13",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI quattro 150 hp manual state, that means the broad 2013-2020 row still spans unrecovered early years and inherits an unsupported 225/45 R17 default instead of the recovered 205/55 R16 baseline.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 2.0 TDI quattro exact EU start-year applicability",
+          "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered AWD manual sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi A3 Sedan 2.0 TDI quattro exact manual ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific AWD manual evidence is limited to the facelift-era 2016-2018 150 hp slice with a 205/55 R16 baseline, so this pass does not prove one production-safe manual package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 2.0 TDI quattro facelift-era splits",
+          "reason": "The recovered evidence places the AWD manual sedan state in the facelift-era program only, but the current broad row does not represent that later-only scope or its separate power-state split explicitly.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-2-0-tdi-quattro-eu-2013-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n14",
+        "value": "AWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n14",
+        "code": "DCT7",
+        "name": "S tronic (DQ250-6A 2013-2016 / DQ381-7A 2017-2020)",
+        "evidence_refs_ref": "e19"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n24",
+          "value": 0.62,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n24",
+          "value": 3.33,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n25",
+          "value": 3.33,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n14",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New official-origin brochure anchors now prove that the facelift sedan program exists publicly from mid-2016 onward: the recovered Germany brochure is valid from June 2016 and the Spain brochure from September 2016. Combined with exact sedan-specific secondary evidence for the 2016-2018 2.0 TDI quattro 184 hp S tronic state, that means the broad 2013-2020 row remains too wide and still hides the recovered 150 hp manual versus 184 hp automatic AWD split.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 2.0 TDI quattro exact EU start-year applicability",
+          "reason": "The recovered official brochure anchors only place the public sedan program in the facelift-era 2016 window, and the exact recovered AWD automatic sedan slice is 2016-2018, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Audi A3 Sedan 2.0 TDI quattro exact automatic ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific AWD automatic evidence is limited to the facelift-era 2016-2018 184 hp slice with a 205/55 R16 baseline, so this pass does not prove one production-safe automatic package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 2.0 TDI quattro facelift-era splits",
+          "reason": "The recovered evidence places the AWD automatic sedan state in the facelift-era program only and shows that it is a different exact power-state slice from the AWD manual row, but the current broad row does not represent that split explicitly.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-30-tfsi-eu-2013-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n15",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n15",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 4.06,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n15",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New public official badge-era anchors now show that 30 TFSI belongs to the late 8V program, not to a clean 2013 row start: the recovered UK brochure explicitly says '2018 Model Year / Edition 2.2 01/18' and the Germany brochure is dated November 2018. Combined with exact sedan-specific secondary evidence for the 2018-March 2020 30 TFSI manual state, the broad row remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan slice.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 30 TFSI exact EU start-year applicability",
+          "reason": "Recovered public official badge-era anchors start in 2018 and the exact recovered sedan-specific 30 TFSI manual slice begins in 2018 as well, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Audi A3 Sedan 30 TFSI exact manual ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific manual evidence is limited to the late 2018-2020 naming-era state with 205/55 R16 baseline tires, and the official brochure anchors only confirm the badge-era timing window, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 30 TFSI naming-era splits",
+          "reason": "The recovered official brochure timing anchors and exact secondary evidence place the 30 TFSI sedan manual state only in the late facelift naming era, but the current broad row does not represent that late-only naming split explicitly.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-30-tfsi-eu-2013-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e17"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.8,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. DQ200 sub-trans 1 final drive (gears 1-4 + reverse).",
+          "value": 4.44,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New public official badge-era anchors now show that 30 TFSI belongs to the late 8V program, not to a clean 2013 row start: the recovered UK brochure explicitly says '2018 Model Year / Edition 2.2 01/18' and the Germany brochure is dated November 2018. Combined with exact sedan-specific secondary evidence for the 2018-March 2020 30 TFSI S tronic state, the broad row remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan automatic slice.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 30 TFSI exact EU start-year applicability",
+          "reason": "Recovered public official badge-era anchors start in 2018 and the exact recovered sedan-specific 30 TFSI S tronic slice begins in 2018 as well, so this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Audi A3 Sedan 30 TFSI exact automatic ratio and tire mapping across the represented row",
+          "reason": "Recovered exact sedan-specific S tronic evidence is limited to the late 2018-2020 naming-era state with 205/55 R16 baseline tires, and the official brochure anchors only confirm the badge-era timing window, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 30 TFSI naming-era splits",
+          "reason": "The recovered official brochure timing anchors and exact secondary evidence place the 30 TFSI sedan automatic state only in the late facelift naming era, but the current broad row does not represent that late-only naming split explicitly.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-35-tfsi-eu-2013-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2017,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n17",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n17",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.73,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.65,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Recovered public badge-era anchors show the 35 TFSI naming window belongs to late 8V, not to a clean 2013 row start: the UK 2018 model-year saloon price-list mirror and Germany November 2018 brochure anchor the public badge-era timing, while exact sedan-specific secondary evidence covers the 2018-2020 35 TFSI manual state. The official Spain 03/2020 new-A3 sedan technical-data PDF is successor-generation 8Y evidence, so it is retained only as negative cross-generation context and must not support this 8V row. The broad 2013-2020 row therefore remains overbroad and its inherited 225/45 R17 default is unsupported for the recovered late sedan slice.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "note_ref": "n26"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 35 TFSI exact EU start-year applicability",
+          "reason": "Recovered public badge-era anchors start in 2018 and the matching secondary sedan slice is 2018-2020, while the official Spain 03/2020 sheet is successor-generation 8Y negative context rather than 8V support; this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Audi A3 Sedan 35 TFSI exact manual ratio and tire mapping across the represented row",
+          "reason": "The recovered exact late-8V sedan evidence remains limited to the badge-era 2018-2020 slice with 205/55 R16 baseline tires, and the 03/2020 official Spain sheet is 8Y/new-A3 material rather than 8V evidence, so this pass does not prove one production-safe ratio and tire package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 35 TFSI badge-era splits",
+          "reason": "The recovered official-origin and secondary evidence places the 35 TFSI sedan manual state only in the late badge-era window, and the public official 03/2020 sheet belongs to the successor 8Y sedan, but the current broad row does not represent that later-only naming split explicitly.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-35-tfsi-eu-2013-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2017,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n18",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n18",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e17"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.65,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. DQ200 sub-trans 1 final drive.",
+          "value": 4.8,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n18",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Recovered public badge-era anchors show the 35 TFSI naming window belongs to late 8V, not to a clean 2013 row start: the UK 2018 model-year saloon price-list mirror and Germany November 2018 brochure anchor the public badge-era timing, while exact sedan-specific secondary evidence covers the 2018-2020 35 TFSI S tronic state. The official Spain 03/2020 new-A3 sedan technical-data PDF is successor-generation 8Y evidence, so it is retained only as negative cross-generation context and must not support this 8V row. The broad 2013-2020 row therefore remains too ambiguous on late non-MHEV versus MHEV automatic identity and its inherited tire/ratio package is unsupported.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "note_ref": "n26"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 35 TFSI exact EU start-year applicability",
+          "reason": "Recovered public badge-era anchors start in 2018 and the matching secondary sedan slice is 2018-2020, while the official Spain 03/2020 sheet is successor-generation 8Y negative context rather than 8V support; this pass does not support the row's inherited 2013 start year.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "item": "Audi A3 Sedan 35 TFSI exact automatic ratio and tire mapping across the represented row",
+          "reason": "The recovered exact late-8V sedan evidence remains limited to the badge-era 2018-2020 slice, and the 03/2020 official Spain sheet is 8Y/new-A3 material rather than 8V evidence, so this pass does not prove one production-safe automatic package across the full 2013-2020 broad row.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V 35 TFSI badge-era splits",
+          "reason": "The recovered official-origin and secondary evidence places the 35 TFSI sedan automatic state only in the late badge-era window, and the public official 03/2020 sheet belongs to the successor 8Y sedan, but the current broad row does not represent that later-only naming and powertrain split explicitly.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8v-40-tfsi-quattro-eu-2013-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "40 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
+        "notes_ref": "n6",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
+        "notes_ref": "n6",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e4"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A3 8V Saloon 2.0 TFSI quattro (40 TFSI quattro, 190 PS) was offered exclusively with the S tronic DCT (6-speed DQ250 pre-2017, 7-speed DQ381 from 2017). No 6-speed manual 2.0 TFSI quattro Saloon variant is documented in the UK MY2018 price list, ADAC Autokatalog, Auto-Data, or Carfolio. The stored row appears to be a mechanically-generated combination that was never produced. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 0.84,
+          "evidence_refs_ref": "e4"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.462,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.462,
+          "evidence_refs_ref": "e4"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n6",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "New official brochure timing anchors tighten the late-8V scope but still do not rescue this row: recovered public official material only anchors the facelift and badge-era windows, while the exact AWD sedan evidence recovered in this run is automatic-only in both checked eras. With only a pre-facelift 2013-2016 1.8 TFSI quattro S tronic sedan and a facelift 2016-2018 2.0 TFSI quattro S tronic sedan recovered, the broad manual placeholder should be treated as unsupported rather than as an inherited exact configuration.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
+          "note_ref": "n8"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n21",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n22",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "New official brochure timing anchors tighten the late-8V scope but still do not rescue this row: recovered public official material only anchors the facelift and badge-era windows, while the exact AWD sedan evidence recovered in this run is automatic-only in both checked eras. With only a pre-facelift 2013-2016 1.8 TFSI quattro S tronic sedan and a facelift 2016-2018 2.0 TFSI quattro S tronic sedan recovered, the broad manual placeholder should be treated as unsupported rather than as an inherited exact configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a3-8v-adac-catalogue",
-          "secondary_technical_sources:audi-a3-8v-wikipedia",
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 40 TFSI quattro exact manual applicability across the represented row",
-        "reason": "Recovered public official brochure timing anchors do not add any exact AWD manual sedan state, and the exact recovered AWD sedan evidence is automatic-only in both the 2013-2016 1.8 TFSI quattro state and the 2016-2018 2.0 TFSI quattro state.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 40 TFSI quattro exact ratio and tire mapping for any manual state",
-        "reason": "The recovered public official brochure timing anchors still do not produce any exact AWD manual sedan state, so this pass does not prove any ratio or baseline-tire package for a manual 40 TFSI quattro sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V quattro powertrain-era splits",
-        "reason": "The recovered public official brochure timing anchors only reinforce that the 8V AWD sedan evidence spans multiple later eras, while the exact recovered states still split into pre-facelift 1.8 TFSI quattro S tronic and facelift 2.0 TFSI quattro S tronic slices that the current broad row does not represent explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8v-40-tfsi-quattro-eu-2013-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2013,
-    "production_end_year": 2020,
-    "model_name": "A3 (8V, 2013-2020)",
-    "variant_name": "40 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 40 TFSI quattro (2.0 TFSI 190 PS) S tronic AWD. CRITICAL: this row merges two production eras. 2013-2016: 1.8 TFSI quattro 180 PS with DQ250-6A 6-speed wet AWD (auto-data 2013 page). 2016-2018: 2.0 TFSI quattro 190 PS / 40 TFSI badge with same DQ250-6A then DQ381-7A from 2017. UK MY2018 price list lists the 2.0 TFSI quattro only with S tronic. Carfolio adjacent 2.0 TFSI quattro S tronic page (non-Saloon labeled but same powertrain): top 0.64 / FD 3.13 - applied as reputable_secondary representative of the 2.0 TFSI quattro DQ381-7A 7-speed era. Tire baseline 205/55 R16.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A3 8V Saloon 40 TFSI quattro (2.0 TFSI 190 PS) S tronic AWD. CRITICAL: this row merges two production eras. 2013-2016: 1.8 TFSI quattro 180 PS with DQ250-6A 6-speed wet AWD (auto-data 2013 page). 2016-2018: 2.0 TFSI quattro 190 PS / 40 TFSI badge with same DQ250-6A then DQ381-7A from 2017. UK MY2018 price list lists the 2.0 TFSI quattro only with S tronic. Carfolio adjacent 2.0 TFSI quattro S tronic page (non-Saloon labeled but same powertrain): top 0.64 / FD 3.13 - applied as reputable_secondary representative of the 2.0 TFSI quattro DQ381-7A 7-speed era. Tire baseline 205/55 R16.",
-      "code": "DCT7",
-      "name": "S tronic (DQ250-6A 2013-2016 / DQ381-7A 2017-2020)",
-      "evidence_refs": [
-        "secondary_technical_sources:a3-8v-adac-catalogue",
-        "secondary_technical_sources:audi-a3-8v-wikipedia",
-        "secondary_technical_sources:s-tronic-dsg-wikipedia",
-        "secondary_technical_sources:carfolio-audi-a3-saloon-8v"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent 2.0 TFSI quattro S tronic page; covers DQ381-7A era.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent 2.0 TFSI quattro S tronic page.",
-        "value": 3.13,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): Haldex AWD rear ratio mirrors front in published specs.",
-        "value": 3.13,
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:s-tronic-dsg-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:carfolio-audi-a3-saloon-8v",
-          "secondary_technical_sources:a3-8v-adac-catalogue"
-        ],
-        "notes": "Audi A3 8V Saloon 40 TFSI quattro (2.0 TFSI 190 PS) S tronic AWD. CRITICAL: this row merges two production eras. 2013-2016: 1.8 TFSI quattro 180 PS with DQ250-6A 6-speed wet AWD (auto-data 2013 page). 2016-2018: 2.0 TFSI quattro 190 PS / 40 TFSI badge with same DQ250-6A then DQ381-7A from 2017. UK MY2018 price list lists the 2.0 TFSI quattro only with S tronic. Carfolio adjacent 2.0 TFSI quattro S tronic page (non-Saloon labeled but same powertrain): top 0.64 / FD 3.13 - applied as reputable_secondary representative of the 2.0 TFSI quattro DQ381-7A 7-speed era. Tire baseline 205/55 R16.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "item": "Audi A3 Sedan 40 TFSI quattro exact manual applicability across the represented row",
+          "reason": "Recovered public official brochure timing anchors do not add any exact AWD manual sedan state, and the exact recovered AWD sedan evidence is automatic-only in both the 2013-2016 1.8 TFSI quattro state and the 2016-2018 2.0 TFSI quattro state.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
+          "item": "Audi A3 Sedan 40 TFSI quattro exact ratio and tire mapping for any manual state",
+          "reason": "The recovered public official brochure timing anchors still do not produce any exact AWD manual sedan state, so this pass does not prove any ratio or baseline-tire package for a manual 40 TFSI quattro sedan row.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9f75939b3958"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "item": "Schema-safe representation of exact 8V quattro powertrain-era splits",
+          "reason": "The recovered public official brochure timing anchors only reinforce that the 8V AWD sedan evidence spans multiple later eras, while the exact recovered states still split into pre-facelift 1.8 TFSI quattro S tronic and facelift 2.0 TFSI quattro S tronic slices that the current broad row does not represent explicitly.",
+          "evidence_refs_ref": "e6"
         }
-      ]
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official brochure timing anchors now make the late 8V window clearer, but they still do not collapse this row to one exact automatic state: recovered public official material spans the facelift and badge-era windows, while the exact AWD sedan evidence still splits into a pre-facelift 2013-2016 1.8 TFSI quattro S tronic state and a facelift 2016-2018 2.0 TFSI quattro S tronic state with a broader tire ladder. The stored broad automatic row therefore still merges at least two powertrain and gearbox-era slices.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
+    {
+      "id": "audi-8v-40-tfsi-quattro-eu-2013-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2013,
+      "production_end_year": 2020,
+      "model_name": "A3 (8V, 2013-2020)",
+      "variant_name": "40 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n19",
+        "value": "AWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n19",
+        "code": "DCT7",
+        "name": "S tronic (DQ250-6A 2013-2016 / DQ381-7A 2017-2020)",
+        "evidence_refs_ref": "e19"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent 2.0 TFSI quattro S tronic page; covers DQ381-7A era.",
+          "value": 0.64,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Carfolio per-variant page for the Audi A3 8V Saloon supplied this value as reputable_secondary. No official Audi 8V technical-data PDF with matching ratio was recovered this pass; Audi MediaCenter and Audi UK 8V tech-data PDFs did not surface for the exact engine/gearbox combination. Holding at reputable_secondary rather than promoting to official_*. Prior repo placeholder (top 0.84 / 0.725 and FD 3.462 / 4.769) was contradicted by every Carfolio exact page checked - see SOURCE_NOTES.md Session 2 ratio table. Adjacent 2.0 TFSI quattro S tronic page.",
+          "value": 3.13,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n25",
+          "value": 3.13,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n19",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "Official brochure timing anchors now make the late 8V window clearer, but they still do not collapse this row to one exact automatic state: recovered public official material spans the facelift and badge-era windows, while the exact AWD sedan evidence still splits into a pre-facelift 2013-2016 1.8 TFSI quattro S tronic state and a facelift 2016-2018 2.0 TFSI quattro S tronic state with a broader tire ladder. The stored broad automatic row therefore still merges at least two powertrain and gearbox-era slices.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 Sedan 40 TFSI quattro exact automatic powertrain mapping across the represented row",
+          "reason": "Recovered public official brochure timing anchors reinforce the later 8V timing windows, but the exact AWD sedan evidence still splits into a 2013-2016 1.8 TFSI quattro S tronic state and a 2016-2018 2.0 TFSI quattro S tronic state, so the broad row does not represent one safe exact automatic configuration across 2013-2020.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi A3 Sedan 40 TFSI quattro exact automatic ratio and tire continuity across the represented row",
+          "reason": "Recovered exact AWD sedan evidence still shows different gearbox speeds, different powertrains, and different tire ladders between the pre-facelift 1.8 TFSI and facelift 2.0 TFSI quattro S tronic states, so the official timing anchors do not make one production-safe numeric package safe across the full broad row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Schema-safe representation of exact 8V quattro powertrain-era splits",
+          "reason": "The recovered public official brochure timing anchors reinforce that the 8V AWD automatic evidence spans multiple later eras, while the exact recovered states still split into pre-facelift 1.8 TFSI quattro S tronic and facelift 2.0 TFSI quattro S tronic slices that the current broad row does not represent explicitly.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 Sedan 40 TFSI quattro exact automatic powertrain mapping across the represented row",
-        "reason": "Recovered public official brochure timing anchors reinforce the later 8V timing windows, but the exact AWD sedan evidence still splits into a 2013-2016 1.8 TFSI quattro S tronic state and a 2016-2018 2.0 TFSI quattro S tronic state, so the broad row does not represent one safe exact automatic configuration across 2013-2020.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi A3 Sedan 40 TFSI quattro exact automatic ratio and tire continuity across the represented row",
-        "reason": "Recovered exact AWD sedan evidence still shows different gearbox speeds, different powertrains, and different tire ladders between the pre-facelift 1.8 TFSI and facelift 2.0 TFSI quattro S tronic states, so the official timing anchors do not make one production-safe numeric package safe across the full broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Schema-safe representation of exact 8V quattro powertrain-era splits",
-        "reason": "The recovered public official brochure timing anchors reinforce that the 8V AWD automatic evidence spans multiple later eras, while the exact recovered states still split into pre-facelift 1.8 TFSI quattro S tronic and facelift 2.0 TFSI quattro S tronic slices that the current broad row does not represent explicitly.",
-        "evidence_refs": [
-          "legacy_research_sources:be16a3c42d91",
-          "legacy_research_sources:bf27b4d53ea2",
-          "legacy_research_sources:c038c5e64fb3",
-          "legacy_research_sources:c149d6f750c4",
-          "secondary_technical_sources:a3-8v-saloon-2018-uk-price-list-mirror",
-          "secondary_technical_sources:a3-8v-sedan-1-8-tfsi-quattro-dct6-autodata",
-          "secondary_technical_sources:a3-8v-sedan-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8Y.json
@@ -1,1747 +1,1427 @@
-[
-  {
-    "id": "audi-8y-30-tdi-eu-2021-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "30 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
+      "n4": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
+      "n5": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
+      "n6": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
+      "n7": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
+      "n8": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
+      "n9": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
+      "n10": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
+      "n11": "Official Audi technical-data material publishes 6-speed manual wording for the checked state. The repo stores normalized code MT6; no supplier gearbox-family code is published.",
+      "n12": "Official Audi technical-data material publishes a single/equal final-drive value for the checked front-wheel-drive state, which the canonical schema stores in final_drive_front.",
+      "n13": "Official Audi technical-data material publishes 7-speed S tronic wording for the checked state. The repo stores normalized code DCT7; no supplier gearbox-family code is published."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e2": [
+        "legacy_research_sources:0763518f2893",
+        "legacy_research_sources:22498f3a74f1",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:544adad583d5",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:7ad6a45bf70a",
+        "legacy_research_sources:7be816632b85",
+        "legacy_research_sources:e26c1ff07b3a",
+        "legacy_research_sources:e6d59d64ee25"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
+      ],
+      "e4": [
         "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
+      "e5": [
+        "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
       ],
-      "notes": "Official Audi technical-data material publishes 6-speed manual wording for the checked state. The repo stores normalized code MT6; no supplier gearbox-family code is published.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.604 as the top forward gear ratio for the checked exact state.",
-        "value": 0.604
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.75,
-          1.952,
-          1.2,
-          0.878,
-          0.711,
-          0.604
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material publishes a single/equal final-drive value for the checked front-wheel-drive state, which the canonical schema stores in final_drive_front.",
-        "value": 3.238
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 16\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi 2023 A3 Sedan 30 TDI technical-data material replaces the inherited family defaults for the checked manual state: FWD, 6-speed manual, 0.604 top gear, equal 3.238 final-drive values, and 205/55 R16 basic tires. The MY2026 price list confirms a later TDI 85 kW manual Limousine state, but unchanged 2021-2026 continuity remains unproven.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 30 TDI manual continuity across 2021-2026",
-        "reason": "The exact official PDF proves a 2023 state and the MY2026 price list confirms later manual availability, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 30 TDI trim-linked tire matrix",
-        "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-30-tdi-eu-2021-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "30 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0763518f2893",
-          "legacy_research_sources:22498f3a74f1",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:544adad583d5",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7ad6a45bf70a",
-          "legacy_research_sources:7be816632b85",
-          "legacy_research_sources:e26c1ff07b3a",
-          "legacy_research_sources:e6d59d64ee25"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "No checked official source supports the represented A3 8Y 30 TDI S tronic sedan row. The official 2023 30 TDI technical-data PDF is manual-only, and the MY2026 price list pairs TDI 85 kW with 6-speed manual while reserving S tronic for the higher-output TDI 110 kW state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A3 8Y 30 TDI S tronic sedan evidence",
-        "reason": "The checked official source chain supports 30 TDI manual and 35 TDI/TDI 110 kW S tronic states, not a 30 TDI DCT7/S tronic sedan state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tdi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Replacement strategy for the represented 30 TDI automatic row",
-        "reason": "The current broad row may need deletion, re-keying to a higher-output 35 TDI/TDI 110 kW state, or an exact market/year split if future official evidence proves a 30 TDI S tronic variant.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-30-tfsi-eu-2021-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e6": [
         "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
+      "e7": [
+        "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material publishes 6-speed manual wording for the checked state. The repo stores normalized code MT6; no supplier gearbox-family code is published.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e8": [
+        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
+      ],
+      "e9": [
+        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
+      ],
+      "e10": [
+        "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
+        "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e11": [
+        "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e12": [
+        "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e13": [
+        "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
+        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e14": [
+        "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
+        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e15": [
+        "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e16": [
+        "audi_mediacenter_sources:8y-a3-2022-price-list-pdf",
+        "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ],
+      "e17": [
+        "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
+        "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-8y-30-tdi-eu-2021-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "30 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.642 as the top forward gear ratio for the checked exact state.",
-        "value": 0.642
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n10",
+        "value": "FWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.769,
-          1.947,
-          1.281,
-          0.973,
-          0.778,
-          0.642
-        ]
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n11",
+        "code": "MT6",
+        "name": "6-speed manual"
       },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material publishes a single/equal final-drive value for the checked front-wheel-drive state, which the canonical schema stores in final_drive_front.",
-        "value": 4.353
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi technical-data material lists 0.604 as the top forward gear ratio for the checked exact state.",
+          "value": 0.604
         },
-        "default_axle_for_speed": "rear"
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n4",
+          "value": [
+            3.75,
+            1.952,
+            1.2,
+            0.878,
+            0.711,
+            0.604
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n12",
+          "value": 3.238
+        }
       },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 55.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 16\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 16\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi 2023 A3 Sedan 30 TDI technical-data material replaces the inherited family defaults for the checked manual state: FWD, 6-speed manual, 0.604 top gear, equal 3.238 final-drive values, and 205/55 R16 basic tires. The MY2026 price list confirms a later TDI 85 kW manual Limousine state, but unchanged 2021-2026 continuity remains unproven.",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi 2023 A3 Sedan 30 TFSI technical-data material replaces the inherited family defaults for the checked 1.0-liter manual state: FWD, 6-speed manual, 0.642 top gear, 4.353 final drive, and 205/55 R16 basic tires. The MY2026 price list shows the later 85 kW TFSI Limousine as a 1.5-liter program, so the row remains over-broad.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 30 TFSI engine/program continuity across 2021-2026",
-        "reason": "The exact official PDF proves a 2023 999 cc / 81 kW state, while the MY2026 price list lists TFSI 85 kW with 1.5-liter displacement; this pass did not recover the exact split point for the broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 30 TFSI trim-linked tire matrix",
-        "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-30-tfsi-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-30-tfsi-eu-2021-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0763518f2893",
-          "legacy_research_sources:22498f3a74f1",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:544adad583d5",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7ad6a45bf70a",
-          "legacy_research_sources:7be816632b85",
-          "legacy_research_sources:e26c1ff07b3a",
-          "legacy_research_sources:e6d59d64ee25"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "No exact official A3 Sedan 30 TFSI S tronic technical-data PDF was recovered. Audi launch material says an entry-level gasoline engine would follow, and the MY2026 price list confirms a later TFSI 85 kW S tronic Limousine state, but it is a 1.5-liter later program rather than clean support for the current 1.0-liter 2021-2026 row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A3 8Y 30 TFSI S tronic ratios and final drive",
-        "reason": "This pass did not recover an official exact 30 TFSI S tronic technical-data PDF; inherited DCT7 family ratios and final drive remain unsupported.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 30 TFSI S tronic engine/program continuity",
-        "reason": "The captured official sources point from an early entry gasoline context to a later 1.5-liter TFSI 85 kW S tronic program, but the current row stores one 1.0-liter 2021-2026 state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-35-tdi-eu-2021-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "35 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0763518f2893",
-          "legacy_research_sources:22498f3a74f1",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:544adad583d5",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7ad6a45bf70a",
-          "legacy_research_sources:7be816632b85",
-          "legacy_research_sources:e26c1ff07b3a",
-          "legacy_research_sources:e6d59d64ee25"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter 2024 Germany technical data / MY2026 price list with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official A3 8Y Sedan/Limousine sources do not support a 35 TDI manual sedan row. The 2020 launch release, 2024 technical-data PDF, 2024 facelift release, and MY2026 price list consistently support the 110 kW diesel sedan as a 7-speed S tronic state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A3 8Y 35 TDI manual sedan evidence",
-        "reason": "Official sedan/limousine sources checked in this run support 35 TDI/TDI 110 kW with S tronic, while the only manual lead found by the source packet was Sportback-only secondary evidence.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Replacement strategy for the represented 35 TDI manual row",
-        "reason": "The current broad row may need deletion or body/market splitting if future official evidence proves a manual sedan state; current official sedan evidence contradicts it.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-35-tdi-eu-2021-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "35 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
+      "unresolved": [
+        {
+          "item": "Audi A3 8Y 30 TDI manual continuity across 2021-2026",
+          "reason": "The exact official PDF proves a 2023 state and the MY2026 price list confirms later manual availability, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Audi A3 8Y 30 TDI trim-linked tire matrix",
+          "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
+          "evidence_refs_ref": "e5"
+        }
       ],
-      "notes": "Official Audi technical-data material publishes 7-speed S tronic wording for the checked state. The repo stores normalized code DCT7; no supplier gearbox-family code is published.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.561 as the top forward gear ratio for the checked exact state.",
-        "value": 0.561
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.579,
-          2.75,
-          1.677,
-          0.889,
-          0.677,
-          0.722,
-          0.561
-        ]
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "audi-8y-30-tdi-eu-2021-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "30 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-            "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
+          "note": "No checked official source supports the represented A3 8Y 30 TDI S tronic sedan row. The official 2023 30 TDI technical-data PDF is manual-only, and the MY2026 price list pairs TDI 85 kW with 6-speed manual while reserving S tronic for the higher-output TDI 110 kW state.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi A3 8Y 30 TDI S tronic sedan evidence",
+          "reason": "The checked official source chain supports 30 TDI manual and 35 TDI/TDI 110 kW S tronic states, not a 30 TDI DCT7/S tronic sedan state.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Replacement strategy for the represented 30 TDI automatic row",
+          "reason": "The current broad row may need deletion, re-keying to a higher-output 35 TDI/TDI 110 kW state, or an exact market/year split if future official evidence proves a 30 TDI S tronic variant.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-30-tfsi-eu-2021-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n10",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n11",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official Audi technical-data material lists 0.642 as the top forward gear ratio for the checked exact state.",
+          "value": 0.642
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n4",
+          "value": [
+            3.769,
+            1.947,
+            1.281,
+            0.973,
+            0.778,
+            0.642
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n12",
+          "value": 4.353
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 55.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 16\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e11",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 16\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi 2023 A3 Sedan 30 TFSI technical-data material replaces the inherited family defaults for the checked 1.0-liter manual state: FWD, 6-speed manual, 0.642 top gear, 4.353 final drive, and 205/55 R16 basic tires. The MY2026 price list shows the later 85 kW TFSI Limousine as a 1.5-liter program, so the row remains over-broad.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 8Y 30 TFSI engine/program continuity across 2021-2026",
+          "reason": "The exact official PDF proves a 2023 999 cc / 81 kW state, while the MY2026 price list lists TFSI 85 kW with 1.5-liter displacement; this pass did not recover the exact split point for the broad row.",
+          "evidence_refs_ref": "e11"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
+          "item": "Audi A3 8Y 30 TFSI trim-linked tire matrix",
+          "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-30-tfsi-eu-2021-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi 2024 A3 Limousine 35 TDI technical-data material replaces the inherited family defaults for the checked S tronic state: FWD, 7-speed S tronic, complete forward ratios ending in 0.561, and 205/55 R16 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 35 TDI S tronic continuity across 2021-2026",
-        "reason": "The exact official PDF proves a 2024 state and the MY2026 price list confirms later 110 kW S tronic availability, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "35 TDI split final-drive representation",
-        "reason": "Official Audi publishes split final-drive values 4.167 / 3.125; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "item": "Audi A3 8Y 35 TDI gearbox-family code",
-        "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tdi-stronic-2024-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-35-tfsi-eu-2021-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-      ],
-      "notes": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-      ],
-      "notes": "Official Audi technical-data material publishes 6-speed manual wording for the checked state. The repo stores normalized code MT6; no supplier gearbox-family code is published.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.510 as the top forward gear ratio for the checked exact state.",
-        "value": 0.51
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.75,
-          2.1,
-          1.276,
-          0.878,
-          0.674,
-          0.51
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material publishes a single/equal final-drive value for the checked front-wheel-drive state, which the canonical schema stores in final_drive_front.",
-        "value": 4.235
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_derived",
+          "note": "No exact official A3 Sedan 30 TFSI S tronic technical-data PDF was recovered. Audi launch material says an entry-level gasoline engine would follow, and the MY2026 price list confirms a later TFSI 85 kW S tronic Limousine state, but it is a 1.5-liter later program rather than clean support for the current 1.0-liter 2021-2026 row.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi A3 8Y 30 TFSI S tronic ratios and final drive",
+          "reason": "This pass did not recover an official exact 30 TFSI S tronic technical-data PDF; inherited DCT7 family ratios and final drive remain unsupported.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Audi A3 8Y 30 TFSI S tronic engine/program continuity",
+          "reason": "The captured official sources point from an early entry gasoline context to a later 1.5-liter TFSI 85 kW S tronic program, but the current row stores one 1.0-liter 2021-2026 state.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-35-tdi-eu-2021-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "35 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n3",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official A3 8Y Sedan/Limousine sources do not support a 35 TDI manual sedan row. The 2020 launch release, 2024 technical-data PDF, 2024 facelift release, and MY2026 price list consistently support the 110 kW diesel sedan as a 7-speed S tronic state.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi A3 8Y 35 TDI manual sedan evidence",
+          "reason": "Official sedan/limousine sources checked in this run support 35 TDI/TDI 110 kW with S tronic, while the only manual lead found by the source packet was Sportback-only secondary evidence.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Replacement strategy for the represented 35 TDI manual row",
+          "reason": "The current broad row may need deletion or body/market splitting if future official evidence proves a manual sedan state; current official sedan evidence contradicts it.",
+          "evidence_refs_ref": "e17"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-35-tdi-eu-2021-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "35 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n10",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n13",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Official Audi technical-data material lists 0.561 as the top forward gear ratio for the checked exact state.",
+          "value": 0.561
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n4",
+          "value": [
+            3.579,
+            2.75,
+            1.677,
+            0.889,
+            0.677,
+            0.722,
+            0.561
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e10",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 16\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi 2024 A3 Limousine 35 TDI technical-data material replaces the inherited family defaults for the checked S tronic state: FWD, 7-speed S tronic, complete forward ratios ending in 0.561, and 205/55 R16 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 8Y 35 TDI S tronic continuity across 2021-2026",
+          "reason": "The exact official PDF proves a 2024 state and the MY2026 price list confirms later 110 kW S tronic availability, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "item": "35 TDI split final-drive representation",
+          "reason": "Official Audi publishes split final-drive values 4.167 / 3.125; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi A3 8Y 35 TDI gearbox-family code",
+          "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-35-tfsi-eu-2021-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n10",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n11",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "Official Audi technical-data material lists 0.510 as the top forward gear ratio for the checked exact state.",
+          "value": 0.51
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n4",
+          "value": [
+            3.75,
+            2.1,
+            1.276,
+            0.878,
+            0.674,
+            0.51
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n12",
+          "value": 4.235
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e13",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 16\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi launch material supports the 35 TFSI manual sedan at launch, and the 2026 A3 Limousine TFSI 110 kW technical-data PDF replaces inherited family defaults for the checked manual state: FWD, 6-speed manual, 0.510 top gear, equal 4.235 final-drive values, and 205/55 R16 basic tires.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 8Y 35 TFSI manual continuity across 2021-2026",
+          "reason": "Official sources prove launch presence and a 2026 exact technical state, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Audi A3 8Y 35 TFSI trim-linked tire matrix",
+          "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
           "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
             "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf",
             "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8y-35-tfsi-eu-2021-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n10",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n13",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Official Audi technical-data material lists 0.653 as the top forward gear ratio for the checked exact state.",
+          "value": 0.653
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n4",
+          "value": [
+            3.5,
+            2.087,
+            1.343,
+            0.94,
+            0.974,
+            0.78,
+            0.653
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 55.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 16\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e14",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 16\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi launch material supports the 35 TFSI S tronic MHEV sedan, and the 2026 A3 Limousine TFSI S tronic 110 kW MHEV technical-data PDF replaces inherited family defaults for the checked S tronic state: FWD, complete forward ratios ending in 0.653, and 205/55 R16 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields.",
+          "evidence_refs_ref": "e14"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi launch material supports the 35 TFSI manual sedan at launch, and the 2026 A3 Limousine TFSI 110 kW technical-data PDF replaces inherited family defaults for the checked manual state: FWD, 6-speed manual, 0.510 top gear, equal 4.235 final-drive values, and 205/55 R16 basic tires.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 35 TFSI manual continuity across 2021-2026",
-        "reason": "Official sources prove launch presence and a 2026 exact technical state, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 35 TFSI trim-linked tire matrix",
-        "reason": "The official technical PDF proves the 205/55 R16 basic tire, while MY2026 price-list tire packages are trim-linked equipment rather than a universal default for every represented year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-manual-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-35-tfsi-eu-2021-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material directly supports FWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
-      ],
-      "notes": "Official Audi technical-data material publishes 7-speed S tronic wording for the checked state. The repo stores normalized code DCT7; no supplier gearbox-family code is published.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.653 as the top forward gear ratio for the checked exact state.",
-        "value": 0.653
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.5,
-          2.087,
-          1.343,
-          0.94,
-          0.974,
-          0.78,
-          0.653
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
+          "item": "Audi A3 8Y 35 TFSI S tronic continuity across 2021-2026",
+          "reason": "Official sources prove launch presence and a 2026 exact technical state, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
           "evidence_refs": [
             "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
             "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
             "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 16\""
+          ]
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
+          "item": "35 TFSI split final-drive representation",
+          "reason": "Official Audi publishes split final-drive values 4.800 / 3.429; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
+          "evidence_refs_ref": "e14"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
+          "item": "Audi A3 8Y 35 TFSI gearbox-family code",
+          "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
+          "evidence_refs_ref": "e9"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi launch material supports the 35 TFSI S tronic MHEV sedan, and the 2026 A3 Limousine TFSI S tronic 110 kW MHEV technical-data PDF replaces inherited family defaults for the checked S tronic state: FWD, complete forward ratios ending in 0.653, and 205/55 R16 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 35 TFSI S tronic continuity across 2021-2026",
-        "reason": "Official sources prove launch presence and a 2026 exact technical state, but this pass did not recover a year-by-year technical-data chain proving one unchanged package across the full represented row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "35 TFSI split final-drive representation",
-        "reason": "Official Audi publishes split final-drive values 4.800 / 3.429; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-2020-launch-release",
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-2024-upgrade-release",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 35 TFSI gearbox-family code",
-        "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-35-tfsi-stronic-mhev-2026-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-40-tfsi-quattro-eu-2021-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "40 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0763518f2893",
-          "legacy_research_sources:22498f3a74f1",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:544adad583d5",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7ad6a45bf70a",
-          "legacy_research_sources:7be816632b85",
-          "legacy_research_sources:e26c1ff07b3a",
-          "legacy_research_sources:e6d59d64ee25"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0763518f2893",
-            "legacy_research_sources:22498f3a74f1",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:544adad583d5",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7ad6a45bf70a",
-            "legacy_research_sources:7be816632b85",
-            "legacy_research_sources:e26c1ff07b3a",
-            "legacy_research_sources:e6d59d64ee25"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "No checked official source supports a manual A3 8Y 40 TFSI quattro sedan row. Official 2023 and 2025 technical-data PDFs plus the MY2026 price list support quattro/AWD sedan states only with 7-speed S tronic.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A3 8Y 40 TFSI quattro manual sedan evidence",
-        "reason": "The checked official source chain supports AWD S tronic states and does not prove a manual AWD sedan mapping for the represented row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Replacement strategy for the represented 40 TFSI quattro manual row",
-        "reason": "The current broad manual AWD row may need deletion or replacement with exact S tronic states; current official evidence contradicts it.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8y-40-tfsi-quattro-eu-2021-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "A3 (8Y, 2021-2026)",
-    "variant_name": "40 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-        "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
       ],
-      "notes": "Official Audi technical-data material directly supports AWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-        "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-      ],
-      "notes": "Official Audi technical-data material publishes 7-speed S tronic wording for the checked state. The repo stores normalized code DCT7; no supplier gearbox-family code is published.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists 0.635 as the top forward gear ratio for the checked exact state.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists the complete forward-ratio set for the checked exact state.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Official Audi technical-data material lists this as the basic tire package for the checked exact state. The broad row span remains manually gated.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "audi-8y-40-tfsi-quattro-eu-2021-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "40 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-2022-price-list-pdf",
-            "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi technical-data material gives the basic tire and the MY2026 price list documents the A3 Limousine trim-linked wheel/tire ladder. Broad year-to-year continuity remains manually gated.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 17\""
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.84
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 17-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 17\""
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 18-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "No checked official source supports a manual A3 8Y 40 TFSI quattro sedan row. Official 2023 and 2025 technical-data PDFs plus the MY2026 price list support quattro/AWD sedan states only with 7-speed S tronic.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi A3 8Y 40 TFSI quattro manual sedan evidence",
+          "reason": "The checked official source chain supports AWD S tronic states and does not prove a manual AWD sedan mapping for the represented row.",
+          "evidence_refs_ref": "e15"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-          ],
-          "notes": "Official Audi MY2026 price-list equipment pages document this 19-inch A3 Limousine wheel/tire package as trim-linked equipment, not as a universal default.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Trim-linked 19\""
+          "item": "Replacement strategy for the represented 40 TFSI quattro manual row",
+          "reason": "The current broad manual AWD row may need deletion or replacement with exact S tronic states; current official evidence contradicts it.",
+          "evidence_refs_ref": "e3"
         }
-      ]
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official Audi 2023 and 2025 A3 Sedan/Limousine AWD technical-data PDFs support the checked S tronic quattro mechanical package, including AWD, 7-speed S tronic, complete forward ratios ending in 0.635, and 225/45 R17 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields, and the 2025 source shows a later 150 kW badging/output transition.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-2022-price-list-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A3 8Y 40 TFSI quattro badging/output continuity across 2021-2026",
-        "reason": "The 2023 source proves a 140 kW 40 TFSI quattro state, while the 2025 source and MY2026 price list show a later TFSI quattro 150 kW state; this pass did not recover the exact split point for the broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
+    {
+      "id": "audi-8y-40-tfsi-quattro-eu-2021-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "A3 (8Y, 2021-2026)",
+      "variant_name": "40 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Official Audi technical-data material directly supports AWD for the checked exact A3 8Y Sedan/Limousine state. The broad row span remains manually gated.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n13",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official Audi technical-data material lists 0.635 as the top forward gear ratio for the checked exact state.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n4",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e16",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 18\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Trim-linked 19\""
+          }
         ]
       },
-      {
-        "item": "40 TFSI quattro split final-drive representation",
-        "reason": "Official Audi publishes split final-drive values 4.167 / 3.125; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-2022-price-list-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-my2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A3 8Y 40 TFSI quattro gearbox-family code",
-        "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8y-a3-sedan-40-tfsi-quattro-2023-tech-data-pdf",
-          "audi_mediacenter_sources:8y-a3-sedan-tfsi-quattro-2025-tech-data-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "Official Audi 2023 and 2025 A3 Sedan/Limousine AWD technical-data PDFs support the checked S tronic quattro mechanical package, including AWD, 7-speed S tronic, complete forward ratios ending in 0.635, and 225/45 R17 basic tires. The split final-drive pair is retained as an unresolved schema issue rather than mapped into axle fields, and the 2025 source shows a later 150 kW badging/output transition.",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A3 8Y 40 TFSI quattro badging/output continuity across 2021-2026",
+          "reason": "The 2023 source proves a 140 kW 40 TFSI quattro state, while the 2025 source and MY2026 price list show a later TFSI quattro 150 kW state; this pass did not recover the exact split point for the broad row.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "item": "40 TFSI quattro split final-drive representation",
+          "reason": "Official Audi publishes split final-drive values 4.167 / 3.125; these are gearbox-path values rather than front/rear axle values in the current canonical schema, so this pass stores the full gear ratios but does not map the split final-drive pair into axle fields.",
+          "evidence_refs_ref": "e16"
+        },
+        {
+          "item": "Audi A3 8Y 40 TFSI quattro gearbox-family code",
+          "reason": "Official Audi material publishes 7-speed S tronic wording but not a supplier gearbox-family code such as DQ381.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B8.json
@@ -1,4525 +1,3266 @@
-[
-  {
-    "id": "audi-b8-1-8-tfsi-eu-2008-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "1.8 TFSI",
-    "engine_code": "1.8L",
-    "engine_name": "1.8L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 1.8 TFSI 6-speed manual FWD. Auto-Data B8 generation list confirms FWD MT6 1.8 TFSI as real pre-facelift variant. Carfolio 2011 page (URL slug misnamed but content matches) supplies ratios top 0.69 / FD 3.30 and standard tyre 205/60 R16 on 7Jx16 wheel. Repo placeholder 0.84/3.462 and 225/45 R18 contradicted; Sport-trim 18-inch was an option, not catalogue baseline.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n4": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+      "n5": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
+      "n8": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n9": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n13": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
+      "n15": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
+      "n16": "Audi A4 B8 1.8 TFSI 6-speed manual FWD. Auto-Data B8 generation list confirms FWD MT6 1.8 TFSI as real pre-facelift variant. Carfolio 2011 page (URL slug misnamed but content matches) supplies ratios top 0.69 / FD 3.30 and standard tyre 205/60 R16 on 7Jx16 wheel. Repo placeholder 0.84/3.462 and 225/45 R18 contradicted; Sport-trim 18-inch was an option, not catalogue baseline.",
+      "n17": "Audi A4 B8 2.0 TDI (143 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms 2007/2008 production start. No exact ratio source for FWD MT6 recovered; ratios remain no_confidence. Tyre default corrected to 205/55 R16 (Carfolio FWD 2.0 TDI auto pages baseline range 205/60 R16 to 225/55 R16).",
+      "n18": "Sonnet redo: no exact source. Repo placeholder 3.462 was a family_default carryover.",
+      "n19": "Audi A4 B8 2.0 TDI quattro 6-speed manual AWD. Carfolio 2008 page + Auto-Data B8 listing confirm. Carfolio reputable_secondary ratios: top 0.63 / single combined final drive 4.49 (front/rear split not published in secondary). Standard tyre 225/55 R16. Repo placeholder values contradicted.",
+      "n20": "Audi A4 B8.5 facelift 2.0 TDI quattro 7-speed S tronic (DL501) AWD. CRITICAL DATE FIX: DL501 was introduced to mainstream A4 only with the B8.5 facelift (Auto-Data shows 2012-2015 production window). production_start_year corrected 2008 -> 2012. transmission.name corrected to '7-speed S tronic (DL501)' per Wikipedia S_tronic article. No exact ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per Auto-Data B8.5 facelift listing.",
+      "n21": "Audi A4 B8 2.0 TFSI (180/211 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms Aug 2008 start. No exact FWD MT6 ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per FWD 2.0 TFSI Carfolio reference (S8) and Auto-Data baseline.",
+      "n22": "Audi A4 B8 2.0 TFSI quattro 6-speed manual AWD. Auto-Data B8 listing + Carfolio 2013 page confirm Aug 2008 start. Carfolio ratio cells were blank for this exact variant; no ratio source recovered. Standard tyre 225/55 R16 (with 225/50 R17 option) per Auto-Data.",
+      "n23": "Audi A4 B8.5 facelift 2.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data B8.5 facelift Jan 2012-2015). transmission.name -> '7-speed S tronic (DL501)'. No exact ratio source recovered (Carfolio cells blank). Standard tyre 225/55 R16 per Auto-Data.",
+      "n24": "Audi A4 B8 3.0 TDI quattro 6-speed manual AWD. Auto-Data + Carfolio + Audi MediaCenter 3.0 TDI clean diesel quattro press release confirm. Carfolio: top 0.54 / combined final drive 3.68. Standard tyre 225/50 R17 (with 245/40 R18 S line option) per Auto-Data B8 listing.",
+      "n25": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive.",
+      "n26": "Audi A4 B8.5 facelift 3.0 TDI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2011 (Auto-Data B8.5 facelift Nov 2011-2015). Audi MediaCenter pre-facelift 3.0 TDI press release confirms pre-facelift was six-speed Tiptronic, not S tronic; S tronic appears only with facelift. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.46 / combined FD 3.88. Standard tyre 225/50 R17 per Auto-Data B8.5.",
+      "n27": "Audi A4 B8.5 facelift 3.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data Feb 2012-2014). The 3.0 TFSI A4 (272 PS, A4-only - distinct from S4) is facelift-only and DL501-only. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.52 / combined FD 3.88. Standard tyre 245/40 R18 on 8.5Jx18 wheel per Carfolio (S line baseline for the engine spec); Auto-Data lists 225/50 R17 as alternate.",
+      "n28": "Sonnet redo: no exact source. Repo placeholder 3.444 was a family_default carryover.",
+      "n29": "Exact secondary S tronic sources agree on AWD and a 7-speed S tronic gearbox, but the available facelift-only evidence does not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
+      "n30": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio combined ratio."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:40d6e1e8fc60",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:4d505818df53",
+        "legacy_research_sources:5e252f7f436b"
+      ],
+      "e2": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 1.8 TFSI 6-speed manual FWD. Auto-Data B8 generation list confirms FWD MT6 1.8 TFSI as real pre-facelift variant. Carfolio 2011 page (URL slug misnamed but content matches) supplies ratios top 0.69 / FD 3.30 and standard tyre 205/60 R16 on 7Jx16 wheel. Repo placeholder 0.84/3.462 and 225/45 R18 contradicted; Sport-trim 18-inch was an option, not catalogue baseline.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 0.69,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 3.3,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ],
-        "notes": "Audi A4 B8 1.8 TFSI 6-speed manual FWD. Auto-Data B8 generation list confirms FWD MT6 1.8 TFSI as real pre-facelift variant. Carfolio 2011 page (URL slug misnamed but content matches) supplies ratios top 0.69 / FD 3.30 and standard tyre 205/60 R16 on 7Jx16 wheel. Repo placeholder 0.84/3.462 and 225/45 R18 contradicted; Sport-trim 18-inch was an option, not catalogue baseline.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-1-8-tfsi-eu-2008-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "1.8 TFSI",
-    "engine_code": "1.8L",
-    "engine_name": "1.8L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-1-8-tfsi-multitronic-carfolio"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-1-8-tfsi-multitronic-carfolio"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-1-8-tfsi-eu-2008-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "1.8 TFSI",
-    "engine_code": "1.8L",
-    "engine_name": "1.8L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-1-8-tfsi-multitronic-carfolio"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-1-8-tfsi-multitronic-carfolio"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-eu-2008-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TDI (143 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms 2007/2008 production start. No exact ratio source for FWD MT6 recovered; ratios remain no_confidence. Tyre default corrected to 205/55 R16 (Carfolio FWD 2.0 TDI auto pages baseline range 205/60 R16 to 225/55 R16).",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TDI (143 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms 2007/2008 production start. No exact ratio source for FWD MT6 recovered; ratios remain no_confidence. Tyre default corrected to 205/55 R16 (Carfolio FWD 2.0 TDI auto pages baseline range 205/60 R16 to 225/55 R16).",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact FWD 2.0 TDI MT6 ratio source recovered. Repo placeholder 0.84 was a family_default carryover.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source. Repo placeholder 3.462 was a family_default carryover.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ],
-        "notes": "Audi A4 B8 2.0 TDI (143 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms 2007/2008 production start. No exact ratio source for FWD MT6 recovered; ratios remain no_confidence. Tyre default corrected to 205/55 R16 (Carfolio FWD 2.0 TDI auto pages baseline range 205/60 R16 to 225/55 R16).",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Exact secondary pre-facelift manual sources agree on AWD, 6-speed manual transmission, and 225/55 R16 baseline tires, but those sources only cover 2008-2011 and do not safely justify correcting the full 2008-2016 row without a year split.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 2.0 TDI quattro manual pre-facelift evidence is not safe for the broad 2008-2016 row",
-        "reason": "Carfolio and Auto-Data exact manual rows agree on AWD, 6-speed manual transmission, and 225/55 R16 tires for 2008-2011, but that subset does not yet resolve whether later B8 years kept the same base tire or ratio package.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-eu-2008-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2007",
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2011"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2007",
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2011"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-eu-2008-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2007",
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2011"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2007",
-          "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2011"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-quattro-eu-2008-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TDI quattro 6-speed manual AWD. Carfolio 2008 page + Auto-Data B8 listing confirm. Carfolio reputable_secondary ratios: top 0.63 / single combined final drive 4.49 (front/rear split not published in secondary). Standard tyre 225/55 R16. Repo placeholder values contradicted.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TDI quattro 6-speed manual AWD. Carfolio 2008 page + Auto-Data B8 listing confirm. Carfolio reputable_secondary ratios: top 0.63 / single combined final drive 4.49 (front/rear split not published in secondary). Standard tyre 225/55 R16. Repo placeholder values contradicted.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 0.63,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio publishes a single combined final drive value; front/rear axle split is not exposed in secondary sources for the longitudinal quattro driveline.",
-        "value": 4.49,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive; explicit rear axle ratio not published in secondary sources.",
-        "value": 4.49,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
-        ],
-        "notes": "Audi A4 B8 2.0 TDI quattro 6-speed manual AWD. Carfolio 2008 page + Auto-Data B8 listing confirm. Carfolio reputable_secondary ratios: top 0.63 / single combined final drive 4.49 (front/rear split not published in secondary). Standard tyre 225/55 R16. Repo placeholder values contradicted.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-quattro-eu-2008-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2012,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
         "secondary_technical_sources:a4-b8-wikipedia"
       ],
-      "notes": "Audi A4 B8.5 facelift 2.0 TDI quattro 7-speed S tronic (DL501) AWD. CRITICAL DATE FIX: DL501 was introduced to mainstream A4 only with the B8.5 facelift (Auto-Data shows 2012-2015 production window). production_start_year corrected 2008 -> 2012. transmission.name corrected to '7-speed S tronic (DL501)' per Wikipedia S_tronic article. No exact ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per Auto-Data B8.5 facelift listing.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
-        "secondary_technical_sources:a4-b8-wikipedia"
+      "e3": [
+        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
+        "secondary_technical_sources:a4-b8-wikipedia",
+        "secondary_technical_sources:dl501-stronic-wikipedia"
       ],
-      "notes": "Audi A4 B8.5 facelift 2.0 TDI quattro 7-speed S tronic (DL501) AWD. CRITICAL DATE FIX: DL501 was introduced to mainstream A4 only with the B8.5 facelift (Auto-Data shows 2012-2015 production window). production_start_year corrected 2008 -> 2012. transmission.name corrected to '7-speed S tronic (DL501)' per Wikipedia S_tronic article. No exact ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per Auto-Data B8.5 facelift listing.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact 2.0 TDI quattro DL501 ratio recovered. Repo placeholder 0.68 was a family_default carryover. Carfolio S7 (id ending -435050) was found to mismatch B8 dimensions and likely covers the B9 - not used.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source. Repo placeholder 3.444 was a family_default carryover.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ],
-        "notes": "Audi A4 B8.5 facelift 2.0 TDI quattro 7-speed S tronic (DL501) AWD. CRITICAL DATE FIX: DL501 was introduced to mainstream A4 only with the B8.5 facelift (Auto-Data shows 2012-2015 production window). production_start_year corrected 2008 -> 2012. transmission.name corrected to '7-speed S tronic (DL501)' per Wikipedia S_tronic article. No exact ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per Auto-Data B8.5 facelift listing.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Exact secondary facelift S tronic sources agree on AWD and 7-speed S tronic transmission, but Auto-Data reports 225/55 R16 tires while Carfolio reports 225/50 R17 and only Carfolio exposed a numeric top-gear/final-drive pair, so the broad row stays unresolved.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 2.0 TDI quattro S tronic exact secondary sources disagree on the baseline tire package",
-        "reason": "The exact facelift Auto-Data row lists 225/55 R16 while the exact 2015 Carfolio row lists 225/50 R17 and 0.39 / 4.27 for top gear and final drive, so the broad 2008-2016 row cannot be safely corrected without a year-specific official source or an explicit split.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tdi-quattro-eu-2008-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
+      "e4": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
         "secondary_technical_sources:a4-b8-wikipedia",
         "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Saved A4 B8 2.0 TDI quattro evidence supports exact MT6 and facelift S tronic slices, not an 8-speed ZF8HP row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 2.0 TDI quattro evidence supports exact MT6 and facelift S tronic slices, not an 8-speed ZF8HP row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-eu-2008-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TFSI (180/211 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms Aug 2008 start. No exact FWD MT6 ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per FWD 2.0 TFSI Carfolio reference (S8) and Auto-Data baseline.",
-      "value": "FWD",
-      "evidence_refs": [
+      ],
+      "e5": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TFSI (180/211 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms Aug 2008 start. No exact FWD MT6 ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per FWD 2.0 TFSI Carfolio reference (S8) and Auto-Data baseline.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact FWD 2.0 TFSI MT6 ratio source. Repo placeholder 0.84 was a family_default carryover.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source. Repo placeholder 3.462 was a family_default carryover.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ],
-        "notes": "Audi A4 B8 2.0 TFSI (180/211 PS) 6-speed manual FWD. Auto-Data B8 generation list confirms Aug 2008 start. No exact FWD MT6 ratio source recovered; ratios remain no_confidence. Standard tyre 225/55 R16 per FWD 2.0 TFSI Carfolio reference (S8) and Auto-Data baseline.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-eu-2008-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
+      ],
+      "e6": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
         "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
+      ],
+      "e7": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
         "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:dl501-stronic-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 is a longitudinal MLB platform; the FWD versions never received the DL501 7-speed S tronic. FWD automatics across the entire B8 generation used the Multitronic CVT instead. Confirmed by Auto-Data B8 pre-facelift variant list and B8.5 facelift listings (no DL501 entry for any FWD A4) plus Carfolio FWD pages consistently showing 8-step Multitronic. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2011",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2013"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:dl501-stronic-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2011",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2013"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-eu-2008-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2011",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2013"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Unsupported exact transmission mapping",
-        "reason": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2011",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2013"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-quattro-eu-2008-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TFSI quattro 6-speed manual AWD. Auto-Data B8 listing + Carfolio 2013 page confirm Aug 2008 start. Carfolio ratio cells were blank for this exact variant; no ratio source recovered. Standard tyre 225/55 R16 (with 225/50 R17 option) per Auto-Data.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 2.0 TFSI quattro 6-speed manual AWD. Auto-Data B8 listing + Carfolio 2013 page confirm Aug 2008 start. Carfolio ratio cells were blank for this exact variant; no ratio source recovered. Standard tyre 225/55 R16 (with 225/50 R17 option) per Auto-Data.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: Carfolio ratio cells blank for 2.0 TFSI quattro MT6. Repo placeholder 0.84 was a family_default carryover.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source. Repo placeholder 3.462 was a family_default carryover.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source for quattro rear axle ratio.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio"
-        ],
-        "notes": "Audi A4 B8 2.0 TFSI quattro 6-speed manual AWD. Auto-Data B8 listing + Carfolio 2013 page confirm Aug 2008 start. Carfolio ratio cells were blank for this exact variant; no ratio source recovered. Standard tyre 225/55 R16 (with 225/50 R17 option) per Auto-Data.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Exact secondary manual sources agree on AWD and a 6-speed manual gearbox, but the pre-facelift Auto-Data row and the 2013 Carfolio row do not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 2.0 TFSI quattro manual exact secondary sources confirm identity but not a safe broad-row ratio package",
-        "reason": "The exact 2008-2011 Auto-Data row and the exact 2013 Carfolio row agree on AWD and the 6-speed manual transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-quattro-eu-2008-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2012,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 2.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data B8.5 facelift Jan 2012-2015). transmission.name -> '7-speed S tronic (DL501)'. No exact ratio source recovered (Carfolio cells blank). Standard tyre 225/55 R16 per Auto-Data.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 2.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data B8.5 facelift Jan 2012-2015). transmission.name -> '7-speed S tronic (DL501)'. No exact ratio source recovered (Carfolio cells blank). Standard tyre 225/55 R16 per Auto-Data.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: Carfolio ratio cells blank. Repo placeholder 0.68 was a family_default carryover.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source. Repo placeholder 3.444 was a family_default carryover.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo: no exact source.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "Audi A4 B8.5 facelift 2.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data B8.5 facelift Jan 2012-2015). transmission.name -> '7-speed S tronic (DL501)'. No exact ratio source recovered (Carfolio cells blank). Standard tyre 225/55 R16 per Auto-Data.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Exact secondary S tronic sources agree on AWD and a 7-speed S tronic gearbox, but the available facelift-only evidence does not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 2.0 TFSI quattro S tronic exact secondary sources confirm identity but not a safe broad-row ratio package",
-        "reason": "The exact 2012-2015 Auto-Data row and the exact 2013 Carfolio row agree on AWD and the 7-speed S tronic transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-quattro-eu-2008-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Follow-up review found that the exact 2008-2011 Auto-Data sedan row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps the transmission field unresolved.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-zf8hp-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 2.0 TFSI quattro Tiptronic pre-facelift evidence conflicts with the broad 2008-2016 ZF8HP row",
-        "reason": "The exact 2008-2011 Auto-Data sedan row identifies the pre-facelift Tiptronic configuration as 6-speed automatic, so the broad ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-zf8hp-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tdi-quattro-eu-2008-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 3.0 TDI quattro 6-speed manual AWD. Auto-Data + Carfolio + Audi MediaCenter 3.0 TDI clean diesel quattro press release confirm. Carfolio: top 0.54 / combined final drive 3.68. Standard tyre 225/50 R17 (with 245/40 R18 S line option) per Auto-Data B8 listing.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata",
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
-        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8 3.0 TDI quattro 6-speed manual AWD. Auto-Data + Carfolio + Audi MediaCenter 3.0 TDI clean diesel quattro press release confirm. Carfolio: top 0.54 / combined final drive 3.68. Standard tyre 225/50 R17 (with 245/40 R18 S line option) per Auto-Data B8 listing.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata",
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e8": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e9": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
+      ],
+      "e10": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
+      ],
+      "e11": [
+        "secondary_technical_sources:a4-b8-1-8-tfsi-multitronic-carfolio"
+      ],
+      "e12": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2007",
+        "secondary_technical_sources:a4-b8-2-0-tdi-multitronic-carfolio-2011"
+      ],
+      "e13": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2011",
+        "secondary_technical_sources:a4-b8-2-0-tfsi-multitronic-carfolio-2013"
+      ],
+      "e14": [
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
+      ],
+      "e15": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
+      ],
+      "e16": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio"
+      ],
+      "e17": [
         "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 0.54,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio combined ratio; front/rear split not exposed.",
-        "value": 3.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive.",
-        "value": 3.68,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata"
-        ],
-        "notes": "Audi A4 B8 3.0 TDI quattro 6-speed manual AWD. Auto-Data + Carfolio + Audi MediaCenter 3.0 TDI clean diesel quattro press release confirm. Carfolio: top 0.54 / combined final drive 3.68. Standard tyre 225/50 R17 (with 245/40 R18 S line option) per Auto-Data B8 listing.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Exact secondary manual sources agree on AWD and a 6-speed manual gearbox, but the pre-facelift Auto-Data row and the 2012 Carfolio row do not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 3.0 TDI quattro manual exact secondary sources confirm identity but not a safe broad-row ratio package",
-        "reason": "The exact 2007-2011 Auto-Data row and the exact 2012 Carfolio row agree on AWD and the 6-speed manual transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tdi-quattro-eu-2008-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2011,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 3.0 TDI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2011 (Auto-Data B8.5 facelift Nov 2011-2015). Audi MediaCenter pre-facelift 3.0 TDI press release confirms pre-facelift was six-speed Tiptronic, not S tronic; S tronic appears only with facelift. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.46 / combined FD 3.88. Standard tyre 225/50 R17 per Auto-Data B8.5.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata",
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 3.0 TDI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2011 (Auto-Data B8.5 facelift Nov 2011-2015). Audi MediaCenter pre-facelift 3.0 TDI press release confirms pre-facelift was six-speed Tiptronic, not S tronic; S tronic appears only with facelift. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.46 / combined FD 3.88. Standard tyre 225/50 R17 per Auto-Data B8.5.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata",
-        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
+      ],
+      "e18": [
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio"
+      ],
+      "e19": [
+        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
+        "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
+      ],
+      "e20": [
+        "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio"
+      ],
+      "e21": [
+        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata"
+      ],
+      "e22": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata",
         "secondary_technical_sources:dl501-stronic-wikipedia",
         "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 0.46,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio combined ratio.",
-        "value": 3.88,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive.",
-        "value": 3.88,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata"
-        ],
-        "notes": "Audi A4 B8.5 facelift 3.0 TDI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2011 (Auto-Data B8.5 facelift Nov 2011-2015). Audi MediaCenter pre-facelift 3.0 TDI press release confirms pre-facelift was six-speed Tiptronic, not S tronic; S tronic appears only with facelift. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.46 / combined FD 3.88. Standard tyre 225/50 R17 per Auto-Data B8.5.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Exact facelift secondary sources agree on AWD and a 7-speed S tronic gearbox, while official Audi MediaCenter clean-diesel material separately supports six-speed tiptronic for the pre-facelift Germany-market automatic family. That automatic-family split means this broad 2008-2016 row cannot be treated as one exact production-safe S tronic configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 3.0 TDI quattro automatic family spans official pre-facelift Tiptronic and later facelift S tronic states",
-        "reason": "Official Audi MediaCenter clean-diesel material supports six-speed tiptronic for the pre-facelift Germany-market family, while exact 2011-2015 secondary sedan sources support a later 7-speed S tronic state. The broad 2008-2016 automatic row therefore mixes distinct transmission eras and is not safe as one exact ratio or tire package.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tdi-quattro-eu-2008-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
+      ],
+      "e23": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
+      ],
+      "e24": [
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata",
+        "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata"
+      ],
+      "e25": [
         "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "Official Audi MediaCenter clean-diesel material states that the Germany-market 3.0 TDI clean diesel quattro family combines six-speed tiptronic with quattro permanent all-wheel drive, and the exact 2007-2011 Auto-Data sedan row matches that Tiptronic family. That directly contradicts the broad-row 8-speed ZF8HP mapping and leaves the stored automatic code unresolved without a split.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-zf8hp-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 3.0 TDI quattro official pre-facelift Tiptronic evidence conflicts with the broad 2008-2016 ZF8HP row",
-        "reason": "Official Audi MediaCenter clean-diesel material and the exact 2007-2011 Auto-Data sedan row both identify the pre-facelift automatic family as six-speed tiptronic, so the broad ZF8HP row conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
-          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-zf8hp-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tfsi-quattro-eu-2008-mt6-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Audi A4 B8 3.0 TFSI (272 hp supercharged V6, A4-only - distinct from S4 with the same engine block) was offered exclusively in the B8.5 facelift (2012-2014) with the DL501 7-speed S tronic. No 6-speed manual A4 3.0 TFSI is documented in any Auto-Data, Carfolio, or Audi MediaCenter source. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tfsi-quattro-eu-2008-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2012,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 3.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data Feb 2012-2014). The 3.0 TFSI A4 (272 PS, A4-only - distinct from S4) is facelift-only and DL501-only. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.52 / combined FD 3.88. Standard tyre 245/40 R18 on 8.5Jx18 wheel per Carfolio (S line baseline for the engine spec); Auto-Data lists 225/50 R17 as alternate.",
-      "value": "AWD",
-      "evidence_refs": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio"
+      ],
+      "e26": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata"
+      ],
+      "e27": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata",
+        "secondary_technical_sources:dl501-stronic-wikipedia",
+        "secondary_technical_sources:a4-b8-wikipedia"
+      ],
+      "e28": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-carfolio",
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e29": [
+        "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-zf8hp-autodata"
+      ],
+      "e30": [
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata"
+      ],
+      "e31": [
+        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata"
+      ],
+      "e32": [
+        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release",
+        "secondary_technical_sources:a4-b8-3-0-tdi-quattro-zf8hp-autodata"
+      ],
+      "e33": [
         "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
         "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio",
         "secondary_technical_sources:dl501-stronic-wikipedia",
         "secondary_technical_sources:a4-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A4 B8.5 facelift 3.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data Feb 2012-2014). The 3.0 TFSI A4 (272 PS, A4-only - distinct from S4) is facelift-only and DL501-only. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.52 / combined FD 3.88. Standard tyre 245/40 R18 on 8.5Jx18 wheel per Carfolio (S line baseline for the engine spec); Auto-Data lists 225/50 R17 as alternate.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
+      ],
+      "e34": [
         "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio",
-        "secondary_technical_sources:dl501-stronic-wikipedia",
-        "secondary_technical_sources:a4-b8-wikipedia"
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e35": [
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
+        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass.",
-        "value": 0.52,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio combined ratio.",
-        "value": 3.88,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive.",
-        "value": 3.88,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ],
-        "notes": "Audi A4 B8.5 facelift 3.0 TFSI quattro 7-speed S tronic (DL501) AWD. DATE FIX: 2008 -> 2012 (Auto-Data Feb 2012-2014). The 3.0 TFSI A4 (272 PS, A4-only - distinct from S4) is facelift-only and DL501-only. transmission.name -> '7-speed S tronic (DL501)'. Carfolio: top 0.52 / combined FD 3.88. Standard tyre 245/40 R18 on 8.5Jx18 wheel per Carfolio (S line baseline for the engine spec); Auto-Data lists 225/50 R17 as alternate.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Exact secondary S tronic sources agree on AWD and a 7-speed S tronic gearbox, but the available facelift-only evidence does not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 3.0 TFSI quattro S tronic exact secondary sources confirm identity but not a safe broad-row ratio package",
-        "reason": "The exact 2012-2014 Auto-Data row and the exact 2012 Carfolio row agree on AWD and the 7-speed S tronic transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-b8-3-0-tfsi-quattro-eu-2008-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2008,
-    "production_end_year": 2016,
-    "model_name": "A4 (B8, 2008-2016)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-        "secondary_technical_sources:a4-b8-wikipedia",
-        "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
+  "configurations": [
+    {
+      "id": "audi-b8-1-8-tfsi-eu-2008-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "1.8 TFSI",
+      "engine_code": "1.8L",
+      "engine_name": "1.8L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "value": "FWD",
+        "evidence_refs_ref": "e19"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e19"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 0.69,
+          "evidence_refs_ref": "e20"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 3.3,
+          "evidence_refs_ref": "e20"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs": [
+            "secondary_technical_sources:a4-b8-18tfsi-fwd-mt6-carfolio",
+            "secondary_technical_sources:a4-b8-generation-autodata-2007-2011"
+          ],
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-b8-1-8-tfsi-eu-2008-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "1.8 TFSI",
+      "engine_code": "1.8L",
+      "engine_name": "1.8L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The ZF 8HP 8-speed automatic was NOT used in any EU Audi A4 B8 variant. First Audi 8HP applications were A8 D4 (2010) and A6 C7 (2011); A4 did not adopt ZF 8HP until the B9 generation (2015+). B8 AWD automatic variants used ZF 6HP Tiptronic (pre-facelift) or DL501 7-speed S tronic (B8.5 facelift). Confirmed by Auto-Data B8 and B8.5 variant catalogues plus Audi MediaCenter 3.0 TDI quattro press release explicitly naming 'six-speed tiptronic' for that variant. Drivetrain, transmission, ratios, and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n7",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.68,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.444,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
+          "note_ref": "n8"
+        },
+        {
+          "note": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-1-8-tfsi-eu-2008-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "1.8 TFSI",
+      "engine_code": "1.8L",
+      "engine_name": "1.8L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 1.8 TFSI FWD automatic evidence identifies 8-step multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-eu-2008-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n17",
+        "value": "FWD",
+        "evidence_refs_ref": "e5"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n17",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact FWD 2.0 TDI MT6 ratio source recovered. Repo placeholder 0.84 was a family_default carryover.",
+          "value": 0.84,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n18",
+          "value": 3.462,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Exact secondary pre-facelift manual sources agree on AWD, 6-speed manual transmission, and 225/55 R16 baseline tires, but those sources only cover 2008-2011 and do not safely justify correcting the full 2008-2016 row without a year split.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 2.0 TDI quattro manual pre-facelift evidence is not safe for the broad 2008-2016 row",
+          "reason": "Carfolio and Auto-Data exact manual rows agree on AWD, 6-speed manual transmission, and 225/55 R16 tires for 2008-2011, but that subset does not yet resolve whether later B8 years kept the same base tire or ratio package.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-eu-2008-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.68,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.444,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-eu-2008-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 2.0 TDI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-quattro-eu-2008-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n19",
+        "value": "AWD",
+        "evidence_refs_ref": "e21"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n19",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e21"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 0.63,
+          "evidence_refs_ref": "e16"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio publishes a single combined final drive value; front/rear axle split is not exposed in secondary sources for the longitudinal quattro driveline.",
+          "value": 4.49,
+          "evidence_refs_ref": "e16"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo (2026-04 v2): mirrored from combined Carfolio final drive; explicit rear axle ratio not published in secondary sources.",
+          "value": 4.49,
+          "evidence_refs_ref": "e16"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e15",
+          "notes_ref": "n19",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-quattro-eu-2008-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2012,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e22",
+        "notes_ref": "n20",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e22",
+        "notes_ref": "n20",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact 2.0 TDI quattro DL501 ratio recovered. Repo placeholder 0.68 was a family_default carryover. Carfolio S7 (id ending -435050) was found to mismatch B8 dimensions and likely covers the B9 - not used.",
+          "value": 0.68,
+          "evidence_refs_ref": "e9"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n28",
+          "value": 3.444,
+          "evidence_refs_ref": "e9"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n20",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Exact secondary facelift S tronic sources agree on AWD and 7-speed S tronic transmission, but Auto-Data reports 225/55 R16 tires while Carfolio reports 225/50 R17 and only Carfolio exposed a numeric top-gear/final-drive pair, so the broad row stays unresolved.",
+          "evidence_refs_ref": "e23"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 2.0 TDI quattro S tronic exact secondary sources disagree on the baseline tire package",
+          "reason": "The exact facelift Auto-Data row lists 225/55 R16 while the exact 2015 Carfolio row lists 225/50 R17 and 0.39 / 4.27 for top gear and final drive, so the broad 2008-2016 row cannot be safely corrected without a year-specific official source or an explicit split.",
+          "evidence_refs_ref": "e23"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tdi-quattro-eu-2008-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Saved A4 B8 2.0 TDI quattro evidence supports exact MT6 and facelift S tronic slices, not an 8-speed ZF8HP row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e24"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 2.0 TDI quattro evidence supports exact MT6 and facelift S tronic slices, not an 8-speed ZF8HP row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e24"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-eu-2008-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n21",
+        "value": "FWD",
+        "evidence_refs_ref": "e5"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n21",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact FWD 2.0 TFSI MT6 ratio source. Repo placeholder 0.84 was a family_default carryover.",
+          "value": 0.84,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n18",
+          "value": 3.462,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n21",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-eu-2008-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.68,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.444,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a 7-speed S tronic/DCT exact row; keep the current DCT7 row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-eu-2008-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact transmission mapping",
+          "reason": "Saved A4 B8 2.0 TFSI FWD automatic evidence identifies multitronic/CVT, not a ZF8HP exact row; keep the current ZF8HP row out of order analysis until an exact official split is built.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-quattro-eu-2008-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n22",
+        "value": "AWD",
+        "evidence_refs_ref": "e25"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n22",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e25"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: Carfolio ratio cells blank for 2.0 TFSI quattro MT6. Repo placeholder 0.84 was a family_default carryover.",
+          "value": 0.84,
+          "evidence_refs_ref": "e10"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n18",
+          "value": 3.462,
+          "evidence_refs_ref": "e10"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact source for quattro rear axle ratio.",
+          "value": 3.462,
+          "evidence_refs_ref": "e10"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
           "evidence_refs": [
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4d505818df53",
-            "legacy_research_sources:5e252f7f436b"
+            "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
+            "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio"
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n22",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Exact secondary manual sources agree on AWD and a 6-speed manual gearbox, but the pre-facelift Auto-Data row and the 2013 Carfolio row do not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
+          "evidence_refs_ref": "e26"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 2.0 TFSI quattro manual exact secondary sources confirm identity but not a safe broad-row ratio package",
+          "reason": "The exact 2008-2011 Auto-Data row and the exact 2013 Carfolio row agree on AWD and the 6-speed manual transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
+          "evidence_refs_ref": "e26"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-quattro-eu-2008-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2012,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n23",
+        "value": "AWD",
+        "evidence_refs_ref": "e27"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n23",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e27"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: Carfolio ratio cells blank. Repo placeholder 0.68 was a family_default carryover.",
+          "value": 0.68,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n28",
+          "value": 3.444,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo: no exact source.",
+          "value": 3.444,
+          "evidence_refs_ref": "e8"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n23",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note_ref": "n29",
+          "evidence_refs_ref": "e28"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 2.0 TFSI quattro S tronic exact secondary sources confirm identity but not a safe broad-row ratio package",
+          "reason": "The exact 2012-2015 Auto-Data row and the exact 2013 Carfolio row agree on AWD and the 7-speed S tronic transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
+          "evidence_refs_ref": "e28"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-quattro-eu-2008-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Follow-up review found that the exact 2008-2011 Auto-Data sedan row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps the transmission field unresolved.",
+          "evidence_refs_ref": "e29"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 2.0 TFSI quattro Tiptronic pre-facelift evidence conflicts with the broad 2008-2016 ZF8HP row",
+          "reason": "The exact 2008-2011 Auto-Data sedan row identifies the pre-facelift Tiptronic configuration as 6-speed automatic, so the broad ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
+          "evidence_refs_ref": "e29"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tdi-quattro-eu-2008-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n24",
+        "value": "AWD",
+        "evidence_refs": [
+          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
+          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
+        ]
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n24",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs": [
+          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 0.54,
+          "evidence_refs_ref": "e17"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): repo placeholder values were generic family_default carryovers contradicted by the available secondary sources. Carfolio per-variant page supplied the value as reputable_secondary; no official Audi B8-specific technical-data PDF with matching ratios was recovered this pass. Carfolio combined ratio; front/rear split not exposed.",
+          "value": 3.68,
+          "evidence_refs_ref": "e17"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n25",
+          "value": 3.68,
+          "evidence_refs_ref": "e17"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs": [
+            "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata"
+          ],
+          "notes_ref": "n24",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Exact secondary manual sources agree on AWD and a 6-speed manual gearbox, but the pre-facelift Auto-Data row and the 2012 Carfolio row do not expose a cross-checked numeric ratio package or a safe full-row tire mapping.",
+          "evidence_refs_ref": "e30"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 3.0 TDI quattro manual exact secondary sources confirm identity but not a safe broad-row ratio package",
+          "reason": "The exact 2007-2011 Auto-Data row and the exact 2012 Carfolio row agree on AWD and the 6-speed manual transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
+          "evidence_refs_ref": "e30"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tdi-quattro-eu-2008-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2011,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n26",
+        "value": "AWD",
+        "evidence_refs": [
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
+          "secondary_technical_sources:dl501-stronic-wikipedia",
+          "secondary_technical_sources:a4-b8-wikipedia",
+          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
+        ]
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n26",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs": [
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata",
+          "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
+          "secondary_technical_sources:dl501-stronic-wikipedia",
+          "secondary_technical_sources:a4-b8-wikipedia"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 0.46,
+          "evidence_refs_ref": "e18"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n30",
+          "value": 3.88,
+          "evidence_refs_ref": "e18"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n25",
+          "value": 3.88,
+          "evidence_refs_ref": "e18"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs": [
+            "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata"
+          ],
+          "notes_ref": "n26",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Exact facelift secondary sources agree on AWD and a 7-speed S tronic gearbox, while official Audi MediaCenter clean-diesel material separately supports six-speed tiptronic for the pre-facelift Germany-market automatic family. That automatic-family split means this broad 2008-2016 row cannot be treated as one exact production-safe S tronic configuration.",
+          "evidence_refs_ref": "e31"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 3.0 TDI quattro automatic family spans official pre-facelift Tiptronic and later facelift S tronic states",
+          "reason": "Official Audi MediaCenter clean-diesel material supports six-speed tiptronic for the pre-facelift Germany-market family, while exact 2011-2015 secondary sedan sources support a later 7-speed S tronic state. The broad 2008-2016 automatic row therefore mixes distinct transmission eras and is not safe as one exact ratio or tire package.",
+          "evidence_refs_ref": "e31"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tdi-quattro-eu-2008-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12"
+        },
+        {
+          "note": "Official Audi MediaCenter clean-diesel material states that the Germany-market 3.0 TDI clean diesel quattro family combines six-speed tiptronic with quattro permanent all-wheel drive, and the exact 2007-2011 Auto-Data sedan row matches that Tiptronic family. That directly contradicts the broad-row 8-speed ZF8HP mapping and leaves the stored automatic code unresolved without a split.",
+          "evidence_refs_ref": "e32"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 3.0 TDI quattro official pre-facelift Tiptronic evidence conflicts with the broad 2008-2016 ZF8HP row",
+          "reason": "Official Audi MediaCenter clean-diesel material and the exact 2007-2011 Auto-Data sedan row both identify the pre-facelift automatic family as six-speed tiptronic, so the broad ZF8HP row conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
+          "evidence_refs_ref": "e32"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tfsi-quattro-eu-2008-mt6-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n15",
+        "value": "AWD",
+        "evidence_refs_ref": "e6"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n15",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 0.84,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 3.462,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 3.462,
+          "evidence_refs_ref": "e6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n15",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tfsi-quattro-eu-2008-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2012,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n27",
+        "value": "AWD",
+        "evidence_refs_ref": "e33"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n27",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e33"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n14",
+          "value": 0.52,
+          "evidence_refs_ref": "e14"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n30",
+          "value": 3.88,
+          "evidence_refs_ref": "e14"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n25",
+          "value": 3.88,
+          "evidence_refs_ref": "e14"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n27",
           "front": {
             "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note_ref": "n29",
+          "evidence_refs_ref": "e34"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 3.0 TFSI quattro S tronic exact secondary sources confirm identity but not a safe broad-row ratio package",
+          "reason": "The exact 2012-2014 Auto-Data row and the exact 2012 Carfolio row agree on AWD and the 7-speed S tronic transmission, but neither pair provides a cross-checked full-row ratio or tire package across the 2008-2016 span.",
+          "evidence_refs_ref": "e34"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
+    {
+      "id": "audi-b8-3-0-tfsi-quattro-eu-2008-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2008,
+      "production_end_year": 2016,
+      "model_name": "A4 (B8, 2008-2016)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD",
+        "evidence_refs_ref": "e7"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e7"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Follow-up review found that exact 2012-2014 and 2012 secondary A4 3.0 TFSI quattro sedan pages identify the checked configuration as AWD with a 7-speed S tronic gearbox, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps this Tiptronic row unresolved.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-generation-autodata-2007-2011",
-          "secondary_technical_sources:a4-b8-wikipedia",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8"
+        },
+        {
+          "note": "Follow-up review found that exact 2012-2014 and 2012 secondary A4 3.0 TFSI quattro sedan pages identify the checked configuration as AWD with a 7-speed S tronic gearbox, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps this Tiptronic row unresolved.",
+          "evidence_refs_ref": "e35"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 3.0 TFSI quattro Tiptronic evidence conflicts with the broad 2008-2016 ZF8HP row",
+          "reason": "Exact 2012-2014 Auto-Data and 2012 Carfolio sedan pages identify the checked 3.0 TFSI quattro state as AWD with 7-speed S tronic, so the broad ZF8HP row likely conflates distinct transmission states and is not safe for order analysis without a split or exact later-year proof.",
+          "evidence_refs_ref": "e35"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A4 (B8, 2011-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 (B8, 2011-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4d505818df53",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A4 3.0 TFSI quattro Tiptronic evidence conflicts with the broad 2008-2016 ZF8HP row",
-        "reason": "Exact 2012-2014 Auto-Data and 2012 Carfolio sedan pages identify the checked 3.0 TFSI quattro state as AWD with 7-speed S tronic, so the broad ZF8HP row likely conflates distinct transmission states and is not safe for order analysis without a split or exact later-year proof.",
-        "evidence_refs": [
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
-          "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B9.json
@@ -1,1791 +1,1166 @@
-[
-  {
-    "id": "audi-b9-30-tdi-eu-2016-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "30 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n4": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
+      "n6": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
+      "n7": "Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Variant '30 TDI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
-        "reason": "Late-B9 official Audi 2019 launch article states four-cylinder TDI engines are offered exclusively with dual-clutch S tronic for the A4 sedan, and the current Audi MediaCenter A4 (until 2024) page lists 30 TDI only as S tronic. No saved official source supports a 30 TDI manual A4 sedan in any B9 year. Marked no_confidence."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-30-tdi-eu-2016-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "30 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / ETKA Europe with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
-        "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-35-tdi-eu-2016-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "35 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Variant '35 TDI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
-        "reason": "Same official late-B9 evidence (2019 launch article + current MediaCenter A4 until-2024 page) supports 35 TDI only as 7-speed S tronic FWD. No saved official source supports a 35 TDI manual A4 sedan in any B9 year. Marked no_confidence."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-35-tdi-eu-2016-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "35 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
-        "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-35-tfsi-eu-2016-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "35 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 0.734
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
-        "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-40-tfsi-eu-2016-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-        "value": 0.734
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
-        "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-45-tfsi-eu-2016-mt6-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Variant '45 TFSI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
-        "reason": "Official Audi 2019 launch article documents 45 TFSI as quattro drive only and gasoline non-entry variants automatic only; current MediaCenter A4 page lists only 45 TFSI quattro S tronic. No saved official source supports an FWD or manual 45 TFSI A4 sedan. Marked no_confidence."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-45-tfsi-eu-2016-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Variant '45 TFSI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
-        "reason": "Same official late-B9 evidence: 45 TFSI is quattro-only on current Audi MediaCenter pages and 2019 launch article. No saved official source supports an FWD 45 TFSI A4 sedan. Marked no_confidence."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-45-tfsi-quattro-eu-2016-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2016,
-    "production_end_year": 2025,
-    "model_name": "A4 (B9, 2016-2025)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:06c8901b4b10",
+        "legacy_research_sources:678bfbe9247b",
+        "legacy_research_sources:7ac3af4db956",
+        "legacy_research_sources:9dbbe8367fa2",
+        "legacy_research_sources:d1c6a5f1d2e6",
+        "legacy_research_sources:e6a149e4a747",
+        "legacy_research_sources:f33bee2d7717",
+        "legacy_research_sources:f3928778422d"
+      ],
+      "e2": [
         "legacy_research_sources:7ac3af4db956",
         "legacy_research_sources:e6a149e4a747"
-      ],
-      "notes": "Exact official Audi MediaCenter A4 Sedan 45 TFSI quattro technical-data PDFs confirm quattro ultra AWD for the checked late-B9 195 kW sedan state, while earlier-year continuity across the inherited row remains unresolved.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:7ac3af4db956",
-        "legacy_research_sources:e6a149e4a747"
-      ],
-      "notes": "Exact official Audi MediaCenter A4 Sedan 45 TFSI quattro technical-data PDFs confirm the 7-speed S tronic gearbox for the checked late-B9 195 kW sedan state, while earlier-year continuity across the inherited row remains unresolved.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 0.734
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-b9-30-tdi-eu-2016-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "30 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 4.41
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "value": 4.41
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
+          "notes_ref": "n2",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06c8901b4b10",
-            "legacy_research_sources:678bfbe9247b",
-            "legacy_research_sources:7ac3af4db956",
-            "legacy_research_sources:9dbbe8367fa2",
-            "legacy_research_sources:d1c6a5f1d2e6",
-            "legacy_research_sources:e6a149e4a747",
-            "legacy_research_sources:f33bee2d7717",
-            "legacy_research_sources:f3928778422d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n7"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant '30 TDI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
+          "reason": "Late-B9 official Audi 2019 launch article states four-cylinder TDI engines are offered exclusively with dual-clutch S tronic for the A4 sedan, and the current Audi MediaCenter A4 (until 2024) page lists 30 TDI only as S tronic. No saved official source supports a 30 TDI manual A4 sedan in any B9 year. Marked no_confidence."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A4 B9 S tronic final-drive ratios from official Audi MediaCenter eTD PDFs. Later exact DE 45 TFSI quattro sedan sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW sedan. Wave 12 validation now also adds exact late-B9 Germany 35 TDI sedan evidence from the 03/20/2024 and 06/13/2024 technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 205/60 R16. The broad row remains unchanged because this pass did not prove the same 35 TDI mapping across the full represented span or recover exact Germany-market continuity beyond Audi's own checked late-B9 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
+    {
+      "id": "audi-b9-30-tdi-eu-2016-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "30 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
+          "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
+    },
+    {
+      "id": "audi-b9-35-tdi-eu-2016-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "35 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
-        "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
-        "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
-        "evidence_refs": [
-          "legacy_research_sources:06c8901b4b10",
-          "legacy_research_sources:678bfbe9247b",
-          "legacy_research_sources:7ac3af4db956",
-          "legacy_research_sources:9dbbe8367fa2",
-          "legacy_research_sources:d1c6a5f1d2e6",
-          "legacy_research_sources:e6a149e4a747",
-          "legacy_research_sources:f33bee2d7717",
-          "legacy_research_sources:f3928778422d"
-        ]
-      },
-      {
-        "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
-        "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant '35 TDI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
+          "reason": "Same official late-B9 evidence (2019 launch article + current MediaCenter A4 until-2024 page) supports 35 TDI only as 7-speed S tronic FWD. No saved official source supports a 35 TDI manual A4 sedan in any B9 year. Marked no_confidence."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-b9-35-tdi-eu-2016-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "35 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
+          "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-35-tfsi-eu-2016-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "35 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.734
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
+          "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-40-tfsi-eu-2016-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n5",
+          "value": 0.734
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n5",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD / Audi UK technical data with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
+          "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-45-tfsi-eu-2016-mt6-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n3",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant '45 TFSI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
+          "reason": "Official Audi 2019 launch article documents 45 TFSI as quattro drive only and gasoline non-entry variants automatic only; current MediaCenter A4 page lists only 45 TFSI quattro S tronic. No saved official source supports an FWD or manual 45 TFSI A4 sedan. Marked no_confidence."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-45-tfsi-eu-2016-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n3",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant '45 TFSI' transmission/drivetrain combination is not supported by any saved official A4 B9 source",
+          "reason": "Same official late-B9 evidence: 45 TFSI is quattro-only on current Audi MediaCenter pages and 2019 launch article. No saved official source supports an FWD 45 TFSI A4 sedan. Marked no_confidence."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-45-tfsi-quattro-eu-2016-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2016,
+      "production_end_year": 2025,
+      "model_name": "A4 (B9, 2016-2025)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official Audi MediaCenter A4 Sedan 45 TFSI quattro technical-data PDFs confirm quattro ultra AWD for the checked late-B9 195 kW sedan state, while earlier-year continuity across the inherited row remains unresolved.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official Audi MediaCenter A4 Sedan 45 TFSI quattro technical-data PDFs confirm the 7-speed S tronic gearbox for the checked late-B9 195 kW sedan state, while earlier-year continuity across the inherited row remains unresolved.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.734
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.41
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.41
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Broad-row Audi A4 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW DE sedan, but this pass did not verify whether the earlier 180 kW years use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A4 B9 35 TDI production-data applicability across the represented span",
+          "reason": "Checked exact late-B9 Germany 35 TDI sedan PDFs resolve a 120 kW S tronic ratio package with final drive 4.048 and basic tire 205/60 R16, but this pass did not recover year-spanning official sheets proving the same package across the full represented 2019-2025 state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A4 B9 35 TDI gearbox-family code, optional tire matrix, and 2025 Germany continuity",
+          "reason": "Official Audi exact material proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 205/60 R16 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or an exact checked Germany 2025 carry-over document.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad 2016-2025 EU continuity remains unproven for the inherited row",
+          "reason": "This source pass exercised the official Audi MediaCenter A4 (until 2024) page and exact Germany 06/13/2024 status eTD PDFs. Audi's model page is labelled 'until 2024', the available eTDs are dated 2024, and earlier-year/market continuity for engine, transmission, ratio, and tire fields was not verified. Driveshaft and wheel-order analysis are disabled until the row is split or new dated official evidence is recovered."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B8.json
@@ -1,1322 +1,979 @@
-[
-  {
-    "id": "audi-b8-2-0-tfsi-eu-2007-dct7-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2007,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n4": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n5": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
+      "n7": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
+      "n8": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
+      "n9": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
+      "n10": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "Audi A5 (B8) 2.0 TFSI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD confirmed by Wikipedia A5 transmissions table and auto-data.net A5 Coupe pre-facelift entry (ID 4514, engine code CDNC, 211 hp, production from June 2008). Wikipedia footnote [34]: 'In 2009, Audi introduced the seven speed S-Tronic transmission option for A5 with 2.0 TFSI quattro (155 kW) for the UK market, which replaced the six speed Tiptronic in the United Kingdom and Germany.' production_start_year corrected from 2007 to 2009 - the 2007-2008 EU 2.0 TFSI quattro automatic was the 6-speed ZF 6HP Tiptronic; DCT7 only entered EU market in 2009. Engine codes CDNC/CPMA/CPMB across lifecycle (211 hp pre-LCI, 225/230 hp post-LCI). Default tyre 225/50 R17 per auto-data.net source.",
+      "n15": "Audi A5 (B8.5 facelift) 3.0 TDI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD. Confirmed by auto-data.net A5 B8.5 facelift 3.0 TDI 245 hp quattro S tronic (ID 19050, engine codes CDUC/CKVB/CKVC, production 2011-2015) and Wikipedia A5 transmissions table footnote: '7-speed S-Tronic (after May 2010)' for Coupe. production_start_year corrected from 2007 to 2010 - the 2007-2010 pre-facelift 3.0 TDI quattro automatic used the 6-speed ZF 6HP26 Tiptronic (NOT DCT7). DCT7 entered the A5 B8 3.0 TDI lineup at the May 2010 facelift boundary. Engine codes for facelift CDUC/CKVB/CKVC (245 hp). Pre-facelift codes CAPA/CCWA/CCLA used 6-speed Tiptronic and are not represented in this row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1f44c1eb95dd",
+        "legacy_research_sources:40d6e1e8fc60",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b"
+      ],
+      "e2": [
+        "secondary_technical_sources:audi-a5-b8-wikipedia"
+      ],
+      "e3": [
         "secondary_technical_sources:audi-a5-b8-wikipedia",
         "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia",
-        "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ],
-        "notes": "PHANTOM ROW. The Audi A5 (B8/8T/8F) 2.0 TFSI FWD with 7-speed S tronic DCT does not exist in any market. On the MLB platform, all A5 B8 FWD automatics use Multitronic CVT exclusively (engine codes CAEA/CDNB/CAEB at 180/211 hp pre-LCI, plus 225/230 hp post-LCI). The S tronic DCT7 is restricted to quattro (AWD) drivetrain only on the A5 B8 platform - mechanically tied to the integrated transfer-case assembly. Confirmed by Wikipedia Audi A5 transmission table (FWD 2.0 TFSI = multitronic only, no DCT7) and auto-data.net A5 B8 generation index (IDs 4510/4512/19038/19048/22399 - all FWD automatics list multitronic, none list DCT). Same pattern is confirmed for the platform-sister A4 B8.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "DCT7 (7-speed S tronic) is not the EU FWD automatic for the A5 B8 2.0 TFSI",
-        "reason": "On the MLB-platform A5 B8 / B8.5 (2007-2016), the FWD 2.0 TFSI automatic is the multitronic CVT, not the 7-speed S tronic DCT. S tronic on the A5 B8 platform is restricted to the quattro drivetrain. The broad EU FWD DCT7 row therefore does not represent a real Audi A5 B8 EU configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-eu-2007-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2007,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia",
-        "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia",
-        "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ],
-        "notes": "PHANTOM ROW. ZF 8HP was never used in any Audi A5 B8 (8T/8F) FWD variant. FWD automatic for all A5 B8 configurations (pre-LCI and facelift) is exclusively Multitronic CVT - confirmed by Wikipedia A5 transmission table and auto-data.net generation index. The A5 B8 platform skipped the ZF 8HP entirely - it transitioned directly from ZF 6HP (6-speed tiptronic, used pre-facelift on larger engines with quattro) to S tronic DCT7 (quattro, from 2009 for TFSI / from May 2010 for TDI). FWD automatics remained on Multitronic throughout. The ZF 8HP did appear on A5 B8 in the US/Canada market for 2.0 TFSI quattro (MY2011+, see Wikipedia footnote [35]), but never on FWD and never in EU.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-2-0-tfsi-fwd-multitronic-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8",
-        "reason": "The A5 B8 / B8.5 MLB platform never adopted the longitudinal ZF 8HP. Audi A5 B8 automatics are the multitronic CVT (FWD) or the 7-speed S tronic DCT (quattro 2.0 TFSI / quattro 3.0 TFSI / quattro 3.0 TDI facelift). No checked official Audi material places ZF 8HP into any A5 B8 EU configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-quattro-eu-2007-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2009,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A5 (B8) 2.0 TFSI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD confirmed by Wikipedia A5 transmissions table and auto-data.net A5 Coupe pre-facelift entry (ID 4514, engine code CDNC, 211 hp, production from June 2008). Wikipedia footnote [34]: 'In 2009, Audi introduced the seven speed S-Tronic transmission option for A5 with 2.0 TFSI quattro (155 kW) for the UK market, which replaced the six speed Tiptronic in the United Kingdom and Germany.' production_start_year corrected from 2007 to 2009 - the 2007-2008 EU 2.0 TFSI quattro automatic was the 6-speed ZF 6HP Tiptronic; DCT7 only entered EU market in 2009. Engine codes CDNC/CPMA/CPMB across lifecycle (211 hp pre-LCI, 225/230 hp post-LCI). Default tyre 225/50 R17 per auto-data.net source.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A5 (B8) 2.0 TFSI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD confirmed by Wikipedia A5 transmissions table and auto-data.net A5 Coupe pre-facelift entry (ID 4514, engine code CDNC, 211 hp, production from June 2008). Wikipedia footnote [34]: 'In 2009, Audi introduced the seven speed S-Tronic transmission option for A5 with 2.0 TFSI quattro (155 kW) for the UK market, which replaced the six speed Tiptronic in the United Kingdom and Germany.' production_start_year corrected from 2007 to 2009 - the 2007-2008 EU 2.0 TFSI quattro automatic was the 6-speed ZF 6HP Tiptronic; DCT7 only entered EU market in 2009. Engine codes CDNC/CPMA/CPMB across lifecycle (211 hp pre-LCI, 225/230 hp post-LCI). Default tyre 225/50 R17 per auto-data.net source.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.68 inherited family-default; not verified from A5 B8 specific Audi tech-data PDF. Note: A6 C7 DL501 (same gearbox family) is documented at 0.519 per Audi 0B5 workshop manual - 0.68 may be incorrect; needs A5 B8 specific verification.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.444 inherited family-default. A6 C7 DL501 uses split AWD 4.093/4.111 - A5 B8 may differ; needs A5 B8 specific verification.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive rear 3.444 inherited family-default; unverified for A5 B8.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ],
-        "notes": "A5 B8 2.0 TFSI quattro 7-speed S tronic baseline tyre 225/50 R17 per auto-data.net (ID 4514). Replaces 245/40 R18 family-default S-line option.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Exact secondary review found a 2008-2011 A5 Coupe 2.0 TFSI quattro S tronic page that supports AWD, 7-speed S tronic, and 225/50 R17 tires, but it does not safely cover the full 2007-2016 row and no second exact source resolved the ratio package in this pass.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 Coupe 2.0 TFSI quattro S tronic pre-facelift evidence is not safe for the broad 2007-2016 row",
-        "reason": "The exact 2008-2011 Auto-Data coupe row supports AWD, S tronic, and 225/50 R17 tires, but without a second exact source or later-year continuity the evidence is insufficient for a safe ratio or tire correction.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "A5 B8 quattro 2.0 TFSI 7-speed S tronic full forward gear ratio set, final drive, and exact Audi Germany-market technical-data sheet",
-        "reason": "The 7-speed S tronic transmission is plausible across the A5 B8 quattro 2.0 TFSI EU lifespan, but no exact Audi MediaCenter Germany-market technical-data PDF for the B8/B8.5 was recoverable in this run; the gear ratios, final drive and tire defaults are still inherited family defaults rather than per-variant verified values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-2-0-tfsi-quattro-eu-2007-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2007,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ],
-        "notes": "PHANTOM ROW for EU market. Wikipedia footnote [35] is decisive: 'Beginning with the 2011 model year, the A5 2.0 TFSI Quattro coupe and cabriolet includes 8 speed Tiptronic transmission option, replacing the 6-speed Tiptronic in the U.S. and Canada markets.' The ZF 8HP + 2.0 TFSI quattro combination is North America (US/CA) only - never EU. The EU path for 2.0 TFSI quattro automatic was ZF 6HP (pre-2009) -> DCT7 (from 2009, see Row 2). Independently corroborated by absence of any ZF 8HP entry in auto-data.net A5 B8 EU variant catalogue (generation indices 1096 and 4152). The combination exists in production but is restricted to USDM/CA - the EU-tagged row is unsupported.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Exact secondary review found a 2009-2011 A5 Coupe 2.0 TFSI quattro Tiptronic page that supports AWD and 245/40 R18 baseline tires, but it does not safely cover the full 2007-2016 row and does not provide a cross-checked exact ratio package in this pass.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-zf8hp-autodata"
-        ]
-      },
-      {
-        "note": "Follow-up review found that the exact 2009-2011 Auto-Data coupe row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps the transmission field unresolved.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-zf8hp-autodata"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 Coupe 2.0 TFSI quattro Tiptronic pre-facelift evidence is not safe for the broad 2007-2016 row",
-        "reason": "The exact 2009-2011 Auto-Data coupe row supports AWD and 245/40 R18 tires, but it also identifies the pre-facelift Tiptronic configuration as 6-speed automatic, so the broad 2007-2016 ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-zf8hp-autodata"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8 quattro 2.0 TFSI",
-        "reason": "The A5 B8 quattro 2.0 TFSI EU automatic is the 7-speed S tronic DCT, not the ZF 8HP. The ZF 8HP did not enter the A5/A4 B8 platform for the 2.0 TFSI; the broad ZF 8HP row therefore does not represent a real Audi A5 B8 EU configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b8-3-0-tdi-quattro-eu-2007-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2010,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A5 (B8.5 facelift) 3.0 TDI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD. Confirmed by auto-data.net A5 B8.5 facelift 3.0 TDI 245 hp quattro S tronic (ID 19050, engine codes CDUC/CKVB/CKVC, production 2011-2015) and Wikipedia A5 transmissions table footnote: '7-speed S-Tronic (after May 2010)' for Coupe. production_start_year corrected from 2007 to 2010 - the 2007-2010 pre-facelift 3.0 TDI quattro automatic used the 6-speed ZF 6HP26 Tiptronic (NOT DCT7). DCT7 entered the A5 B8 3.0 TDI lineup at the May 2010 facelift boundary. Engine codes for facelift CDUC/CKVB/CKVC (245 hp). Pre-facelift codes CAPA/CCWA/CCLA used 6-speed Tiptronic and are not represented in this row.",
-      "value": "AWD",
-      "evidence_refs": [
+      ],
+      "e4": [
         "secondary_technical_sources:audi-a5-b8-wikipedia",
         "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
+      ],
+      "e6": [
+        "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-zf8hp-autodata"
+      ],
+      "e7": [
+        "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e8": [
+        "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-autodata",
+        "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-ultimatespecs"
       ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A5 (B8.5 facelift) 3.0 TDI quattro 7-speed S tronic DCT (DL501 / 0B5) AWD. Confirmed by auto-data.net A5 B8.5 facelift 3.0 TDI 245 hp quattro S tronic (ID 19050, engine codes CDUC/CKVB/CKVC, production 2011-2015) and Wikipedia A5 transmissions table footnote: '7-speed S-Tronic (after May 2010)' for Coupe. production_start_year corrected from 2007 to 2010 - the 2007-2010 pre-facelift 3.0 TDI quattro automatic used the 6-speed ZF 6HP26 Tiptronic (NOT DCT7). DCT7 entered the A5 B8 3.0 TDI lineup at the May 2010 facelift boundary. Engine codes for facelift CDUC/CKVB/CKVC (245 hp). Pre-facelift codes CAPA/CCWA/CCLA used 6-speed Tiptronic and are not represented in this row.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia",
-        "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.68 inherited family-default; A6 C7 DL501 documented at 0.519 - 0.68 may be incorrect for A5 B8.5 3.0 TDI quattro DCT7. Needs A5 B8.5 specific verification.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.444 inherited family-default; A6 C7 DL501 uses split 4.093/4.111 - A5 B8.5 may differ; unverified.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive rear 3.444 inherited family-default; unverified.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ],
-        "notes": "A5 B8.5 3.0 TDI quattro DCT7 baseline tyre 225/50 R17 cross-checked against A5 B8 platform standard. Replaces 245/40 R18 family-default S-line option.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-dct7-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "A5 B8 3.0 TDI quattro pre-facelift transmission was 6-speed tiptronic (ZF 6HP), not 7-speed S tronic",
-        "reason": "The Audi A4 3.0 TDI clean diesel quattro press release confirms the pre-facelift V6 TDI quattro family on the MLB platform paired the engine with the six-speed tiptronic (ZF 6HP26). The 7-speed S tronic only became the standard 3.0 TDI quattro automatic from the B8.5 facelift (≈2011). The current broad row covers 2007 onward; its DCT7 mapping is only valid for the late B8.5 facelift portion of the production span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-b8-3-0-tdi-quattro-eu-2007-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B8",
-    "body_code": "B8",
-    "production_start_year": 2007,
-    "production_end_year": 2016,
-    "model_name": "A5 (B8, 2007-2016)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a5-b8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "audi-b8-2-0-tfsi-eu-2007-dct7-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2007,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
+        "notes_ref": "n8",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
+        "notes_ref": "n8",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e3"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ],
-        "notes": "PHANTOM ROW. ZF 8HP was never used with the Audi A5 (B8/8T/8F) 3.0 TDI quattro in any market. Pre-facelift (2007-2010): 3.0 TDI quattro automatic = 6-speed ZF 6HP26 Tiptronic (auto-data.net ID 4518, 240 hp, engine codes CAPA/CCWA/CCLA) - explicitly 6-speed. Facelift B8.5 (2011-2016): 3.0 TDI quattro automatic = 7-speed S tronic DCT (auto-data.net ID 19050, 245 hp, codes CDUC/CKVB/CKVC). The A5 B8 platform skipped the ZF 8HP entirely on the 3.0 TDI line, transitioning directly from ZF 6HP to DCT7 at the May 2010 facelift. No ZF 8HP variant appears at any production year for A5 B8 3.0 TDI quattro on auto-data.net or Wikipedia.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 0.68,
+          "evidence_refs_ref": "e3"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 3.444,
+          "evidence_refs_ref": "e3"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f44c1eb95dd",
-            "legacy_research_sources:40d6e1e8fc60",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "DCT7 (7-speed S tronic) is not the EU FWD automatic for the A5 B8 2.0 TFSI",
+          "reason": "On the MLB-platform A5 B8 / B8.5 (2007-2016), the FWD 2.0 TFSI automatic is the multitronic CVT, not the 7-speed S tronic DCT. S tronic on the A5 B8 platform is restricted to the quattro drivetrain. The broad EU FWD DCT7 row therefore does not represent a real Audi A5 B8 EU configuration.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
+    {
+      "id": "audi-b8-2-0-tfsi-eu-2007-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2007,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "value": "FWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 0.667,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n9",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "Follow-up review found that the exact 2007-2011 Auto-Data coupe row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, and an independent Ultimate Specs page corroborates the 2007-2011 quattro Tiptronic identity, so the broad-row 8-speed ZF8HP mapping remains unresolved.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-autodata",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-ultimatespecs"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a5-b8-wikipedia"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8",
+          "reason": "The A5 B8 / B8.5 MLB platform never adopted the longitudinal ZF 8HP. Audi A5 B8 automatics are the multitronic CVT (FWD) or the 7-speed S tronic DCT (quattro 2.0 TFSI / quattro 3.0 TFSI / quattro 3.0 TDI facelift). No checked official Audi material places ZF 8HP into any A5 B8 EU configuration.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-quattro-eu-2007-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2009,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n14",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n14",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.68 inherited family-default; not verified from A5 B8 specific Audi tech-data PDF. Note: A6 C7 DL501 (same gearbox family) is documented at 0.519 per Audi 0B5 workshop manual - 0.68 may be incorrect; needs A5 B8 specific verification.",
+          "value": 0.68,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.444 inherited family-default. A6 C7 DL501 uses split AWD 4.093/4.111 - A5 B8 may differ; needs A5 B8 specific verification.",
+          "value": 3.444,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive rear 3.444 inherited family-default; unverified for A5 B8.",
+          "value": 3.444,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes": "A5 B8 2.0 TFSI quattro 7-speed S tronic baseline tyre 225/50 R17 per auto-data.net (ID 4514). Replaces 245/40 R18 family-default S-line option.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:1f44c1eb95dd",
-          "legacy_research_sources:40d6e1e8fc60",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b"
-        ]
-      },
-      {
-        "item": "Audi A5 Coupe 3.0 TDI quattro Tiptronic pre-facelift evidence conflicts with the broad 2007-2016 ZF8HP row",
-        "reason": "The exact 2007-2011 Auto-Data coupe row identifies the pre-facelift Tiptronic configuration as 6-speed automatic, and Ultimate Specs independently corroborates the 2007-2011 quattro Tiptronic identity, so the broad ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
-        "evidence_refs": [
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-autodata",
-          "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-ultimatespecs"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8 3.0 TDI quattro",
-        "reason": "The A4/A5 B8 platform's 3.0 TDI quattro automatic was the 6-speed tiptronic (ZF 6HP) pre-facelift and the 7-speed S tronic from the B8.5 facelift. No checked official Audi material maps the ZF 8HP onto the A5 B8 3.0 TDI quattro family in any market.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b8-a4-3-0-tdi-clean-diesel-quattro-press-release"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note": "Exact secondary review found a 2008-2011 A5 Coupe 2.0 TFSI quattro S tronic page that supports AWD, 7-speed S tronic, and 225/50 R17 tires, but it does not safely cover the full 2007-2016 row and no second exact source resolved the ratio package in this pass.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 Coupe 2.0 TFSI quattro S tronic pre-facelift evidence is not safe for the broad 2007-2016 row",
+          "reason": "The exact 2008-2011 Auto-Data coupe row supports AWD, S tronic, and 225/50 R17 tires, but without a second exact source or later-year continuity the evidence is insufficient for a safe ratio or tire correction.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "A5 B8 quattro 2.0 TFSI 7-speed S tronic full forward gear ratio set, final drive, and exact Audi Germany-market technical-data sheet",
+          "reason": "The 7-speed S tronic transmission is plausible across the A5 B8 quattro 2.0 TFSI EU lifespan, but no exact Audi MediaCenter Germany-market technical-data PDF for the B8/B8.5 was recoverable in this run; the gear ratios, final drive and tire defaults are still inherited family defaults rather than per-variant verified values.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-b8-2-0-tfsi-quattro-eu-2007-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2007,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note": "Exact secondary review found a 2009-2011 A5 Coupe 2.0 TFSI quattro Tiptronic page that supports AWD and 245/40 R18 baseline tires, but it does not safely cover the full 2007-2016 row and does not provide a cross-checked exact ratio package in this pass.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note": "Follow-up review found that the exact 2009-2011 Auto-Data coupe row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, which conflicts with the broad-row 8-speed ZF8HP mapping and keeps the transmission field unresolved.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 Coupe 2.0 TFSI quattro Tiptronic pre-facelift evidence is not safe for the broad 2007-2016 row",
+          "reason": "The exact 2009-2011 Auto-Data coupe row supports AWD and 245/40 R18 tires, but it also identifies the pre-facelift Tiptronic configuration as 6-speed automatic, so the broad 2007-2016 ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8 quattro 2.0 TFSI",
+          "reason": "The A5 B8 quattro 2.0 TFSI EU automatic is the 7-speed S tronic DCT, not the ZF 8HP. The ZF 8HP did not enter the A5/A4 B8 platform for the 2.0 TFSI; the broad ZF 8HP row therefore does not represent a real Audi A5 B8 EU configuration.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tdi-quattro-eu-2007-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2010,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n15",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n15",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.68 inherited family-default; A6 C7 DL501 documented at 0.519 - 0.68 may be incorrect for A5 B8.5 3.0 TDI quattro DCT7. Needs A5 B8.5 specific verification.",
+          "value": 0.68,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.444 inherited family-default; A6 C7 DL501 uses split 4.093/4.111 - A5 B8.5 may differ; unverified.",
+          "value": 3.444,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive rear 3.444 inherited family-default; unverified.",
+          "value": 3.444,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e4",
+          "notes": "A5 B8.5 3.0 TDI quattro DCT7 baseline tyre 225/50 R17 cross-checked against A5 B8 platform standard. Replaces 245/40 R18 family-default S-line option.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "A5 B8 3.0 TDI quattro pre-facelift transmission was 6-speed tiptronic (ZF 6HP), not 7-speed S tronic",
+          "reason": "The Audi A4 3.0 TDI clean diesel quattro press release confirms the pre-facelift V6 TDI quattro family on the MLB platform paired the engine with the six-speed tiptronic (ZF 6HP26). The 7-speed S tronic only became the standard 3.0 TDI quattro automatic from the B8.5 facelift (≈2011). The current broad row covers 2007 onward; its DCT7 mapping is only valid for the late B8.5 facelift portion of the production span.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b8-3-0-tdi-quattro-eu-2007-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B8",
+      "body_code": "B8",
+      "production_start_year": 2007,
+      "production_end_year": 2016,
+      "model_name": "A5 (B8, 2007-2016)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note": "Follow-up review found that the exact 2007-2011 Auto-Data coupe row identifies this pre-facelift Tiptronic configuration as 6-speed automatic, and an independent Ultimate Specs page corroborates the 2007-2011 quattro Tiptronic identity, so the broad-row 8-speed ZF8HP mapping remains unresolved.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A5 (B8, 2012-2016) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 (B8, 2012-2016) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 Coupe 3.0 TDI quattro Tiptronic pre-facelift evidence conflicts with the broad 2007-2016 ZF8HP row",
+          "reason": "The exact 2007-2011 Auto-Data coupe row identifies the pre-facelift Tiptronic configuration as 6-speed automatic, and Ultimate Specs independently corroborates the 2007-2011 quattro Tiptronic identity, so the broad ZF8HP row likely conflates distinct transmission eras and is not safe for order analysis without a split or later-year proof.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is not used on the A5 B8 3.0 TDI quattro",
+          "reason": "The A4/A5 B8 platform's 3.0 TDI quattro automatic was the 6-speed tiptronic (ZF 6HP) pre-facelift and the 7-speed S tronic from the B8.5 facelift. No checked official Audi material maps the ZF 8HP onto the A5 B8 3.0 TDI quattro family in any market.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B9.json
@@ -1,399 +1,284 @@
-[
-  {
-    "id": "audi-b9-40-tfsi-eu-2017-dct7-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2017,
-    "production_end_year": 2024,
-    "model_name": "A5 (B9, 2017-2024)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
+      "n2": "Official Audi 03/20/2024 technical-data PDF publishes one final-drive value 4.410 for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n3": "Official Audi 03/20/2024 technical-data material confirms 225/50 R17 as the exact basic tire package for the late-B9 A5 Coupé 45 TFSI quattro S tronic row."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-        "value": 0.725
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1f64a70f7798",
+        "legacy_research_sources:40902bf8de39",
+        "legacy_research_sources:4d089475ce12",
+        "legacy_research_sources:4dfe6573fbd8",
+        "legacy_research_sources:6f2489b6d6b2",
+        "legacy_research_sources:a615f24ca1f7",
+        "legacy_research_sources:b04c6ac99a88",
+        "legacy_research_sources:b901a9c86975",
+        "legacy_research_sources:bd3399c45b29",
+        "legacy_research_sources:c6e2f8abe80a",
+        "legacy_research_sources:ed529186a624"
+      ],
+      "e2": [
+        "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:b9-a5-coupe-until-2024-model-page",
+        "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-b9-40-tfsi-eu-2017-dct7-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2017,
+      "production_end_year": 2024,
+      "model_name": "A5 (B9, 2017-2024)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-        "value": 4.234
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f64a70f7798",
-            "legacy_research_sources:40902bf8de39",
-            "legacy_research_sources:4d089475ce12",
-            "legacy_research_sources:4dfe6573fbd8",
-            "legacy_research_sources:6f2489b6d6b2",
-            "legacy_research_sources:a615f24ca1f7",
-            "legacy_research_sources:b04c6ac99a88",
-            "legacy_research_sources:b901a9c86975",
-            "legacy_research_sources:bd3399c45b29",
-            "legacy_research_sources:c6e2f8abe80a",
-            "legacy_research_sources:ed529186a624"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.234
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Verified Audi A5 B9 S tronic final-drive ratios from official Audi UK and Audi MediaCenter technical PDFs. Later exact 45 TFSI quattro Coupe and Sportback sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW MHEV configuration. Wave 11 validation added exact late-B9 Germany 40 TFSI evidence from the 03/20/2024 A5 Coupé and 06/13/2024 A5 Sportback technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 4.234, and basic tire 225/50 R17. Wave 13 now adds the parallel late-B9 Germany 35 TDI evidence from checked 03/20/2024 Coupé and 06/13/2024 Sportback technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 225/50 R17. The broad 2017-2024 row remains unchanged because official 2020 launch material still shows earlier model states and this pass did not recover year-spanning evidence proving one unchanged package across the whole row.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f64a70f7798",
-            "legacy_research_sources:40902bf8de39",
-            "legacy_research_sources:4d089475ce12",
-            "legacy_research_sources:4dfe6573fbd8",
-            "legacy_research_sources:6f2489b6d6b2",
-            "legacy_research_sources:a615f24ca1f7",
-            "legacy_research_sources:b04c6ac99a88",
-            "legacy_research_sources:b901a9c86975",
-            "legacy_research_sources:bd3399c45b29",
-            "legacy_research_sources:c6e2f8abe80a",
-            "legacy_research_sources:ed529186a624"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1f64a70f7798",
-            "legacy_research_sources:40902bf8de39",
-            "legacy_research_sources:4d089475ce12",
-            "legacy_research_sources:4dfe6573fbd8",
-            "legacy_research_sources:6f2489b6d6b2",
-            "legacy_research_sources:a615f24ca1f7",
-            "legacy_research_sources:b04c6ac99a88",
-            "legacy_research_sources:b901a9c86975",
-            "legacy_research_sources:bd3399c45b29",
-            "legacy_research_sources:c6e2f8abe80a",
-            "legacy_research_sources:ed529186a624"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi A5 B9 S tronic final-drive ratios from official Audi UK and Audi MediaCenter technical PDFs. Later exact 45 TFSI quattro Coupe and Sportback sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 225/50 R17 basic tire for the 195 kW MHEV configuration. Wave 11 validation added exact late-B9 Germany 40 TFSI evidence from the 03/20/2024 A5 Coupé and 06/13/2024 A5 Sportback technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 4.234, and basic tire 225/50 R17. Wave 13 now adds the parallel late-B9 Germany 35 TDI evidence from checked 03/20/2024 Coupé and 06/13/2024 Sportback technical-data PDFs: Frontantrieb, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.048, and basic tire 225/50 R17. The broad 2017-2024 row remains unchanged because official 2020 launch material still shows earlier model states and this pass did not recover year-spanning evidence proving one unchanged package across the whole row.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data (exact 2024 Coupe + Sportback states) with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi A5 B9 40 TFSI production-data applicability across the full represented span",
-        "reason": "Checked exact late-B9 Germany Coupé and Sportback PDFs resolve the 150 kW 40 TFSI mapping, but official 2020 launch material still shows an earlier 140 kW 40 TFSI state and this pass did not recover the early exact technical-data sheets needed to prove one unchanged 2019-2024 package.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A5 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW Coupe and Sportback, but this pass did not verify whether the earlier years in the broad row use the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      },
-      {
-        "item": "Audi A5 B9 40 TFSI transmission-code and optional tire-matrix confirmation",
-        "reason": "Official Audi exact material now proves the late-B9 40 TFSI drivetrain, full ratio set, reverse ratio, final drive 4.234, and the 225/50 R17 basic tire, but it does not publish the gearbox-family code or a full optional wheel/tire matrix for the exact 40 TFSI target.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      },
-      {
-        "item": "Broad-row Audi A5 B9 35 TDI production-data applicability across the full represented span",
-        "reason": "Checked exact late-B9 Germany Coupé and Sportback PDFs resolve the 120 kW 35 TDI mapping, but this pass did not recover a year-by-year official chain proving one unchanged 2019-2024 package.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      },
-      {
-        "item": "Audi A5 B9 35 TDI gearbox-family code and optional tire-matrix confirmation",
-        "reason": "Official Audi exact material now proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 225/50 R17 basic tire, but it does not publish the gearbox-family code or a full optional wheel/tire matrix for the exact 35 TDI target.",
-        "evidence_refs": [
-          "legacy_research_sources:1f64a70f7798",
-          "legacy_research_sources:40902bf8de39",
-          "legacy_research_sources:4d089475ce12",
-          "legacy_research_sources:4dfe6573fbd8",
-          "legacy_research_sources:6f2489b6d6b2",
-          "legacy_research_sources:a615f24ca1f7",
-          "legacy_research_sources:b04c6ac99a88",
-          "legacy_research_sources:b901a9c86975",
-          "legacy_research_sources:bd3399c45b29",
-          "legacy_research_sources:c6e2f8abe80a",
-          "legacy_research_sources:ed529186a624"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-b9-45-tfsi-quattro-eu-2017-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2024,
-    "production_end_year": 2024,
-    "model_name": "A5 (B9, 2024)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
       ],
-      "notes": "Official Audi 03/20/2024 technical-data material confirms that the exact late-B9 A5 Coupé 45 TFSI quattro S tronic state uses quattro all-wheel drive with ultra technology.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Official Audi 03/20/2024 technical-data material confirms 7-speed S tronic wording and a wet dual-clutch layout for the exact late-B9 A5 Coupé 45 TFSI quattro state.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 03/20/2024 technical-data PDF lists 0.433 as the 7th-gear ratio for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
-        "value": 0.433
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 03/20/2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.557,
-          0.433
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 03/20/2024 technical-data PDF publishes one final-drive value 4.410 for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 4.41
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 03/20/2024 technical-data PDF publishes one final-drive value 4.410 for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 4.41
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 03/20/2024 technical-data material confirms 225/50 R17 as the exact basic tire package for the late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Broad-row Audi A5 B9 40 TFSI production-data applicability across the full represented span",
+          "reason": "Checked exact late-B9 Germany Coupé and Sportback PDFs resolve the 150 kW 40 TFSI mapping, but official 2020 launch material still shows an earlier 140 kW 40 TFSI state and this pass did not recover the early exact technical-data sheets needed to prove one unchanged 2019-2024 package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A5 B9 45 TFSI quattro top_gear_ratio applicability across the full represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 195 kW Coupe and Sportback, but this pass did not verify whether the earlier years in the broad row use the same exact mapping.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 B9 40 TFSI transmission-code and optional tire-matrix confirmation",
+          "reason": "Official Audi exact material now proves the late-B9 40 TFSI drivetrain, full ratio set, reverse ratio, final drive 4.234, and the 225/50 R17 basic tire, but it does not publish the gearbox-family code or a full optional wheel/tire matrix for the exact 40 TFSI target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row Audi A5 B9 35 TDI production-data applicability across the full represented span",
+          "reason": "Checked exact late-B9 Germany Coupé and Sportback PDFs resolve the 120 kW 35 TDI mapping, but this pass did not recover a year-by-year official chain proving one unchanged 2019-2024 package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A5 B9 35 TDI gearbox-family code and optional tire-matrix confirmation",
+          "reason": "Official Audi exact material now proves the late-B9 35 TDI drivetrain, full ratio set, reverse ratio, final drive 4.048, and the 225/50 R17 basic tire, but it does not publish the gearbox-family code or a full optional wheel/tire matrix for the exact 35 TDI target.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-b9-45-tfsi-quattro-eu-2017-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2024,
+      "production_end_year": 2024,
+      "model_name": "A5 (B9, 2024)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Official Audi 03/20/2024 technical-data material confirms that the exact late-B9 A5 Coupé 45 TFSI quattro S tronic state uses quattro all-wheel drive with ultra technology.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Official Audi 03/20/2024 technical-data material confirms 7-speed S tronic wording and a wet dual-clutch layout for the exact late-B9 A5 Coupé 45 TFSI quattro state.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-          ],
-          "notes": "Official Audi 03/20/2024 technical-data material confirms 225/50 R17 as the exact basic tire package for the late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi 03/20/2024 technical-data PDF lists 0.433 as the 7th-gear ratio for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
+          "value": 0.433
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi 03/20/2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 for the exact late-B9 A5 Coupé 45 TFSI quattro S tronic row.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.557,
+            0.433
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "value": 4.41
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "value": 4.41
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 6 validation narrows this row to the exact late-B9 Coupé state actually supported by the evidence. The official Audi 03/20/2024 technical-data PDF proves the exact A5 Coupé 45 TFSI quattro S tronic 195 kW MHEV package with quattro all-wheel drive, wet 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, one published final-drive value 4.410, and basic 225/50 R17 tires. The Audi MediaCenter model page scopes the outgoing A5 Coupé as 'until 2024', so the row is retimed conservatively to the exact 2024 state instead of carrying unsupported continuity back to 2017.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 6 validation narrows this row to the exact late-B9 Coupé state actually supported by the evidence. The official Audi 03/20/2024 technical-data PDF proves the exact A5 Coupé 45 TFSI quattro S tronic 195 kW MHEV package with quattro all-wheel drive, wet 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, one published final-drive value 4.410, and basic 225/50 R17 tires. The Audi MediaCenter model page scopes the outgoing A5 Coupé as 'until 2024', so the row is retimed conservatively to the exact 2024 state instead of carrying unsupported continuity back to 2017.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-until-2024-model-page",
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi A5 Coupé 45 TFSI quattro continuity before the checked 2024 state",
+          "reason": "The checked official Audi evidence closes the exact 2024 Coupé state, but this pass did not recover a year-by-year official chain proving the same 195 kW 45 TFSI quattro package unchanged across earlier B9 years.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Audi A5 Coupé 45 TFSI quattro exact optional wheel and tire matrix",
+          "reason": "The checked official Audi exact sheet proves only the basic 225/50 R17 package for the late-B9 Coupé row. This pass did not recover a clean official optional wheel/tire matrix or any staggered-fitment proof for the exact target.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A5 Coupé 45 TFSI quattro exact public gearbox-family naming",
+          "reason": "The checked official Audi exact sheet proves wet-clutch 7-speed S tronic wording for the 2024 Coupé state but does not publish a gearbox-family code beyond Audi's public transmission naming.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi A5 Coupé 45 TFSI quattro continuity before the checked 2024 state",
-        "reason": "The checked official Audi evidence closes the exact 2024 Coupé state, but this pass did not recover a year-by-year official chain proving the same 195 kW 45 TFSI quattro package unchanged across earlier B9 years.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-until-2024-model-page",
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A5 Coupé 45 TFSI quattro exact optional wheel and tire matrix",
-        "reason": "The checked official Audi exact sheet proves only the basic 225/50 R17 package for the late-B9 Coupé row. This pass did not recover a clean official optional wheel/tire matrix or any staggered-fitment proof for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A5 Coupé 45 TFSI quattro exact public gearbox-family naming",
-        "reason": "The checked official Audi exact sheet proves wet-clutch 7-speed S tronic wording for the 2024 Coupé state but does not publish a gearbox-family code beyond Audi's public transmission naming.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:b9-a5-coupe-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C7.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C7.json
@@ -1,1582 +1,936 @@
-[
-  {
-    "id": "audi-c7-2-0-tfsi-eu-2011-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n4": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
+      "n5": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
+      "n6": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
+      "n7": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "Audi A6 (C7) 3.0 TDI quattro single-turbo + DL501 (0B5) 7-speed S tronic is the standard EU production pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic for all standard 3.0 TDI quattro variants throughout C7 lifecycle (2011-2014: 204/245 PS; 2014-2018: 190/218/272 PS). Engine codes CGLD/CFGC/CKVB (single-turbo, 150-176 kW). RATIO CORRECTIONS APPLIED: top gear 0.68 -> 0.519 (DL501 7th gear per Audi workshop manual, also matches shard's own Wave 17 verification_notes); final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material - the DL501 in A6 C7 quattro uses split AWD reductions, not a single FD value, and 3.444 was incorrect for either axle. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
+      "n10": "Audi A6 (C7) 3.0 TFSI supercharged V6 quattro + DL501 (0B5) 7-speed S tronic is the standard EU pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic as standard for 3.0 TFSI quattro (220 kW and 228 kW) EU/UK market. For the 228 kW saloon, Wikipedia explicitly notes: '7-speed S-Tronic is used in the UK model.' S6 C7 (4.0 TFSI biturbo, 309 kW) also uses DL501, confirming the gearbox family. RATIO CORRECTIONS (identical to Row 2): top gear 0.68 -> 0.519; final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide. Note: post-LCI 245 kW state (CREC/CVWA, 2014+) has high probability of retaining 0B5 but is not independently confirmed in current source pack.",
+      "n11": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "Audi A6 (C7) 3.0 BiTDI quattro + ZF 8HP (0BK / 8HP50) confirmed by Wikipedia A6 C7 transmissions table: 8-speed Tiptronic exclusively for '3.0 TDI quattro (313 PS, 320 PS, 326 PS)' - the BiTDI product (engine code CDUD, 230 kW). UK-market labelling: '3.0 BiTDI quattro'. SCOPE NOTE: this row's engine_code '3.0L' is ambiguous and conflates single-turbo (CGLD/CFGC/CKVB - paired with DL501 in Row 2) with biturbo (CDUD - paired with ZF 8HP only here); the row should be read as BiTDI sub-variant only. Top gear 0.667 plausible for ZF8HP50 8th gear (standard HP50 ratio set). Final drive 3.077 plausible for ZF 8HP applications on MLB-platform A6/A7/A8 family - both unconfirmed from A6 C7 BiTDI specific official tech data. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
+      "n15": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "secondary_technical_sources:audi-a6-c7-wikipedia"
       ],
-      "notes": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
+      "e2": [
+        "legacy_research_sources:07f701f57e44",
+        "legacy_research_sources:3bd8ca8fa320",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:7a80724d8596",
+        "legacy_research_sources:92623d6bbb03",
+        "legacy_research_sources:9fe846420ccb",
+        "legacy_research_sources:c143819cabc5",
+        "legacy_research_sources:df617cc28562",
+        "legacy_research_sources:e0ba5607333f",
+        "legacy_research_sources:f7b0bdd3aad4"
+      ],
+      "e3": [
+        "legacy_research_sources:07f701f57e44",
+        "legacy_research_sources:3bd8ca8fa320",
+        "legacy_research_sources:7a80724d8596",
+        "legacy_research_sources:9fe846420ccb",
+        "legacy_research_sources:e0ba5607333f",
+        "legacy_research_sources:f7b0bdd3aad4"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
-        "value": 0.68,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
-        "value": 3.444,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "PHANTOM ROW. Audi A6 (C7/4G) MLB longitudinal platform: the DL501 (Audi code 0B5, 7-speed wet-clutch S tronic) is mechanically incompatible with FWD - it is designed exclusively for quattro architectures with integrated rear-axle output. The A6 C7 FWD range used 6-speed manual (0B2/0B3) for entry power states and Multitronic CVT (0AW) for FWD automatic. The S tronic DCT7 did not appear with the 2.0 TFSI until the very late C7.5 facelift (approximately 2016+ as 2.0 45 TFSI ultra), and only in a specific late-lifecycle configuration - not applicable to a 2011 production-start row. Wikipedia A6 C7 transmission table confirms: 180 PS variant = 6-speed manual (std) / multitronic (opt); 211 PS variant = multitronic (std); 245 PS C7.5 (2017+) = 7-speed S tronic. No DL501 for the 2011-era FWD 2.0 TFSI.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "DCT7 (7-speed S tronic) is not standard for the EU A6 C7 2.0 TFSI",
-        "reason": "Audi A6 C7 (2011-2018) EU 2.0 TFSI was sold with 6-speed manual or multitronic CVT for the 132 kW and 155 kW states; the 7-speed S tronic only appeared with the late C7.5 facelift 2.0 45 TFSI ultra (≈2016+). The broad 2011 row does not capture an EU-standard DCT7 2.0 TFSI.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-c7-2-0-tfsi-eu-2011-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ],
-      "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "audi-c7-2-0-tfsi-eu-2011-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n5",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK / 8HP45) on Audi A6 C7 MLB is paired with quattro drivetrains throughout the EU range; FWD automatic uses Multitronic CVT. The 2.0 TFSI + ZF 8HP + FWD combination in the Wikipedia transmission table represents the China-market A6L (long-wheelbase, FAW-VW) where ZF 8HP replaced Multitronic for the Chinese-domestic model - this is a distinct product from the EU 4G sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 0.68,
+          "evidence_refs_ref": "e1"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 3.444,
+          "evidence_refs_ref": "e1"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is not an EU-market option on the A6 C7 2.0 TFSI",
-        "reason": "The 8-speed tiptronic 2.0 TFSI A6 C7 is associated with the China-market A6L (long-wheelbase) allocation, not with the EU-DE Sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c7-3-0-tdi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
       ],
-      "notes": "Audi A6 (C7) 3.0 TDI quattro single-turbo + DL501 (0B5) 7-speed S tronic is the standard EU production pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic for all standard 3.0 TDI quattro variants throughout C7 lifecycle (2011-2014: 204/245 PS; 2014-2018: 190/218/272 PS). Engine codes CGLD/CFGC/CKVB (single-turbo, 150-176 kW). RATIO CORRECTIONS APPLIED: top gear 0.68 -> 0.519 (DL501 7th gear per Audi workshop manual, also matches shard's own Wave 17 verification_notes); final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material - the DL501 in A6 C7 quattro uses split AWD reductions, not a single FD value, and 3.444 was incorrect for either axle. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A6 (C7) 3.0 TDI quattro single-turbo + DL501 (0B5) 7-speed S tronic is the standard EU production pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic for all standard 3.0 TDI quattro variants throughout C7 lifecycle (2011-2014: 204/245 PS; 2014-2018: 190/218/272 PS). Engine codes CGLD/CFGC/CKVB (single-turbo, 150-176 kW). RATIO CORRECTIONS APPLIED: top gear 0.68 -> 0.519 (DL501 7th gear per Audi workshop manual, also matches shard's own Wave 17 verification_notes); final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material - the DL501 in A6 C7 quattro uses split AWD reductions, not a single FD value, and 3.444 was incorrect for either axle. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 (C7) 3.0 TDI quattro single-turbo + DL501 (0B5) 7-speed S tronic is the standard EU production pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic for all standard 3.0 TDI quattro variants throughout C7 lifecycle (2011-2014: 204/245 PS; 2014-2018: 190/218/272 PS). Engine codes CGLD/CFGC/CKVB (single-turbo, 150-176 kW). RATIO CORRECTIONS APPLIED: top gear 0.68 -> 0.519 (DL501 7th gear per Audi workshop manual, also matches shard's own Wave 17 verification_notes); final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material - the DL501 in A6 C7 quattro uses split AWD reductions, not a single FD value, and 3.444 was incorrect for either axle. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-        "value": 0.519,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 (C7) 3.0 TDI quattro single-turbo + DL501 (0B5) 7-speed S tronic is the standard EU production pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic for all standard 3.0 TDI quattro variants throughout C7 lifecycle (2011-2014: 204/245 PS; 2014-2018: 190/218/272 PS). Engine codes CGLD/CFGC/CKVB (single-turbo, 150-176 kW). RATIO CORRECTIONS APPLIED: top gear 0.68 -> 0.519 (DL501 7th gear per Audi workshop manual, also matches shard's own Wave 17 verification_notes); final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material - the DL501 in A6 C7 quattro uses split AWD reductions, not a single FD value, and 3.444 was incorrect for either axle. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-        "value": 4.093,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 C7 quattro DL501 (0B5) uses split AWD reductions: 4.093 front / 4.111 rear per Audi 0B5 workshop manual. Replaces incorrect single 3.444 value.",
-        "value": 4.111,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "DCT7 (7-speed S tronic) is not standard for the EU A6 C7 2.0 TFSI",
+          "reason": "Audi A6 C7 (2011-2018) EU 2.0 TFSI was sold with 6-speed manual or multitronic CVT for the 132 kW and 155 kW states; the 7-speed S tronic only appeared with the late C7.5 facelift 2.0 45 TFSI ultra (≈2016+). The broad 2011 row does not capture an EU-standard DCT7 2.0 TFSI.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide. Replaces incorrect 245/40 R19 family-default (which is a sport-spec mid-range option, not baseline).",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "audi-c7-2-0-tfsi-eu-2011-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n6",
+        "value": "FWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "0B5 7-speed S tronic full forward gear ratio set (gears 1-6) for the C7 3.0 TDI quattro",
-        "reason": "Wave 17 Audi workshop-manual material recovered only 7th gear (0.519) and reverse (2.944) plus split AWD axle reductions 4.093 front / 4.111 rear for the EU 0B5 application; the complete 1st-6th gear ratio set was not recovered in any reviewed pass and remains unmapped to the broad-row schema.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c7-3-0-tdi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
       ],
-      "notes": "Audi A6 (C7) 3.0 BiTDI quattro + ZF 8HP (0BK / 8HP50) confirmed by Wikipedia A6 C7 transmissions table: 8-speed Tiptronic exclusively for '3.0 TDI quattro (313 PS, 320 PS, 326 PS)' - the BiTDI product (engine code CDUD, 230 kW). UK-market labelling: '3.0 BiTDI quattro'. SCOPE NOTE: this row's engine_code '3.0L' is ambiguous and conflates single-turbo (CGLD/CFGC/CKVB - paired with DL501 in Row 2) with biturbo (CDUD - paired with ZF 8HP only here); the row should be read as BiTDI sub-variant only. Top gear 0.667 plausible for ZF8HP50 8th gear (standard HP50 ratio set). Final drive 3.077 plausible for ZF 8HP applications on MLB-platform A6/A7/A8 family - both unconfirmed from A6 C7 BiTDI specific official tech data. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A6 (C7) 3.0 BiTDI quattro + ZF 8HP (0BK / 8HP50) confirmed by Wikipedia A6 C7 transmissions table: 8-speed Tiptronic exclusively for '3.0 TDI quattro (313 PS, 320 PS, 326 PS)' - the BiTDI product (engine code CDUD, 230 kW). UK-market labelling: '3.0 BiTDI quattro'. SCOPE NOTE: this row's engine_code '3.0L' is ambiguous and conflates single-turbo (CGLD/CFGC/CKVB - paired with DL501 in Row 2) with biturbo (CDUD - paired with ZF 8HP only here); the row should be read as BiTDI sub-variant only. Top gear 0.667 plausible for ZF8HP50 8th gear (standard HP50 ratio set). Final drive 3.077 plausible for ZF 8HP applications on MLB-platform A6/A7/A8 family - both unconfirmed from A6 C7 BiTDI specific official tech data. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.667 plausible for ZF8HP50 8th gear standard HP50 ratio set, but unverified for A6 C7 BiTDI specific application.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.077 plausible for ZF 8HP on MLB A6/A7/A8 family but unverified for A6 C7 BiTDI specific.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive rear 3.077 inherited; unverified.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is not an EU-market option on the A6 C7 2.0 TFSI",
+          "reason": "The 8-speed tiptronic 2.0 TFSI A6 C7 is associated with the China-market A6L (long-wheelbase) allocation, not with the EU-DE Sedan/Avant. No checked official Audi material places the ZF 8HP into the EU FWD 2.0 TFSI A6 C7 lineup.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-c7-3-0-tdi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n9",
+        "value": "AWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n9",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n9",
+          "value": 0.519,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n9",
+          "value": 4.093,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Audi A6 C7 quattro DL501 (0B5) uses split AWD reductions: 4.093 front / 4.111 rear per Audi 0B5 workshop manual. Replaces incorrect single 3.444 value.",
+          "value": 4.111,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide. Replaces incorrect 245/40 R19 family-default (which is a sport-spec mid-range option, not baseline).",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "0B5 7-speed S tronic full forward gear ratio set (gears 1-6) for the C7 3.0 TDI quattro",
+          "reason": "Wave 17 Audi workshop-manual material recovered only 7th gear (0.519) and reverse (2.944) plus split AWD axle reductions 4.093 front / 4.111 rear for the EU 0B5 application; the complete 1st-6th gear ratio set was not recovered in any reviewed pass and remains unmapped to the broad-row schema.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-c7-3-0-tdi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n14",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n14",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.667 plausible for ZF8HP50 8th gear standard HP50 ratio set, but unverified for A6 C7 BiTDI specific application.",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.077 plausible for ZF 8HP on MLB A6/A7/A8 family but unverified for A6 C7 BiTDI specific.",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive rear 3.077 inherited; unverified.",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is not standard for the EU A6 C7 3.0 TDI quattro (150-200 kW)",
+          "reason": "Audi allocated the 8-speed tiptronic only to the high-power 3.0 BiTDI quattro (313-326 PS / 230-240 kW) sold in the UK as 3.0 BiTDI; the standard EU 3.0 TDI quattro (150/180 kW pre-facelift, 140/160/200 kW post-facelift) ran the 0B5 7-speed S tronic across the full C7 production span. The broad ZF 8HP row does not match any standard EU 3.0 TDI quattro variant.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-c7-3-0-tfsi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n10",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n10",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n10",
+          "value": 0.519,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n10",
+          "value": 4.093,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Audi A6 C7 quattro DL501 (0B5) split AWD reductions: 4.093 front / 4.111 rear per Audi 0B5 workshop manual.",
+          "value": 4.111,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide. Replaces incorrect 245/40 R19.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "0B5 7-speed S tronic full forward gear ratio set (gears 1-6) and late-facelift 245 kW EU-DE gearbox confirmation",
+          "reason": "Wave 17 Audi workshop-manual material recovered 7th gear 0.519 and reverse 2.944 plus split AWD axle reductions 4.093 front / 4.111 rear for the early 220 kW and 228 kW EU sedan states only; an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan was not recovered and the complete 1st-6th gear ratio set is still unmapped.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-c7-3-0-tfsi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A6 (C7, 2011-2018)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n4",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is not standard for the EU A6 C7 3.0 TDI quattro (150-200 kW)",
-        "reason": "Audi allocated the 8-speed tiptronic only to the high-power 3.0 BiTDI quattro (313-326 PS / 230-240 kW) sold in the UK as 3.0 BiTDI; the standard EU 3.0 TDI quattro (150/180 kW pre-facelift, 140/160/200 kW post-facelift) ran the 0B5 7-speed S tronic across the full C7 production span. The broad ZF 8HP row does not match any standard EU 3.0 TDI quattro variant.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c7-3-0-tfsi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
       ],
-      "notes": "Audi A6 (C7) 3.0 TFSI supercharged V6 quattro + DL501 (0B5) 7-speed S tronic is the standard EU pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic as standard for 3.0 TFSI quattro (220 kW and 228 kW) EU/UK market. For the 228 kW saloon, Wikipedia explicitly notes: '7-speed S-Tronic is used in the UK model.' S6 C7 (4.0 TFSI biturbo, 309 kW) also uses DL501, confirming the gearbox family. RATIO CORRECTIONS (identical to Row 2): top gear 0.68 -> 0.519; final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide. Note: post-LCI 245 kW state (CREC/CVWA, 2014+) has high probability of retaining 0B5 but is not independently confirmed in current source pack.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi A6 (C7) 3.0 TFSI supercharged V6 quattro + DL501 (0B5) 7-speed S tronic is the standard EU pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic as standard for 3.0 TFSI quattro (220 kW and 228 kW) EU/UK market. For the 228 kW saloon, Wikipedia explicitly notes: '7-speed S-Tronic is used in the UK model.' S6 C7 (4.0 TFSI biturbo, 309 kW) also uses DL501, confirming the gearbox family. RATIO CORRECTIONS (identical to Row 2): top gear 0.68 -> 0.519; final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide. Note: post-LCI 245 kW state (CREC/CVWA, 2014+) has high probability of retaining 0B5 but is not independently confirmed in current source pack.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 (C7) 3.0 TFSI supercharged V6 quattro + DL501 (0B5) 7-speed S tronic is the standard EU pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic as standard for 3.0 TFSI quattro (220 kW and 228 kW) EU/UK market. For the 228 kW saloon, Wikipedia explicitly notes: '7-speed S-Tronic is used in the UK model.' S6 C7 (4.0 TFSI biturbo, 309 kW) also uses DL501, confirming the gearbox family. RATIO CORRECTIONS (identical to Row 2): top gear 0.68 -> 0.519; final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide. Note: post-LCI 245 kW state (CREC/CVWA, 2014+) has high probability of retaining 0B5 but is not independently confirmed in current source pack.",
-        "value": 0.519,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 (C7) 3.0 TFSI supercharged V6 quattro + DL501 (0B5) 7-speed S tronic is the standard EU pairing. Wikipedia A6 C7 transmissions table confirms 7-speed S tronic as standard for 3.0 TFSI quattro (220 kW and 228 kW) EU/UK market. For the 228 kW saloon, Wikipedia explicitly notes: '7-speed S-Tronic is used in the UK model.' S6 C7 (4.0 TFSI biturbo, 309 kW) also uses DL501, confirming the gearbox family. RATIO CORRECTIONS (identical to Row 2): top gear 0.68 -> 0.519; final drives 3.444 -> 4.093 (front) / 4.111 (rear) per Audi 0B5 workshop-manual material. TIRE CORRECTION: 245/40 R19 -> 225/55 R17 per Audi A6 C7 EU wheel/tyre guide. Note: post-LCI 245 kW state (CREC/CVWA, 2014+) has high probability of retaining 0B5 but is not independently confirmed in current source pack.",
-        "value": 4.093,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Audi A6 C7 quattro DL501 (0B5) split AWD reductions: 4.093 front / 4.111 rear per Audi 0B5 workshop manual.",
-        "value": 4.111,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "Audi A6 C7 EU baseline tyre 225/55 R17 per Audi wheel/tyre guide. Replaces incorrect 245/40 R19.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
+          "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
+          "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
+          "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "ZF 8HP (8-speed tiptronic) is a US/Canada/South Korea allocation for the A6 C7 3.0 TFSI quattro, not EU-DE",
+          "reason": "Wave 17 official Audi workshop-manual material in C7.json verification_notes records that the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan is marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The broad EU ZF 8HP 3.0 TFSI quattro row is therefore unsupported.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "0B5 7-speed S tronic full forward gear ratio set (gears 1-6) and late-facelift 245 kW EU-DE gearbox confirmation",
-        "reason": "Wave 17 Audi workshop-manual material recovered 7th gear 0.519 and reverse 2.944 plus split AWD axle reductions 4.093 front / 4.111 rear for the early 220 kW and 228 kW EU sedan states only; an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan was not recovered and the complete 1st-6th gear ratio set is still unmapped.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c7-3-0-tfsi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A6 (C7, 2011-2018)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
       ],
-      "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-a6-c7-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ],
-        "notes": "PHANTOM ROW for EU market. The ZF 8HP (Audi 0BK) + 3.0 TFSI quattro combination is a USDM/Canada/South Korea allocation only - the EU/UK A6 C7 3.0 TFSI quattro uses DL501 7-speed S tronic instead (see Row 4). Wikipedia A6 C7 transmissions table: '8-speed Tiptronic is used in the US, Canada models' for the 3.0 TFSI quattro 310 PS saloon - no EU/UK entry. Audi workshop-manual material records the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan as marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The combination exists in production but not for the EU market covered by this shard.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07f701f57e44",
-            "legacy_research_sources:3bd8ca8fa320",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7a80724d8596",
-            "legacy_research_sources:92623d6bbb03",
-            "legacy_research_sources:9fe846420ccb",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:e0ba5607333f",
-            "legacy_research_sources:f7b0bdd3aad4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 checked the exact Audi A6 C7 3.0 TFSI quattro target and still did not recover one production-safe year-spanning EU-DE gearbox mapping. Official Audi workshop-manual material allocates the early 220 kW and 228 kW A6 sedan to the 7-speed dual-clutch gearbox 0B5 (S tronic) with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 front / 4.111 rear, while the only checked official 0BK 8-speed automatic allocation for the 228 kW car is marked USA/Canada/South Korea rather than EU-DE. Official Audi wheel/tyre guide material also points to 225/55 R17 baseline tires with 245/45 R18, 255/40 R19, and 255/35 R20 options for the checked 220/228/245 kW sedan states, contradicting the current broad-row 19/20/21-inch defaults. Production JSON remains unchanged because this pass did not recover an exact late-facelift EU-DE gearbox-code and ratio package, and the current schema cannot safely collapse split AWD reductions plus year/power-state variation into one broad-row final-drive mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-a6-c7-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe gearbox and ratio mapping across the represented row span",
-        "reason": "Official early EU-family material proves 0B5 S tronic with 7th gear 0.519, reverse 2.944, and split AWD axle reductions 4.093 / 4.111 for the 220 kW and 228 kW states, but this pass did not recover an exact late-facelift EU-DE document proving the same gearbox family or ratio package for the later 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro exact facelift EU-DE gearbox code and numeric ratio set",
-        "reason": "Checked official Audi material establishes the early 0B5 S tronic mapping and shows that the recovered 0BK automatic allocation belongs to non-EU markets, but this pass did not recover an exact Audi Germany-market facelift technical-data or workshop allocation sheet for the 245 kW sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "Audi A6 C7 3.0 TFSI quattro one production-safe final-drive representation",
-        "reason": "The early official 0B5 source publishes split AWD axle reductions rather than one simple final-drive number, and the current schema cannot safely encode that together with unresolved late-facelift mapping in one broad sedan row.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:92623d6bbb03",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      },
-      {
-        "item": "ZF 8HP (8-speed tiptronic) is a US/Canada/South Korea allocation for the A6 C7 3.0 TFSI quattro, not EU-DE",
-        "reason": "Wave 17 official Audi workshop-manual material in C7.json verification_notes records that the only checked 0BK 8-speed automatic allocation for the 228 kW A6 sedan is marked USA/Canada/South Korea, while the EU-DE 220 kW and 228 kW states ran 0B5 7-speed S tronic. The broad EU ZF 8HP 3.0 TFSI quattro row is therefore unsupported.",
-        "evidence_refs": [
-          "legacy_research_sources:07f701f57e44",
-          "legacy_research_sources:3bd8ca8fa320",
-          "legacy_research_sources:7a80724d8596",
-          "legacy_research_sources:9fe846420ccb",
-          "legacy_research_sources:e0ba5607333f",
-          "legacy_research_sources:f7b0bdd3aad4"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C8.json
@@ -1,570 +1,405 @@
-[
-  {
-    "id": "audi-c8-40-tfsi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "A6 (C8, 2019-2025)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.564
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market technical-data sheets now confirm late-C8 exact mappings for the A6 Sedan 45 TFSI quattro and 55 TFSI quattro: quattro ultra AWD, 7-speed S tronic, final drive 4.410, exact forward ratios, and base tires 225/60 R17 (45 TFSI quattro) or 225/55 R18 (55 TFSI quattro). The broad A6 row remains unchanged because checked exact evidence is late-cycle only, the row spans multiple year and output states, and this pass did not prove one shared gearbox and tire package across the full 2019-2026 variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 45 TFSI quattro production-data applicability across the full C8 row span",
-        "reason": "Checked exact 2024 Germany-market evidence resolves the late-cycle 195 kW 45 TFSI quattro ratio and basic-tire mapping, but this pass did not recover an earlier exact 180 kW or launch-era technical-data sheet that proves the same package across the full 2019-2026 span.",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ]
-      },
-      {
-        "item": "Audi A6 55 TFSI quattro production-data applicability across the full C8 row span",
-        "reason": "Checked exact 2024 Germany-market evidence resolves the late-cycle 250 kW 55 TFSI quattro mapping, but a related 2026-era official sedan sheet already changes the upper ratios, so a broad-row overwrite would be unsafe without a proven year split.",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ]
-      },
-      {
-        "item": "Audi A6 exact transmission-code and optional tire-matrix confirmation",
-        "reason": "Official Audi sheets prove the 7-speed S tronic wording, full ratio sets, and basic tires for the checked exact variants, but they do not publish the transmission code or the full optional wheel and tire matrix.",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c8-45-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "A6 (C8, 2019-2025)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:01c00967f62a",
+        "legacy_research_sources:07cc5dc911b9",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:720a93990098",
+        "legacy_research_sources:876c20c63603",
+        "legacy_research_sources:e4992bd8c221",
+        "legacy_research_sources:edd605c5ca47",
+        "legacy_research_sources:f83cdba50e26"
+      ],
+      "e2": [
         "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf"
       ],
-      "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 45 TFSI quattro technical-data material confirms quattro ultra AWD for the checked late-C8 195 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf"
+      "e3": [
+        "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf"
       ],
-      "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 45 TFSI quattro technical-data material confirms the 7-speed S tronic transmission wording for the checked late-C8 195 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-        "value": 3.564
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-        "value": 3.564
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2024 195 kW S tronic state) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
+      "e4": [
+        "audi_mediacenter_sources:c8-a6-until-2025-model-page",
+        "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf",
+        "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:c8-a6-until-2025-model-page",
+        "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf",
+        "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter old-line A6 Sedan material scopes this exact 45 TFSI quattro row to the 2019-2025 pre-successor sedan. The 2024 exact technical-data sheet confirms the checked late-cycle 195 kW state uses quattro ultra AWD, 7-speed S tronic, 4.410 final drive, the 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 ratio set, and 225/60 R17 basic tires, but this pass did not recover an earlier exact 180 kW or launch-era sheet proving one unchanged numeric package across the full retimed row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 45 TFSI quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
-        "reason": "The checked 2024 technical-data sheet resolves the late-cycle 195 kW 45 TFSI quattro package, but this pass did not recover an earlier exact 180 kW or launch-era A6 Sedan sheet proving one unchanged numeric mapping across the full old-line row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
-        ]
-      },
-      {
-        "item": "Audi A6 45 TFSI quattro exact transmission-code and optional tire-matrix confirmation",
-        "reason": "Official Audi exact material proves the 7-speed S tronic wording and 225/60 R17 basic tires for the checked late-cycle sedan state, but it does not publish the transmission family code or a full optional wheel/tire matrix.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-c8-55-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "A6 (C8, 2019-2025)",
-    "variant_name": "55 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 55 TFSI quattro technical-data material confirms quattro ultra AWD for the checked late-C8 250 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 55 TFSI quattro technical-data material confirms the 7-speed S tronic transmission wording for the checked late-C8 250 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-        "value": 0.725
+  "configurations": [
+    {
+      "id": "audi-c8-40-tfsi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "A6 (C8, 2019-2025)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-        "value": 3.564
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-        "value": 3.564
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:01c00967f62a",
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:720a93990098",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:e4992bd8c221",
-          "legacy_research_sources:edd605c5ca47",
-          "legacy_research_sources:f83cdba50e26"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.564
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01c00967f62a",
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:720a93990098",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:e4992bd8c221",
-            "legacy_research_sources:edd605c5ca47",
-            "legacy_research_sources:f83cdba50e26"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact current 250 kW tiptronic state) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter old-line A6 Sedan material scopes this exact 55 TFSI quattro row to the 2019-2025 pre-successor sedan. The 2024 exact technical-data sheet confirms the checked late-cycle 250 kW state uses quattro ultra AWD, 7-speed S tronic, 4.410 final drive, the 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 ratio set, and 225/55 R18 basic tires, but this pass did not recover an earlier exact A6 Sedan sheet proving one unchanged numeric package across the full retimed row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A6 55 TFSI quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
-        "reason": "The checked 2024 technical-data sheet resolves the late-cycle 250 kW 55 TFSI quattro package, but this pass did not recover an earlier exact A6 Sedan sheet proving one unchanged numeric mapping across the full old-line row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a6-2025-new-sedan-release"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
         ]
       },
-      {
-        "item": "Audi A6 55 TFSI quattro exact transmission-code and optional tire-matrix confirmation",
-        "reason": "Official Audi exact material proves the 7-speed S tronic wording and 225/55 R18 basic tires for the checked late-cycle sedan state, but it does not publish the transmission family code or a full optional wheel/tire matrix.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a6-55-tfsi-quattro-2024-tech-data-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany-market technical-data sheets now confirm late-C8 exact mappings for the A6 Sedan 45 TFSI quattro and 55 TFSI quattro: quattro ultra AWD, 7-speed S tronic, final drive 4.410, exact forward ratios, and base tires 225/60 R17 (45 TFSI quattro) or 225/55 R18 (55 TFSI quattro). The broad A6 row remains unchanged because checked exact evidence is late-cycle only, the row spans multiple year and output states, and this pass did not prove one shared gearbox and tire package across the full 2019-2026 variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 45 TFSI quattro production-data applicability across the full C8 row span",
+          "reason": "Checked exact 2024 Germany-market evidence resolves the late-cycle 195 kW 45 TFSI quattro ratio and basic-tire mapping, but this pass did not recover an earlier exact 180 kW or launch-era technical-data sheet that proves the same package across the full 2019-2026 span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A6 55 TFSI quattro production-data applicability across the full C8 row span",
+          "reason": "Checked exact 2024 Germany-market evidence resolves the late-cycle 250 kW 55 TFSI quattro mapping, but a related 2026-era official sedan sheet already changes the upper ratios, so a broad-row overwrite would be unsafe without a proven year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A6 exact transmission-code and optional tire-matrix confirmation",
+          "reason": "Official Audi sheets prove the 7-speed S tronic wording, full ratio sets, and basic tires for the checked exact variants, but they do not publish the transmission code or the full optional wheel and tire matrix.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-c8-45-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "A6 (C8, 2019-2025)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 45 TFSI quattro technical-data material confirms quattro ultra AWD for the checked late-C8 195 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 45 TFSI quattro technical-data material confirms the 7-speed S tronic transmission wording for the checked late-C8 195 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.564
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.564
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter old-line A6 Sedan material scopes this exact 45 TFSI quattro row to the 2019-2025 pre-successor sedan. The 2024 exact technical-data sheet confirms the checked late-cycle 195 kW state uses quattro ultra AWD, 7-speed S tronic, 4.410 final drive, the 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 ratio set, and 225/60 R17 basic tires, but this pass did not recover an earlier exact 180 kW or launch-era sheet proving one unchanged numeric package across the full retimed row.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 45 TFSI quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
+          "reason": "The checked 2024 technical-data sheet resolves the late-cycle 195 kW 45 TFSI quattro package, but this pass did not recover an earlier exact 180 kW or launch-era A6 Sedan sheet proving one unchanged numeric mapping across the full old-line row.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi A6 45 TFSI quattro exact transmission-code and optional tire-matrix confirmation",
+          "reason": "Official Audi exact material proves the 7-speed S tronic wording and 225/60 R17 basic tires for the checked late-cycle sedan state, but it does not publish the transmission family code or a full optional wheel/tire matrix.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-c8-55-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "A6 (C8, 2019-2025)",
+      "variant_name": "55 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 55 TFSI quattro technical-data material confirms quattro ultra AWD for the checked late-C8 250 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Exact official Audi MediaCenter 2024 A6 Sedan 55 TFSI quattro technical-data material confirms the 7-speed S tronic transmission wording for the checked late-C8 250 kW sedan state, while earlier numeric continuity remains unresolved across the retimed 2019-2025 old-line row.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 3.564
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 3.564
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter old-line A6 Sedan material scopes this exact 55 TFSI quattro row to the 2019-2025 pre-successor sedan. The 2024 exact technical-data sheet confirms the checked late-cycle 250 kW state uses quattro ultra AWD, 7-speed S tronic, 4.410 final drive, the 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 ratio set, and 225/55 R18 basic tires, but this pass did not recover an earlier exact A6 Sedan sheet proving one unchanged numeric package across the full retimed row.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A6 55 TFSI quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
+          "reason": "The checked 2024 technical-data sheet resolves the late-cycle 250 kW 55 TFSI quattro package, but this pass did not recover an earlier exact A6 Sedan sheet proving one unchanged numeric mapping across the full old-line row.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Audi A6 55 TFSI quattro exact transmission-code and optional tire-matrix confirmation",
+          "reason": "Official Audi exact material proves the 7-speed S tronic wording and 225/55 R18 basic tires for the checked late-cycle sedan state, but it does not publish the transmission family code or a full optional wheel/tire matrix.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C7.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C7.json
@@ -1,21 +1,31 @@
-[
-  {
-    "id": "audi-c7-a7-3-0-tdi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A7 Sportback (C7, 2011-2018)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Wave 16 checked the exact A7 Sportback C7 3.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data or price-list sheet safe enough for production use. Official Audi OEM service books published via NHTSA do show a different MY2011 3.0 TFSI transmission mapping (0BK AWD with front ratio 2.848 and rear ratio 2.851) from the current broad-row 7-speed S tronic assumption, while reputable secondary exact pages consistently describe EU-style quattro S tronic states with 17- or 18-inch baseline tires instead of the current 20-inch default. Wave 17 adds exact launch-era official evidence for the diesel A7 Sportback 3.0 TDI quattro: Audi SSP 478 confirms the 180 kW / 245 PS launch car used S tronic quattro and that the A7 Sportback launched with 17-inch wheels standard and 18- to 20-inch wheels optional, but this still does not close exact EU-DE final-drive, top-gear, full-ratio, reverse-ratio, or year-split tire mapping for the diesel row. Production JSON remains unchanged because the checked evidence is still market- or year-mixed and does not prove one exact EU-DE ratio package for either the TFSI or TDI target.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:3aa04686acb7",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:56f41caeb63b",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:74a18a558949",
+        "legacy_research_sources:7e39fc533470",
+        "legacy_research_sources:824f56c4f3a7",
+        "legacy_research_sources:a1d14382bcee",
+        "legacy_research_sources:bbc34df1e9f3",
+        "legacy_research_sources:bdbd52866d52",
+        "legacy_research_sources:c00f0527a92d",
+        "legacy_research_sources:c143819cabc5",
+        "legacy_research_sources:ccacc2c59e31",
+        "legacy_research_sources:d0ef656899fb",
+        "legacy_research_sources:df617cc28562",
+        "legacy_research_sources:eac349833cc2"
+      ],
+      "e2": [
         "legacy_research_sources:3aa04686acb7",
         "legacy_research_sources:56f41caeb63b",
         "legacy_research_sources:824f56c4f3a7",
@@ -25,634 +35,285 @@
         "legacy_research_sources:ccacc2c59e31",
         "legacy_research_sources:d0ef656899fb",
         "legacy_research_sources:eac349833cc2"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.68
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 16 checked the exact A7 Sportback C7 3.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data or price-list sheet safe enough for production use. Official Audi OEM service books published via NHTSA do show a different MY2011 3.0 TFSI transmission mapping (0BK AWD with front ratio 2.848 and rear ratio 2.851) from the current broad-row 7-speed S tronic assumption, while reputable secondary exact pages consistently describe EU-style quattro S tronic states with 17- or 18-inch baseline tires instead of the current 20-inch default. Wave 17 adds exact launch-era official evidence for the diesel A7 Sportback 3.0 TDI quattro: Audi SSP 478 confirms the 180 kW / 245 PS launch car used S tronic quattro and that the A7 Sportback launched with 17-inch wheels standard and 18- to 20-inch wheels optional, but this still does not close exact EU-DE final-drive, top-gear, full-ratio, reverse-ratio, or year-split tire mapping for the diesel row. Production JSON remains unchanged because the checked evidence is still market- or year-mixed and does not prove one exact EU-DE ratio package for either the TFSI or TDI target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-DE official transmission mapping for Audi A7 Sportback C7 3.0 TFSI quattro",
-        "reason": "Official Audi OEM service books published via NHTSA show a MY2011 3.0 TFSI 0BK AWD automatic mapping, while reputable secondary EU-style pages describe 7-speed S tronic states, and this pass did not recover an exact Audi Germany-market technical-data or price-list document that resolves the market-specific transmission shape.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Exact EU-DE final drive, top gear, and full ratio confirmation for Audi A7 Sportback C7 3.0 TFSI quattro",
-        "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 3.0 TFSI quattro target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback C7 3.0 TFSI quattro exact tire-baseline and year-split continuity",
-        "reason": "Reputable secondary exact pages point to 255/45 R18 and 235/55 R17 or 255/45 R18 baseline tires for pre-facelift and facelift states, which contradicts the current 255/35 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Exact EU-DE official transmission and ratio mapping for Audi A7 Sportback C7 3.0 TDI quattro",
-        "reason": "Official Audi launch material proves only that the 180 kW / 245 PS diesel launch state used S tronic quattro and 17-inch standard wheels with 18- to 20-inch options, while this pass did not recover an exact Germany-market technical-data or workshop table publishing final drive, top gear, full ratios, or reverse for the diesel target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback C7 3.0 TDI quattro exact tire-baseline and year-split continuity",
-        "reason": "Launch-era official Audi evidence only closes the wheel-size policy, not the exact tire dimensions, and reputable secondary exact pages still disagree between 235/55 R17 and 255/45 R18 baseline tires across early and facelift diesel states.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-c7-a7-3-0-tfsi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C7",
-    "body_code": "C7",
-    "production_start_year": 2011,
-    "production_end_year": 2018,
-    "model_name": "A7 Sportback (C7, 2011-2018)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:3aa04686acb7",
-        "legacy_research_sources:56f41caeb63b",
-        "legacy_research_sources:824f56c4f3a7",
-        "legacy_research_sources:a1d14382bcee",
-        "legacy_research_sources:bbc34df1e9f3",
-        "legacy_research_sources:bdbd52866d52",
-        "legacy_research_sources:ccacc2c59e31",
-        "legacy_research_sources:d0ef656899fb",
-        "legacy_research_sources:eac349833cc2"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.68
+  "configurations": [
+    {
+      "id": "audi-c7-a7-3-0-tdi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A7 Sportback (C7, 2011-2018)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.68
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3aa04686acb7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:56f41caeb63b",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:74a18a558949",
-            "legacy_research_sources:7e39fc533470",
-            "legacy_research_sources:824f56c4f3a7",
-            "legacy_research_sources:a1d14382bcee",
-            "legacy_research_sources:bbc34df1e9f3",
-            "legacy_research_sources:bdbd52866d52",
-            "legacy_research_sources:c00f0527a92d",
-            "legacy_research_sources:c143819cabc5",
-            "legacy_research_sources:ccacc2c59e31",
-            "legacy_research_sources:d0ef656899fb",
-            "legacy_research_sources:df617cc28562",
-            "legacy_research_sources:eac349833cc2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-DE official transmission mapping for Audi A7 Sportback C7 3.0 TFSI quattro",
+          "reason": "Official Audi OEM service books published via NHTSA show a MY2011 3.0 TFSI 0BK AWD automatic mapping, while reputable secondary EU-style pages describe 7-speed S tronic states, and this pass did not recover an exact Audi Germany-market technical-data or price-list document that resolves the market-specific transmission shape.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact EU-DE final drive, top gear, and full ratio confirmation for Audi A7 Sportback C7 3.0 TFSI quattro",
+          "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 3.0 TFSI quattro target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback C7 3.0 TFSI quattro exact tire-baseline and year-split continuity",
+          "reason": "Reputable secondary exact pages point to 255/45 R18 and 235/55 R17 or 255/45 R18 baseline tires for pre-facelift and facelift states, which contradicts the current 255/35 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact EU-DE official transmission and ratio mapping for Audi A7 Sportback C7 3.0 TDI quattro",
+          "reason": "Official Audi launch material proves only that the 180 kW / 245 PS diesel launch state used S tronic quattro and 17-inch standard wheels with 18- to 20-inch options, while this pass did not recover an exact Germany-market technical-data or workshop table publishing final drive, top gear, full ratios, or reverse for the diesel target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback C7 3.0 TDI quattro exact tire-baseline and year-split continuity",
+          "reason": "Launch-era official Audi evidence only closes the wheel-size policy, not the exact tire dimensions, and reputable secondary exact pages still disagree between 235/55 R17 and 255/45 R18 baseline tires across early and facelift diesel states.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Wave 16 checked the exact A7 Sportback C7 3.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data or price-list sheet safe enough for production use. Official Audi OEM service books published via NHTSA do show a different MY2011 3.0 TFSI transmission mapping (0BK AWD with front ratio 2.848 and rear ratio 2.851) from the current broad-row 7-speed S tronic assumption, while reputable secondary exact pages consistently describe EU-style quattro S tronic states with 17- or 18-inch baseline tires instead of the current 20-inch default. Wave 17 adds exact launch-era official evidence for the diesel A7 Sportback 3.0 TDI quattro: Audi SSP 478 confirms the 180 kW / 245 PS launch car used S tronic quattro and that the A7 Sportback launched with 17-inch wheels standard and 18- to 20-inch wheels optional, but this still does not close exact EU-DE final-drive, top-gear, full-ratio, reverse-ratio, or year-split tire mapping for the diesel row. Production JSON remains unchanged because the checked evidence is still market- or year-mixed and does not prove one exact EU-DE ratio package for either the TFSI or TDI target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
+    {
+      "id": "audi-c7-a7-3-0-tfsi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C7",
+      "body_code": "C7",
+      "production_start_year": 2011,
+      "production_end_year": 2018,
+      "model_name": "A7 Sportback (C7, 2011-2018)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.68
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 35.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-DE official transmission mapping for Audi A7 Sportback C7 3.0 TFSI quattro",
+          "reason": "Official Audi OEM service books published via NHTSA show a MY2011 3.0 TFSI 0BK AWD automatic mapping, while reputable secondary EU-style pages describe 7-speed S tronic states, and this pass did not recover an exact Audi Germany-market technical-data or price-list document that resolves the market-specific transmission shape.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact EU-DE final drive, top gear, and full ratio confirmation for Audi A7 Sportback C7 3.0 TFSI quattro",
+          "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 3.0 TFSI quattro target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback C7 3.0 TFSI quattro exact tire-baseline and year-split continuity",
+          "reason": "Reputable secondary exact pages point to 255/45 R18 and 235/55 R17 or 255/45 R18 baseline tires for pre-facelift and facelift states, which contradicts the current 255/35 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact EU-DE official transmission and ratio mapping for Audi A7 Sportback C7 3.0 TDI quattro",
+          "reason": "Official Audi launch material proves only that the 180 kW / 245 PS diesel launch state used S tronic quattro and 17-inch standard wheels with 18- to 20-inch options, while this pass did not recover an exact Germany-market technical-data or workshop table publishing final drive, top gear, full ratios, or reverse for the diesel target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback C7 3.0 TDI quattro exact tire-baseline and year-split continuity",
+          "reason": "Launch-era official Audi evidence only closes the wheel-size policy, not the exact tire dimensions, and reputable secondary exact pages still disagree between 235/55 R17 and 255/45 R18 baseline tires across early and facelift diesel states.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-DE official transmission mapping for Audi A7 Sportback C7 3.0 TFSI quattro",
-        "reason": "Official Audi OEM service books published via NHTSA show a MY2011 3.0 TFSI 0BK AWD automatic mapping, while reputable secondary EU-style pages describe 7-speed S tronic states, and this pass did not recover an exact Audi Germany-market technical-data or price-list document that resolves the market-specific transmission shape.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Exact EU-DE final drive, top gear, and full ratio confirmation for Audi A7 Sportback C7 3.0 TFSI quattro",
-        "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 3.0 TFSI quattro target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback C7 3.0 TFSI quattro exact tire-baseline and year-split continuity",
-        "reason": "Reputable secondary exact pages point to 255/45 R18 and 235/55 R17 or 255/45 R18 baseline tires for pre-facelift and facelift states, which contradicts the current 255/35 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Exact EU-DE official transmission and ratio mapping for Audi A7 Sportback C7 3.0 TDI quattro",
-        "reason": "Official Audi launch material proves only that the 180 kW / 245 PS diesel launch state used S tronic quattro and 17-inch standard wheels with 18- to 20-inch options, while this pass did not recover an exact Germany-market technical-data or workshop table publishing final drive, top gear, full ratios, or reverse for the diesel target.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback C7 3.0 TDI quattro exact tire-baseline and year-split continuity",
-        "reason": "Launch-era official Audi evidence only closes the wheel-size policy, not the exact tire dimensions, and reputable secondary exact pages still disagree between 235/55 R17 and 255/45 R18 baseline tires across early and facelift diesel states.",
-        "evidence_refs": [
-          "legacy_research_sources:3aa04686acb7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:56f41caeb63b",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:74a18a558949",
-          "legacy_research_sources:7e39fc533470",
-          "legacy_research_sources:824f56c4f3a7",
-          "legacy_research_sources:a1d14382bcee",
-          "legacy_research_sources:bbc34df1e9f3",
-          "legacy_research_sources:bdbd52866d52",
-          "legacy_research_sources:c00f0527a92d",
-          "legacy_research_sources:c143819cabc5",
-          "legacy_research_sources:ccacc2c59e31",
-          "legacy_research_sources:d0ef656899fb",
-          "legacy_research_sources:df617cc28562",
-          "legacy_research_sources:eac349833cc2"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C8.json
@@ -1,419 +1,334 @@
-[
-  {
-    "id": "audi-c8-a7-45-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2018,
-    "production_end_year": 2025,
-    "model_name": "A7 Sportback (C8, 2018-2025)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Official Audi 2024 technical-data PDF publishes one populated final-drive value 4.410 for the exact A7 Sportback 55 TFSI quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n3": "Official Audi 2024 technical-data PDF lists 225/55 R18 on 8 J x 18 wheels as the basic package for the exact A7 Sportback 55 TFSI quattro S tronic state, and the official 2025 German price list confirms the same square 18-inch package in the A7 family wheel table."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:07cc5dc911b9",
+        "legacy_research_sources:441dcae0f8b9",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:876c20c63603",
+        "legacy_research_sources:8cfb64b90dee",
+        "legacy_research_sources:d1d0954039e3",
+        "legacy_research_sources:dded4fecb402"
+      ],
+      "e2": [
+        "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
+      ],
+      "e4": [
         "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
         "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
       ],
-      "notes": "Official Audi launch and technical-data material for the exact A7 Sportback 55 TFSI quattro confirm quattro all-wheel drive with ultra technology for this row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
-        "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Official Audi launch and technical-data material for the exact A7 Sportback 55 TFSI quattro confirm 7-speed S tronic wording and a hydraulically operated wet dual-clutch layout. The public source chain does not publish an internal gearbox family code beyond that wording.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e5": [
+        "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf",
+        "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-c8-a7-45-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2018,
+      "production_end_year": 2025,
+      "model_name": "A7 Sportback (C8, 2018-2025)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2024 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact A7 Sportback 55 TFSI quattro S tronic state.",
-        "value": 0.386
+        "evidence_refs_ref": "e4",
+        "notes": "Official Audi launch and technical-data material for the exact A7 Sportback 55 TFSI quattro confirm quattro all-wheel drive with ultra technology for this row.",
+        "value": "AWD"
       },
-      "gear_ratios": {
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact A7 Sportback 55 TFSI quattro S tronic state.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.508,
-          0.386
-        ]
+        "evidence_refs_ref": "e4",
+        "notes": "Official Audi launch and technical-data material for the exact A7 Sportback 55 TFSI quattro confirm 7-speed S tronic wording and a hydraulically operated wet dual-clutch layout. The public source chain does not publish an internal gearbox family code beyond that wording.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
       },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2024 technical-data PDF publishes one populated final-drive value 4.410 for the exact A7 Sportback 55 TFSI quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 4.41
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2024 technical-data PDF publishes one populated final-drive value 4.410 for the exact A7 Sportback 55 TFSI quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 4.41
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-        ],
-        "notes": "Official Audi 2024 technical-data PDF lists 225/55 R18 on 8 J x 18 wheels as the basic package for the exact A7 Sportback 55 TFSI quattro S tronic state, and the official 2025 German price list confirms the same square 18-inch package in the A7 family wheel table.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf",
-            "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-          ],
-          "notes": "Official Audi 2024 technical-data PDF lists 225/55 R18 on 8 J x 18 wheels as the basic package for the exact A7 Sportback 55 TFSI quattro S tronic state, and the official 2025 German price list confirms the same square 18-inch package in the A7 family wheel table.",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi 2024 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact A7 Sportback 55 TFSI quattro S tronic state.",
+          "value": 0.386
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi 2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact A7 Sportback 55 TFSI quattro S tronic state.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.508,
+            0.386
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "value": 4.41
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "value": 4.41
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-          ],
-          "notes": "Official Audi 2025 German price list shows an A7 family square 19-inch summer wheel package with 245/45 R19 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Square 19\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-          ],
-          "notes": "Official Audi 2025 German price list shows A7 family square 20-inch summer wheel packages with 255/40 R20 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "Official Audi 2025 German price list shows an A7 family square 19-inch summer wheel package with 245/45 R19 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Square 20\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-          ],
-          "notes": "Official Audi 2025 German price list shows A7 family square 21-inch summer wheel packages with 255/35 R21 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "Official Audi 2025 German price list shows A7 family square 20-inch summer wheel packages with 255/40 R20 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Square 21\""
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "Official Audi 2025 German price list shows A7 family square 21-inch summer wheel packages with 255/35 R21 tires. The checked wheel table is family-level for conventional A7 Sportback models rather than a dedicated 55 TFSI-only column.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 5 closes the exact A7 Sportback 55 TFSI quattro row with official Audi source material. The 2018 launch article explicitly names the A7 Sportback 55 TFSI quattro S tronic, says the model launches on the German market in early March 2018, and states that the 3.0 TFSI is paired with seven-speed S tronic and quattro ultra technology. The official 2024 technical-data PDF for the exact 55 TFSI quattro S tronic 250 kW state proves quattro AWD, wet-clutch 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 4.410, top speed 250 km/h, and basic 225/55 R18 tires. The official Audi model page scopes the family as until 2025, while the checked 2025 price list supports square 18-inch through 21-inch A7-family wheel packages without showing any staggered A7 setup.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:c8-a7-until-2025-model-page",
+            "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
+            "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 5 closes the exact A7 Sportback 55 TFSI quattro row with official Audi source material. The 2018 launch article explicitly names the A7 Sportback 55 TFSI quattro S tronic, says the model launches on the German market in early March 2018, and states that the 3.0 TFSI is paired with seven-speed S tronic and quattro ultra technology. The official 2024 technical-data PDF for the exact 55 TFSI quattro S tronic 250 kW state proves quattro AWD, wet-clutch 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 4.410, top speed 250 km/h, and basic 225/55 R18 tires. The official Audi model page scopes the family as until 2025, while the checked 2025 price list supports square 18-inch through 21-inch A7-family wheel packages without showing any staggered A7 setup.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A7 Sportback 55 TFSI quattro exact continuity beyond the checked 2018 launch and 2024/2025 source chain",
-        "reason": "The checked official Audi chain strongly supports the exact 55 TFSI quattro launch state from early 2018 and the old-line family scope until 2025, but this pass did not recover year-by-year technical-data sheets for every intermediate model year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-until-2025-model-page",
-          "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback 55 TFSI quattro exact transmission-code naming",
-        "reason": "Official Audi exact sources prove 7-speed S tronic wording and a wet dual-clutch layout, but they do not publish an internal gearbox family code beyond that market-facing name.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
-          "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback 55 TFSI quattro exact per-variant wheel matrix",
-        "reason": "The checked official 2025 Audi price list supports square 18-inch, 19-inch, 20-inch, and 21-inch A7-family wheel packages and shows no staggered A7 setup, but the wheel table is family-level rather than a dedicated 55 TFSI-only matrix.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:c8-a7-2025-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-c8-a7-55-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "A7 Sportback (C8, 2019-2026)",
-    "variant_name": "55 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.564
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.564
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
+          "item": "Audi A7 Sportback 55 TFSI quattro exact continuity beyond the checked 2018 launch and 2024/2025 source chain",
+          "reason": "The checked official Audi chain strongly supports the exact 55 TFSI quattro launch state from early 2018 and the old-line family scope until 2025, but this pass did not recover year-by-year technical-data sheets for every intermediate model year.",
           "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:441dcae0f8b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:8cfb64b90dee",
-            "legacy_research_sources:d1d0954039e3",
-            "legacy_research_sources:dded4fecb402"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+            "audi_mediacenter_sources:c8-a7-until-2025-model-page",
+            "audi_mediacenter_sources:c8-a7-2018-launch-subpage",
+            "audi_mediacenter_sources:c8-a7-55-tfsi-quattro-2024-tech-data-pdf"
+          ]
+        },
+        {
+          "item": "Audi A7 Sportback 55 TFSI quattro exact transmission-code naming",
+          "reason": "Official Audi exact sources prove 7-speed S tronic wording and a wet dual-clutch layout, but they do not publish an internal gearbox family code beyond that market-facing name.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi A7 Sportback 55 TFSI quattro exact per-variant wheel matrix",
+          "reason": "The checked official 2025 Audi price list supports square 18-inch, 19-inch, 20-inch, and 21-inch A7-family wheel packages and shows no staggered A7 setup, but the wheel table is family-level rather than a dedicated 55 TFSI-only matrix.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-c8-a7-55-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "A7 Sportback (C8, 2019-2026)",
+      "variant_name": "55 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.564
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.564
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany-market technical-data material now confirms late-cycle exact A7 Sportback mappings for both quattro variants: 45 TFSI quattro with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 4.410, and basic tire 225/55 R18; and 55 TFSI quattro with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.410, and the same 225/55 R18 basic tire. The broad A7 row remains unchanged because the checked exact evidence does not prove the same mappings across the full 2019-2026 span or across the shared 45/55 TFSI row.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:441dcae0f8b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:8cfb64b90dee",
-            "legacy_research_sources:d1d0954039e3",
-            "legacy_research_sources:dded4fecb402"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:441dcae0f8b9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:8cfb64b90dee",
-            "legacy_research_sources:d1d0954039e3",
-            "legacy_research_sources:dded4fecb402"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market technical-data material now confirms late-cycle exact A7 Sportback mappings for both quattro variants: 45 TFSI quattro with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 4.410, and basic tire 225/55 R18; and 55 TFSI quattro with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 4.410, and the same 225/55 R18 basic tire. The broad A7 row remains unchanged because the checked exact evidence does not prove the same mappings across the full 2019-2026 span or across the shared 45/55 TFSI row.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A7 Sportback 45 TFSI quattro production-data applicability across the full C8 row span",
+          "reason": "Checked exact Germany-market evidence resolves the late-cycle 195 kW 45 TFSI quattro mapping, but this pass did not recover a launch-year or 2026 technical-data sheet that proves the same package across the full 2019-2026 row span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback 55 TFSI quattro production-data applicability across the full C8 row span",
+          "reason": "Checked exact Germany-market evidence resolves the late-cycle 250 kW 55 TFSI quattro mapping, but this pass did not recover an exact 2019-era technical-data sheet proving the same package across the full 2019-2026 row span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Mixed 45/55 TFSI row applicability for exact A7 Sportback quattro data",
+          "reason": "The broad production row still mixes 45 TFSI quattro and 55 TFSI quattro variants, so the checked exact ratio and tire packages should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A7 Sportback exact transmission-code and optional tire-matrix confirmation",
+          "reason": "Official Audi exact material proves the 7-speed S tronic wording, full ratio sets, final drive 4.410, and the basic 225/55 R18 fitment, but it does not publish the transmission code or the full optional wheel and tire matrix.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A7 Sportback 45 TFSI quattro production-data applicability across the full C8 row span",
-        "reason": "Checked exact Germany-market evidence resolves the late-cycle 195 kW 45 TFSI quattro mapping, but this pass did not recover a launch-year or 2026 technical-data sheet that proves the same package across the full 2019-2026 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback 55 TFSI quattro production-data applicability across the full C8 row span",
-        "reason": "Checked exact Germany-market evidence resolves the late-cycle 250 kW 55 TFSI quattro mapping, but this pass did not recover an exact 2019-era technical-data sheet proving the same package across the full 2019-2026 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ]
-      },
-      {
-        "item": "Mixed 45/55 TFSI row applicability for exact A7 Sportback quattro data",
-        "reason": "The broad production row still mixes 45 TFSI quattro and 55 TFSI quattro variants, so the checked exact ratio and tire packages should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ]
-      },
-      {
-        "item": "Audi A7 Sportback exact transmission-code and optional tire-matrix confirmation",
-        "reason": "Official Audi exact material proves the 7-speed S tronic wording, full ratio sets, final drive 4.410, and the basic 225/55 R18 fitment, but it does not publish the transmission code or the full optional wheel and tire matrix.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:441dcae0f8b9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8cfb64b90dee",
-          "legacy_research_sources:d1d0954039e3",
-          "legacy_research_sources:dded4fecb402"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D4.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D4.json
@@ -1,430 +1,280 @@
-[
-  {
-    "id": "audi-d4-3-0-tfsi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D4",
-    "body_code": "D4",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "A8 (D4, 2011-2017)",
-    "variant_name": "3.0 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 Supercharged",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Wave 16 checked the exact A8 D4 4.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data sheet safe enough for production use. Official Audi source channels only confirmed broad A8 eight-speed tiptronic family context, while reputable secondary exact pages distinguish an early 420 PS state with 235/60 R17 tires from a later 435 PS state with 235/55 R18 tires, both contradicting the current 255/40 R20 default. Production JSON remains unchanged because no exact Audi Germany-market final-drive, top-gear, or full-ratio table was recovered.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:02178a0e9ad4",
+        "legacy_research_sources:0ec6aab6f4c9",
+        "legacy_research_sources:15a6aa30433c",
+        "legacy_research_sources:355f6e5e52f0",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:54c09ca62bf2",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:7688ab3c3d77",
+        "legacy_research_sources:b2aa53aedfdc",
+        "legacy_research_sources:bd452ec32ba7"
+      ],
+      "e2": [
         "legacy_research_sources:02178a0e9ad4",
         "legacy_research_sources:0ec6aab6f4c9",
         "legacy_research_sources:15a6aa30433c",
         "legacy_research_sources:355f6e5e52f0",
         "legacy_research_sources:b2aa53aedfdc",
         "legacy_research_sources:bd452ec32ba7"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 16 checked the exact A8 D4 4.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data sheet safe enough for production use. Official Audi source channels only confirmed broad A8 eight-speed tiptronic family context, while reputable secondary exact pages distinguish an early 420 PS state with 235/60 R17 tires from a later 435 PS state with 235/55 R18 tires, both contradicting the current 255/40 R20 default. Production JSON remains unchanged because no exact Audi Germany-market final-drive, top-gear, or full-ratio table was recovered.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-DE ratio mapping for Audi A8 D4 4.0 TFSI quattro",
-        "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 4.0 TFSI quattro target.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ]
-      },
-      {
-        "item": "Audi A8 D4 4.0 TFSI quattro exact tire-baseline and year-split continuity",
-        "reason": "Reputable secondary exact pages distinguish at least two 4.0 TFSI quattro states with 235/60 R17 and 235/55 R18 baseline tires, contradicting the current 255/40 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-d4-4-0-tfsi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D4",
-    "body_code": "D4",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "A8 (D4, 2011-2017)",
-    "variant_name": "4.0 TFSI quattro",
-    "engine_code": "4.0L",
-    "engine_name": "4.0L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:02178a0e9ad4",
-        "legacy_research_sources:0ec6aab6f4c9",
-        "legacy_research_sources:15a6aa30433c",
-        "legacy_research_sources:355f6e5e52f0",
-        "legacy_research_sources:b2aa53aedfdc",
-        "legacy_research_sources:bd452ec32ba7"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
+  "configurations": [
+    {
+      "id": "audi-d4-3-0-tfsi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D4",
+      "body_code": "D4",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "A8 (D4, 2011-2017)",
+      "variant_name": "3.0 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 Supercharged",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02178a0e9ad4",
-            "legacy_research_sources:0ec6aab6f4c9",
-            "legacy_research_sources:15a6aa30433c",
-            "legacy_research_sources:355f6e5e52f0",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:54c09ca62bf2",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7688ab3c3d77",
-            "legacy_research_sources:b2aa53aedfdc",
-            "legacy_research_sources:bd452ec32ba7"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-DE ratio mapping for Audi A8 D4 4.0 TFSI quattro",
+          "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 4.0 TFSI quattro target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A8 D4 4.0 TFSI quattro exact tire-baseline and year-split continuity",
+          "reason": "Reputable secondary exact pages distinguish at least two 4.0 TFSI quattro states with 235/60 R17 and 235/55 R18 baseline tires, contradicting the current 255/40 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Wave 16 checked the exact A8 D4 4.0 TFSI quattro target and still did not recover an exact EU-DE official technical-data sheet safe enough for production use. Official Audi source channels only confirmed broad A8 eight-speed tiptronic family context, while reputable secondary exact pages distinguish an early 420 PS state with 235/60 R17 tires from a later 435 PS state with 235/55 R18 tires, both contradicting the current 255/40 R20 default. Production JSON remains unchanged because no exact Audi Germany-market final-drive, top-gear, or full-ratio table was recovered.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
+    {
+      "id": "audi-d4-4-0-tfsi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D4",
+      "body_code": "D4",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "A8 (D4, 2011-2017)",
+      "variant_name": "4.0 TFSI quattro",
+      "engine_code": "4.0L",
+      "engine_name": "4.0L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-DE ratio mapping for Audi A8 D4 4.0 TFSI quattro",
+          "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 4.0 TFSI quattro target.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi A8 D4 4.0 TFSI quattro exact tire-baseline and year-split continuity",
+          "reason": "Reputable secondary exact pages distinguish at least two 4.0 TFSI quattro states with 235/60 R17 and 235/55 R18 baseline tires, contradicting the current 255/40 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-DE ratio mapping for Audi A8 D4 4.0 TFSI quattro",
-        "reason": "No checked Audi Germany-market official source in this pass published numeric final-drive, top-gear, or full-ratio fields for the exact 4.0 TFSI quattro target.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ]
-      },
-      {
-        "item": "Audi A8 D4 4.0 TFSI quattro exact tire-baseline and year-split continuity",
-        "reason": "Reputable secondary exact pages distinguish at least two 4.0 TFSI quattro states with 235/60 R17 and 235/55 R18 baseline tires, contradicting the current 255/40 R20 default, but this pass did not recover an exact official Germany-market tire matrix that proves one safe production baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:02178a0e9ad4",
-          "legacy_research_sources:0ec6aab6f4c9",
-          "legacy_research_sources:15a6aa30433c",
-          "legacy_research_sources:355f6e5e52f0",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:54c09ca62bf2",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7688ab3c3d77",
-          "legacy_research_sources:b2aa53aedfdc",
-          "legacy_research_sources:bd452ec32ba7"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D5.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D5.json
@@ -1,1251 +1,902 @@
-[
-  {
-    "id": "audi-d5-50-tfsi-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "50 TFSI",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n3": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
+      "n4": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
+      "n5": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
+      "n6": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
+      "n7": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n8": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact 2020 + current 360 kW states) with High confidence.",
+      "n9": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
+      "n10": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). Basic tires per eTD: 235/55 R18 on 8J×18 forged wheels.",
+      "n11": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
+      "n12": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. Basic tires per eTD: 255/45 R19 on 9J×19 cast aluminium flow-forming wheels.",
+      "n13": "Batch 4 review replaces the mixed D5 petrol/PHEV family note with row-specific Audi MediaCenter evidence for the facelift-era A8 60 TFSI e quattro tiptronic state. The checked 12/15/2025 technical-data PDF proves permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and basic 255/45 R19 tires. The 2021 enhanced A8 launch release confirms the facelift-era 60 TFSI e quattro is in the range and the MY2026 price list keeps it on sale, but production JSON remains unchanged because this pass did not recover launch-era or year-spanning documents proving one exact 2018-2026 mapping."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:39e9836c4406",
+        "legacy_research_sources:3b7e4dcf4760",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:4c4a6ad675f8",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:7160abc38bb3",
+        "legacy_research_sources:b20cb3ff78c5",
+        "legacy_research_sources:bd797ac39b22",
+        "legacy_research_sources:c2eafaaa3bb4",
+        "legacy_research_sources:e2310c408b54",
+        "legacy_research_sources:ed5679233d8c",
+        "legacy_research_sources:fc9d1c242093"
+      ],
+      "e2": [
+        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
+        "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+      ],
+      "e9": [
         "legacy_research_sources:b20cb3ff78c5",
         "legacy_research_sources:bd797ac39b22",
         "legacy_research_sources:c2eafaaa3bb4"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.848
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.848
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:39e9836c4406",
-          "legacy_research_sources:3b7e4dcf4760",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4c4a6ad675f8",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7160abc38bb3",
-          "legacy_research_sources:b20cb3ff78c5",
-          "legacy_research_sources:bd797ac39b22",
-          "legacy_research_sources:c2eafaaa3bb4",
-          "legacy_research_sources:e2310c408b54",
-          "legacy_research_sources:ed5679233d8c",
-          "legacy_research_sources:fc9d1c242093"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review checked adjacent official Germany-market D5 petrol material while cleaning the exact 55 TFSI and 60 TFSI e rows. The checked late-cycle technical-data PDFs and MY2026 price list resolve the petrol range to 55 TFSI quattro, but this pass did not recover an exact Germany-market A8 50 TFSI technical-data or price-list row, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Germany-market Audi A8 50 TFSI mapping",
-        "reason": "The checked late-cycle official Germany-market source chain did not recover an exact A8 50 TFSI technical-data sheet or price-list row for this represented configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 50 TFSI represented-row drivetrain, ratio, and tire applicability",
-        "reason": "Without an exact Germany-market 50 TFSI source for the represented row, the inherited AWD, 8-speed tiptronic, ratio, and tire data remain unresolved and should not be promoted from family-default assumptions.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 50 TFSI petrol is China-market only; no EU/Germany variant exists",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) explicitly states: 'The 3.0 TFSI powers the Audi A8 55 TFSI quattro and the A8 L 55 TFSI quattro with 250 kW (340 PS). A variant with 210 kW (286 PS) is available in China.' No A8 50 TFSI eTD PDF exists on the Audi MediaCenter for any market other than China; the EU/Germany petrol range for the D5 is the 55 TFSI quattro only. This row should be removed from EU scope or re-filed under market: CN.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-d5-50-tfsi-quattro-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "50 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "legacy_research_sources:b20cb3ff78c5",
-        "legacy_research_sources:bd797ac39b22",
-        "legacy_research_sources:c2eafaaa3bb4"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Drivetrain confidence downgraded: there is no EU A8 50 TFSI quattro, so the legacy press-release citation does not apply to this row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 2.848
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:39e9836c4406",
-          "legacy_research_sources:3b7e4dcf4760",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4c4a6ad675f8",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7160abc38bb3",
-          "legacy_research_sources:b20cb3ff78c5",
-          "legacy_research_sources:bd797ac39b22",
-          "legacy_research_sources:c2eafaaa3bb4",
-          "legacy_research_sources:e2310c408b54",
-          "legacy_research_sources:ed5679233d8c",
-          "legacy_research_sources:fc9d1c242093"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review checked adjacent official Germany-market D5 petrol material while cleaning the exact 55 TFSI and 60 TFSI e rows. The checked late-cycle technical-data PDFs and MY2026 price list resolve the petrol range to 55 TFSI quattro, but this pass did not recover an exact Germany-market A8 50 TFSI quattro technical-data or price-list row, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Germany-market Audi A8 50 TFSI quattro mapping",
-        "reason": "The checked late-cycle official Germany-market source chain did not recover an exact A8 50 TFSI quattro technical-data sheet or price-list row for this represented configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 50 TFSI quattro represented-row ratio and tire applicability",
-        "reason": "Without an exact Germany-market 50 TFSI quattro source for the represented row, the inherited 8-speed tiptronic, ratio, and tire data remain unresolved even though AWD is still carried from earlier legacy evidence.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 50 TFSI petrol is China-market only; no EU/Germany variant exists",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) explicitly states: 'The 3.0 TFSI powers the Audi A8 55 TFSI quattro and the A8 L 55 TFSI quattro with 250 kW (340 PS). A variant with 210 kW (286 PS) is available in China.' No A8 50 TFSI eTD PDF exists on the Audi MediaCenter for any market other than China; the EU/Germany petrol range for the D5 is the 55 TFSI quattro only. This row should be removed from EU scope or re-filed under market: CN.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-d5-55-tfsi-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "55 TFSI",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e10": [
+        "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
         "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
       ],
-      "notes": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
+      "e11": [
+        "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
+        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
       ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). Basic tires per eTD: 235/55 R18 on 8J×18 forged wheels.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
+      "e12": [
+        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
+        "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review replaces the mixed D5 petrol/PHEV family note with row-specific Audi MediaCenter evidence for the late-cycle A8 55 TFSI quattro tiptronic state. The checked 10/16/2024 and 10/23/2025 technical-data PDFs agree on permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and basic 235/55 R18 tires. The 2021 enhanced A8 launch release and MY2026 price list confirm the late-cycle 55 TFSI quattro naming and continued sale, but production JSON remains unchanged because this pass did not recover launch-era exact technical data proving that same mapping across the represented 2018-2026 AWD row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A8 55 TFSI AWD production-data applicability across the full D5 2018-2026 row span",
-        "reason": "The checked 2024 and 2025 Audi MediaCenter technical-data PDFs resolve a late-cycle exact 55 TFSI quattro state, but this pass did not recover launch-era technical-data sheets proving the same mapping across the represented 2018-2026 AWD row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Audi A8 55 TFSI AWD exact transmission-code and optional wheel/tire matrix coverage",
-        "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 235/55 R18 basic tire, but it does not publish a gearbox family code or a full exact optional wheel/tire matrix for the represented row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 55 TFSI AWD precise production-end timing",
-        "reason": "The checked MY2026 price list proves continued sale of the late-cycle 55 TFSI quattro state, but it does not by itself prove the exact production-stop date behind the current 2026 row end.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Variant name '55 TFSI' without quattro suffix does not match any official Audi badge",
-        "reason": "Audi MediaCenter eTD PDFs and the D5.5 launch press release consistently brand the EU/Germany A8 3.0 TFSI as 'A8 55 TFSI quattro'. No A8 55 TFSI without quattro is sold in the EU. The canonical EU petrol row is `audi-d5-55-tfsi-quattro-eu-2018-zf8hp-awd`.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-d5-55-tfsi-quattro-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "55 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-      ],
-      "notes": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged).",
-        "value": 0.667
+  "configurations": [
+    {
+      "id": "audi-d5-50-tfsi-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "50 TFSI",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-10-23) for A8 55 TFSI quattro tiptronic 250kW MHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 235/55 R18 (8J×18 forged). Basic tires per eTD: 235/55 R18 on 8J×18 forged wheels.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.848
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 review checked adjacent official Germany-market D5 petrol material while cleaning the exact 55 TFSI and 60 TFSI e rows. The checked late-cycle technical-data PDFs and MY2026 price list resolve the petrol range to 55 TFSI quattro, but this pass did not recover an exact Germany-market A8 50 TFSI technical-data or price-list row, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market material now confirms the late-cycle exact A8 55 TFSI quattro mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and a 235/55 R18 basic tire. Wave 14 also checks the exact 50 TFSI quattro target and finds that Germany-market search and facelift material resolve the petrol A8 to 55 TFSI quattro, while Audi explicitly describes the lower-output 210 kW 3.0 TFSI variant as China-only. Wave 15 adds exact official A8 60 TFSI e quattro facelift-era technical data showing AWD, 8-speed tiptronic, the same forward-ratio family, reverse 3.317, final drive 3.076, and a 255/45 R19 basic tire, but production JSON remains unchanged because this pass did not recover launch-era or year-spanning documents proving one exact 60 TFSI e mapping across the represented D5 row.",
-        "evidence_refs": [
-          "legacy_research_sources:39e9836c4406",
-          "legacy_research_sources:3b7e4dcf4760",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:4c4a6ad675f8",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:7160abc38bb3",
-          "legacy_research_sources:b20cb3ff78c5",
-          "legacy_research_sources:bd797ac39b22",
-          "legacy_research_sources:c2eafaaa3bb4",
-          "legacy_research_sources:e2310c408b54",
-          "legacy_research_sources:ed5679233d8c",
-          "legacy_research_sources:fc9d1c242093"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
-        "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
-        "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
-        "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-d5-60-tfsi-e-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "60 TFSI e",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
       ],
-      "notes": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. Basic tires per eTD: 255/45 R19 on 9J×19 cast aluminium flow-forming wheels.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Exact Germany-market Audi A8 50 TFSI mapping",
+          "reason": "The checked late-cycle official Germany-market source chain did not recover an exact A8 50 TFSI technical-data sheet or price-list row for this represented configuration.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi A8 50 TFSI represented-row drivetrain, ratio, and tire applicability",
+          "reason": "Without an exact Germany-market 50 TFSI source for the represented row, the inherited AWD, 8-speed tiptronic, ratio, and tire data remain unresolved and should not be promoted from family-default assumptions.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi A8 50 TFSI petrol is China-market only; no EU/Germany variant exists",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) explicitly states: 'The 3.0 TFSI powers the Audi A8 55 TFSI quattro and the A8 L 55 TFSI quattro with 250 kW (340 PS). A variant with 210 kW (286 PS) is available in China.' No A8 50 TFSI eTD PDF exists on the Audi MediaCenter for any market other than China; the EU/Germany petrol range for the D5 is the 55 TFSI quattro only. This row should be removed from EU scope or re-filed under market: CN.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-d5-50-tfsi-quattro-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "50 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e9",
+        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Drivetrain confidence downgraded: there is no EU A8 50 TFSI quattro, so the legacy press-release citation does not apply to this row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "notes_ref": "n2",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 2.848
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 2.848
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 review checked adjacent official Germany-market D5 petrol material while cleaning the exact 55 TFSI and 60 TFSI e rows. The checked late-cycle technical-data PDFs and MY2026 price list resolve the petrol range to 55 TFSI quattro, but this pass did not recover an exact Germany-market A8 50 TFSI quattro technical-data or price-list row, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review replaces the mixed D5 petrol/PHEV family note with row-specific Audi MediaCenter evidence for the facelift-era A8 60 TFSI e quattro tiptronic state. The checked 12/15/2025 technical-data PDF proves permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and basic 255/45 R19 tires. The 2021 enhanced A8 launch release confirms the facelift-era 60 TFSI e quattro is in the range and the MY2026 price list keeps it on sale, but production JSON remains unchanged because this pass did not recover launch-era or year-spanning documents proving one exact 2018-2026 mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
-        "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
-        "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
-        "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L PHEV.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Variant name '60 TFSI e' without quattro suffix does not match any official Audi badge",
-        "reason": "Audi MediaCenter eTD PDFs and the D5.5 launch press release consistently brand the EU/Germany A8 PHEV as 'A8 60 TFSI e quattro'. The canonical EU PHEV row is `audi-d5-60-tfsi-e-quattro-eu-2018-zf8hp-awd`.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-d5-60-tfsi-e-quattro-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "D5",
-    "body_code": "D5",
-    "production_start_year": 2018,
-    "production_end_year": 2026,
-    "model_name": "A8 (D5, 2018-2026)",
-    "variant_name": "60 TFSI e quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
       ],
-      "notes": "quattro permanent AWD with self-locking centre differential. Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. D5 petrol axle final drive ratio is 3.076 (single value front and rear).",
-        "value": 3.076
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDF (Germany programme, status 2025-12-15) for A8 60 TFSI e quattro tiptronic 340kW PHEV: 8-speed tiptronic (ZF 8HP), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, final drive 3.076, basic tires 255/45 R19 (9J×19 cast). System output 340 kW (462 PS); battery 17.9/14.4 kWh gross/net at 400V; combined EAER 52–58 km. Basic tires per eTD: 255/45 R19 on 9J×19 cast aluminium flow-forming wheels.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "family_default",
+          "item": "Exact Germany-market Audi A8 50 TFSI quattro mapping",
+          "reason": "The checked late-cycle official Germany-market source chain did not recover an exact A8 50 TFSI quattro technical-data sheet or price-list row for this represented configuration.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi A8 50 TFSI quattro represented-row ratio and tire applicability",
+          "reason": "Without an exact Germany-market 50 TFSI quattro source for the represented row, the inherited 8-speed tiptronic, ratio, and tire data remain unresolved even though AWD is still carried from earlier legacy evidence.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi A8 50 TFSI petrol is China-market only; no EU/Germany variant exists",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) explicitly states: 'The 3.0 TFSI powers the Audi A8 55 TFSI quattro and the A8 L 55 TFSI quattro with 250 kW (340 PS). A variant with 210 kW (286 PS) is available in China.' No A8 50 TFSI eTD PDF exists on the Audi MediaCenter for any market other than China; the EU/Germany petrol range for the D5 is the 55 TFSI quattro only. This row should be removed from EU scope or re-filed under market: CN.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-d5-55-tfsi-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "55 TFSI",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n9",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.076
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.076
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 review replaces the mixed D5 petrol/PHEV family note with row-specific Audi MediaCenter evidence for the late-cycle A8 55 TFSI quattro tiptronic state. The checked 10/16/2024 and 10/23/2025 technical-data PDFs agree on permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and basic 235/55 R18 tires. The 2021 enhanced A8 launch release and MY2026 price list confirm the late-cycle 55 TFSI quattro naming and continued sale, but production JSON remains unchanged because this pass did not recover launch-era exact technical data proving that same mapping across the represented 2018-2026 AWD row.",
           "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact 2020 + current 360 kW states) with High confidence.",
+            "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
+            "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
+            "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
+            "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A8 55 TFSI AWD production-data applicability across the full D5 2018-2026 row span",
+          "reason": "The checked 2024 and 2025 Audi MediaCenter technical-data PDFs resolve a late-cycle exact 55 TFSI quattro state, but this pass did not recover launch-era technical-data sheets proving the same mapping across the represented 2018-2026 AWD row.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:d5-a8-55-tfsi-2024-tech-data-pdf",
+            "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
+            "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
+          ]
+        },
+        {
+          "item": "Audi A8 55 TFSI AWD exact transmission-code and optional wheel/tire matrix coverage",
+          "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 235/55 R18 basic tire, but it does not publish a gearbox family code or a full exact optional wheel/tire matrix for the represented row.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi A8 55 TFSI AWD precise production-end timing",
+          "reason": "The checked MY2026 price list proves continued sale of the late-cycle 55 TFSI quattro state, but it does not by itself prove the exact production-stop date behind the current 2026 row end.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+          ]
+        },
+        {
+          "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Variant name '55 TFSI' without quattro suffix does not match any official Audi badge",
+          "reason": "Audi MediaCenter eTD PDFs and the D5.5 launch press release consistently brand the EU/Germany A8 3.0 TFSI as 'A8 55 TFSI quattro'. No A8 55 TFSI without quattro is sold in the EU. The canonical EU petrol row is `audi-d5-55-tfsi-quattro-eu-2018-zf8hp-awd`.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:d5-a8-55-tfsi-2025-tech-data-pdf",
+            "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
+          ]
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-d5-55-tfsi-quattro-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "55 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n9",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.076
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.076
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany-market material now confirms the late-cycle exact A8 55 TFSI quattro mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and a 235/55 R18 basic tire. Wave 14 also checks the exact 50 TFSI quattro target and finds that Germany-market search and facelift material resolve the petrol A8 to 55 TFSI quattro, while Audi explicitly describes the lower-output 210 kW 3.0 TFSI variant as China-only. Wave 15 adds exact official A8 60 TFSI e quattro facelift-era technical data showing AWD, 8-speed tiptronic, the same forward-ratio family, reverse 3.317, final drive 3.076, and a 255/45 R19 basic tire, but production JSON remains unchanged because this pass did not recover launch-era or year-spanning documents proving one exact 60 TFSI e mapping across the represented D5 row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
+          "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
+          "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
+          "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-d5-60-tfsi-e-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "60 TFSI e",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n11",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n5",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.076
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.076
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
+            "aspect_pct": 45.0,
+            "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact 2020 + current 360 kW states) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:39e9836c4406",
-            "legacy_research_sources:3b7e4dcf4760",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:4c4a6ad675f8",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:7160abc38bb3",
-            "legacy_research_sources:b20cb3ff78c5",
-            "legacy_research_sources:bd797ac39b22",
-            "legacy_research_sources:c2eafaaa3bb4",
-            "legacy_research_sources:e2310c408b54",
-            "legacy_research_sources:ed5679233d8c",
-            "legacy_research_sources:fc9d1c242093"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter technical data (exact 2020 + current 360 kW states) with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e12"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
+          "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
+          "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
+          "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L PHEV.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Variant name '60 TFSI e' without quattro suffix does not match any official Audi badge",
+          "reason": "Audi MediaCenter eTD PDFs and the D5.5 launch press release consistently brand the EU/Germany A8 PHEV as 'A8 60 TFSI e quattro'. The canonical EU PHEV row is `audi-d5-60-tfsi-e-quattro-eu-2018-zf8hp-awd`.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review replaces the mixed D5 petrol/PHEV family note with row-specific Audi MediaCenter evidence for the facelift-era A8 60 TFSI e quattro tiptronic state. The checked 12/15/2025 technical-data PDF proves permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.076, and basic 255/45 R19 tires. The 2021 enhanced A8 launch release confirms the facelift-era 60 TFSI e quattro is in the range and the MY2026 price list keeps it on sale, but production JSON remains unchanged because this pass did not recover launch-era or year-spanning documents proving one exact 2018-2026 mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
+    {
+      "id": "audi-d5-60-tfsi-e-quattro-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "D5",
+      "body_code": "D5",
+      "production_start_year": 2018,
+      "production_end_year": 2026,
+      "model_name": "A8 (D5, 2018-2026)",
+      "variant_name": "60 TFSI e quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n11",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n5",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.076
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.076
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n12",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 45.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
+          "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
+          "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
+          "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
+          "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L PHEV.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi A8 60 TFSI e quattro production-data applicability across the full D5 2018-2026 row span",
-        "reason": "The checked 2025 Audi MediaCenter technical-data PDF resolves a facelift-era exact 60 TFSI e quattro state, but this pass did not recover launch-era or year-spanning technical-data sheets proving one unchanged mapping across the current 2018-2026 row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro exact hybrid-module detail and optional wheel/tire matrix coverage",
-        "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording, the full ratio set, final drive 3.076, and the 255/45 R19 basic tire, but it does not publish a gearbox family code, the exact hybrid module layout, or a full exact optional wheel/tire matrix for the represented row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-60-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi A8 60 TFSI e quattro launch-era market naming continuity",
-        "reason": "The checked 2021 enhanced A8 launch release and MY2026 price list prove the facelift-era 60 TFSI e quattro state is in the range, but this pass did not recover a launch-era exact technical-data or price-list document tying that same naming and mechanical package back across the full current row span.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release",
-          "audi_mediacenter_sources:d5-a8-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "22-inch S line wheel option (275/30 R22) not confirmed by official D5.5 sources",
-        "reason": "The Audi MediaCenter D5.5 launch press release (2021-11-02) describes the wheel range as 18 to 21 inches; no official eTD or price list fetched in this run lists a 22-inch factory option for the A8/A8 L PHEV.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:d5-a8-2021-enhanced-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/e_tron_gt/J1.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/e_tron_gt/J1.json
@@ -1,340 +1,250 @@
-[
-  {
-    "id": "audi-j1-rs-e-tron-gt-eu-2022-ss1-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "J1",
-    "body_code": "J1",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "e-tron GT (J1, 2022-2026)",
-    "variant_name": "RS e-tron GT",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor (Performance)",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
+      "n3": "Issue #975 official-source review confirmed the EU BEV variant mapping for Audi e-tron GT J1: the supported base variant is `e-tron GT quattro`, and the standalone `e-tron GT` alias was removed from the car library. This pass adds exact Germany-market technical-data evidence for both the base e-tron GT quattro and the RS e-tron GT: base-car documents confirm AWD, 2-speed automatic wording, top speed 245 km/h, and basic staggered 225/55 R19 front + 275/45 R19 rear tires; RS documents confirm AWD, rear 2-speed architecture context, top speed 250 km/h, and basic staggered 245/45 R20 front + 285/40 R20 rear tires. The broad row remains unchanged because exact EV ratio mapping is axle-split or year-split and the current schema cannot safely encode those details."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:06e51bca96e0",
+        "legacy_research_sources:2a4116fbafbf",
+        "legacy_research_sources:48491b2f1f4e",
+        "legacy_research_sources:50f644eb8086",
+        "legacy_research_sources:9082383f872a",
+        "legacy_research_sources:ae91c7109615",
+        "legacy_research_sources:af6ef0d8b15a",
+        "legacy_research_sources:e6959b573c42"
+      ],
+      "e2": [
         "legacy_research_sources:2a4116fbafbf",
         "legacy_research_sources:50f644eb8086",
         "legacy_research_sources:9082383f872a"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-      "code": "SS1",
-      "name": "2-speed automatic (rear) / single-speed (front)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-        "value": 8.057
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-        "value": 8.057
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06e51bca96e0",
-            "legacy_research_sources:2a4116fbafbf",
-            "legacy_research_sources:48491b2f1f4e",
-            "legacy_research_sources:50f644eb8086",
-            "legacy_research_sources:9082383f872a",
-            "legacy_research_sources:ae91c7109615",
-            "legacy_research_sources:af6ef0d8b15a",
-            "legacy_research_sources:e6959b573c42"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06e51bca96e0",
-            "legacy_research_sources:2a4116fbafbf",
-            "legacy_research_sources:48491b2f1f4e",
-            "legacy_research_sources:50f644eb8086",
-            "legacy_research_sources:9082383f872a",
-            "legacy_research_sources:ae91c7109615",
-            "legacy_research_sources:af6ef0d8b15a",
-            "legacy_research_sources:e6959b573c42"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Issue #975 official-source review confirmed the EU BEV variant mapping for Audi e-tron GT J1: the supported base variant is `e-tron GT quattro`, and the standalone `e-tron GT` alias was removed from the car library. This pass adds exact Germany-market technical-data evidence for both the base e-tron GT quattro and the RS e-tron GT: base-car documents confirm AWD, 2-speed automatic wording, top speed 245 km/h, and basic staggered 225/55 R19 front + 275/45 R19 rear tires; RS documents confirm AWD, rear 2-speed architecture context, top speed 250 km/h, and basic staggered 245/45 R20 front + 285/40 R20 rear tires. The broad row remains unchanged because exact EV ratio mapping is axle-split or year-split and the current schema cannot safely encode those details.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi e-tron GT quattro exact axle reduction ratios and schema-safe top-gear mapping",
-        "reason": "Exact Germany-market base-car technical sheets confirm AWD, 2-speed automatic wording, top speed, and staggered tires, but the checked official sources did not publish a schema-safe single reduction-ratio or top-gear value for the base e-tron GT quattro.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ]
-      },
-      {
-        "item": "Audi RS e-tron GT axle-split ratio continuity and exact optional tire dimensions",
-        "reason": "Official Audi sources show the RS e-tron GT uses axle-split and rear-two-speed hardware, but the checked facelift/current technical sheets do not publish the same reduction-ratio detail as the 2022 launch material, and this pass did not recover exact official 21-inch tire dimensions.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-j1-e-tron-gt-quattro-eu-2022-ss1-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "J1",
-    "body_code": "J1",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "e-tron GT (J1, 2022-2026)",
-    "variant_name": "e-tron GT quattro",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:2a4116fbafbf",
-        "legacy_research_sources:50f644eb8086",
-        "legacy_research_sources:9082383f872a"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-      "code": "SS1",
-      "name": "2-speed automatic (rear) / single-speed (front)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-        "value": 1.0
+  "configurations": [
+    {
+      "id": "audi-j1-rs-e-tron-gt-eu-2022-ss1-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "J1",
+      "body_code": "J1",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "e-tron GT (J1, 2022-2026)",
+      "variant_name": "RS e-tron GT",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor (Performance)",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-        "value": 8.057
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "2-speed automatic (rear) / single-speed (front)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-        "value": 8.057
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06e51bca96e0",
-            "legacy_research_sources:2a4116fbafbf",
-            "legacy_research_sources:48491b2f1f4e",
-            "legacy_research_sources:50f644eb8086",
-            "legacy_research_sources:9082383f872a",
-            "legacy_research_sources:ae91c7109615",
-            "legacy_research_sources:af6ef0d8b15a",
-            "legacy_research_sources:e6959b573c42"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 8.057
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 8.057
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:06e51bca96e0",
-            "legacy_research_sources:2a4116fbafbf",
-            "legacy_research_sources:48491b2f1f4e",
-            "legacy_research_sources:50f644eb8086",
-            "legacy_research_sources:9082383f872a",
-            "legacy_research_sources:ae91c7109615",
-            "legacy_research_sources:af6ef0d8b15a",
-            "legacy_research_sources:e6959b573c42"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data / 2022 drive-event press PDF (exact 2024 + current states) with High confidence."
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi e-tron GT quattro exact axle reduction ratios and schema-safe top-gear mapping",
+          "reason": "Exact Germany-market base-car technical sheets confirm AWD, 2-speed automatic wording, top speed, and staggered tires, but the checked official sources did not publish a schema-safe single reduction-ratio or top-gear value for the base e-tron GT quattro.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi RS e-tron GT axle-split ratio continuity and exact optional tire dimensions",
+          "reason": "Official Audi sources show the RS e-tron GT uses axle-split and rear-two-speed hardware, but the checked facelift/current technical sheets do not publish the same reduction-ratio detail as the 2022 launch material, and this pass did not recover exact official 21-inch tire dimensions.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Issue #975 official-source review confirmed the EU BEV variant mapping for Audi e-tron GT J1: the supported base variant is `e-tron GT quattro`, and the standalone `e-tron GT` alias was removed from the car library. This pass adds exact Germany-market technical-data evidence for both the base e-tron GT quattro and the RS e-tron GT: base-car documents confirm AWD, 2-speed automatic wording, top speed 245 km/h, and basic staggered 225/55 R19 front + 275/45 R19 rear tires; RS documents confirm AWD, rear 2-speed architecture context, top speed 250 km/h, and basic staggered 245/45 R20 front + 285/40 R20 rear tires. The broad row remains unchanged because exact EV ratio mapping is axle-split or year-split and the current schema cannot safely encode those details.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
+    {
+      "id": "audi-j1-e-tron-gt-quattro-eu-2022-ss1-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "J1",
+      "body_code": "J1",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "e-tron GT (J1, 2022-2026)",
+      "variant_name": "e-tron GT quattro",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "SS1",
+        "name": "2-speed automatic (rear) / single-speed (front)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 8.057
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 8.057
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 265.0,
+            "aspect_pct": 35.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter Germany technical data (exact 2023 + 2026 states) with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi e-tron GT quattro exact axle reduction ratios and schema-safe top-gear mapping",
+          "reason": "Exact Germany-market base-car technical sheets confirm AWD, 2-speed automatic wording, top speed, and staggered tires, but the checked official sources did not publish a schema-safe single reduction-ratio or top-gear value for the base e-tron GT quattro.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi RS e-tron GT axle-split ratio continuity and exact optional tire dimensions",
+          "reason": "Official Audi sources show the RS e-tron GT uses axle-split and rear-two-speed hardware, but the checked facelift/current technical sheets do not publish the same reduction-ratio detail as the 2022 launch material, and this pass did not recover exact official 21-inch tire dimensions.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi e-tron GT quattro exact axle reduction ratios and schema-safe top-gear mapping",
-        "reason": "Exact Germany-market base-car technical sheets confirm AWD, 2-speed automatic wording, top speed, and staggered tires, but the checked official sources did not publish a schema-safe single reduction-ratio or top-gear value for the base e-tron GT quattro.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ]
-      },
-      {
-        "item": "Audi RS e-tron GT axle-split ratio continuity and exact optional tire dimensions",
-        "reason": "Official Audi sources show the RS e-tron GT uses axle-split and rear-two-speed hardware, but the checked facelift/current technical sheets do not publish the same reduction-ratio detail as the 2022 launch material, and this pass did not recover exact official 21-inch tire dimensions.",
-        "evidence_refs": [
-          "legacy_research_sources:06e51bca96e0",
-          "legacy_research_sources:2a4116fbafbf",
-          "legacy_research_sources:48491b2f1f4e",
-          "legacy_research_sources:50f644eb8086",
-          "legacy_research_sources:9082383f872a",
-          "legacy_research_sources:ae91c7109615",
-          "legacy_research_sources:af6ef0d8b15a",
-          "legacy_research_sources:e6959b573c42"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q2/GA.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q2/GA.json
@@ -1,714 +1,536 @@
-[
-  {
-    "id": "audi-ga-30-tfsi-eu-2017-mt6-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "GA",
-    "body_code": "GA",
-    "production_start_year": 2017,
-    "production_end_year": 2024,
-    "model_name": "Q2 (GA, 2017-2024)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Q2 GA all variants FWD as standard, AWD optional only on quattro derivatives (not in this scope).",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n3": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:3c0c0aa886bf",
+        "legacy_research_sources:3ff9cb8ff793",
+        "legacy_research_sources:44937c13793f",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:891a3906d052",
+        "legacy_research_sources:a24edcc340c2",
+        "legacy_research_sources:ae186108fea8",
+        "legacy_research_sources:e4d20bd4419f"
+      ],
+      "e2": [
         "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. 6-speed manual confirmed by Wikipedia Q2 powertrain table.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3c0c0aa886bf",
-          "legacy_research_sources:3ff9cb8ff793",
-          "legacy_research_sources:44937c13793f",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:891a3906d052",
-          "legacy_research_sources:a24edcc340c2",
-          "legacy_research_sources:ae186108fea8",
-          "legacy_research_sources:e4d20bd4419f"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 30 TFSI manual placeholder. The checked Spain 2020 technical sheet and the 02/04/2026 Audi MediaCenter Germany technical-data PDF both prove a front-wheel-drive 6-speed manual 30 TFSI state, but they publish materially different ratio and final-drive packages while both use 205/60 R16 baseline tires. Those official states contradict the inherited 0.840, 3.462, and 215/50 R17 carryover values and show that the broad EU 2017-2024 row overlaps multiple exact states, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q2 30 TFSI manual applicability across the represented EU 2017-2024 row span",
-        "reason": "The checked 2020 Spain and 2026 Germany official sheets both prove exact manual states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Represented-row manual ratio, final-drive, and tire applicability",
-        "reason": "The checked 2020 Spain and 2026 Germany official manual sheets disagree with each other and both contradict the inherited 0.840 top gear, 3.462 final drive, and 215/50 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-30-tfsi-2026-manual-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-ga-30-tfsi-eu-2017-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "GA",
-    "body_code": "GA",
-    "production_start_year": 2017,
-    "production_end_year": 2024,
-    "model_name": "Q2 (GA, 2017-2024)",
-    "variant_name": "30 TFSI",
-    "engine_code": "1.0L",
-    "engine_name": "1.0L I3 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Transmission code DQ200 (7-speed dry-clutch S tronic, 0AM/0CW) per VW Group engineering norms: 1.0 TFSI EA211 at 200 Nm is well within DQ200 250 Nm limit and is the textbook DQ200 application across MQB-A small-car platforms (Polo, Ibiza, A1, Q2). DQ381 (420-430 Nm wet-clutch) was prior repo label and is incorrect: DQ381 is used only above the DQ200 torque limit and replaced DQ250, not DQ200. Existing top_gear_ratio 0.725 and final_drive_front 4.769 are consistent with documented DQ200 1.0-TFSI ratios, so they remain plausible but require Audi MediaCenter tech-data PDF for official_exact confirmation.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
+      ],
+      "e3": [
+        "legacy_research_sources:4f1a7d2b9c0e",
+        "audi_mediacenter_sources:ga-q2-30-tfsi-2026-manual-tech-data-pdf"
+      ],
+      "e4": [
         "secondary_technical_sources:q2-ga-wikipedia",
         "secondary_technical_sources:vwgroup-dsg-wikipedia"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:ga-q2-model-page",
+        "legacy_research_sources:4f1a7d2b9c0e",
+        "legacy_research_sources:9a7c1e5d4b62"
+      ],
+      "e6": [
+        "legacy_research_sources:4f1a7d2b9c0e",
+        "audi_mediacenter_sources:ga-q2-35-tfsi-2026-manual-tech-data-pdf",
+        "legacy_research_sources:9a7c1e5d4b62"
+      ],
+      "e7": [
+        "legacy_research_sources:4f1a7d2b9c0e",
+        "audi_mediacenter_sources:ga-q2-35-tfsi-2026-s-tronic-tech-data-pdf",
+        "legacy_research_sources:9a7c1e5d4b62"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3c0c0aa886bf",
-          "legacy_research_sources:3ff9cb8ff793",
-          "legacy_research_sources:44937c13793f",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:891a3906d052",
-          "legacy_research_sources:a24edcc340c2",
-          "legacy_research_sources:ae186108fea8",
-          "legacy_research_sources:e4d20bd4419f"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific official Audi source-gap evidence for the broad Q2 30 TFSI S tronic placeholder. The recovered official packet closes Spain 2020 and Germany 2026 manual 30 TFSI states, but it does not recover any official 30 TFSI S tronic technical-data sheet. The checked Audi MediaCenter model page and the recovered Switzerland MY25 price list also do not safely close this broad automatic EU row, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:ga-q2-model-page",
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "legacy_research_sources:9a7c1e5d4b62"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi Q2 30 TFSI S tronic applicability across the represented EU 2017-2024 row span",
-        "reason": "The recovered official packet does not safely close a 30 TFSI S tronic row: the checked Audi MediaCenter model page does not expose a 30 TFSI S tronic sheet, the Spain 2020 technical packet does not include one, and the recovered Switzerland MY25 price list omits 30 TFSI entirely.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:ga-q2-model-page",
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "legacy_research_sources:9a7c1e5d4b62"
-        ]
-      },
-      {
-        "item": "Represented-row DCT7 ratio, final-drive, and tire applicability",
-        "reason": "Because no checked official 30 TFSI S tronic technical-data sheet was recovered for this row, the inherited 0.725 top gear, 4.769 final drive, and 215/50 R17 tire mapping remain unsupported broad-row carryover values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:ga-q2-model-page",
-          "legacy_research_sources:4f1a7d2b9c0e"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-ga-35-tfsi-eu-2017-mt6-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "GA",
-    "body_code": "GA",
-    "production_start_year": 2017,
-    "production_end_year": 2024,
-    "model_name": "Q2 (GA, 2017-2024)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. 6-speed manual confirmed by Wikipedia Q2 powertrain table for both 1.4 TFSI COD (pre-facelift) and 1.5 TFSI evo (post-facelift) variants.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
+  "configurations": [
+    {
+      "id": "audi-ga-30-tfsi-eu-2017-mt6-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "GA",
+      "body_code": "GA",
+      "production_start_year": 2017,
+      "production_end_year": 2024,
+      "model_name": "Q2 (GA, 2017-2024)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Q2 GA all variants FWD as standard, AWD optional only on quattro derivatives (not in this scope).",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3c0c0aa886bf",
-          "legacy_research_sources:3ff9cb8ff793",
-          "legacy_research_sources:44937c13793f",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:891a3906d052",
-          "legacy_research_sources:a24edcc340c2",
-          "legacy_research_sources:ae186108fea8",
-          "legacy_research_sources:e4d20bd4419f"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. 6-speed manual confirmed by Wikipedia Q2 powertrain table.",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e2"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 30 TFSI manual placeholder. The checked Spain 2020 technical sheet and the 02/04/2026 Audi MediaCenter Germany technical-data PDF both prove a front-wheel-drive 6-speed manual 30 TFSI state, but they publish materially different ratio and final-drive packages while both use 205/60 R16 baseline tires. Those official states contradict the inherited 0.840, 3.462, and 215/50 R17 carryover values and show that the broad EU 2017-2024 row overlaps multiple exact states, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 35 TFSI manual placeholder. The checked Spain 2020 technical sheet and the 02/04/2026 Audi MediaCenter Germany technical-data PDF both prove a front-wheel-drive 6-speed manual 35 TFSI state, and the recovered Switzerland MY25 price list confirms late-cycle manual coexistence, but the exact 2020 Spain and 2026 Germany ratio packages differ materially while the official baseline tire program stays at 205/60 R16. Those official states contradict the inherited 0.840, 3.462, and 215/50 R17 carryover values and show that the broad EU 2017-2024 row overlaps multiple exact states, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-manual-tech-data-pdf",
-          "legacy_research_sources:9a7c1e5d4b62"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q2 35 TFSI manual applicability across the represented EU 2017-2024 row span",
-        "reason": "The checked 2020 Spain and 2026 Germany official sheets plus the late Switzerland price list prove real 35 TFSI manual states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-manual-tech-data-pdf",
-          "legacy_research_sources:9a7c1e5d4b62"
-        ]
-      },
-      {
-        "item": "Represented-row manual ratio, final-drive, and tire applicability",
-        "reason": "The checked 2020 Spain and 2026 Germany official manual sheets disagree with each other and both contradict the inherited 0.840 top gear, 3.462 final drive, and 215/50 R17 broad-row carryover values.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-manual-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-ga-35-tfsi-eu-2017-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "GA",
-    "body_code": "GA",
-    "production_start_year": 2017,
-    "production_end_year": 2024,
-    "model_name": "Q2 (GA, 2017-2024)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Transmission code DQ200 (7-speed dry-clutch S tronic) per VW Group engineering norms: 1.4 TFSI COD / 1.5 TFSI evo at 250 Nm sits exactly at DQ200 torque limit and is the standard pairing for MQB FWD 250-Nm applications (Golf 1.5 TSI 130 PS, A3 1.4 TFSI 150 PS). DQ381 (420-430 Nm wet-clutch) was prior repo label and is incorrect for this torque level. Existing top_gear_ratio 0.725 and final_drive_front 4.769 retained pending Audi MediaCenter tech-data PDF confirmation.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ200)",
-      "evidence_refs": [
-        "secondary_technical_sources:q2-ga-wikipedia",
-        "secondary_technical_sources:vwgroup-dsg-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3c0c0aa886bf",
-          "legacy_research_sources:3ff9cb8ff793",
-          "legacy_research_sources:44937c13793f",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:891a3906d052",
-          "legacy_research_sources:a24edcc340c2",
-          "legacy_research_sources:ae186108fea8",
-          "legacy_research_sources:e4d20bd4419f"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
+          "item": "Audi Q2 30 TFSI manual applicability across the represented EU 2017-2024 row span",
+          "reason": "The checked 2020 Spain and 2026 Germany official sheets both prove exact manual states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Represented-row manual ratio, final-drive, and tire applicability",
+          "reason": "The checked 2020 Spain and 2026 Germany official manual sheets disagree with each other and both contradict the inherited 0.840 top gear, 3.462 final drive, and 215/50 R17 broad-row carryover values.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-ga-30-tfsi-eu-2017-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "GA",
+      "body_code": "GA",
+      "production_start_year": 2017,
+      "production_end_year": 2024,
+      "model_name": "Q2 (GA, 2017-2024)",
+      "variant_name": "30 TFSI",
+      "engine_code": "1.0L",
+      "engine_name": "1.0L I3 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Transmission code DQ200 (7-speed dry-clutch S tronic, 0AM/0CW) per VW Group engineering norms: 1.0 TFSI EA211 at 200 Nm is well within DQ200 250 Nm limit and is the textbook DQ200 application across MQB-A small-car platforms (Polo, Ibiza, A1, Q2). DQ381 (420-430 Nm wet-clutch) was prior repo label and is incorrect: DQ381 is used only above the DQ200 torque limit and replaced DQ250, not DQ200. Existing top_gear_ratio 0.725 and final_drive_front 4.769 are consistent with documented DQ200 1.0-TFSI ratios, so they remain plausible but require Audi MediaCenter tech-data PDF for official_exact confirmation.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific official Audi source-gap evidence for the broad Q2 30 TFSI S tronic placeholder. The recovered official packet closes Spain 2020 and Germany 2026 manual 30 TFSI states, but it does not recover any official 30 TFSI S tronic technical-data sheet. The checked Audi MediaCenter model page and the recovered Switzerland MY25 price list also do not safely close this broad automatic EU row, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3c0c0aa886bf",
-            "legacy_research_sources:3ff9cb8ff793",
-            "legacy_research_sources:44937c13793f",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:891a3906d052",
-            "legacy_research_sources:a24edcc340c2",
-            "legacy_research_sources:ae186108fea8",
-            "legacy_research_sources:e4d20bd4419f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 19\""
+          "note_ref": "n2"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi Q2 30 TFSI S tronic applicability across the represented EU 2017-2024 row span",
+          "reason": "The recovered official packet does not safely close a 30 TFSI S tronic row: the checked Audi MediaCenter model page does not expose a 30 TFSI S tronic sheet, the Spain 2020 technical packet does not include one, and the recovered Switzerland MY25 price list omits 30 TFSI entirely.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Represented-row DCT7 ratio, final-drive, and tire applicability",
+          "reason": "Because no checked official 30 TFSI S tronic technical-data sheet was recovered for this row, the inherited 0.725 top gear, 4.769 final drive, and 215/50 R17 tire mapping remain unsupported broad-row carryover values.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:ga-q2-model-page",
+            "legacy_research_sources:4f1a7d2b9c0e"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 35 TFSI S tronic placeholder. The checked Spain 2020 technical sheet, the 02/04/2026 Audi MediaCenter Germany technical-data PDF, and the recovered Switzerland MY25 price list all support a real front-wheel-drive 35 TFSI S tronic state, but they still represent late market-specific exact states rather than one unchanged EU 2017-2024 row. Those official states contradict the inherited 0.725, 4.769, and 215/50 R17 carryover values, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-s-tronic-tech-data-pdf",
-          "legacy_research_sources:9a7c1e5d4b62"
+    {
+      "id": "audi-ga-35-tfsi-eu-2017-mt6-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "GA",
+      "body_code": "GA",
+      "production_start_year": 2017,
+      "production_end_year": 2024,
+      "model_name": "Q2 (GA, 2017-2024)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. 6-speed manual confirmed by Wikipedia Q2 powertrain table for both 1.4 TFSI COD (pre-facelift) and 1.5 TFSI evo (post-facelift) variants.",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 35 TFSI manual placeholder. The checked Spain 2020 technical sheet and the 02/04/2026 Audi MediaCenter Germany technical-data PDF both prove a front-wheel-drive 6-speed manual 35 TFSI state, and the recovered Switzerland MY25 price list confirms late-cycle manual coexistence, but the exact 2020 Spain and 2026 Germany ratio packages differ materially while the official baseline tire program stays at 205/60 R16. Those official states contradict the inherited 0.840, 3.462, and 215/50 R17 carryover values and show that the broad EU 2017-2024 row overlaps multiple exact states, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q2 35 TFSI manual applicability across the represented EU 2017-2024 row span",
+          "reason": "The checked 2020 Spain and 2026 Germany official sheets plus the late Switzerland price list prove real 35 TFSI manual states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Represented-row manual ratio, final-drive, and tire applicability",
+          "reason": "The checked 2020 Spain and 2026 Germany official manual sheets disagree with each other and both contradict the inherited 0.840 top gear, 3.462 final drive, and 215/50 R17 broad-row carryover values.",
+          "evidence_refs": [
+            "legacy_research_sources:4f1a7d2b9c0e",
+            "audi_mediacenter_sources:ga-q2-35-tfsi-2026-manual-tech-data-pdf"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q2 35 TFSI S tronic applicability across the represented EU 2017-2024 row span",
-        "reason": "The checked 2020 Spain and 2026 Germany official sheets plus the late Switzerland price list prove real 35 TFSI S tronic states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-s-tronic-tech-data-pdf",
-          "legacy_research_sources:9a7c1e5d4b62"
+    },
+    {
+      "id": "audi-ga-35-tfsi-eu-2017-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "GA",
+      "body_code": "GA",
+      "production_start_year": 2017,
+      "production_end_year": 2024,
+      "model_name": "Q2 (GA, 2017-2024)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes": "Sonnet redo research (2026-04 v2): Audi badge naming '30 TFSI' / '35 TFSI' was introduced group-wide in October 2018 (MY2019); the Q2 GA went on sale November 2016 (MY2017) under the older '1.0 TFSI' / '1.4 TFSI COD' badges. The repo's production_start_year=2017 reflects the powertrain availability window; the variant_name field uses the post-2018 nomenclature. Both are correct under different conventions, but readers should treat '30/35 TFSI' as the post-rename badge for a row that spans 2017-onwards production. Engine code for 35 TFSI rows should be read as 1.4L EA211 COD (2017-2020) then 1.5L EA211 evo (2020+) - the repo's single 1.5L tag does not capture the pre-facelift state. Transmission code DQ200 (7-speed dry-clutch S tronic) per VW Group engineering norms: 1.4 TFSI COD / 1.5 TFSI evo at 250 Nm sits exactly at DQ200 torque limit and is the standard pairing for MQB FWD 250-Nm applications (Golf 1.5 TSI 130 PS, A3 1.4 TFSI 150 PS). DQ381 (420-430 Nm wet-clutch) was prior repo label and is incorrect for this torque level. Existing top_gear_ratio 0.725 and final_drive_front 4.769 retained pending Audi MediaCenter tech-data PDF confirmation.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ200)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 19\""
+          }
         ]
       },
-      {
-        "item": "Represented-row S tronic ratio, final-drive, and tire applicability",
-        "reason": "The checked official 2020 Spain and 2026 Germany S tronic sheets contradict the inherited 0.725 top gear, 4.769 final drive, and 215/50 R17 broad-row carryover values, even though they remain too market- and era-specific for a direct broad-row rewrite.",
-        "evidence_refs": [
-          "legacy_research_sources:4f1a7d2b9c0e",
-          "audi_mediacenter_sources:ga-q2-35-tfsi-2026-s-tronic-tech-data-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific official Audi evidence for the broad Q2 35 TFSI S tronic placeholder. The checked Spain 2020 technical sheet, the 02/04/2026 Audi MediaCenter Germany technical-data PDF, and the recovered Switzerland MY25 price list all support a real front-wheel-drive 35 TFSI S tronic state, but they still represent late market-specific exact states rather than one unchanged EU 2017-2024 row. Those official states contradict the inherited 0.725, 4.769, and 215/50 R17 carryover values, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q2 35 TFSI S tronic applicability across the represented EU 2017-2024 row span",
+          "reason": "The checked 2020 Spain and 2026 Germany official sheets plus the late Switzerland price list prove real 35 TFSI S tronic states, but they do not prove the full represented EU 2017-2024 row as one unchanged mapping.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Represented-row S tronic ratio, final-drive, and tire applicability",
+          "reason": "The checked official 2020 Spain and 2026 Germany S tronic sheets contradict the inherited 0.725 top gear, 4.769 final drive, and 215/50 R17 broad-row carryover values, even though they remain too market- and era-specific for a direct broad-row rewrite.",
+          "evidence_refs": [
+            "legacy_research_sources:4f1a7d2b9c0e",
+            "audi_mediacenter_sources:ga-q2-35-tfsi-2026-s-tronic-tech-data-pdf"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q3/8U.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q3/8U.json
@@ -1,1495 +1,1181 @@
-[
-  {
-    "id": "audi-8u-1-4-tfsi-eu-2012-mt6-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "1.4 TFSI",
-    "engine_code": "1.4L",
-    "engine_name": "1.4L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL): 1.4 TFSI 150 PS / 6-speed manual is a purchasable EU/UK variant across the entire pre-LCI and post-LCI span. Engine code CZDA. PQ35 platform, transverse FWD-only (no quattro variant of 1.4 TFSI exists). Default tyre per Audi UK SE-spec brochure is 235/55 R17 (NOT the 235/50 R18 family-default - that is the S line option). Gear ratios remain unverified; no official Audi UK technical-data PDF has been recovered for the 1.4 TFSI manual.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n3": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n4": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n5": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
+      "n6": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n7": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+      "n8": "Value from prior-session Audi UK Q3 TFSI quattro S tronic technical-data PDF (cited file is now a SPA shell). Cross-corroborated by auto-data.net 211 PS variant entry. Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
+      "n9": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL): 1.4 TFSI 150 PS / 6-speed manual is a purchasable EU/UK variant across the entire pre-LCI and post-LCI span. Engine code CZDA. PQ35 platform, transverse FWD-only (no quattro variant of 1.4 TFSI exists). Default tyre per Audi UK SE-spec brochure is 235/55 R17 (NOT the 235/50 R18 family-default - that is the S line option). Gear ratios remain unverified; no official Audi UK technical-data PDF has been recovered for the 1.4 TFSI manual.",
+      "n10": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD AUTOMATIC: gearbox CORRECTED from '7-speed S tronic (DQ500)' to '6-speed S tronic (DQ250)'. Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL) explicitly describe this variant as '6-speed S tronic' - NOT 7-speed. The DQ500 (7-speed wet clutch) is reserved for high-torque quattro applications on this platform; the DQ200 (7-speed dry clutch) is an MQB-era unit not available on PQ35-based Q3 8U. The DQ250 (6-speed wet clutch, 0AM/02E family) is the correct unit for FWD 1.4 TFSI Q3 8U. Drivetrain FWD confirmed; PQ35 platform. Default tyre 235/55 R17 per Audi UK SE-spec.",
+      "n11": "Audi UK Q3 SE-spec 235/55 R17 confirmed by 2014 and 2016 UK brochures.",
+      "n12": "Audi Q3 (8U) 2.0 TDI FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 and 2016 ATL): pre-LCI 140 PS and 177 PS variants and post-LCI 150 PS variant all available with 6-speed manual FWD. Gearbox is the 02Q (VW Group 6MT for FWD petrol/diesel). The 2.0 TDI FWD is exclusively manual in both pre-LCI and post-LCI Q3 8U lineups - no automatic FWD TDI variant is offered (see Row 3 phantom). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default).",
+      "n13": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+      "n14": "Audi Q3 (8U) 2.0 TDI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS variants) and corroborated by two independent secondary sources (auto-data.net and car-specs.net). 6-speed manual is the 0AJ (quattro version of 02Q). Default tyre 235/55 R17 cross-checked across UK brochure SE-spec and both secondary sources. Gear ratios remain unverified.",
+      "n15": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n16": "Audi Q3 (8U) 2.0 TDI quattro 7-speed S tronic AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS) and 2016 brochure (150/184 PS). Gearbox is DQ500 (Audi 0BH) wet-clutch 7-speed DCT, which integrates the Haldex transfer-case output for the rear axle on PQ35 quattro applications. DCT7 transmission code is correct. DQ500 family designation is correct (DQ250 6-speed has no Haldex-integrated variant for Q3 8U). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default). Gear ratios unverified.",
+      "n17": "Audi Q3 (8U) 2.0 TFSI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (170 PS variant). Gearbox is 0AJ. Note: previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell from press.audi.co.uk - the value 0.813 for top gear was extracted in a prior session from a real PDF that could not be re-saved due to the SPA barrier. Cross-check: 0AJ 6th gear for quattro TFSI is typically 0.756-0.813 - 0.813 is at the upper end and plausible for this variant. Tyre 215/65 R16 is the technical-minimum (steel wheels) fitment in the technical data PDF; 235/55 R17 is the standard SE-spec alloy fitment per UK brochure.",
+      "n18": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 215/65 R16 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved.",
+      "n19": "Audi Q3 (8U) 2.0 TFSI quattro 7-speed S tronic AWD - best-evidenced row in the shard. Confirmed by Audi UK Q3 2014 brochure (170/211 PS) and 2016 brochure (180 PS). Gearbox is DQ500 (Audi 0BH). The previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell - values 0.667 (top gear), 4.769 (front FD), 3.444 (rear FD) and 235/55 R17 (tyre) were extracted in a prior session from a real PDF and are corroborated by auto-data.net secondary source for the 211 PS variant. The 4.769/3.444 split-final-drive pattern is mechanically correct for Haldex quattro with DQ500 + integrated transfer case.",
+      "n20": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 235/55 R17 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
         "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL): 1.4 TFSI 150 PS / 6-speed manual is a purchasable EU/UK variant across the entire pre-LCI and post-LCI span. Engine code CZDA. PQ35 platform, transverse FWD-only (no quattro variant of 1.4 TFSI exists). Default tyre per Audi UK SE-spec brochure is 235/55 R17 (NOT the 235/50 R18 family-default - that is the S line option). Gear ratios remain unverified; no official Audi UK technical-data PDF has been recovered for the 1.4 TFSI manual.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
+      ],
+      "e2": [
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:6a198c9d097d",
+        "legacy_research_sources:f15178e8436e"
+      ],
+      "e3": [
+        "legacy_research_sources:7b9e3a4d0c41"
+      ],
+      "e4": [
         "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.84 is plausible for VW Group 6-speed manual MQ200/MQ250-class but unverified - no official Audi tech-data PDF recovered for Q3 8U 1.4 TFSI manual. Downgraded from family_default to no_confidence pending source.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.462 is family-default inherited; not verified from Q3 8U 1.4 TFSI specific tech data.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ],
-        "notes": "Audi UK Q3 SE-spec base wheel 17in / 235/55 R17 confirmed by 2014 and 2016 UK brochures.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift 2.0 TDI quattro 177 PS S tronic sheet, but no exact official FWD diesel technical sheet. This broad 2012-2018 FWD manual row therefore remains an unsupported placeholder and must not inherit the recovered quattro automatic state.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 8U exact FWD diesel manual mapping against recovered official diesel evidence",
-        "reason": "The only exact official diesel technical sheet recovered in this pass is the AWD 177 PS S tronic row, which does not validate this FWD manual configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Schema-safe exact FWD diesel replacement for the broad 2012-2018 manual row",
-        "reason": "This pass did not recover an official FWD diesel technical sheet that would justify narrowing or rewriting the stored broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-1-4-tfsi-eu-2012-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "1.4 TFSI",
-    "engine_code": "1.4L",
-    "engine_name": "1.4L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD AUTOMATIC: gearbox CORRECTED from '7-speed S tronic (DQ500)' to '6-speed S tronic (DQ250)'. Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL) explicitly describe this variant as '6-speed S tronic' - NOT 7-speed. The DQ500 (7-speed wet clutch) is reserved for high-torque quattro applications on this platform; the DQ200 (7-speed dry clutch) is an MQB-era unit not available on PQ35-based Q3 8U. The DQ250 (6-speed wet clutch, 0AM/02E family) is the correct unit for FWD 1.4 TFSI Q3 8U. Drivetrain FWD confirmed; PQ35 platform. Default tyre 235/55 R17 per Audi UK SE-spec.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 1.4 TFSI 150 PS FWD AUTOMATIC: gearbox CORRECTED from '7-speed S tronic (DQ500)' to '6-speed S tronic (DQ250)'. Audi UK Q3 brochures (2014 Edition 6.2 and 2016 ATL) explicitly describe this variant as '6-speed S tronic' - NOT 7-speed. The DQ500 (7-speed wet clutch) is reserved for high-torque quattro applications on this platform; the DQ200 (7-speed dry clutch) is an MQB-era unit not available on PQ35-based Q3 8U. The DQ250 (6-speed wet clutch, 0AM/02E family) is the correct unit for FWD 1.4 TFSI Q3 8U. Drivetrain FWD confirmed; PQ35 platform. Default tyre 235/55 R17 per Audi UK SE-spec.",
-      "code": "DCT6",
-      "name": "6-speed S tronic (DQ250)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Stored top gear 0.725 was associated with DQ500 7-speed gear sets; for the corrected DQ250 6-speed gearbox, the value is plausible-but-unverified (DQ250 6th typically 0.650-0.750). Downgraded to no_confidence pending official Audi DQ250 spec.",
-        "value": 0.725,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 4.077 is family-default inherited; DQ250 final drives for PQ35 FWD 1.4 TFSI applications are typically 3.9-4.1 - value plausible but unverified for this exact variant.",
-        "value": 4.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ],
-        "notes": "Audi UK Q3 SE-spec 235/55 R17 confirmed by 2014 and 2016 UK brochures.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift 2.0 TDI quattro 177 PS S tronic sheet, but no exact official FWD diesel technical sheet. This broad 2012-2018 FWD automatic row therefore remains an unsupported placeholder and must not inherit the recovered quattro automatic state.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 8U exact FWD diesel automatic mapping against recovered official diesel evidence",
-        "reason": "The only exact official diesel technical sheet recovered in this pass is the AWD 177 PS S tronic row, which does not validate this FWD automatic configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Schema-safe exact FWD diesel replacement for the broad 2012-2018 automatic row",
-        "reason": "This pass did not recover an official FWD diesel technical sheet that would justify narrowing or rewriting the stored broad automatic row.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tdi-eu-2012-mt6-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 2.0 TDI FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 and 2016 ATL): pre-LCI 140 PS and 177 PS variants and post-LCI 150 PS variant all available with 6-speed manual FWD. Gearbox is the 02Q (VW Group 6MT for FWD petrol/diesel). The 2.0 TDI FWD is exclusively manual in both pre-LCI and post-LCI Q3 8U lineups - no automatic FWD TDI variant is offered (see Row 3 phantom). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default).",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 2.0 TDI FWD 6-speed manual confirmed by Audi UK Q3 brochures (2014 and 2016 ATL): pre-LCI 140 PS and 177 PS variants and post-LCI 150 PS variant all available with 6-speed manual FWD. Gearbox is the 02Q (VW Group 6MT for FWD petrol/diesel). The 2.0 TDI FWD is exclusively manual in both pre-LCI and post-LCI Q3 8U lineups - no automatic FWD TDI variant is offered (see Row 3 phantom). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default).",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.84 plausible for 02Q (range 0.775-0.84) but unverified for this specific Q3 8U 2.0 TDI application.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.462 inherited family-default; within typical Q3 TDI FWD range but unverified for this variant.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ],
-        "notes": "Audi UK Q3 SE-spec 235/55 R17 confirmed by 2014 and 2016 UK brochures.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tdi-eu-2012-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
-      "value": "FWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ500)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
-        "value": 0.725,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
-        "value": 4.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ],
-        "notes": "PHANTOM ROW. The Audi Q3 (8U) 2.0 TDI FWD with automatic transmission does not exist in any market. Confirmed by Audi UK Q3 2014 brochure (Edition 6.2): variant table lists only '2.0 TDI 140 PS / 6-speed manual' and '2.0 TDI 177 PS / 6-speed manual' for FWD TDI - no FWD TDI automatic. Audi UK Q3 2016 brochure (ATL post-LCI): lists only '2.0 TDI 150 PS / 6-speed manual' for FWD TDI. The S tronic in the Q3 8U is reserved for the quattro AWD drivetrain only - the DQ500 transmission is integrated with the Haldex transfer case. FWD TDI cannot use the same DQ500+Haldex assembly. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates set.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:6a198c9d097d",
-          "legacy_research_sources:f15178e8436e"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tdi-quattro-eu-2012-mt6-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
+        "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
+      ],
+      "e5": [
+        "legacy_research_sources:6c2ebf019f9d",
+        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
+      ],
+      "e6": [
+        "legacy_research_sources:9d7fc9f138f2",
+        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e7": [
         "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
         "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
         "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
       ],
-      "notes": "Audi Q3 (8U) 2.0 TDI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS variants) and corroborated by two independent secondary sources (auto-data.net and car-specs.net). 6-speed manual is the 0AJ (quattro version of 02Q). Default tyre 235/55 R17 cross-checked across UK brochure SE-spec and both secondary sources. Gear ratios remain unverified.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
+      "e8": [
+        "legacy_research_sources:7b9e3a4d0c41",
         "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
         "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
       ],
-      "notes": "Audi Q3 (8U) 2.0 TDI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS variants) and corroborated by two independent secondary sources (auto-data.net and car-specs.net). 6-speed manual is the 0AJ (quattro version of 02Q). Default tyre 235/55 R17 cross-checked across UK brochure SE-spec and both secondary sources. Gear ratios remain unverified.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.84 plausible for 0AJ (range 0.756-0.840) but unverified for this Q3 8U 2.0 TDI quattro variant.",
-        "value": 0.84,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.462 plausible for 0AJ in this torque application but unverified.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive rear 3.462 inherited; unverified.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
+      "e9": [
+        "legacy_research_sources:9d7fc9f138f2",
+        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
+        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
+      ],
+      "e10": [
+        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
+        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
+      ],
+      "e11": [
+        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
+        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure",
+        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-8u-1-4-tfsi-eu-2012-mt6-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "1.4 TFSI",
+      "engine_code": "1.4L",
+      "engine_name": "1.4L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
-        ],
-        "notes": "235/55 R17 cross-checked by Audi UK Q3 brochure SE-spec and two independent secondary sources.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n9",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n9",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.84 is plausible for VW Group 6-speed manual MQ200/MQ250-class but unverified - no official Audi tech-data PDF recovered for Q3 8U 1.4 TFSI manual. Downgraded from family_default to no_confidence pending source.",
+          "value": 0.84,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.462 is family-default inherited; not verified from Q3 8U 1.4 TFSI specific tech data.",
+          "value": 3.462,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
-            "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
-          ],
-          "notes": "Independent exact secondary Q3 manual pages agree on 235/55 R17 as the checked baseline tire, but the broader row's optional wheel matrix still lacks exact continuity.",
+          "evidence_refs_ref": "e1",
+          "notes": "Audi UK Q3 SE-spec base wheel 17in / 235/55 R17 confirmed by 2014 and 2016 UK brochures.",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift 2.0 TDI quattro 177 PS S tronic sheet, but no exact official FWD diesel technical sheet. This broad 2012-2018 FWD manual row therefore remains an unsupported placeholder and must not inherit the recovered quattro automatic state.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
+          "note_ref": "n6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Exact secondary Q3 manual pages still support the checked AWD/manual identity and 235/55 R17 baseline tire, but the follow-up official Audi UK diesel sheet recovered in this pass is for the pre-facelift 177 PS quattro S tronic automatic state, not for the manual row. This broad AWD manual placeholder therefore remains unresolved and must not inherit the recovered official automatic configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 8U exact AWD diesel manual mapping against recovered official diesel evidence",
-        "reason": "The follow-up official Audi UK diesel technical sheet recovered in this pass is the pre-facelift 177 PS quattro S tronic state, so it does not validate this broad AWD manual row.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
-        ]
-      },
-      {
-        "item": "Schema-safe split between manual-secondary and official automatic diesel quattro states",
-        "reason": "The broad row still combines a secondary-backed manual identity with a separate official early automatic diesel sheet, so this pass does not justify one shared exact-row mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
-          "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tdi-quattro-eu-2012-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 2.0 TDI quattro 7-speed S tronic AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS) and 2016 brochure (150/184 PS). Gearbox is DQ500 (Audi 0BH) wet-clutch 7-speed DCT, which integrates the Haldex transfer-case output for the rear axle on PQ35 quattro applications. DCT7 transmission code is correct. DQ500 family designation is correct (DQ250 6-speed has no Haldex-integrated variant for Q3 8U). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default). Gear ratios unverified.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Audi Q3 (8U) 2.0 TDI quattro 7-speed S tronic AWD confirmed by Audi UK Q3 2014 brochure (140/177 PS) and 2016 brochure (150/184 PS). Gearbox is DQ500 (Audi 0BH) wet-clutch 7-speed DCT, which integrates the Haldex transfer-case output for the rear axle on PQ35 quattro applications. DCT7 transmission code is correct. DQ500 family designation is correct (DQ250 6-speed has no Haldex-integrated variant for Q3 8U). Default tyre 235/55 R17 per Audi UK SE-spec (NOT 235/50 R18 family-default). Gear ratios unverified.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ500)",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Top gear 0.725 plausible for DQ500 7th gear but unverified for this specific Q3 8U variant.",
-        "value": 0.725,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 4.077 plausible but unverified for Q3 8U 2.0 TDI quattro DCT7.",
-        "value": 4.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive rear 4.077 inherited; unverified.",
-        "value": 4.077,
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ],
-        "notes": "235/55 R17 per Audi UK Q3 SE-spec brochures.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
+          "item": "Audi Q3 8U exact FWD diesel manual mapping against recovered official diesel evidence",
+          "reason": "The only exact official diesel technical sheet recovered in this pass is the AWD 177 PS S tronic row, which does not validate this FWD manual configuration.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Schema-safe exact FWD diesel replacement for the broad 2012-2018 manual row",
+          "reason": "This pass did not recover an official FWD diesel technical sheet that would justify narrowing or rewriting the stored broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-1-4-tfsi-eu-2012-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "1.4 TFSI",
+      "engine_code": "1.4L",
+      "engine_name": "1.4L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n10",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n10",
+        "code": "DCT6",
+        "name": "6-speed S tronic (DQ250)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Stored top gear 0.725 was associated with DQ500 7-speed gear sets; for the corrected DQ250 6-speed gearbox, the value is plausible-but-unverified (DQ250 6th typically 0.650-0.750). Downgraded to no_confidence pending official Audi DQ250 spec.",
+          "value": 0.725,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 4.077 is family-default inherited; DQ250 final drives for PQ35 FWD 1.4 TFSI applications are typically 3.9-4.1 - value plausible but unverified for this exact variant.",
+          "value": 4.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift 2.0 TDI quattro 177 PS S tronic sheet, but no exact official FWD diesel technical sheet. This broad 2012-2018 FWD automatic row therefore remains an unsupported placeholder and must not inherit the recovered quattro automatic state.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 8U exact FWD diesel automatic mapping against recovered official diesel evidence",
+          "reason": "The only exact official diesel technical sheet recovered in this pass is the AWD 177 PS S tronic row, which does not validate this FWD automatic configuration.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Schema-safe exact FWD diesel replacement for the broad 2012-2018 automatic row",
+          "reason": "This pass did not recover an official FWD diesel technical sheet that would justify narrowing or rewriting the stored broad automatic row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tdi-eu-2012-mt6-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.84 plausible for 02Q (range 0.775-0.84) but unverified for this specific Q3 8U 2.0 TDI application.",
+          "value": 0.84,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.462 inherited family-default; within typical Q3 TDI FWD range but unverified for this variant.",
+          "value": 3.462,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n7"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tdi-eu-2012-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ500)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 0.725,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 4.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
+          "note_ref": "n7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift Q3 2.0 TDI quattro 177 PS S tronic technical sheet showing AWD, 7-speed S tronic, grouped gearbox/final-drive presentation, and basic 215/65 R16 tires. That official packet hardens the early automatic state, but it does not close full 2012-2018 continuity for this broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi owner manual / brochure archive / ETKA Europe with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:audi-q3-8u-2016-uk-brochure"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 8U 2.0 TDI quattro S tronic exact early-era versus full-row applicability",
-        "reason": "The recovered official Audi UK diesel technical sheet proves one exact pre-facelift 177 PS quattro S tronic state, but it does not by itself prove the whole 2012-2018 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Schema-safe continuity beyond the recovered exact pre-facelift diesel quattro S tronic sheet",
-        "reason": "The current broad row still spans years beyond the recovered exact official 177 PS automatic sheet, so this pass does not justify treating one early UK technical PDF as the full-row mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:7b9e3a4d0c41"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tfsi-quattro-eu-2012-mt6-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
       ],
-      "notes": "Audi Q3 (8U) 2.0 TFSI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (170 PS variant). Gearbox is 0AJ. Note: previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell from press.audi.co.uk - the value 0.813 for top gear was extracted in a prior session from a real PDF that could not be re-saved due to the SPA barrier. Cross-check: 0AJ 6th gear for quattro TFSI is typically 0.756-0.813 - 0.813 is at the upper end and plausible for this variant. Tyre 215/65 R16 is the technical-minimum (steel wheels) fitment in the technical data PDF; 235/55 R17 is the standard SE-spec alloy fitment per UK brochure.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
-      ],
-      "notes": "Audi Q3 (8U) 2.0 TFSI quattro 6-speed manual AWD confirmed by Audi UK Q3 2014 brochure (170 PS variant). Gearbox is 0AJ. Note: previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell from press.audi.co.uk - the value 0.813 for top gear was extracted in a prior session from a real PDF that could not be re-saved due to the SPA barrier. Cross-check: 0AJ 6th gear for quattro TFSI is typically 0.756-0.813 - 0.813 is at the upper end and plausible for this variant. Tyre 215/65 R16 is the technical-minimum (steel wheels) fitment in the technical data PDF; 235/55 R17 is the standard SE-spec alloy fitment per UK brochure.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:6c2ebf019f9d",
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
-        ],
-        "notes": "Top gear 0.813 from prior-session Audi UK Q3 TFSI quattro technical-data PDF (cited file is now a 2,450-byte SPA shell; value plausible for 0AJ at upper end of 0.756-0.813 range). Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
-        "value": 0.813
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:6c2ebf019f9d",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
-        ],
-        "notes": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 215/65 R16 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
+          "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tdi-quattro-eu-2012-mt6-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n14",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n14",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.84 plausible for 0AJ (range 0.756-0.840) but unverified for this Q3 8U 2.0 TDI quattro variant.",
+          "value": 0.84,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.462 plausible for 0AJ in this torque application but unverified.",
+          "value": 3.462,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive rear 3.462 inherited; unverified.",
+          "value": 3.462,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e7",
+          "notes": "235/55 R17 cross-checked by Audi UK Q3 brochure SE-spec and two independent secondary sources.",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs": [
+              "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
+              "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs"
+            ],
+            "notes": "Independent exact secondary Q3 manual pages agree on 235/55 R17 as the checked baseline tire, but the broader row's optional wheel matrix still lacks exact continuity.",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Exact secondary Q3 manual pages still support the checked AWD/manual identity and 235/55 R17 baseline tire, but the follow-up official Audi UK diesel sheet recovered in this pass is for the pre-facelift 177 PS quattro S tronic automatic state, not for the manual row. This broad AWD manual placeholder therefore remains unresolved and must not inherit the recovered official automatic configuration.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n7"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 8U exact AWD diesel manual mapping against recovered official diesel evidence",
+          "reason": "The follow-up official Audi UK diesel technical sheet recovered in this pass is the pre-facelift 177 PS quattro S tronic state, so it does not validate this broad AWD manual row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Schema-safe split between manual-secondary and official automatic diesel quattro states",
+          "reason": "The broad row still combines a secondary-backed manual identity with a separate official early automatic diesel sheet, so this pass does not justify one shared exact-row mapping.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tdi-quattro-eu-2012-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "value": "AWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n16",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ500)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Top gear 0.725 plausible for DQ500 7th gear but unverified for this specific Q3 8U variant.",
+          "value": 0.725,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 4.077 plausible but unverified for Q3 8U 2.0 TDI quattro DCT7.",
+          "value": 4.077,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive rear 4.077 inherited; unverified.",
+          "value": 4.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes": "235/55 R17 per Audi UK Q3 SE-spec brochures.",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Follow-up official Audi UK diesel review recovered an exact pre-facelift Q3 2.0 TDI quattro 177 PS S tronic technical sheet showing AWD, 7-speed S tronic, grouped gearbox/final-drive presentation, and basic 215/65 R16 tires. That official packet hardens the early automatic state, but it does not close full 2012-2018 continuity for this broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 8U 2.0 TDI quattro S tronic exact early-era versus full-row applicability",
+          "reason": "The recovered official Audi UK diesel technical sheet proves one exact pre-facelift 177 PS quattro S tronic state, but it does not by itself prove the whole 2012-2018 broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Schema-safe continuity beyond the recovered exact pre-facelift diesel quattro S tronic sheet",
+          "reason": "The current broad row still spans years beyond the recovered exact official 177 PS automatic sheet, so this pass does not justify treating one early UK technical PDF as the full-row mapping.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tfsi-quattro-eu-2012-mt6-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n17",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n17",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
           "evidence_refs": [
             "legacy_research_sources:6c2ebf019f9d",
+            "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
             "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
           ],
-          "notes": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 215/65 R16 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved.",
+          "notes": "Top gear 0.813 from prior-session Audi UK Q3 TFSI quattro technical-data PDF (cited file is now a 2,450-byte SPA shell; value plausible for 0AJ at upper end of 0.756-0.813 range). Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
+          "value": 0.813
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n18",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 65.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The exact Audi UK technical-data PDF now confirms the checked Q3 2.0 TFSI quattro manual state: quattro AWD, 6-speed manual transmission, top gear 0.813, and 215/65 R16 baseline tires. The same sheet presents grouped gearbox/final-drive values that do not map cleanly to the current front/rear final-drive schema, so the broad row remains only partially resolved.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The exact Audi UK technical-data PDF now confirms the checked Q3 2.0 TFSI quattro manual state: quattro AWD, 6-speed manual transmission, top gear 0.813, and 215/65 R16 baseline tires. The same sheet presents grouped gearbox/final-drive values that do not map cleanly to the current front/rear final-drive schema, so the broad row remains only partially resolved.",
-        "evidence_refs": [
-          "legacy_research_sources:6c2ebf019f9d",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
-        "reason": "The checked Audi UK technical-data PDF safely resolves AWD, 6-speed manual transmission, top gear 0.813, and 215/65 R16 for one exact state, but the broad row still lacks full 2012-2018 continuity proof.",
-        "evidence_refs": [
-          "legacy_research_sources:6c2ebf019f9d",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata"
-        ]
-      },
-      {
-        "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "The checked Audi UK technical-data PDF resolves top gear for one exact state, but its grouped gearbox/final-drive presentation does not map cleanly to the current front/rear final-drive fields.",
-        "evidence_refs": [
-          "legacy_research_sources:6c2ebf019f9d"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8u-2-0-tfsi-quattro-eu-2012-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8U",
-    "body_code": "8U",
-    "production_start_year": 2012,
-    "production_end_year": 2018,
-    "model_name": "Q3 (8U, 2012-2018)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure",
-        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
       ],
-      "notes": "Audi Q3 (8U) 2.0 TFSI quattro 7-speed S tronic AWD - best-evidenced row in the shard. Confirmed by Audi UK Q3 2014 brochure (170/211 PS) and 2016 brochure (180 PS). Gearbox is DQ500 (Audi 0BH). The previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell - values 0.667 (top gear), 4.769 (front FD), 3.444 (rear FD) and 235/55 R17 (tyre) were extracted in a prior session from a real PDF and are corroborated by auto-data.net secondary source for the 211 PS variant. The 4.769/3.444 split-final-drive pattern is mechanically correct for Haldex quattro with DQ500 + integrated transfer case.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-        "secondary_technical_sources:audi-q3-8u-2016-uk-brochure",
-        "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-      ],
-      "notes": "Audi Q3 (8U) 2.0 TFSI quattro 7-speed S tronic AWD - best-evidenced row in the shard. Confirmed by Audi UK Q3 2014 brochure (170/211 PS) and 2016 brochure (180 PS). Gearbox is DQ500 (Audi 0BH). The previously cited Audi UK technical-data PDF reference (legacy_research_sources) is a 2,450-byte SPA shell - values 0.667 (top gear), 4.769 (front FD), 3.444 (rear FD) and 235/55 R17 (tyre) were extracted in a prior session from a real PDF and are corroborated by auto-data.net secondary source for the 211 PS variant. The 4.769/3.444 split-final-drive pattern is mechanically correct for Haldex quattro with DQ500 + integrated transfer case.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ500)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "Value from prior-session Audi UK Q3 TFSI quattro S tronic technical-data PDF (cited file is now a SPA shell). Cross-corroborated by auto-data.net 211 PS variant entry. Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "Value from prior-session Audi UK Q3 TFSI quattro S tronic technical-data PDF (cited file is now a SPA shell). Cross-corroborated by auto-data.net 211 PS variant entry. Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
-        "value": 4.769
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:audi-q3-8u-2014-uk-brochure",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "Value from prior-session Audi UK Q3 TFSI quattro S tronic technical-data PDF (cited file is now a SPA shell). Cross-corroborated by auto-data.net 211 PS variant entry. Confidence reduced from 'official_derived' to 'reputable_secondary' to reflect that the saved evidence file is not auditable.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ],
-        "notes": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 235/55 R17 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
+          "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
+          "reason": "The checked Audi UK technical-data PDF safely resolves AWD, 6-speed manual transmission, top gear 0.813, and 215/65 R16 for one exact state, but the broad row still lacks full 2012-2018 continuity proof.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "The checked Audi UK technical-data PDF resolves top gear for one exact state, but its grouped gearbox/final-drive presentation does not map cleanly to the current front/rear final-drive fields.",
           "evidence_refs": [
-            "legacy_research_sources:9d7fc9f138f2",
-            "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-          ],
-          "notes": "The exact Audi UK technical-data PDF and an exact Auto-Data corroboration both point to 235/55 R17 as the checked baseline tire. Applied as official-derived evidence for the EU row while the broader option matrix remains unresolved.",
+            "legacy_research_sources:6c2ebf019f9d"
+          ]
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8u-2-0-tfsi-quattro-eu-2012-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8U",
+      "body_code": "8U",
+      "production_start_year": 2012,
+      "production_end_year": 2018,
+      "model_name": "Q3 (8U, 2012-2018)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e11",
+        "notes_ref": "n19",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e11",
+        "notes_ref": "n19",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ500)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n8",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n8",
+          "value": 4.769
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n8",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n20",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n20",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The exact Audi UK technical-data PDF now confirms the checked Q3 2.0 TFSI quattro S tronic state: quattro AWD, 7-speed S tronic, top gear 0.667, final drives 4.769 / 3.444, and 235/55 R17 baseline tires. The broader 2012-2018 row still lacks full year-span and option-matrix continuity.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6a198c9d097d",
-            "legacy_research_sources:f15178e8436e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The exact Audi UK technical-data PDF now confirms the checked Q3 2.0 TFSI quattro S tronic state: quattro AWD, 7-speed S tronic, top gear 0.667, final drives 4.769 / 3.444, and 235/55 R17 baseline tires. The broader 2012-2018 row still lacks full year-span and option-matrix continuity.",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
+          "reason": "The checked Audi UK technical-data PDF safely resolves AWD, 7-speed S tronic, top gear 0.667, final drives 4.769 / 3.444, and 235/55 R17 for one exact state, but the broad row still lacks full 2012-2018 continuity proof.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "The checked Audi UK technical-data PDF resolves top gear and both final-drive fields for one exact state, but the broad row still lacks full forward-gear and year-span continuity.",
+          "evidence_refs": [
+            "legacy_research_sources:9d7fc9f138f2"
+          ]
+        },
+        {
+          "item": "Q3 8U source-finding pass status",
+          "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 (8U, 2012-2018) EU ratio-relevant variant mapping",
-        "reason": "The checked Audi UK technical-data PDF safely resolves AWD, 7-speed S tronic, top gear 0.667, final drives 4.769 / 3.444, and 235/55 R17 for one exact state, but the broad row still lacks full 2012-2018 continuity proof.",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2",
-          "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata"
-        ]
-      },
-      {
-        "item": "Audi Q3 (8U, 2012-2018) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "The checked Audi UK technical-data PDF resolves top gear and both final-drive fields for one exact state, but the broad row still lacks full forward-gear and year-span continuity.",
-        "evidence_refs": [
-          "legacy_research_sources:9d7fc9f138f2"
-        ]
-      },
-      {
-        "item": "Q3 8U source-finding pass status",
-        "reason": "Q3 8U source-finding pass collected official Audi UK 2014 ('Edition 6.2 06/14') and 2016 'atl' Q3 brochures plus three Audi UK technical-data PDFs (Q3 2.0 TFSI 170 PS, Q3 2.0 TDI quattro 177 PS, and Q3 2.0 TFSI quattro S tronic) under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/audi-q3-8u/. The packet confirms model, engine, drivetrain, S tronic vs manual, and tire-package availability per UK pricing/specification guide, but the packet was not synthesized into per-row exact gear-ratio/final-drive evidence and no new source pack was registered. The broad 2012-2018 row should remain low-confidence, with driveshaft and wheel-order analysis disabled, until a per-variant exact technical PDF is parsed and added to the source pack."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q3/F3.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q3/F3.json
@@ -1,851 +1,770 @@
-[
-  {
-    "id": "audi-f3-35-tdi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F3",
-    "body_code": "F3",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "Q3 (F3, 2019-2025)",
-    "variant_name": "35 TDI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-        "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
-        "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TDI = 150 PS / 340 Nm / FWD / 7-speed S tronic. The 340 Nm output exceeds the DQ200 dry-clutch DCT 250 Nm limit, so the gearbox is the DQ381-7F (longitudinal MQB-A2 wet-clutch 7-speed DCT, FWD variant). Final drive split: existing prior-agent extraction recorded 4.813 / 3.667 for the AWD sibling rows; the same DQ381-7F architecture publishes two final drives (sub-transmission 1 odd-gear shaft = 4.813, sub-transmission 2 even-gear shaft = 3.667) which both drive the same FWD axle. Repo's prior 4.769 family_default replaced with the official sub-transmission 1 ratio 4.813 in final_drive_front, and sub-transmission 2 ratio 3.667 added to final_drive_rear with note that for FWD DCT variants this field encodes the second sub-transmission output ratio, not a physical rear axle. Forward gear ratio array remains unpopulated (PDF was not extracted by prior agent and is currently 404; only top gear 0.561 is published).",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note.",
+      "n2": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TDI = 150 PS / 340 Nm / FWD / 7-speed S tronic. The 340 Nm output exceeds the DQ200 dry-clutch DCT 250 Nm limit, so the gearbox is the DQ381-7F (longitudinal MQB-A2 wet-clutch 7-speed DCT, FWD variant). Final drive split: existing prior-agent extraction recorded 4.813 / 3.667 for the AWD sibling rows; the same DQ381-7F architecture publishes two final drives (sub-transmission 1 odd-gear shaft = 4.813, sub-transmission 2 even-gear shaft = 3.667) which both drive the same FWD axle. Repo's prior 4.769 family_default replaced with the official sub-transmission 1 ratio 4.813 in final_drive_front, and sub-transmission 2 ratio 3.667 added to final_drive_rear with note that for FWD DCT variants this field encodes the second sub-transmission output ratio, not a physical rear axle. Forward gear ratio array remains unpopulated (PDF was not extracted by prior agent and is currently 404; only top gear 0.561 is published).",
+      "n3": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TFSI = 150 PS / 250 Nm / FWD / 7-speed S tronic. Gearbox is the DQ381-7F (MQB-A2 longitudinal wet-clutch 7-speed DCT, FWD variant). Sub-transmission split: sub-trans 1 (odd gears 1/3/5/7) final drive 5.200; sub-trans 2 (even gears 2/4/6) final drive 3.900. Both drive the same FWD axle. Repo's 4.769 family_default replaced with the official sub-trans 1 value 5.200 in final_drive_front, sub-trans 2 value 3.900 added to final_drive_rear with same FWD-DCT semantic note. Forward gear ratios array [3.19, 2.75, 1.897, 1.04, 0.793, 0.86, 0.661] kept as official_derived from prior-agent PDF extraction; the apparent 5/6 inversion (0.793 -> 0.860) is a known DCT sub-transmission cross-over artifact: gears 5 (odd) and 6 (even) ride on different sub-transmission shafts with different final drives, so the OVERALL road ratio is monotonic when each gear is multiplied by its sub-transmission FD. Sub-trans 1 internal set {3.19, 1.897, 0.793, 0.661} and sub-trans 2 internal set {2.75, 1.04, 0.86} are each strictly monotonic.",
+      "n4": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TDI = 190 PS / 400 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed; for AWD DCT these correspond to sub-transmission 1 (odd) and sub-transmission 2 (even) output ratios that feed both front axle and the Haldex rear coupling. Top gear 0.561 confirmed from prior-agent PDF extraction. Full forward gear ratio array remains unpopulated.",
+      "n6": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TFSI = 190 PS / 320 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed. Top gear 0.635 confirmed from prior-agent PDF extraction (does not match standard DQ381 gear set, indicating an application-specific ratio set). Full forward gear ratio array remains unpopulated."
     },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "secondary_technical_sources:q3-f3-wikipedia",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-        "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
-        "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TDI = 150 PS / 340 Nm / FWD / 7-speed S tronic. The 340 Nm output exceeds the DQ200 dry-clutch DCT 250 Nm limit, so the gearbox is the DQ381-7F (longitudinal MQB-A2 wet-clutch 7-speed DCT, FWD variant). Final drive split: existing prior-agent extraction recorded 4.813 / 3.667 for the AWD sibling rows; the same DQ381-7F architecture publishes two final drives (sub-transmission 1 odd-gear shaft = 4.813, sub-transmission 2 even-gear shaft = 3.667) which both drive the same FWD axle. Repo's prior 4.769 family_default replaced with the official sub-transmission 1 ratio 4.813 in final_drive_front, and sub-transmission 2 ratio 3.667 added to final_drive_rear with note that for FWD DCT variants this field encodes the second sub-transmission output ratio, not a physical rear axle. Forward gear ratio array remains unpopulated (PDF was not extracted by prior agent and is currently 404; only top gear 0.561 is published).",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381-7F)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.561 as the 7th-gear ratio for the old-generation Q3 35 TDI S tronic state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
-        "value": 0.561
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TDI = 150 PS / 340 Nm / FWD / 7-speed S tronic. The 340 Nm output exceeds the DQ200 dry-clutch DCT 250 Nm limit, so the gearbox is the DQ381-7F (longitudinal MQB-A2 wet-clutch 7-speed DCT, FWD variant). Final drive split: existing prior-agent extraction recorded 4.813 / 3.667 for the AWD sibling rows; the same DQ381-7F architecture publishes two final drives (sub-transmission 1 odd-gear shaft = 4.813, sub-transmission 2 even-gear shaft = 3.667) which both drive the same FWD axle. Repo's prior 4.769 family_default replaced with the official sub-transmission 1 ratio 4.813 in final_drive_front, and sub-transmission 2 ratio 3.667 added to final_drive_rear with note that for FWD DCT variants this field encodes the second sub-transmission output ratio, not a physical rear axle. Forward gear ratio array remains unpopulated (PDF was not extracted by prior agent and is currently 404; only top gear 0.561 is published). For FWD DCT variants this is sub-transmission 1 (odd gears 1/3/5/7) output ratio.",
-        "value": 4.813,
-        "evidence_refs": [
-          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-          "secondary_technical_sources:q3-f3-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the old-generation Q3 35 TDI S tronic state. Applied as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-            "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf"
-          ],
-          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the old-generation Q3 35 TDI S tronic state. The broader optional wheel/tire matrix remains unresolved.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 65.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 3 review replaces the copied Q3 cluster note with row-specific Audi MediaCenter evidence for the old-generation Q3 35 TDI S tronic state: the 2018 launch press kit and Germany model-year 2021 price list show the same front-wheel-drive 7-speed S tronic identity, while the 2024 and 2025 technical-data PDFs resolve the late-cycle exact mapping with 0.561 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row keeps a conservative placeholder final-drive field because the checked official source publishes two final-drive values that the current single-slot row shape cannot safely encode.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 35 TDI year-by-year continuity across the represented 2019-2025 row span",
-        "reason": "The checked official Audi source chain brackets the old-generation 35 TDI S tronic state at launch, in the Germany model-year 2021 price list, and in the exact 2024 and 2025 technical-data sheets, but this pass still did not recover a year-by-year official chain proving one unchanged package across every model year represented by the row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe encoding of exact Audi Q3 35 TDI split final-drive values",
-        "reason": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs publish split final drives 4.813 / 3.667 for the target, but the current row has only one final_drive_front field and cannot safely encode both values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q3 35 TDI optional wheel/tire matrix and gearbox family-code confirmation",
-        "reason": "The checked official source chain resolves the exact 215/65 R17 base tire and market-facing 7-speed S tronic wording at launch, mid-cycle, and in the 2024/2025 late-cycle technical-data sheets, but this pass did not recover an exact old-generation optional wheel/tire matrix or an official gearbox family code.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-f3-35-tfsi-eu-2019-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F3",
-    "body_code": "F3",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "Q3 (F3, 2019-2025)",
-    "variant_name": "35 TFSI",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-        "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TFSI = 150 PS / 250 Nm / FWD / 7-speed S tronic. Gearbox is the DQ381-7F (MQB-A2 longitudinal wet-clutch 7-speed DCT, FWD variant). Sub-transmission split: sub-trans 1 (odd gears 1/3/5/7) final drive 5.200; sub-trans 2 (even gears 2/4/6) final drive 3.900. Both drive the same FWD axle. Repo's 4.769 family_default replaced with the official sub-trans 1 value 5.200 in final_drive_front, sub-trans 2 value 3.900 added to final_drive_rear with same FWD-DCT semantic note. Forward gear ratios array [3.19, 2.75, 1.897, 1.04, 0.793, 0.86, 0.661] kept as official_derived from prior-agent PDF extraction; the apparent 5/6 inversion (0.793 -> 0.860) is a known DCT sub-transmission cross-over artifact: gears 5 (odd) and 6 (even) ride on different sub-transmission shafts with different final drives, so the OVERALL road ratio is monotonic when each gear is multiplied by its sub-transmission FD. Sub-trans 1 internal set {3.19, 1.897, 0.793, 0.661} and sub-trans 2 internal set {2.75, 1.04, 0.86} are each strictly monotonic.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "secondary_technical_sources:q3-f3-wikipedia",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-        "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TFSI = 150 PS / 250 Nm / FWD / 7-speed S tronic. Gearbox is the DQ381-7F (MQB-A2 longitudinal wet-clutch 7-speed DCT, FWD variant). Sub-transmission split: sub-trans 1 (odd gears 1/3/5/7) final drive 5.200; sub-trans 2 (even gears 2/4/6) final drive 3.900. Both drive the same FWD axle. Repo's 4.769 family_default replaced with the official sub-trans 1 value 5.200 in final_drive_front, sub-trans 2 value 3.900 added to final_drive_rear with same FWD-DCT semantic note. Forward gear ratios array [3.19, 2.75, 1.897, 1.04, 0.793, 0.86, 0.661] kept as official_derived from prior-agent PDF extraction; the apparent 5/6 inversion (0.793 -> 0.860) is a known DCT sub-transmission cross-over artifact: gears 5 (odd) and 6 (even) ride on different sub-transmission shafts with different final drives, so the OVERALL road ratio is monotonic when each gear is multiplied by its sub-transmission FD. Sub-trans 1 internal set {3.19, 1.897, 0.793, 0.661} and sub-trans 2 internal set {2.75, 1.04, 0.86} are each strictly monotonic.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381-7F)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.661 as the 7th-gear ratio for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while full 2019-2025 continuity remains unresolved.",
-        "value": 0.661
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while full 2019-2025 continuity remains unresolved. Sonnet redo research (2026-04 v2): apparent 5/6 inversion is a DCT sub-trans cross-over (sub-trans 1 odd-gear FD 5.200 vs sub-trans 2 even-gear FD 3.900) - internal sub-transmission ratio sets are each monotonic.",
-        "value": [
-          3.19,
-          2.75,
-          1.897,
-          1.04,
-          0.793,
-          0.86,
-          0.661
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TFSI = 150 PS / 250 Nm / FWD / 7-speed S tronic. Gearbox is the DQ381-7F (MQB-A2 longitudinal wet-clutch 7-speed DCT, FWD variant). Sub-transmission split: sub-trans 1 (odd gears 1/3/5/7) final drive 5.200; sub-trans 2 (even gears 2/4/6) final drive 3.900. Both drive the same FWD axle. Repo's 4.769 family_default replaced with the official sub-trans 1 value 5.200 in final_drive_front, sub-trans 2 value 3.900 added to final_drive_rear with same FWD-DCT semantic note. Forward gear ratios array [3.19, 2.75, 1.897, 1.04, 0.793, 0.86, 0.661] kept as official_derived from prior-agent PDF extraction; the apparent 5/6 inversion (0.793 -> 0.860) is a known DCT sub-transmission cross-over artifact: gears 5 (odd) and 6 (even) ride on different sub-transmission shafts with different final drives, so the OVERALL road ratio is monotonic when each gear is multiplied by its sub-transmission FD. Sub-trans 1 internal set {3.19, 1.897, 0.793, 0.661} and sub-trans 2 internal set {2.75, 1.04, 0.86} are each strictly monotonic. For FWD DCT variants this is sub-transmission 1 (odd gears) output ratio.",
-        "value": 5.2,
-        "evidence_refs": [
-          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-          "secondary_technical_sources:q3-f3-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-            "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
-          ],
-          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 35 TFSI S tronic state. The broader optional wheel/tire matrix remains unresolved.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 65.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:252eccf99577",
-            "legacy_research_sources:2c76c716cf17",
-            "legacy_research_sources:307b4bc397ba",
-            "legacy_research_sources:3c27d2c5b039",
-            "legacy_research_sources:450723bbeba5",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6f5476f1d60e",
-            "legacy_research_sources:814f63488d22",
-            "legacy_research_sources:8dbd6602ef26",
-            "legacy_research_sources:e60dd4460f09",
-            "legacy_research_sources:e7a5c628203d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:252eccf99577",
-            "legacy_research_sources:2c76c716cf17",
-            "legacy_research_sources:307b4bc397ba",
-            "legacy_research_sources:3c27d2c5b039",
-            "legacy_research_sources:450723bbeba5",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:6f5476f1d60e",
-            "legacy_research_sources:814f63488d22",
-            "legacy_research_sources:8dbd6602ef26",
-            "legacy_research_sources:e60dd4460f09",
-            "legacy_research_sources:e7a5c628203d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 2 review replaces the broad mixed-transmission note with exact row-specific evidence for the old-generation Q3 35 TFSI S tronic state represented by this DCT7 row. The 2018 launch press kit and the Germany model-year 2021 price list confirm the exact front-wheel-drive 7-Gang S tronic row as launch and mid-cycle overlap, and the checked 2024 and 2025 technical-data PDFs resolve the exact late-cycle DCT7 mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, split final drives 5.200 / 3.900, and basic 215/65 R17 tires. The row keeps a conservative placeholder final-drive field because the checked official source publishes two final-drive values that the current single-slot row shape cannot safely encode.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 35 TFSI production-data applicability across the represented 2019-2025 row span",
-        "reason": "The checked 2018 launch press kit, Germany model-year 2021 price list, and exact 2024 and 2025 S tronic technical-data PDFs confirm the old-generation 35 TFSI S tronic state as launch, mid-cycle, and late-cycle overlap, but this pass did not recover a year-by-year official chain proving one unchanged DCT7 package across every model year represented by the row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe encoding of exact Audi Q3 35 TFSI S tronic split final-drive values",
-        "reason": "The checked official 2024 and 2025 Q3 35 TFSI S tronic technical-data PDFs publish split final drives 5.200 / 3.900, but the current row has only one final_drive_front field and cannot safely encode both values.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q3 35 TFSI optional wheel/tire matrix and gearbox family-code confirmation",
-        "reason": "The checked official source chain resolves the basic 215/65 R17 tire package and market-facing 7-speed S tronic wording at launch, mid-cycle, and in the 2024/2025 late-cycle technical-data sheets, but this pass did not recover a full exact optional wheel/tire matrix or an official gearbox family code for the S tronic state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-f3-40-tdi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F3",
-    "body_code": "F3",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "Q3 (F3, 2019-2025)",
-    "variant_name": "40 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
         "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
         "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TDI = 190 PS / 400 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed; for AWD DCT these correspond to sub-transmission 1 (odd) and sub-transmission 2 (even) output ratios that feed both front axle and the Haldex rear coupling. Top gear 0.561 confirmed from prior-agent PDF extraction. Full forward gear ratio array remains unpopulated.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
+      "e2": [
+        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+        "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
+      ],
+      "e7": [
         "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf",
         "secondary_technical_sources:q3-f3-wikipedia"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TDI = 190 PS / 400 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed; for AWD DCT these correspond to sub-transmission 1 (odd) and sub-transmission 2 (even) output ratios that feed both front axle and the Haldex rear coupling. Top gear 0.561 confirmed from prior-agent PDF extraction. Full forward gear ratio array remains unpopulated.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381-7A)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 0.561 as the checked 7th-gear ratio for the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
-        "value": 0.561
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 4.813 for the checked front final-drive field of the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
-        "value": 4.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 3.667 for the checked rear final-drive field of the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
-        "value": 3.667
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the checked basic tire for the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while the full optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-            "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-          ],
-          "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the checked basic tire package for the old-generation Q3 40 TDI quattro state. The broader optional wheel/tire matrix remains unresolved.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 65.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
+      "e8": [
+        "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
+        "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf"
+      ],
+      "e9": [
+        "legacy_research_sources:252eccf99577",
+        "legacy_research_sources:2c76c716cf17",
+        "legacy_research_sources:307b4bc397ba",
+        "legacy_research_sources:3c27d2c5b039",
+        "legacy_research_sources:450723bbeba5",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:6f5476f1d60e",
+        "legacy_research_sources:814f63488d22",
+        "legacy_research_sources:8dbd6602ef26",
+        "legacy_research_sources:e60dd4460f09",
+        "legacy_research_sources:e7a5c628203d"
+      ],
+      "e10": [
+        "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
+      ],
+      "e11": [
+        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+        "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release",
+        "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 2 review replaces the inherited Q3 40 TDI quattro assumptions with official Audi MediaCenter exact 2024 and 2025 old-generation technical-data sheets: AWD, 7-speed S tronic, 0.561 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row end year is corrected to 2025 because Audi scopes this generation as 'Q3 (until 2025)' and launches the third-generation Q3 in Germany and Europe from October 2025.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-until-2025-model-page",
-          "audi_mediacenter_sources:f3-q3-third-generation-launch-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 40 TDI quattro year-by-year continuity across the represented 2019-2025 row span",
-        "reason": "Checked exact Germany-program 2024 and 2025 technical-data PDFs agree on the core drivetrain, top-gear, split final-drive, and basic-tire package, but this pass did not recover a year-by-year official sheet chain proving one unchanged mapping across every model year in the row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q3 40 TDI quattro optional wheel/tire matrix",
-        "reason": "The 2018 Q3 launch press kit documents the old-generation family wheel program with standard 17-inch, trim-linked 18-inch, and optional 19-inch and 20-inch packages, but this pass did not recover an exact 40 TDI quattro option matrix tying every tire size to this exact row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
-        ]
-      },
-      {
-        "item": "Audi Q3 40 TDI quattro gearbox family-code confirmation",
-        "reason": "Checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-f3-40-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F3",
-    "body_code": "F3",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "Q3 (F3, 2019-2025)",
-    "variant_name": "40 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
-        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TFSI = 190 PS / 320 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed. Top gear 0.635 confirmed from prior-agent PDF extraction (does not match standard DQ381 gear set, indicating an application-specific ratio set). Full forward gear ratio array remains unpopulated.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "secondary_technical_sources:q3-f3-wikipedia",
-        "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
-        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
-        "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 40 TFSI = 190 PS / 320 Nm / quattro / 7-speed S tronic. Gearbox is the DQ381-7A (MQB-A2 wet-clutch 7-speed DCT, AWD variant with Haldex rear coupling). Existing official_derived final drives (front 4.813 / rear 3.667) confirmed. Top gear 0.635 confirmed from prior-agent PDF extraction (does not match standard DQ381 gear set, indicating an application-specific ratio set). Full forward gear ratio array remains unpopulated.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381-7A)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.635 as the 7th-gear ratio for the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
-        "value": 0.635
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 4.813 for the front final-drive field of the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
-        "value": 4.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 3.667 for the rear final-drive field of the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
-        "value": 3.667
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-            "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-          ],
-          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 40 TFSI quattro state. The broader optional wheel/tire matrix remains unresolved.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 65.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 2 review strengthens the exact old-generation Q3 40 TFSI quattro row with matched official Audi MediaCenter 2024 and 2025 technical-data PDFs: AWD, 7-speed S tronic, 0.635 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row end year remains 2025 because Audi scopes this generation as 'Q3 (until 2025)' and launches the third-generation Q3 in Germany and Europe from October 2025.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-until-2025-model-page",
-          "audi_mediacenter_sources:f3-q3-third-generation-launch-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 40 TFSI quattro year-by-year continuity across the represented 2019-2025 row span",
-        "reason": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs resolve the same exact late old-generation 40 TFSI quattro state, but this pass did not recover a year-by-year official sheet chain proving one unchanged package across every model year represented by the row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q3 40 TFSI quattro optional wheel/tire matrix",
-        "reason": "The checked official Audi MediaCenter 2025 technical-data PDF resolves the basic 215/65 R17 tire package, but this pass did not recover an exact old-generation optional wheel/tire matrix tied to this exact row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
-        ]
-      },
-      {
-        "item": "Audi Q3 40 TFSI quattro gearbox family-code confirmation",
-        "reason": "The checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-f3-45-tfsi-e-eu-2021-dct6-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F3",
-    "body_code": "F3",
-    "production_start_year": 2021,
-    "production_end_year": 2025,
-    "model_name": "Q3 (F3, 2019-2025)",
-    "variant_name": "45 TFSI e",
-    "engine_code": "1.4L",
-    "engine_name": "1.4L I4 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
-        "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
-        "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
-        "secondary_technical_sources:q3-f3-wikipedia",
-        "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-        "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note.",
-      "code": "DCT6",
-      "name": "6-speed S tronic (DQ400e PHEV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2024 technical-data PDF lists 0.840 as the 6th-gear ratio for the exact old-generation Q3 45 TFSI e S tronic state. Applied here as official-derived evidence after the launch release and MY2021 price list closed the exact 2021+ identity and transmission mapping.",
-        "value": 0.84
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
-          "secondary_technical_sources:q3-f3-mediacenter-phev-wayback"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note.",
-        "value": [
-          3.5,
-          2.773,
-          1.852,
-          1.023,
-          1.02,
-          0.84
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note. For FWD DCT variants this is sub-transmission 1 (odd gears) output ratio.",
-        "value": 4.588,
-        "evidence_refs": [
-          "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
-          "secondary_technical_sources:q3-f3-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
+  "configurations": [
+    {
+      "id": "audi-f3-35-tdi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F3",
+      "body_code": "F3",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "Q3 (F3, 2019-2025)",
+      "variant_name": "35 TDI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
         "evidence_refs": [
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
           "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-          "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release",
-          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
+          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
+          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf"
         ],
-        "notes": "The checked official Audi Germany model-year 2021 price list and launch release confirm 17-inch wheels as the exact launch baseline for the Q3 45 TFSI e, and the later official Audi MediaCenter 2024 technical-data PDF independently confirms 215/65 R17 as the basic tire size.",
-        "front": {
-          "width_mm": 215.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release",
-            "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
-          ],
-          "notes": "Official Audi Germany model-year 2021 material shows the exact Q3 45 TFSI e starts on a 17-inch square setup; the later technical-data PDF independently confirms 215/65 R17 as the basic tire size.",
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs": [
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "secondary_technical_sources:q3-f3-wikipedia",
+          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+          "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
+          "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf"
+        ],
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381-7F)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.561 as the 7th-gear ratio for the old-generation Q3 35 TDI S tronic state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
+          "value": 0.561
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TDI = 150 PS / 340 Nm / FWD / 7-speed S tronic. The 340 Nm output exceeds the DQ200 dry-clutch DCT 250 Nm limit, so the gearbox is the DQ381-7F (longitudinal MQB-A2 wet-clutch 7-speed DCT, FWD variant). Final drive split: existing prior-agent extraction recorded 4.813 / 3.667 for the AWD sibling rows; the same DQ381-7F architecture publishes two final drives (sub-transmission 1 odd-gear shaft = 4.813, sub-transmission 2 even-gear shaft = 3.667) which both drive the same FWD axle. Repo's prior 4.769 family_default replaced with the official sub-transmission 1 ratio 4.813 in final_drive_front, and sub-transmission 2 ratio 3.667 added to final_drive_rear with note that for FWD DCT variants this field encodes the second sub-transmission output ratio, not a physical rear axle. Forward gear ratio array remains unpopulated (PDF was not extracted by prior agent and is currently 404; only top gear 0.561 is published). For FWD DCT variants this is sub-transmission 1 (odd gears 1/3/5/7) output ratio.",
+          "value": 4.813,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the old-generation Q3 35 TDI S tronic state. Applied as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
           "front": {
             "width_mm": 215.0,
             "aspect_pct": 65.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e5",
+            "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the old-generation Q3 35 TDI S tronic state. The broader optional wheel/tire matrix remains unresolved.",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-          ],
-          "notes": "The checked official Audi Germany model-year 2021 price list lists a square 235/55 R18 package for the exact Q3 45 TFSI e, and the launch release confirms 18-inch wheels are available as official options.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 55.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-          ],
-          "notes": "The checked official Audi Germany model-year 2021 price list lists a square 235/50 R19 package for the exact Q3 45 TFSI e, and the launch release confirms 19-inch wheels are available as official options.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" square 235"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-          ],
-          "notes": "The checked official Audi Germany model-year 2021 price list lists a square 255/45 R19 package for the exact Q3 45 TFSI e, and the launch release confirms 19-inch wheels are available as official options.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" square 255"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
-          ],
-          "notes": "The checked official Audi Germany model-year 2021 price list lists a square 255/40 R20 package for the exact Q3 45 TFSI e, and the launch release confirms 20-inch wheels are available as official options.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" square"
+          "note": "Batch 3 review replaces the copied Q3 cluster note with row-specific Audi MediaCenter evidence for the old-generation Q3 35 TDI S tronic state: the 2018 launch press kit and Germany model-year 2021 price list show the same front-wheel-drive 7-speed S tronic identity, while the 2024 and 2025 technical-data PDFs resolve the late-cycle exact mapping with 0.561 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row keeps a conservative placeholder final-drive field because the checked official source publishes two final-drive values that the current single-slot row shape cannot safely encode.",
+          "evidence_refs_ref": "e8"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 35 TDI year-by-year continuity across the represented 2019-2025 row span",
+          "reason": "The checked official Audi source chain brackets the old-generation 35 TDI S tronic state at launch, in the Germany model-year 2021 price list, and in the exact 2024 and 2025 technical-data sheets, but this pass still did not recover a year-by-year official chain proving one unchanged package across every model year represented by the row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Schema-safe encoding of exact Audi Q3 35 TDI split final-drive values",
+          "reason": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs publish split final drives 4.813 / 3.667 for the target, but the current row has only one final_drive_front field and cannot safely encode both values.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Audi Q3 35 TDI optional wheel/tire matrix and gearbox family-code confirmation",
+          "reason": "The checked official source chain resolves the exact 215/65 R17 base tire and market-facing 7-speed S tronic wording at launch, mid-cycle, and in the 2024/2025 late-cycle technical-data sheets, but this pass did not recover an exact old-generation optional wheel/tire matrix or an official gearbox family code.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-35-tdi-2024-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-35-tdi-2025-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+            "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Batch 8 review re-keys the old unsupported 2019/DCT7 placeholder to the exact old-generation Q3 45 TFSI e state supported by official Audi material. The 2020 launch release fixes German presales to January 2021 and explicitly says the plug-in hybrid drives the front wheels through a six-speed S tronic. The checked Germany model-year 2021 price list independently confirms Frontantrieb, 6-Gang S tronic, 17-inch standard wheels, and the 18/19/20-inch option ladder for the exact 45 TFSI e row. The later official Audi MediaCenter 2024 technical-data PDF then supplies the exact forward ratios 3.500 / 2.773 / 1.852 / 1.020 / 1.023 / 0.840 and confirms 215/65 R17 as the basic tire size for the same 110/180 kW old-generation Q3 45 TFSI e state.",
+    {
+      "id": "audi-f3-35-tfsi-eu-2019-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F3",
+      "body_code": "F3",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "Q3 (F3, 2019-2025)",
+      "variant_name": "35 TFSI",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release",
-          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
           "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-          "audi_mediacenter_sources:f3-q3-until-2025-model-page"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q3 45 TFSI e schema-safe encoding of official split final-drive values",
-        "reason": "The checked official Audi MediaCenter 2024 technical-data PDF publishes final-drive ratios 4.588 / 3.545 for the exact Q3 45 TFSI e state, but the current schema exposes only one front final-drive field and cannot safely encode both official values without losing fidelity.",
+          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf"
+        ],
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
         "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf"
+          "audi_mediacenter_sources:f3-q3-35-tfsi-2025-s-tronic-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "secondary_technical_sources:q3-f3-wikipedia",
+          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+          "audi_mediacenter_sources:f3-q3-2018-launch-press-kit",
+          "audi_mediacenter_sources:f3-q3-35-tfsi-2024-s-tronic-tech-data-pdf"
+        ],
+        "notes_ref": "n3",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381-7F)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.661 as the 7th-gear ratio for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while full 2019-2025 continuity remains unresolved.",
+          "value": 0.661
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while full 2019-2025 continuity remains unresolved. Sonnet redo research (2026-04 v2): apparent 5/6 inversion is a DCT sub-trans cross-over (sub-trans 1 odd-gear FD 5.200 vs sub-trans 2 even-gear FD 3.900) - internal sub-transmission ratio sets are each monotonic.",
+          "value": [
+            3.19,
+            2.75,
+            1.897,
+            1.04,
+            0.793,
+            0.86,
+            0.661
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) 'Extensive engine range' press release confirms 35 TFSI = 150 PS / 250 Nm / FWD / 7-speed S tronic. Gearbox is the DQ381-7F (MQB-A2 longitudinal wet-clutch 7-speed DCT, FWD variant). Sub-transmission split: sub-trans 1 (odd gears 1/3/5/7) final drive 5.200; sub-trans 2 (even gears 2/4/6) final drive 3.900. Both drive the same FWD axle. Repo's 4.769 family_default replaced with the official sub-trans 1 value 5.200 in final_drive_front, sub-trans 2 value 3.900 added to final_drive_rear with same FWD-DCT semantic note. Forward gear ratios array [3.19, 2.75, 1.897, 1.04, 0.793, 0.86, 0.661] kept as official_derived from prior-agent PDF extraction; the apparent 5/6 inversion (0.793 -> 0.860) is a known DCT sub-transmission cross-over artifact: gears 5 (odd) and 6 (even) ride on different sub-transmission shafts with different final drives, so the OVERALL road ratio is monotonic when each gear is multiplied by its sub-transmission FD. Sub-trans 1 internal set {3.19, 1.897, 0.793, 0.661} and sub-trans 2 internal set {2.75, 1.04, 0.86} are each strictly monotonic. For FWD DCT variants this is sub-transmission 1 (odd gears) output ratio.",
+          "value": 5.2,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 35 TFSI S tronic state. Applied here as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 35 TFSI S tronic state. The broader optional wheel/tire matrix remains unresolved.",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
         ]
       },
-      {
-        "item": "Audi Q3 45 TFSI e wheel-package continuity beyond the checked Germany MY2021 matrix",
-        "reason": "The checked official Audi Germany model-year 2021 price list and launch release resolve the launch 17/18/19/20-inch square wheel ladder for the exact 45 TFSI e row, but this pass did not recover later year-by-year Audi wheel matrices proving every option carried unchanged through the full 2021-2025 span.",
+      "verification_notes": [
+        {
+          "note": "Batch 2 review replaces the broad mixed-transmission note with exact row-specific evidence for the old-generation Q3 35 TFSI S tronic state represented by this DCT7 row. The 2018 launch press kit and the Germany model-year 2021 price list confirm the exact front-wheel-drive 7-Gang S tronic row as launch and mid-cycle overlap, and the checked 2024 and 2025 technical-data PDFs resolve the exact late-cycle DCT7 mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, split final drives 5.200 / 3.900, and basic 215/65 R17 tires. The row keeps a conservative placeholder final-drive field because the checked official source publishes two final-drive values that the current single-slot row shape cannot safely encode.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 35 TFSI production-data applicability across the represented 2019-2025 row span",
+          "reason": "The checked 2018 launch press kit, Germany model-year 2021 price list, and exact 2024 and 2025 S tronic technical-data PDFs confirm the old-generation 35 TFSI S tronic state as launch, mid-cycle, and late-cycle overlap, but this pass did not recover a year-by-year official chain proving one unchanged DCT7 package across every model year represented by the row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Schema-safe encoding of exact Audi Q3 35 TFSI S tronic split final-drive values",
+          "reason": "The checked official 2024 and 2025 Q3 35 TFSI S tronic technical-data PDFs publish split final drives 5.200 / 3.900, but the current row has only one final_drive_front field and cannot safely encode both values.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Audi Q3 35 TFSI optional wheel/tire matrix and gearbox family-code confirmation",
+          "reason": "The checked official source chain resolves the basic 215/65 R17 tire package and market-facing 7-speed S tronic wording at launch, mid-cycle, and in the 2024/2025 late-cycle technical-data sheets, but this pass did not recover a full exact optional wheel/tire matrix or an official gearbox family code for the S tronic state.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-f3-40-tdi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F3",
+      "body_code": "F3",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "Q3 (F3, 2019-2025)",
+      "variant_name": "40 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
-          "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
+          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf"
+        ],
+        "notes_ref": "n5",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs": [
+          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-wikipedia"
+        ],
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381-7A)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 0.561 as the checked 7th-gear ratio for the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
+          "value": 0.561
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 4.813 for the checked front final-drive field of the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
+          "value": 4.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs list 3.667 for the checked rear final-drive field of the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while year-by-year continuity remains unresolved.",
+          "value": 3.667
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the checked basic tire for the old-generation Q3 40 TDI quattro state. Applied as official-derived evidence for the broader EU row while the full optional wheel/tire matrix remains unresolved.",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes": "Exact Audi MediaCenter Germany-program 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the checked basic tire package for the old-generation Q3 40 TDI quattro state. The broader optional wheel/tire matrix remains unresolved.",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
         ]
       },
-      {
-        "item": "Audi Q3 45 TFSI e exact gearbox family-code naming",
-        "reason": "The checked official Audi sources explicitly publish 6-speed S tronic wording and PHEV gearbox integration details, but they do not name the supplier or family code behind the repo's normalized DCT6 mapping.",
+      "verification_notes": [
+        {
+          "note": "Batch 2 review replaces the inherited Q3 40 TDI quattro assumptions with official Audi MediaCenter exact 2024 and 2025 old-generation technical-data sheets: AWD, 7-speed S tronic, 0.561 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row end year is corrected to 2025 because Audi scopes this generation as 'Q3 (until 2025)' and launches the third-generation Q3 in Germany and Europe from October 2025.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-40-tdi-quattro-2025-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-until-2025-model-page",
+            "audi_mediacenter_sources:f3-q3-third-generation-launch-release"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 40 TDI quattro year-by-year continuity across the represented 2019-2025 row span",
+          "reason": "Checked exact Germany-program 2024 and 2025 technical-data PDFs agree on the core drivetrain, top-gear, split final-drive, and basic-tire package, but this pass did not recover a year-by-year official sheet chain proving one unchanged mapping across every model year in the row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q3 40 TDI quattro optional wheel/tire matrix",
+          "reason": "The 2018 Q3 launch press kit documents the old-generation family wheel program with standard 17-inch, trim-linked 18-inch, and optional 19-inch and 20-inch packages, but this pass did not recover an exact 40 TDI quattro option matrix tying every tire size to this exact row.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
+          ]
+        },
+        {
+          "item": "Audi Q3 40 TDI quattro gearbox family-code confirmation",
+          "reason": "Checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-f3-40-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F3",
+      "body_code": "F3",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "Q3 (F3, 2019-2025)",
+      "variant_name": "40 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
+          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf"
+        ],
+        "notes_ref": "n6",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs": [
+          "secondary_technical_sources:q3-f3-wikipedia",
+          "secondary_technical_sources:q3-f3-mediacenter-engine-range-wayback",
+          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
+          "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf"
+        ],
+        "notes_ref": "n6",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381-7A)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 0.635 as the 7th-gear ratio for the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
+          "value": 0.635
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 4.813 for the front final-drive field of the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
+          "value": 4.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs list 3.667 for the rear final-drive field of the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while year-by-year continuity remains unresolved.",
+          "value": 3.667
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 40 TFSI quattro state. Applied as official-derived evidence while the broader optional wheel/tire matrix remains unresolved.",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e2",
+            "notes": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs confirm 215/65 R17 as the basic tire package for the exact old-generation Q3 40 TFSI quattro state. The broader optional wheel/tire matrix remains unresolved.",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 2 review strengthens the exact old-generation Q3 40 TFSI quattro row with matched official Audi MediaCenter 2024 and 2025 technical-data PDFs: AWD, 7-speed S tronic, 0.635 top gear, split final drives 4.813 / 3.667, and basic 215/65 R17 tires. The row end year remains 2025 because Audi scopes this generation as 'Q3 (until 2025)' and launches the third-generation Q3 in Germany and Europe from October 2025.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-until-2025-model-page",
+            "audi_mediacenter_sources:f3-q3-third-generation-launch-release"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 40 TFSI quattro year-by-year continuity across the represented 2019-2025 row span",
+          "reason": "The checked official Audi MediaCenter 2024 and 2025 technical-data PDFs resolve the same exact late old-generation 40 TFSI quattro state, but this pass did not recover a year-by-year official sheet chain proving one unchanged package across every model year represented by the row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi Q3 40 TFSI quattro optional wheel/tire matrix",
+          "reason": "The checked official Audi MediaCenter 2025 technical-data PDF resolves the basic 215/65 R17 tire package, but this pass did not recover an exact old-generation optional wheel/tire matrix tied to this exact row.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-40-tfsi-quattro-2025-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-2018-launch-press-kit"
+          ]
+        },
+        {
+          "item": "Audi Q3 40 TFSI quattro gearbox family-code confirmation",
+          "reason": "The checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-f3-45-tfsi-e-eu-2021-dct6-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F3",
+      "body_code": "F3",
+      "production_start_year": 2021,
+      "production_end_year": 2025,
+      "model_name": "Q3 (F3, 2019-2025)",
+      "variant_name": "45 TFSI e",
+      "engine_code": "1.4L",
+      "engine_name": "1.4L I4 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
           "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
           "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
           "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
+        ],
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+          "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
+          "secondary_technical_sources:q3-f3-wikipedia",
+          "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+          "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
+        ],
+        "notes_ref": "n1",
+        "code": "DCT6",
+        "name": "6-speed S tronic (DQ400e PHEV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes": "The checked official Audi MediaCenter 2024 technical-data PDF lists 0.840 as the 6th-gear ratio for the exact old-generation Q3 45 TFSI e S tronic state. Applied here as official-derived evidence after the launch release and MY2021 price list closed the exact 2021+ identity and transmission mapping.",
+          "value": 0.84
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+            "secondary_technical_sources:q3-f3-mediacenter-phev-wayback"
+          ],
+          "notes_ref": "n1",
+          "value": [
+            3.5,
+            2.773,
+            1.852,
+            1.023,
+            1.02,
+            0.84
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes": "Sonnet redo research (2026-04 v2): Audi MediaCenter (Wayback) Q3 PHEV press release confirms 45 TFSI e = FWD / 6-speed S tronic (DQ400e PHEV-specific 6-speed wet-clutch DCT) / 1.4 TFSI + 85 kW PSM electric motor, German production start January 2021. Gear ratio array previously stored as [3.5, 2.773, 1.852, 1.02, 1.023, 0.84] had a transcription swap at indices 3 and 4 (1.020 vs 1.023, ~0.3% difference) - corrected to [3.5, 2.773, 1.852, 1.023, 1.020, 0.840] which gives a strictly monotonic decrease and matches the DQ400e internal sub-transmission semantics (sub-trans 1 odd gears {3.5, 1.852, 1.023}, sub-trans 2 even gears {2.773, 1.020, 0.840}, each monotonic). Final drive split: sub-trans 1 (odd gears 1/3/5) FD 4.588; sub-trans 2 (even gears 2/4/6) FD 3.545. Repo's 4.769 family_default replaced with the official sub-trans 1 value in final_drive_front, sub-trans 2 value added to final_drive_rear with FWD-DCT semantic note. For FWD DCT variants this is sub-transmission 1 (odd gears) output ratio.",
+          "value": 4.588,
+          "evidence_refs": [
+            "secondary_technical_sources:q3-f3-mediacenter-phev-wayback",
+            "secondary_technical_sources:q3-f3-wikipedia"
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "The checked official Audi Germany model-year 2021 price list and launch release confirm 17-inch wheels as the exact launch baseline for the Q3 45 TFSI e, and the later official Audi MediaCenter 2024 technical-data PDF independently confirms 215/65 R17 as the basic tire size.",
+          "front": {
+            "width_mm": 215.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e11",
+            "notes": "Official Audi Germany model-year 2021 material shows the exact Q3 45 TFSI e starts on a 17-inch square setup; the later technical-data PDF independently confirms 215/65 R17 as the basic tire size.",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e4",
+            "notes": "The checked official Audi Germany model-year 2021 price list lists a square 235/55 R18 package for the exact Q3 45 TFSI e, and the launch release confirms 18-inch wheels are available as official options.",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e4",
+            "notes": "The checked official Audi Germany model-year 2021 price list lists a square 235/50 R19 package for the exact Q3 45 TFSI e, and the launch release confirms 19-inch wheels are available as official options.",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" square 235"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e4",
+            "notes": "The checked official Audi Germany model-year 2021 price list lists a square 255/45 R19 package for the exact Q3 45 TFSI e, and the launch release confirms 19-inch wheels are available as official options.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" square 255"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e4",
+            "notes": "The checked official Audi Germany model-year 2021 price list lists a square 255/40 R20 package for the exact Q3 45 TFSI e, and the launch release confirms 20-inch wheels are available as official options.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" square"
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 8 review re-keys the old unsupported 2019/DCT7 placeholder to the exact old-generation Q3 45 TFSI e state supported by official Audi material. The 2020 launch release fixes German presales to January 2021 and explicitly says the plug-in hybrid drives the front wheels through a six-speed S tronic. The checked Germany model-year 2021 price list independently confirms Frontantrieb, 6-Gang S tronic, 17-inch standard wheels, and the 18/19/20-inch option ladder for the exact 45 TFSI e row. The later official Audi MediaCenter 2024 technical-data PDF then supplies the exact forward ratios 3.500 / 2.773 / 1.852 / 1.020 / 1.023 / 0.840 and confirms 215/65 R17 as the basic tire size for the same 110/180 kW old-generation Q3 45 TFSI e state.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release",
+            "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+            "audi_mediacenter_sources:f3-q3-until-2025-model-page"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q3 45 TFSI e schema-safe encoding of official split final-drive values",
+          "reason": "The checked official Audi MediaCenter 2024 technical-data PDF publishes final-drive ratios 4.588 / 3.545 for the exact Q3 45 TFSI e state, but the current schema exposes only one front final-drive field and cannot safely encode both official values without losing fidelity.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi Q3 45 TFSI e wheel-package continuity beyond the checked Germany MY2021 matrix",
+          "reason": "The checked official Audi Germany model-year 2021 price list and launch release resolve the launch 17/18/19/20-inch square wheel ladder for the exact 45 TFSI e row, but this pass did not recover later year-by-year Audi wheel matrices proving every option carried unchanged through the full 2021-2025 span.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi Q3 45 TFSI e exact gearbox family-code naming",
+          "reason": "The checked official Audi sources explicitly publish 6-speed S tronic wording and PHEV gearbox integration details, but they do not name the supplier or family code behind the repo's normalized DCT6 mapping.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:f3-q3-45-tfsi-e-2024-tech-data-pdf",
+            "audi_mediacenter_sources:f3-q3-2021-price-list-pdf",
+            "audi_mediacenter_sources:f3-q3-tfsi-e-2020-launch-release"
+          ]
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q4_e_tron/FZ.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q4_e_tron/FZ.json
@@ -1,321 +1,243 @@
-[
-  {
-    "id": "audi-fz-40-e-tron-eu-2022-ss1-rwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FZ",
-    "body_code": "FZ",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "Q4 e-tron (FZ, 2022-2026)",
-    "variant_name": "40 e-tron",
-    "engine_code": "Electric",
-    "engine_name": "Electric Single Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
+      "n2": "Issue #975 official-source review confirmed the supported EU Q4 e-tron BEV variant mapping, and this pass adds exact Audi official evidence that the launch-era 50 e-tron quattro uses axle-split one-speed reduction ratios (rear 11.5:1, front 10.0:1) plus mixed-size tires with a wider rear axle. It also adds exact official evidence that the launch-era rear-drive Q4 40 e-tron used a one-speed rear-drive ratio of 13:1 and that the later reintroduced Germany-market Q4 40 e-tron uses basic 235/55 R19 front + 255/50 R19 rear tires. The broad row remains unchanged because the current schema cannot safely encode the axle-split EV ratio mapping, the 40 e-tron name is reused across materially different sub-eras, and the later official lineup temporarily renames the upper quattro variant away from the original 50 e-tron quattro naming.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:02f80102b1fb",
         "legacy_research_sources:2d1d32db2857",
+        "legacy_research_sources:4ea362ce6a8e",
+        "legacy_research_sources:6236ede09312",
+        "legacy_research_sources:a7a38f705f5d",
+        "legacy_research_sources:b75aa6c442cb",
         "legacy_research_sources:fd03c253ad14"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "value": 1.0
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "value": 9.756
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02f80102b1fb",
-            "legacy_research_sources:2d1d32db2857",
-            "legacy_research_sources:4ea362ce6a8e",
-            "legacy_research_sources:6236ede09312",
-            "legacy_research_sources:a7a38f705f5d",
-            "legacy_research_sources:b75aa6c442cb",
-            "legacy_research_sources:fd03c253ad14"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02f80102b1fb",
-            "legacy_research_sources:2d1d32db2857",
-            "legacy_research_sources:4ea362ce6a8e",
-            "legacy_research_sources:6236ede09312",
-            "legacy_research_sources:a7a38f705f5d",
-            "legacy_research_sources:b75aa6c442cb",
-            "legacy_research_sources:fd03c253ad14"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        }
+      "e2": [
+        "legacy_research_sources:2d1d32db2857",
+        "legacy_research_sources:fd03c253ad14"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Issue #975 official-source review confirmed the supported EU Q4 e-tron BEV variant mapping, and this pass adds exact Audi official evidence that the launch-era 50 e-tron quattro uses axle-split one-speed reduction ratios (rear 11.5:1, front 10.0:1) plus mixed-size tires with a wider rear axle. It also adds exact official evidence that the launch-era rear-drive Q4 40 e-tron used a one-speed rear-drive ratio of 13:1 and that the later reintroduced Germany-market Q4 40 e-tron uses basic 235/55 R19 front + 255/50 R19 rear tires. The broad row remains unchanged because the current schema cannot safely encode the axle-split EV ratio mapping, the 40 e-tron name is reused across materially different sub-eras, and the later official lineup temporarily renames the upper quattro variant away from the original 50 e-tron quattro naming.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Encode axle-split EV reduction ratios for the exact Q4 50 e-tron quattro in repo schema",
-        "reason": "Official Audi sources now prove rear 11.5:1 and front 10.0:1 one-speed reduction ratios for the exact launch-era 50 e-tron quattro, but the current broad row stores only one final_drive_ratio field and cannot safely represent the axle split.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ]
-      },
-      {
-        "item": "Exact official numeric tire sizes and post-2024 naming continuity for the broad Q4 e-tron row",
-        "reason": "Official Audi launch material confirms mixed-size tires with a wider rear axle, while later official updates rename the upper quattro variant to 55 e-tron quattro, so this pass did not project one exact tire or ratio package across the full 2022-2026 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-fz-50-e-tron-quattro-eu-2022-ss1-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FZ",
-    "body_code": "FZ",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "Q4 e-tron (FZ, 2022-2026)",
-    "variant_name": "50 e-tron quattro",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:2d1d32db2857",
-        "legacy_research_sources:fd03c253ad14"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "value": 1.0
+  "configurations": [
+    {
+      "id": "audi-fz-40-e-tron-eu-2022-ss1-rwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FZ",
+      "body_code": "FZ",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "Q4 e-tron (FZ, 2022-2026)",
+      "variant_name": "40 e-tron",
+      "engine_code": "Electric",
+      "engine_name": "Electric Single Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "value": 9.756
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "value": 9.756
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02f80102b1fb",
-            "legacy_research_sources:2d1d32db2857",
-            "legacy_research_sources:4ea362ce6a8e",
-            "legacy_research_sources:6236ede09312",
-            "legacy_research_sources:a7a38f705f5d",
-            "legacy_research_sources:b75aa6c442cb",
-            "legacy_research_sources:fd03c253ad14"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.756
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:02f80102b1fb",
-            "legacy_research_sources:2d1d32db2857",
-            "legacy_research_sources:4ea362ce6a8e",
-            "legacy_research_sources:6236ede09312",
-            "legacy_research_sources:a7a38f705f5d",
-            "legacy_research_sources:b75aa6c442cb",
-            "legacy_research_sources:fd03c253ad14"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Encode axle-split EV reduction ratios for the exact Q4 50 e-tron quattro in repo schema",
+          "reason": "Official Audi sources now prove rear 11.5:1 and front 10.0:1 one-speed reduction ratios for the exact launch-era 50 e-tron quattro, but the current broad row stores only one final_drive_ratio field and cannot safely represent the axle split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact official numeric tire sizes and post-2024 naming continuity for the broad Q4 e-tron row",
+          "reason": "Official Audi launch material confirms mixed-size tires with a wider rear axle, while later official updates rename the upper quattro variant to 55 e-tron quattro, so this pass did not project one exact tire or ratio package across the full 2022-2026 broad row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Issue #975 official-source review confirmed the supported EU Q4 e-tron BEV variant mapping, and this pass adds exact Audi official evidence that the launch-era 50 e-tron quattro uses axle-split one-speed reduction ratios (rear 11.5:1, front 10.0:1) plus mixed-size tires with a wider rear axle. It also adds exact official evidence that the launch-era rear-drive Q4 40 e-tron used a one-speed rear-drive ratio of 13:1 and that the later reintroduced Germany-market Q4 40 e-tron uses basic 235/55 R19 front + 255/50 R19 rear tires. The broad row remains unchanged because the current schema cannot safely encode the axle-split EV ratio mapping, the 40 e-tron name is reused across materially different sub-eras, and the later official lineup temporarily renames the upper quattro variant away from the original 50 e-tron quattro naming.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
+    {
+      "id": "audi-fz-50-e-tron-quattro-eu-2022-ss1-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FZ",
+      "body_code": "FZ",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "Q4 e-tron (FZ, 2022-2026)",
+      "variant_name": "50 e-tron quattro",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.756
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.756
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 50.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi Technology Portal / MediaCenter with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Encode axle-split EV reduction ratios for the exact Q4 50 e-tron quattro in repo schema",
+          "reason": "Official Audi sources now prove rear 11.5:1 and front 10.0:1 one-speed reduction ratios for the exact launch-era 50 e-tron quattro, but the current broad row stores only one final_drive_ratio field and cannot safely represent the axle split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact official numeric tire sizes and post-2024 naming continuity for the broad Q4 e-tron row",
+          "reason": "Official Audi launch material confirms mixed-size tires with a wider rear axle, while later official updates rename the upper quattro variant to 55 e-tron quattro, so this pass did not project one exact tire or ratio package across the full 2022-2026 broad row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Encode axle-split EV reduction ratios for the exact Q4 50 e-tron quattro in repo schema",
-        "reason": "Official Audi sources now prove rear 11.5:1 and front 10.0:1 one-speed reduction ratios for the exact launch-era 50 e-tron quattro, but the current broad row stores only one final_drive_ratio field and cannot safely represent the axle split.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ]
-      },
-      {
-        "item": "Exact official numeric tire sizes and post-2024 naming continuity for the broad Q4 e-tron row",
-        "reason": "Official Audi launch material confirms mixed-size tires with a wider rear axle, while later official updates rename the upper quattro variant to 55 e-tron quattro, so this pass did not project one exact tire or ratio package across the full 2022-2026 broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:02f80102b1fb",
-          "legacy_research_sources:2d1d32db2857",
-          "legacy_research_sources:4ea362ce6a8e",
-          "legacy_research_sources:6236ede09312",
-          "legacy_research_sources:a7a38f705f5d",
-          "legacy_research_sources:b75aa6c442cb",
-          "legacy_research_sources:fd03c253ad14"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q5/8R.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q5/8R.json
@@ -1,1028 +1,852 @@
-[
-  {
-    "id": "audi-8r-2-0-tfsi-eu-2011-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n4": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for pre-facelift 2.0 TFSI 211hp Q5 8R (production 2008-2011); facelift switched to ZF 8HP. Repo year span 2011-2017 too broad — DCT7 era ~2010-2012 only. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
+      "n6": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for facelift 2.0 TFSI Q5 8R (211hp Oct 2012-2013; 225hp 2012-2015). Repo year window 2011-2017 should be ~2012-2015. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
+      "n7": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for 3.0 TDI Q5 8R from May 2008 through ~mid-2014 (240hp pre-facelift to Sep 2012; 245hp early facelift Jun 2012-2014). After 2014 the 3.0 TDI quattro switched to ZF 8HP. Repo year span 2011-2017 too broad. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default.",
+      "n8": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for late-facelift 3.0 TDI 240hp Q5 8R (2013-2017). Auto-data lists this variant with 235/55 R19 / 255/45 R20 as standard tires (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
+      "n9": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n15": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n16": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
     },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "value": 0.68
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-            "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 55.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-            "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-            "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:428937eb9fd6",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:753cf52ddd21"
+      ],
+      "e2": [
+        "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
+        "secondary_technical_sources:q5-8r-facelift-gen-autodata"
+      ],
+      "e3": [
+        "legacy_research_sources:5c2e1a7d8f4b",
+        "legacy_research_sources:6e9b3d4a1c2f",
+        "legacy_research_sources:7d0c4e1b9a6f"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific contradiction evidence for the broad Q5 8R 2.0 TFSI front-wheel-drive S tronic placeholder. The recovered early Germany-market lineup article names only 2.0 TFSI quattro petrol states, and the stronger secondary facelift tables recovered in this packet also split 2.0 TFSI only into quattro exact slices. That means the broad 2011-2017 FWD DCT7 row is unsupported by the recovered packet and cannot inherit AWD petrol evidence, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi Q5 8R 2.0 TFSI front-wheel-drive S tronic applicability across the represented EU 2011-2017 row span",
-        "reason": "The recovered packet does not close any front-wheel-drive 2.0 TFSI Q5 state. The checked early official article names only quattro petrol states, and the stronger secondary facelift tables likewise recover only quattro exact slices.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      },
-      {
-        "item": "Represented-row front-wheel-drive DCT7 ratio, final-drive, and tire applicability",
-        "reason": "Because no checked exact front-wheel-drive 2.0 TFSI Q5 state was recovered in this packet, the inherited DCT7 gearbox family, 0.680 top gear, 3.444 final drive, and 235/55 R18 tire mapping remain unsupported broad-row carryover values.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-8r-2-0-tfsi-eu-2011-zf8hp-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "audi-8r-2-0-tfsi-eu-2011-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "value": 0.667
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "value": 3.077
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.68
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific contradiction evidence for the broad Q5 8R 2.0 TFSI front-wheel-drive S tronic placeholder. The recovered early Germany-market lineup article names only 2.0 TFSI quattro petrol states, and the stronger secondary facelift tables recovered in this packet also split 2.0 TFSI only into quattro exact slices. That means the broad 2011-2017 FWD DCT7 row is unsupported by the recovered packet and cannot inherit AWD petrol evidence, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n9"
+        },
+        {
+          "note_ref": "n10"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n15"
+        },
+        {
+          "note_ref": "n16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi Q5 8R 2.0 TFSI front-wheel-drive S tronic applicability across the represented EU 2011-2017 row span",
+          "reason": "The recovered packet does not close any front-wheel-drive 2.0 TFSI Q5 state. The checked early official article names only quattro petrol states, and the stronger secondary facelift tables likewise recover only quattro exact slices.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Represented-row front-wheel-drive DCT7 ratio, final-drive, and tire applicability",
+          "reason": "Because no checked exact front-wheel-drive 2.0 TFSI Q5 state was recovered in this packet, the inherited DCT7 gearbox family, 0.680 top gear, 3.444 final drive, and 235/55 R18 tire mapping remain unsupported broad-row carryover values.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-8r-2-0-tfsi-eu-2011-zf8hp-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave replaces the stale generic backlog note with row-specific contradiction evidence for the broad Q5 8R 2.0 TFSI front-wheel-drive tiptronic placeholder. The recovered early Germany-market lineup article names only 2.0 TFSI quattro petrol states, and the stronger secondary facelift tables recovered in this packet also split 2.0 TFSI only into quattro exact slices. That means the broad 2011-2017 FWD ZF8HP row is unsupported by the recovered packet and cannot inherit AWD petrol evidence, so production JSON remains unchanged.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n9"
+        },
+        {
+          "note_ref": "n10"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n15"
+        },
+        {
+          "note_ref": "n16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi Q5 8R 2.0 TFSI front-wheel-drive tiptronic applicability across the represented EU 2011-2017 row span",
+          "reason": "The recovered packet does not close any front-wheel-drive 2.0 TFSI Q5 state. The checked early official article names only quattro petrol states, and the stronger secondary facelift tables likewise recover only quattro exact slices.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Represented-row front-wheel-drive ZF8HP ratio, final-drive, and tire applicability",
+          "reason": "Because no checked exact front-wheel-drive 2.0 TFSI Q5 state was recovered in this packet, the inherited ZF8HP gearbox family, 0.667 top gear, 3.077 final drive, and 235/55 R18 tire mapping remain unsupported broad-row carryover values.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8r-2-0-tfsi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.68
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
           "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
+            "legacy_research_sources:428937eb9fd6",
+            "legacy_research_sources:4b4b833b364a",
+            "legacy_research_sources:4b8ab423f879",
+            "legacy_research_sources:5e252f7f436b",
+            "legacy_research_sources:753cf52ddd21",
+            "secondary_technical_sources:q5-8r-2-0-tfsi-211-dct7-autodata",
+            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata"
+          ],
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8r-2-0-tfsi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs": [
+            "legacy_research_sources:428937eb9fd6",
+            "legacy_research_sources:4b4b833b364a",
+            "legacy_research_sources:4b8ab423f879",
+            "legacy_research_sources:5e252f7f436b",
+            "legacy_research_sources:753cf52ddd21",
+            "secondary_technical_sources:q5-8rf-2-0-tfsi-225-zf8hp-autodata",
             "secondary_technical_sources:q5-8r-facelift-gen-autodata"
           ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
+          "notes_ref": "n6",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "unverified",
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8r-3-0-tdi-quattro-eu-2011-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n7",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL501)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.68
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.444
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
           "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
+            "legacy_research_sources:428937eb9fd6",
+            "legacy_research_sources:4b4b833b364a",
+            "legacy_research_sources:4b8ab423f879",
+            "legacy_research_sources:5e252f7f436b",
+            "legacy_research_sources:753cf52ddd21",
+            "secondary_technical_sources:q5-8r-3-0-tdi-240-dct7-autodata",
+            "secondary_technical_sources:q5-8rf-3-0-tdi-245-dct7-autodata"
+          ],
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 55.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8r-3-0-tdi-quattro-eu-2011-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "8R",
+      "body_code": "8R",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "Q5 (8R, 2011-2017)",
+      "variant_name": "3.0 TDI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n8",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs": [
+            "legacy_research_sources:428937eb9fd6",
+            "legacy_research_sources:4b4b833b364a",
+            "legacy_research_sources:4b8ab423f879",
+            "legacy_research_sources:5e252f7f436b",
+            "legacy_research_sources:753cf52ddd21",
+            "secondary_technical_sources:q5-8rf-3-0-tdi-240-zf8hp-autodata",
             "secondary_technical_sources:q5-8r-facelift-gen-autodata"
           ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-            "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2) found no FWD 2.0 TFSI variant of Q5 8R in either the pre-facelift (auto-data gen 1121) or facelift (auto-data gen 4176) inventory. Only diesel 2.0 TDI is offered FWD. Marked no_confidence as a phantom EU configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave replaces the stale generic backlog note with row-specific contradiction evidence for the broad Q5 8R 2.0 TFSI front-wheel-drive tiptronic placeholder. The recovered early Germany-market lineup article names only 2.0 TFSI quattro petrol states, and the stronger secondary facelift tables recovered in this packet also split 2.0 TFSI only into quattro exact slices. That means the broad 2011-2017 FWD ZF8HP row is unsupported by the recovered packet and cannot inherit AWD petrol evidence, so production JSON remains unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi Q5 8R 2.0 TFSI front-wheel-drive tiptronic applicability across the represented EU 2011-2017 row span",
-        "reason": "The recovered packet does not close any front-wheel-drive 2.0 TFSI Q5 state. The checked early official article names only quattro petrol states, and the stronger secondary facelift tables likewise recover only quattro exact slices.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      },
-      {
-        "item": "Represented-row front-wheel-drive ZF8HP ratio, final-drive, and tire applicability",
-        "reason": "Because no checked exact front-wheel-drive 2.0 TFSI Q5 state was recovered in this packet, the inherited ZF8HP gearbox family, 0.667 top gear, 3.077 final drive, and 235/55 R18 tire mapping remain unsupported broad-row carryover values.",
-        "evidence_refs": [
-          "legacy_research_sources:5c2e1a7d8f4b",
-          "legacy_research_sources:6e9b3d4a1c2f",
-          "legacy_research_sources:7d0c4e1b9a6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8r-2-0-tfsi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for pre-facelift 2.0 TFSI 211hp Q5 8R (production 2008-2011); facelift switched to ZF 8HP. Repo year span 2011-2017 too broad — DCT7 era ~2010-2012 only. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for pre-facelift 2.0 TFSI 211hp Q5 8R (production 2008-2011); facelift switched to ZF 8HP. Repo year span 2011-2017 too broad — DCT7 era ~2010-2012 only. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.68
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21",
-          "secondary_technical_sources:q5-8r-2-0-tfsi-211-dct7-autodata",
-          "secondary_technical_sources:q5-8r-pre-facelift-gen-autodata"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for pre-facelift 2.0 TFSI 211hp Q5 8R (production 2008-2011); facelift switched to ZF 8HP. Repo year span 2011-2017 too broad — DCT7 era ~2010-2012 only. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8r-2-0-tfsi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for facelift 2.0 TFSI Q5 8R (211hp Oct 2012-2013; 225hp 2012-2015). Repo year window 2011-2017 should be ~2012-2015. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for facelift 2.0 TFSI Q5 8R (211hp Oct 2012-2013; 225hp 2012-2015). Repo year window 2011-2017 should be ~2012-2015. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21",
-          "secondary_technical_sources:q5-8rf-2-0-tfsi-225-zf8hp-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for facelift 2.0 TFSI Q5 8R (211hp Oct 2012-2013; 225hp 2012-2015). Repo year window 2011-2017 should be ~2012-2015. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 55.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  },
-  {
-    "id": "audi-8r-3-0-tdi-quattro-eu-2011-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for 3.0 TDI Q5 8R from May 2008 through ~mid-2014 (240hp pre-facelift to Sep 2012; 245hp early facelift Jun 2012-2014). After 2014 the 3.0 TDI quattro switched to ZF 8HP. Repo year span 2011-2017 too broad. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for 3.0 TDI Q5 8R from May 2008 through ~mid-2014 (240hp pre-facelift to Sep 2012; 245hp early facelift Jun 2012-2014). After 2014 the 3.0 TDI quattro switched to ZF 8HP. Repo year span 2011-2017 too broad. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL501)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.68
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.444
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21",
-          "secondary_technical_sources:q5-8r-3-0-tdi-240-dct7-autodata",
-          "secondary_technical_sources:q5-8rf-3-0-tdi-245-dct7-autodata"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms DCT7 (DL501) + quattro for 3.0 TDI Q5 8R from May 2008 through ~mid-2014 (240hp pre-facelift to Sep 2012; 245hp early facelift Jun 2012-2014). After 2014 the 3.0 TDI quattro switched to ZF 8HP. Repo year span 2011-2017 too broad. Auto-data lists standard tire 235/60 R18 (not 235/55 R18). Gear ratio values remain family_default.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 55.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8r-3-0-tdi-quattro-eu-2011-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "8R",
-    "body_code": "8R",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "Q5 (8R, 2011-2017)",
-    "variant_name": "3.0 TDI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for late-facelift 3.0 TDI 240hp Q5 8R (2013-2017). Auto-data lists this variant with 235/55 R19 / 255/45 R20 as standard tires (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for late-facelift 3.0 TDI 240hp Q5 8R (2013-2017). Auto-data lists this variant with 235/55 R19 / 255/45 R20 as standard tires (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21",
-          "secondary_technical_sources:q5-8rf-3-0-tdi-240-zf8hp-autodata",
-          "secondary_technical_sources:q5-8r-facelift-gen-autodata"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence. Sonnet redo research (2026-04 v2): auto-data confirms ZF 8HP (8-speed tiptronic) + quattro for late-facelift 3.0 TDI 240hp Q5 8R (2013-2017). Auto-data lists this variant with 235/55 R19 / 255/45 R20 as standard tires (not 235/55 R18). Gear ratio values remain family_default — no primary source.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 55.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:428937eb9fd6",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:753cf52ddd21"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 (8R, 2011-2017) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      },
-      {
-        "item": "Audi Q5 (8R, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:428937eb9fd6",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:753cf52ddd21"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q5/FY.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q5/FY.json
@@ -1,1028 +1,802 @@
-[
-  {
-    "id": "audi-fy-40-tfsi-eu-2017-dct7-fwd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FY",
-    "body_code": "FY",
-    "production_start_year": 2017,
-    "production_end_year": 2026,
-    "model_name": "Q5 (FY, 2017-2026)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-      "value": "FWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
+      "n2": "Sonnet redo research (2026-04 v2): ADAC Autokatalog pre-facelift confirms 'Q5 35 TDI quattro S tronic' production span 08/2018-07/2020 at 110 kW/150 PS, quattro, 7-speed S tronic (DL382). Repo's prior production_end_year of 2019 is too narrow; corrected to 2020. Tire 235/65 R17 confirmed by existing Audi MediaCenter PDF reference (already in repo as official_exact). Forward gear ratios for the DL382 7-speed remain unpopulated - no accessible primary source PDF (Audi MediaCenter PDFs returned 404, auto-data and ultimatespecs returned wrong vehicles or redirects). The 'DCT7' code is the correct family but the precise internal designation is DL382 (longitudinal wet-clutch DCT, marketed as 'S tronic 7-speed').",
+      "n3": "Official Audi 09/27/2019 technical-data PDF publishes one final-drive value 5.302 for the exact FY Q5 35 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n4": "Official Audi 09/27/2019 technical-data material confirms 235/65 R17 as the exact basic tire package for the FY Q5 35 TDI quattro S tronic row, and the exact ADAC variant page cross-checks the same baseline size.",
+      "n5": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 45 TFSI quattro S tronic' production span 01/2019-07/2020 at 180 kW (pre-facelift) and 09/2020-11/2024 at 195 kW (facelift). Existing repo evidence from two Audi MediaCenter tech-data PDFs (2019 and 2024) corroborates 7-speed S tronic + quattro ultra. Power state increase at facelift could be split into two rows for precision; the current single row spanning 2019-2024 is a reasonable approximation. Tire 235/65 R17 confirmed official_derived. Forward gear ratios remain unpopulated - no accessible primary EU spec source. The internal transmission designation is DL382 (longitudinal wet-clutch DCT marketed as 'S tronic 7-speed').",
+      "n6": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs agree on final drive 5.302 for the FY Q5 45 TFSI quattro state.",
+      "n7": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 55 TFSI e quattro S tronic' production span 09/2019-08/2020 (pre-facelift) and 02/2021-11/2024 (facelift). Car and Driver 2021 spec page explicitly lists 'Transmission: 7-Speed S tronic Dual-Clutch Auto' - decisively refuting any suggestion that the FY PHEV uses the 8-speed Tiptronic (ZF 8HP) found on Q7/Q8 PHEVs (different platforms). The Q5 FY PHEV uses an e-S tronic (DL382-derived 7-speed wet-clutch DCT with integrated electric motor on the MLB Evo platform). Three Audi MediaCenter PDFs (2019 launch, 2021 tech-data, 2024 tech-data) already in repo confirm 7-speed S tronic + quattro ultra. Tire 235/60 R18 confirmed official_exact. Forward gear ratios remain unpopulated.",
+      "n8": "Official Audi 2021 and 2024 technical-data PDFs publish one populated final-drive value 5.302 for the exact FY Q5 55 TFSI e quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n9": "Official Audi 2021 and 2024 technical-data PDFs both list 235/60 R18 on 8 J x 18 wheels as the basic non-staggered tire package for the exact FY Q5 55 TFSI e quattro state. Applied as official exact evidence while the optional wheel/tire matrix remains unresolved.",
+      "n10": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter / technical data PDF with High confidence.",
+      "n11": "Sonnet redo research (2026-04 v2): ADAC Autokatalog facelift catalogue confirms 'Q5 40 TDI quattro S tronic' production span 09/2020-11/2024 at 150 kW/204 PS, quattro, 7-speed S tronic (DL382). The '40 TDI' commercial designation was introduced at the 09/2020 facelift; pre-facelift equivalents had different power states. Repo's production_start_year 2020 / end 2024 is correct (the '-2017-' substring in the row id is a legacy naming artifact, not the actual variant start). Tire 235/65 R17 confirmed official_exact via existing Audi MediaCenter 2024 tech-data PDF reference. Forward gear ratios remain unpopulated - no accessible primary EU spec source for the DL382 in this application. The internal transmission designation is DL382.",
+      "n12": "Official Audi 06/04/2024 technical-data PDF publishes one final-drive value 5.302 for the exact later FY Q5 40 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n13": "Official Audi 06/04/2024 technical-data material confirms 235/65 R17 as the exact basic tire package for the later FY Q5 40 TDI quattro S tronic row, and the exact ADAC facelift variant page cross-checks the same baseline size."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "secondary_technical_sources:q5-fy-adac-prefacelift",
         "secondary_technical_sources:q5-fy-adac-facelift",
         "secondary_technical_sources:q5-fy-wikipedia"
+      ],
+      "e2": [
+        "legacy_research_sources:0704ea887c86",
+        "legacy_research_sources:4395fed0b13e",
+        "legacy_research_sources:54af60a9ddf0",
+        "legacy_research_sources:58f92c263343",
+        "legacy_research_sources:6db6eab4aafb",
+        "legacy_research_sources:7e60864b72c3",
+        "legacy_research_sources:84ab012d7125",
+        "legacy_research_sources:a6de0bcaa857",
+        "legacy_research_sources:aaa1bd276e93",
+        "legacy_research_sources:b24b22157008",
+        "legacy_research_sources:e6b28c39d7e6",
+        "legacy_research_sources:efd444c9156f",
+        "legacy_research_sources:f8d3f991ca53"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
+        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
+        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
+        "secondary_technical_sources:fy-q5-35-tdi-quattro-adac"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
+        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
+        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
+        "audi_mediacenter_sources:fy-q5-2025-e-hybrid-launch-release"
+      ],
+      "e9": [
+        "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
+        "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
       ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)",
-      "evidence_refs": [
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-adac-facelift",
-        "secondary_technical_sources:q5-fy-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-fy-40-tfsi-eu-2017-dct7-fwd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FY",
+      "body_code": "FY",
+      "production_start_year": 2017,
+      "production_end_year": 2026,
+      "model_name": "Q5 (FY, 2017-2026)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-        "value": 0.725,
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
+        "notes_ref": "n1",
+        "value": "FWD",
+        "evidence_refs_ref": "e1"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-        "value": 5.302,
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)",
+        "evidence_refs_ref": "e1"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-fy-adac-prefacelift",
-            "secondary_technical_sources:q5-fy-adac-facelift",
-            "secondary_technical_sources:q5-fy-wikipedia"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
+          "notes_ref": "n1",
+          "value": 0.725,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 5.302,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Verified Audi Q5 FY S tronic final-drive ratios from official Audi MediaCenter and Audi technical data PDFs. Exact Germany-market technical-data sheets for the Q5 45 TFSI quattro now confirm top gear 0.433, full forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 5.302, and basic tire 235/65 R17 across checked 2019 and 2024 documents, which is sufficient to correct the variant-scoped production top gear and add the exact ratio set. Wave 10 validation now also confirms the late-FY exact Q5 40 TFSI quattro mapping from the 06/04/2024 Germany technical-data PDF: quattro all-wheel drive with ultra technology, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 5.302, and basic tire 235/65 R17. Wave 11 validation adds exact 40 TDI quattro context across two contradictory official FY-era Germany states: the 09/27/2019 sheet proves AWD, 6-speed manual, forward ratios 3.778 / 1.957 / 1.241 / 0.912 / 0.692 / 0.571, reverse 3.333, final drive 2.647, and basic tire 235/65 R17; the 06/04/2024 sheet proves quattro ultra AWD, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 5.302, and the same 235/65 R17 basic tire. Wave 12 validation now adds exact 35 TDI Germany context across two official front-wheel-drive states: the 2019 120 kW Q5 35 TDI S tronic sheet and the 2024 120 kW MHEV Q5 35 TDI S tronic sheet both prove Frontantrieb, the same forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, and the same 235/65 R17 basic tire, but they publish different final drives 5.302 and 4.885 and do not support any checked Germany-market 35 TDI quattro state. The existing 03/27/2025 front-wheel-drive 150 kW Q5 SUV source is retained only as evidence that a newer-generation Q5 state exists and must not be treated as FY 40 TFSI evidence. Later exact 55 TFSI e quattro sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 235/60 R18 basic tire for the 270 kW PHEV configuration, but the broad FY row remains unchanged until the represented production span is proven at the same granularity.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-fy-adac-prefacelift",
-            "secondary_technical_sources:q5-fy-adac-facelift",
-            "secondary_technical_sources:q5-fy-wikipedia"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:q5-fy-adac-prefacelift",
-            "secondary_technical_sources:q5-fy-adac-facelift",
-            "secondary_technical_sources:q5-fy-wikipedia"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms NO FWD TFSI Q5 FY exists in the EU/DE market - all TFSI variants are quattro-only across both pre-facelift (-07/2020) and facelift (09/2020-11/2024) catalogs. The only FWD Q5 FY in DE is the 35 TDI (diesel). Additionally, the '40 TFSI' commercial designation only appears at the 12/2021 facelift (as quattro), so the row's production_start_year of 2017 is also wrong. This FWD + TFSI + 2017 combination does not exist - marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verified Audi Q5 FY S tronic final-drive ratios from official Audi MediaCenter and Audi technical data PDFs. Exact Germany-market technical-data sheets for the Q5 45 TFSI quattro now confirm top gear 0.433, full forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 5.302, and basic tire 235/65 R17 across checked 2019 and 2024 documents, which is sufficient to correct the variant-scoped production top gear and add the exact ratio set. Wave 10 validation now also confirms the late-FY exact Q5 40 TFSI quattro mapping from the 06/04/2024 Germany technical-data PDF: quattro all-wheel drive with ultra technology, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, final drive 5.302, and basic tire 235/65 R17. Wave 11 validation adds exact 40 TDI quattro context across two contradictory official FY-era Germany states: the 09/27/2019 sheet proves AWD, 6-speed manual, forward ratios 3.778 / 1.957 / 1.241 / 0.912 / 0.692 / 0.571, reverse 3.333, final drive 2.647, and basic tire 235/65 R17; the 06/04/2024 sheet proves quattro ultra AWD, 7-speed S tronic, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, final drive 5.302, and the same 235/65 R17 basic tire. Wave 12 validation now adds exact 35 TDI Germany context across two official front-wheel-drive states: the 2019 120 kW Q5 35 TDI S tronic sheet and the 2024 120 kW MHEV Q5 35 TDI S tronic sheet both prove Frontantrieb, the same forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, and the same 235/65 R17 basic tire, but they publish different final drives 5.302 and 4.885 and do not support any checked Germany-market 35 TDI quattro state. The existing 03/27/2025 front-wheel-drive 150 kW Q5 SUV source is retained only as evidence that a newer-generation Q5 state exists and must not be treated as FY 40 TFSI evidence. Later exact 55 TFSI e quattro sheets also resolve top gear 0.433, the full 7-speed ratio set, and the 235/60 R18 basic tire for the 270 kW PHEV configuration, but the broad FY row remains unchanged until the represented production span is proven at the same granularity.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi MediaCenter eTD technical data with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q5-fy-adac-prefacelift",
-          "secondary_technical_sources:q5-fy-adac-facelift",
-          "secondary_technical_sources:q5-fy-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Broad-row Audi Q5 FY 40 TFSI production-data applicability across the represented span",
-        "reason": "The checked 06/04/2024 Germany FY sheet resolves a late-FY 40 TFSI quattro state, but this pass did not recover official earlier FY or later new-generation sheets proving one unchanged 40 TFSI package across the broad 2017-2026 row.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 40 TFSI exact optional tire matrix and row-shape continuity",
-        "reason": "Official Audi exact material now proves the FY 40 TFSI quattro drivetrain, full ratio set, reverse ratio, final drive 5.302, and the 235/65 R17 basic tire, but it does not close a full FY optional wheel/tire matrix or prove how the library's current front-drive 40 TFSI variant should be split from the later FY quattro state.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Broad-row Audi Q5 FY 55 TFSI e quattro top_gear_ratio applicability across the represented span",
-        "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 270 kW 55 TFSI e quattro configuration, but this pass did not verify whether every year represented by the broad FY row uses the same exact mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Broad-row Audi Q5 FY 40 TDI quattro production-data applicability across the represented span",
-        "reason": "Checked official Germany-market FY evidence now proves at least two contradictory 40 TDI quattro states within the represented row: a 2019 6-speed manual package with final drive 2.647 and a 2024 7-speed S tronic package with final drive 5.302, so no single production mapping is safe without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 40 TDI quattro exact optional tire matrix, gearbox-family code, and FY boundary",
-        "reason": "Official Audi exact material now proves both the 2019 manual and 2024 S tronic 40 TDI quattro ratio packages and the shared 235/65 R17 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or any FY continuity beyond Audi's own 'bis 2024' boundary.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Whether Audi Q5 FY 35 TDI quattro belongs in the broad row at all",
-        "reason": "Checked official Germany-market FY 35 TDI technical-data sheets from 2019 and 2024 both describe front-wheel-drive Q5 35 TDI S tronic states and this pass did not recover any official Germany evidence for a 35 TDI quattro configuration.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      },
-      {
-        "item": "Broad-row Audi Q5 FY 35 TDI production-data applicability, final-drive continuity, and tire-matrix scope",
-        "reason": "Official Audi exact material now proves two front-wheel-drive 35 TDI FY states with the same forward ratio set, reverse ratio, and 235/65 R17 basic tire but different final drives 5.302 and 4.885, while Audi's own model page still scopes FY Q5 only 'bis 2024'; no safe broad production mapping or full optional wheel/tire matrix is closed yet.",
-        "evidence_refs": [
-          "legacy_research_sources:0704ea887c86",
-          "legacy_research_sources:4395fed0b13e",
-          "legacy_research_sources:54af60a9ddf0",
-          "legacy_research_sources:58f92c263343",
-          "legacy_research_sources:6db6eab4aafb",
-          "legacy_research_sources:7e60864b72c3",
-          "legacy_research_sources:84ab012d7125",
-          "legacy_research_sources:a6de0bcaa857",
-          "legacy_research_sources:aaa1bd276e93",
-          "legacy_research_sources:b24b22157008",
-          "legacy_research_sources:e6b28c39d7e6",
-          "legacy_research_sources:efd444c9156f",
-          "legacy_research_sources:f8d3f991ca53"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-fy-35-tdi-quattro-eu-2017-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FY",
-    "body_code": "FY",
-    "production_start_year": 2018,
-    "production_end_year": 2020,
-    "model_name": "Q5 (FY, 2018-2019)",
-    "variant_name": "35 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-prefacelift"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog pre-facelift confirms 'Q5 35 TDI quattro S tronic' production span 08/2018-07/2020 at 110 kW/150 PS, quattro, 7-speed S tronic (DL382). Repo's prior production_end_year of 2019 is too narrow; corrected to 2020. Tire 235/65 R17 confirmed by existing Audi MediaCenter PDF reference (already in repo as official_exact). Forward gear ratios for the DL382 7-speed remain unpopulated - no accessible primary source PDF (Audi MediaCenter PDFs returned 404, auto-data and ultimatespecs returned wrong vehicles or redirects). The 'DCT7' code is the correct family but the precise internal designation is DL382 (longitudinal wet-clutch DCT, marketed as 'S tronic 7-speed').",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-wikipedia"
+      "unresolved": [
+        {
+          "item": "Broad-row Audi Q5 FY 40 TFSI production-data applicability across the represented span",
+          "reason": "The checked 06/04/2024 Germany FY sheet resolves a late-FY 40 TFSI quattro state, but this pass did not recover official earlier FY or later new-generation sheets proving one unchanged 40 TFSI package across the broad 2017-2026 row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi Q5 FY 40 TFSI exact optional tire matrix and row-shape continuity",
+          "reason": "Official Audi exact material now proves the FY 40 TFSI quattro drivetrain, full ratio set, reverse ratio, final drive 5.302, and the 235/65 R17 basic tire, but it does not close a full FY optional wheel/tire matrix or prove how the library's current front-drive 40 TFSI variant should be split from the later FY quattro state.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Broad-row Audi Q5 FY 55 TFSI e quattro top_gear_ratio applicability across the represented span",
+          "reason": "Official Audi MediaCenter eTD PDFs now prove top gear 0.433 and the full gear-ratio set for the later 270 kW 55 TFSI e quattro configuration, but this pass did not verify whether every year represented by the broad FY row uses the same exact mapping.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Broad-row Audi Q5 FY 40 TDI quattro production-data applicability across the represented span",
+          "reason": "Checked official Germany-market FY evidence now proves at least two contradictory 40 TDI quattro states within the represented row: a 2019 6-speed manual package with final drive 2.647 and a 2024 7-speed S tronic package with final drive 5.302, so no single production mapping is safe without a year split.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi Q5 FY 40 TDI quattro exact optional tire matrix, gearbox-family code, and FY boundary",
+          "reason": "Official Audi exact material now proves both the 2019 manual and 2024 S tronic 40 TDI quattro ratio packages and the shared 235/65 R17 basic tire, but it does not publish a gearbox-family code, a full optional wheel/tire matrix, or any FY continuity beyond Audi's own 'bis 2024' boundary.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Whether Audi Q5 FY 35 TDI quattro belongs in the broad row at all",
+          "reason": "Checked official Germany-market FY 35 TDI technical-data sheets from 2019 and 2024 both describe front-wheel-drive Q5 35 TDI S tronic states and this pass did not recover any official Germany evidence for a 35 TDI quattro configuration.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Broad-row Audi Q5 FY 35 TDI production-data applicability, final-drive continuity, and tire-matrix scope",
+          "reason": "Official Audi exact material now proves two front-wheel-drive 35 TDI FY states with the same forward ratio set, reverse ratio, and 235/65 R17 basic tire but different final drives 5.302 and 4.885, while Audi's own model page still scopes FY Q5 only 'bis 2024'; no safe broad production mapping or full optional wheel/tire matrix is closed yet.",
+          "evidence_refs_ref": "e2"
+        }
       ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog pre-facelift confirms 'Q5 35 TDI quattro S tronic' production span 08/2018-07/2020 at 110 kW/150 PS, quattro, 7-speed S tronic (DL382). Repo's prior production_end_year of 2019 is too narrow; corrected to 2020. Tire 235/65 R17 confirmed by existing Audi MediaCenter PDF reference (already in repo as official_exact). Forward gear ratios for the DL382 7-speed remain unpopulated - no accessible primary source PDF (Audi MediaCenter PDFs returned 404, auto-data and ultimatespecs returned wrong vehicles or redirects). The 'DCT7' code is the correct family but the precise internal designation is DL382 (longitudinal wet-clutch DCT, marketed as 'S tronic 7-speed').",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ],
-        "notes": "Official Audi 09/27/2019 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact FY Q5 35 TDI quattro S tronic row.",
-        "value": 0.386
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ],
-        "notes": "Official Audi 09/27/2019 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact FY Q5 35 TDI quattro S tronic row.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.508,
-          0.386
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ],
-        "notes": "Official Audi 09/27/2019 technical-data PDF publishes one final-drive value 5.302 for the exact FY Q5 35 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ],
-        "notes": "Official Audi 09/27/2019 technical-data PDF publishes one final-drive value 5.302 for the exact FY Q5 35 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-fy-35-tdi-quattro-eu-2017-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FY",
+      "body_code": "FY",
+      "production_start_year": 2018,
+      "production_end_year": 2020,
+      "model_name": "Q5 (FY, 2018-2019)",
+      "variant_name": "35 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
         "evidence_refs": [
           "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
-          "secondary_technical_sources:fy-q5-35-tdi-quattro-adac"
+          "secondary_technical_sources:q5-fy-adac-prefacelift"
         ],
-        "notes": "Official Audi 09/27/2019 technical-data material confirms 235/65 R17 as the exact basic tire package for the FY Q5 35 TDI quattro S tronic row, and the exact ADAC variant page cross-checks the same baseline size.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n2",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-adac-prefacelift",
+          "secondary_technical_sources:q5-fy-wikipedia"
+        ],
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi 09/27/2019 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact FY Q5 35 TDI quattro S tronic row.",
+          "value": 0.386
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi 09/27/2019 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact FY Q5 35 TDI quattro S tronic row.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.508,
+            0.386
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n3",
+          "value": 5.302
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n3",
+          "value": 5.302
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 235.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 6 validation rewrites this row from a broad unsupported FY placeholder into the exact AWD state actually supported by the evidence. The official Audi 09/27/2019 technical-data PDF proves the exact FY Q5 35 TDI quattro S tronic 120 kW package with quattro all-wheel drive, 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 5.302, and basic 235/65 R17 tires. The exact ADAC variant page narrows the checked lifecycle to 08/2018-05/2019, which is normalized here to the conservative 2018-2019 year bucket. Later official Audi 04/02/2024 35 TDI material is retained only as contradiction evidence because it describes a front-wheel-drive FY Q5 35 TDI S tronic state rather than the checked quattro row.",
           "evidence_refs": [
             "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-35-tdi-2024-tech-data-pdf",
             "secondary_technical_sources:fy-q5-35-tdi-quattro-adac"
-          ],
-          "notes": "Official Audi 09/27/2019 technical-data material confirms 235/65 R17 as the exact basic tire package for the FY Q5 35 TDI quattro S tronic row, and the exact ADAC variant page cross-checks the same baseline size.",
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi Q5 FY 35 TDI quattro EU-market lifecycle inside the 2018-2019 year bucket",
+          "reason": "The checked official Audi 2019 technical-data PDF proves the exact quattro state and the exact ADAC page narrows it to 08/2018-05/2019, but this pass did not recover a second independent exact-source ledger for every EU market month inside the normalized 2018-2019 bucket.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi Q5 FY 35 TDI quattro exact optional wheel and tire matrix",
+          "reason": "The checked official Audi exact sheet proves only the basic 235/65 R17 package for the exact 35 TDI quattro row. Broader optional wheel sizes or any staggered package were not recovered for this exact 2018-2019 AWD state.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi Q5 FY 35 TDI quattro exact public gearbox-family naming",
+          "reason": "The checked official Audi exact sheet proves 7-speed S tronic dual-clutch wording for the 2018-2019 AWD state but does not publish a gearbox-family code such as DL382.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-fy-45-tfsi-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FY",
+      "body_code": "FY",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "Q5 (FY, 2019-2024)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-adac-prefacelift",
+          "secondary_technical_sources:q5-fy-adac-facelift",
+          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf"
+        ],
+        "notes_ref": "n5",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "secondary_technical_sources:q5-fy-adac-prefacelift",
+          "secondary_technical_sources:q5-fy-adac-facelift",
+          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-wikipedia",
+          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf"
+        ],
+        "notes_ref": "n5",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs list 0.433 as the checked top-gear ratio for the FY Q5 45 TFSI quattro state.",
+          "value": 0.433
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs agree on the full forward ratio set for the FY Q5 45 TFSI quattro state.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.557,
+            0.433
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 5.302
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 5.302
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs confirm 235/65 R17 as the basic tire package for the FY Q5 45 TFSI quattro state. Applied as official-derived evidence for the corrected 2019-2024 row while the full optional wheel/tire matrix remains unresolved.",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 65.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 6 validation rewrites this row from a broad unsupported FY placeholder into the exact AWD state actually supported by the evidence. The official Audi 09/27/2019 technical-data PDF proves the exact FY Q5 35 TDI quattro S tronic 120 kW package with quattro all-wheel drive, 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 5.302, and basic 235/65 R17 tires. The exact ADAC variant page narrows the checked lifecycle to 08/2018-05/2019, which is normalized here to the conservative 2018-2019 year bucket. Later official Audi 04/02/2024 35 TDI material is retained only as contradiction evidence because it describes a front-wheel-drive FY Q5 35 TDI S tronic state rather than the checked quattro row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-35-tdi-2024-tech-data-pdf",
-          "secondary_technical_sources:fy-q5-35-tdi-quattro-adac"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi Q5 FY 35 TDI quattro EU-market lifecycle inside the 2018-2019 year bucket",
-        "reason": "The checked official Audi 2019 technical-data PDF proves the exact quattro state and the exact ADAC page narrows it to 08/2018-05/2019, but this pass did not recover a second independent exact-source ledger for every EU market month inside the normalized 2018-2019 bucket.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf",
-          "secondary_technical_sources:fy-q5-35-tdi-quattro-adac"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 35 TDI quattro exact optional wheel and tire matrix",
-        "reason": "The checked official Audi exact sheet proves only the basic 235/65 R17 package for the exact 35 TDI quattro row. Broader optional wheel sizes or any staggered package were not recovered for this exact 2018-2019 AWD state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 35 TDI quattro exact public gearbox-family naming",
-        "reason": "The checked official Audi exact sheet proves 7-speed S tronic dual-clutch wording for the 2018-2019 AWD state but does not publish a gearbox-family code such as DL382.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-35-tdi-quattro-2019-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-fy-45-tfsi-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FY",
-    "body_code": "FY",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "Q5 (FY, 2019-2024)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-adac-facelift",
-        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 45 TFSI quattro S tronic' production span 01/2019-07/2020 at 180 kW (pre-facelift) and 09/2020-11/2024 at 195 kW (facelift). Existing repo evidence from two Audi MediaCenter tech-data PDFs (2019 and 2024) corroborates 7-speed S tronic + quattro ultra. Power state increase at facelift could be split into two rows for precision; the current single row spanning 2019-2024 is a reasonable approximation. Tire 235/65 R17 confirmed official_derived. Forward gear ratios remain unpopulated - no accessible primary EU spec source. The internal transmission designation is DL382 (longitudinal wet-clutch DCT marketed as 'S tronic 7-speed').",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-adac-facelift",
-        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-wikipedia",
-        "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 45 TFSI quattro S tronic' production span 01/2019-07/2020 at 180 kW (pre-facelift) and 09/2020-11/2024 at 195 kW (facelift). Existing repo evidence from two Audi MediaCenter tech-data PDFs (2019 and 2024) corroborates 7-speed S tronic + quattro ultra. Power state increase at facelift could be split into two rows for precision; the current single row spanning 2019-2024 is a reasonable approximation. Tire 235/65 R17 confirmed official_derived. Forward gear ratios remain unpopulated - no accessible primary EU spec source. The internal transmission designation is DL382 (longitudinal wet-clutch DCT marketed as 'S tronic 7-speed').",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs list 0.433 as the checked top-gear ratio for the FY Q5 45 TFSI quattro state.",
-        "value": 0.433
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs agree on the full forward ratio set for the FY Q5 45 TFSI quattro state.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.557,
-          0.433
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs agree on final drive 5.302 for the FY Q5 45 TFSI quattro state.",
-        "value": 5.302
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs agree on final drive 5.302 for the FY Q5 45 TFSI quattro state.",
-        "value": 5.302
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs confirm 235/65 R17 as the basic tire package for the FY Q5 45 TFSI quattro state. Applied as official-derived evidence for the corrected 2019-2024 row while the full optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs confirm 235/65 R17 as the basic tire package for the FY Q5 45 TFSI quattro state. The broader optional wheel/tire matrix remains unresolved.",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_derived",
+          "note": "Batch 3 review replaces the copied FY Q5 cluster note with row-specific Audi MediaCenter evidence for the exact FY Q5 45 TFSI quattro state. The checked 2019 and 2024 technical-data PDFs agree on quattro ultra AWD, 7-speed S tronic, top gear 0.433, the full 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 ratio set, final drive 5.302, and basic 235/65 R17 tires. The row start is corrected to 2019 because this pass did not recover official 2017 or 2018 evidence for a Germany-market 45 TFSI quattro state, and the row end is capped at 2024 because Audi's own model hub scopes the FY Q5 as 'until 2024' before the third-generation launch.",
           "evidence_refs": [
             "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-            "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-          ],
-          "notes": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs confirm 235/65 R17 as the basic tire package for the FY Q5 45 TFSI quattro state. The broader optional wheel/tire matrix remains unresolved.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 65.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+            "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-until-2024-model-page",
+            "audi_mediacenter_sources:fy-q5-third-generation-launch-release"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 3 review replaces the copied FY Q5 cluster note with row-specific Audi MediaCenter evidence for the exact FY Q5 45 TFSI quattro state. The checked 2019 and 2024 technical-data PDFs agree on quattro ultra AWD, 7-speed S tronic, top gear 0.433, the full 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 ratio set, final drive 5.302, and basic 235/65 R17 tires. The row start is corrected to 2019 because this pass did not recover official 2017 or 2018 evidence for a Germany-market 45 TFSI quattro state, and the row end is capped at 2024 because Audi's own model hub scopes the FY Q5 as 'until 2024' before the third-generation launch.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-until-2024-model-page",
-          "audi_mediacenter_sources:fy-q5-third-generation-launch-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 FY 45 TFSI quattro optional wheel/tire matrix",
-        "reason": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs resolve the basic 235/65 R17 tire package, but this pass did not recover a full FY optional wheel/tire matrix tied to this exact row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 45 TFSI quattro gearbox family-code confirmation",
-        "reason": "The checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-45-tfsi-quattro-2024-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-fy-55-tfsi-e-quattro-eu-2019-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FY",
-    "body_code": "FY",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "Q5 (FY, 2019-2025)",
-    "variant_name": "55 TFSI e quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-adac-facelift",
-        "secondary_technical_sources:q5-fy-tfsi-e-caranddriver"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 55 TFSI e quattro S tronic' production span 09/2019-08/2020 (pre-facelift) and 02/2021-11/2024 (facelift). Car and Driver 2021 spec page explicitly lists 'Transmission: 7-Speed S tronic Dual-Clutch Auto' - decisively refuting any suggestion that the FY PHEV uses the 8-speed Tiptronic (ZF 8HP) found on Q7/Q8 PHEVs (different platforms). The Q5 FY PHEV uses an e-S tronic (DL382-derived 7-speed wet-clutch DCT with integrated electric motor on the MLB Evo platform). Three Audi MediaCenter PDFs (2019 launch, 2021 tech-data, 2024 tech-data) already in repo confirm 7-speed S tronic + quattro ultra. Tire 235/60 R18 confirmed official_exact. Forward gear ratios remain unpopulated.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
-        "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-prefacelift",
-        "secondary_technical_sources:q5-fy-adac-facelift",
-        "secondary_technical_sources:q5-fy-wikipedia",
-        "secondary_technical_sources:q5-fy-tfsi-e-caranddriver"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog confirms 'Q5 55 TFSI e quattro S tronic' production span 09/2019-08/2020 (pre-facelift) and 02/2021-11/2024 (facelift). Car and Driver 2021 spec page explicitly lists 'Transmission: 7-Speed S tronic Dual-Clutch Auto' - decisively refuting any suggestion that the FY PHEV uses the 8-speed Tiptronic (ZF 8HP) found on Q7/Q8 PHEVs (different platforms). The Q5 FY PHEV uses an e-S tronic (DL382-derived 7-speed wet-clutch DCT with integrated electric motor on the MLB Evo platform). Three Audi MediaCenter PDFs (2019 launch, 2021 tech-data, 2024 tech-data) already in repo confirm 7-speed S tronic + quattro ultra. Tire 235/60 R18 confirmed official_exact. Forward gear ratios remain unpopulated.",
-      "code": "DCT7",
-      "name": "7-speed e-S tronic (DL382-based PHEV variant)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2021 and 2024 technical-data PDFs both list 0.433 as the top-gear ratio for the exact FY Q5 55 TFSI e quattro S tronic state. Applied as official exact evidence while launch-year numeric continuity remains inferred rather than directly printed in a 2019 ratio table.",
-        "value": 0.433
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2021 and 2024 technical-data PDFs both list the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 for the exact FY Q5 55 TFSI e quattro S tronic state. Applied as official exact evidence while launch-year numeric continuity remains inferred rather than directly printed in a 2019 ratio table.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.557,
-          0.433
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2021 and 2024 technical-data PDFs publish one populated final-drive value 5.302 for the exact FY Q5 55 TFSI e quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2021 and 2024 technical-data PDFs publish one populated final-drive value 5.302 for the exact FY Q5 55 TFSI e quattro S tronic state. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2021 and 2024 technical-data PDFs both list 235/60 R18 on 8 J x 18 wheels as the basic non-staggered tire package for the exact FY Q5 55 TFSI e quattro state. Applied as official exact evidence while the optional wheel/tire matrix remains unresolved.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 60.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Audi Q5 FY 45 TFSI quattro optional wheel/tire matrix",
+          "reason": "The checked official Audi MediaCenter 2019 and 2024 technical-data PDFs resolve the basic 235/65 R17 tire package, but this pass did not recover a full FY optional wheel/tire matrix tied to this exact row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Audi Q5 FY 45 TFSI quattro gearbox family-code confirmation",
+          "reason": "The checked official Audi sources use the market-facing 7-speed S tronic wording and do not name the supplier or family code behind the repo's normalized DCT7 transmission mapping.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-fy-55-tfsi-e-quattro-eu-2019-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FY",
+      "body_code": "FY",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "Q5 (FY, 2019-2025)",
+      "variant_name": "55 TFSI e quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-adac-prefacelift",
+          "secondary_technical_sources:q5-fy-adac-facelift",
+          "secondary_technical_sources:q5-fy-tfsi-e-caranddriver"
+        ],
+        "notes_ref": "n7",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
+          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-adac-prefacelift",
+          "secondary_technical_sources:q5-fy-adac-facelift",
+          "secondary_technical_sources:q5-fy-wikipedia",
+          "secondary_technical_sources:q5-fy-tfsi-e-caranddriver"
+        ],
+        "notes_ref": "n7",
+        "code": "DCT7",
+        "name": "7-speed e-S tronic (DL382-based PHEV variant)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-            "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf"
-          ],
-          "notes": "Official Audi 2021 and 2024 technical-data PDFs both list 235/60 R18 on 8 J x 18 wheels as the basic non-staggered tire package for the exact FY Q5 55 TFSI e quattro state. Applied as official exact evidence while the optional wheel/tire matrix remains unresolved.",
+          "evidence_refs_ref": "e5",
+          "notes": "Official Audi 2021 and 2024 technical-data PDFs both list 0.433 as the top-gear ratio for the exact FY Q5 55 TFSI e quattro S tronic state. Applied as official exact evidence while launch-year numeric continuity remains inferred rather than directly printed in a 2019 ratio table.",
+          "value": 0.433
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official Audi 2021 and 2024 technical-data PDFs both list the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433 for the exact FY Q5 55 TFSI e quattro S tronic state. Applied as official exact evidence while launch-year numeric continuity remains inferred rather than directly printed in a 2019 ratio table.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.557,
+            0.433
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "value": 5.302
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "value": 5.302
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 60.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0704ea887c86",
-            "legacy_research_sources:4395fed0b13e",
-            "legacy_research_sources:54af60a9ddf0",
-            "legacy_research_sources:58f92c263343",
-            "legacy_research_sources:6db6eab4aafb",
-            "legacy_research_sources:7e60864b72c3",
-            "legacy_research_sources:84ab012d7125",
-            "legacy_research_sources:a6de0bcaa857",
-            "legacy_research_sources:aaa1bd276e93",
-            "legacy_research_sources:b24b22157008",
-            "legacy_research_sources:e6b28c39d7e6",
-            "legacy_research_sources:efd444c9156f",
-            "legacy_research_sources:f8d3f991ca53"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter / technical data PDF with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 60.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0704ea887c86",
-            "legacy_research_sources:4395fed0b13e",
-            "legacy_research_sources:54af60a9ddf0",
-            "legacy_research_sources:58f92c263343",
-            "legacy_research_sources:6db6eab4aafb",
-            "legacy_research_sources:7e60864b72c3",
-            "legacy_research_sources:84ab012d7125",
-            "legacy_research_sources:a6de0bcaa857",
-            "legacy_research_sources:aaa1bd276e93",
-            "legacy_research_sources:b24b22157008",
-            "legacy_research_sources:e6b28c39d7e6",
-            "legacy_research_sources:efd444c9156f",
-            "legacy_research_sources:f8d3f991ca53"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi MediaCenter / technical data PDF with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 validation strengthens this exact FY Q5 55 TFSI e quattro row with an official three-step Audi chain: the 2019 launch PDF introduces the exact 55 TFSI e quattro and its seven-speed S tronic / quattro ultra PHEV layout, the official 2021 technical-data PDF and the official 2024 technical-data PDF both prove the same exact numeric package with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, one published final-drive value 5.302, and basic 235/60 R18 tires, and the 2025 e-hybrid launch release marks the successor handover away from FY naming. The row now promotes the exact 2021/2024 numeric package while keeping launch-year numeric continuity and the mid-2025 handover granularity unresolved.",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 validation strengthens this exact FY Q5 55 TFSI e quattro row with an official three-step Audi chain: the 2019 launch PDF introduces the exact 55 TFSI e quattro and its seven-speed S tronic / quattro ultra PHEV layout, the official 2021 technical-data PDF and the official 2024 technical-data PDF both prove the same exact numeric package with forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.557 / 0.433, reverse 2.750, one published final-drive value 5.302, and basic 235/60 R18 tires, and the 2025 e-hybrid launch release marks the successor handover away from FY naming. The row now promotes the exact 2021/2024 numeric package while keeping launch-year numeric continuity and the mid-2025 handover granularity unresolved.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-2025-e-hybrid-launch-release"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q5 FY 55 TFSI e quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
-        "reason": "The checked official 2021 and 2024 technical-data PDFs prove the same exact numeric package for the outgoing FY 55 TFSI e quattro state, but this pass did not recover a 2019 or 2020 ratio table proving that same package applied unchanged from launch.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2021-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-2025-e-hybrid-launch-release"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 55 TFSI e quattro exact transmission-code, optional tire matrix, and mid-2025 handover granularity",
-        "reason": "Official Audi material proves the 7-speed S tronic wording and the successor e-hybrid handover starting in mid-June 2025, but it does not publish the transmission family code, a full optional wheel/tire matrix, or a finer-grained boundary inside the shared 2025 year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
-          "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-2025-e-hybrid-launch-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-fy-40-tdi-quattro-eu-2017-dct7-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "FY",
-    "body_code": "FY",
-    "production_start_year": 2020,
-    "production_end_year": 2024,
-    "model_name": "Q5 (FY, 2020-2024)",
-    "variant_name": "40 TDI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TDI Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-facelift"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog facelift catalogue confirms 'Q5 40 TDI quattro S tronic' production span 09/2020-11/2024 at 150 kW/204 PS, quattro, 7-speed S tronic (DL382). The '40 TDI' commercial designation was introduced at the 09/2020 facelift; pre-facelift equivalents had different power states. Repo's production_start_year 2020 / end 2024 is correct (the '-2017-' substring in the row id is a legacy naming artifact, not the actual variant start). Tire 235/65 R17 confirmed official_exact via existing Audi MediaCenter 2024 tech-data PDF reference. Forward gear ratios remain unpopulated - no accessible primary EU spec source for the DL382 in this application. The internal transmission designation is DL382.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:q5-fy-wikipedia",
-        "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-        "secondary_technical_sources:q5-fy-adac-facelift"
+      "unresolved": [
+        {
+          "item": "Audi Q5 FY 55 TFSI e quattro exact ratio, final-drive, and tire applicability across the retimed 2019-2025 row",
+          "reason": "The checked official 2021 and 2024 technical-data PDFs prove the same exact numeric package for the outgoing FY 55 TFSI e quattro state, but this pass did not recover a 2019 or 2020 ratio table proving that same package applied unchanged from launch.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Audi Q5 FY 55 TFSI e quattro exact transmission-code, optional tire matrix, and mid-2025 handover granularity",
+          "reason": "Official Audi material proves the 7-speed S tronic wording and the successor e-hybrid handover starting in mid-June 2025, but it does not publish the transmission family code, a full optional wheel/tire matrix, or a finer-grained boundary inside the shared 2025 year.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:fy-q5-55-tfsi-e-2019-launch-pdf",
+            "audi_mediacenter_sources:fy-q5-55-tfsi-e-2024-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-2025-e-hybrid-launch-release"
+          ]
+        }
       ],
-      "notes": "Sonnet redo research (2026-04 v2): ADAC Autokatalog facelift catalogue confirms 'Q5 40 TDI quattro S tronic' production span 09/2020-11/2024 at 150 kW/204 PS, quattro, 7-speed S tronic (DL382). The '40 TDI' commercial designation was introduced at the 09/2020 facelift; pre-facelift equivalents had different power states. Repo's production_start_year 2020 / end 2024 is correct (the '-2017-' substring in the row id is a legacy naming artifact, not the actual variant start). Tire 235/65 R17 confirmed official_exact via existing Audi MediaCenter 2024 tech-data PDF reference. Forward gear ratios remain unpopulated - no accessible primary EU spec source for the DL382 in this application. The internal transmission designation is DL382.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL382)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 06/04/2024 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact later FY Q5 40 TDI quattro S tronic row.",
-        "value": 0.386
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 06/04/2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact later FY Q5 40 TDI quattro S tronic row.",
-        "value": [
-          3.188,
-          2.19,
-          1.517,
-          1.057,
-          0.738,
-          0.508,
-          0.386
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 06/04/2024 technical-data PDF publishes one final-drive value 5.302 for the exact later FY Q5 40 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ],
-        "notes": "Official Audi 06/04/2024 technical-data PDF publishes one final-drive value 5.302 for the exact later FY Q5 40 TDI quattro S tronic row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 5.302
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "audi-fy-40-tdi-quattro-eu-2017-dct7-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "FY",
+      "body_code": "FY",
+      "production_start_year": 2020,
+      "production_end_year": 2024,
+      "model_name": "Q5 (FY, 2020-2024)",
+      "variant_name": "40 TDI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TDI Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
         "evidence_refs": [
           "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-          "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
+          "secondary_technical_sources:q5-fy-adac-facelift"
         ],
-        "notes": "Official Audi 06/04/2024 technical-data material confirms 235/65 R17 as the exact basic tire package for the later FY Q5 40 TDI quattro S tronic row, and the exact ADAC facelift variant page cross-checks the same baseline size.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n11",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "secondary_technical_sources:q5-fy-wikipedia",
+          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
+          "secondary_technical_sources:q5-fy-adac-facelift"
+        ],
+        "notes_ref": "n11",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL382)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-            "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
-          ],
-          "notes": "Official Audi 06/04/2024 technical-data material confirms 235/65 R17 as the exact basic tire package for the later FY Q5 40 TDI quattro S tronic row, and the exact ADAC facelift variant page cross-checks the same baseline size.",
+          "evidence_refs_ref": "e6",
+          "notes": "Official Audi 06/04/2024 technical-data PDF lists 0.386 as the 7th-gear ratio for the exact later FY Q5 40 TDI quattro S tronic row.",
+          "value": 0.386
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official Audi 06/04/2024 technical-data PDF lists the forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386 for the exact later FY Q5 40 TDI quattro S tronic row.",
+          "value": [
+            3.188,
+            2.19,
+            1.517,
+            1.057,
+            0.738,
+            0.508,
+            0.386
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n12",
+          "value": 5.302
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n12",
+          "value": 5.302
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n13",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 65.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 65.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 6 validation narrows this row from a mixed FY placeholder into the later dual-clutch state actually supported by the evidence. The official Audi 06/04/2024 technical-data PDF proves the exact later FY Q5 40 TDI quattro S tronic package with quattro all-wheel drive, 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 5.302, and basic 235/65 R17 tires. The exact ADAC facelift variant page anchors this later state to 09/2020-11/2023, while the Audi model page still scopes the FY Q5 as 'until 2024' and the third-generation launch release shows the successor arriving afterwards. Earlier official 09/27/2019 40 TDI quattro material is retained only as contradiction evidence because it proves an older AWD 6-speed manual state that must not be merged into this later S tronic row.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2019-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-until-2024-model-page",
+            "audi_mediacenter_sources:fy-q5-third-generation-launch-release",
+            "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 6 validation narrows this row from a mixed FY placeholder into the later dual-clutch state actually supported by the evidence. The official Audi 06/04/2024 technical-data PDF proves the exact later FY Q5 40 TDI quattro S tronic package with quattro all-wheel drive, 7-speed dual-clutch S tronic transmission, forward ratios 3.188 / 2.190 / 1.517 / 1.057 / 0.738 / 0.508 / 0.386, reverse 2.750, one published final-drive value 5.302, and basic 235/65 R17 tires. The exact ADAC facelift variant page anchors this later state to 09/2020-11/2023, while the Audi model page still scopes the FY Q5 as 'until 2024' and the third-generation launch release shows the successor arriving afterwards. Earlier official 09/27/2019 40 TDI quattro material is retained only as contradiction evidence because it proves an older AWD 6-speed manual state that must not be merged into this later S tronic row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2019-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-until-2024-model-page",
-          "audi_mediacenter_sources:fy-q5-third-generation-launch-release",
-          "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact Audi Q5 FY 40 TDI quattro EU-market lifecycle inside the 2020-2024 year bucket",
+          "reason": "The checked official Audi 2024 technical-data PDF proves the later S tronic state, the exact ADAC facelift page anchors 09/2020-11/2023, and Audi's own FY model page scopes the generation until 2024, but this pass did not recover a second market-by-market exact-source ledger for every EU month inside the normalized 2020-2024 bucket.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
+            "audi_mediacenter_sources:fy-q5-until-2024-model-page",
+            "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
+          ]
+        },
+        {
+          "item": "Audi Q5 FY 40 TDI quattro exact optional wheel and tire matrix for the later S tronic state",
+          "reason": "The checked official Audi exact sheet proves only the basic 235/65 R17 package for the later 40 TDI quattro S tronic row. This pass did not promote broader optional wheel packages because the exact official matrix was not recovered cleanly enough for production data.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi Q5 FY 40 TDI quattro exact public gearbox-family naming",
+          "reason": "The checked official Audi exact sheet proves 7-speed S tronic dual-clutch wording for the later AWD state but does not publish a gearbox-family code such as DL382.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact Audi Q5 FY 40 TDI quattro EU-market lifecycle inside the 2020-2024 year bucket",
-        "reason": "The checked official Audi 2024 technical-data PDF proves the later S tronic state, the exact ADAC facelift page anchors 09/2020-11/2023, and Audi's own FY model page scopes the generation until 2024, but this pass did not recover a second market-by-market exact-source ledger for every EU month inside the normalized 2020-2024 bucket.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf",
-          "audi_mediacenter_sources:fy-q5-until-2024-model-page",
-          "secondary_technical_sources:fy-q5-40-tdi-quattro-adac"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 40 TDI quattro exact optional wheel and tire matrix for the later S tronic state",
-        "reason": "The checked official Audi exact sheet proves only the basic 235/65 R17 package for the later 40 TDI quattro S tronic row. This pass did not promote broader optional wheel packages because the exact official matrix was not recovered cleanly enough for production data.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q5 FY 40 TDI quattro exact public gearbox-family naming",
-        "reason": "The checked official Audi exact sheet proves 7-speed S tronic dual-clutch wording for the later AWD state but does not publish a gearbox-family code such as DL382.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:fy-q5-40-tdi-quattro-2024-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q7/4M.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q7/4M.json
@@ -1,1453 +1,954 @@
-[
-  {
-    "id": "audi-4m-45-tfsi-quattro-eu-2016-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2016,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2016-2026)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf"
-      ],
-      "notes": "Official Audi exact-trim brochure material confirms that Q7 45 TFSI quattro uses permanent all-wheel drive with self-locking center differential in the checked 185 kW state. This exact identity source is not EU-market, so EU lifecycle continuity across the broad 2016-2026 row remains unresolved.",
-      "value": "AWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n3": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
+      "n4": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V.",
+      "n5": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n6": "Official Audi Germany-market technical-data sheets now confirm the exact Q7 55 TFSI e quattro mapping for the current facelift-era configuration: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and base tire 255/55 R19. This pass also adds exact current non-PHEV Q7 55 TFSI quattro evidence from official Germany-market material: permanent quattro AWD, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final drive 3.204, and a checked 5-seat basic tire 255/60 R18. Wave 14 checks the exact 45 TFSI quattro target and finds that the sampled Germany-market launch/current Q7 material resolves the petrol SUV to 55 TFSI quattro / 250 kW instead, with no recovered exact Germany 45 TFSI quattro technical-data sheet. The broad Q7 row remains unchanged because this pass did not prove the same values across the full 2016-2026 span or recover one production-safe tire baseline and gearbox-family mapping for all represented non-PHEV and PHEV variants.",
+      "n7": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Drivetrain: quattro permanent AWD with self-locking centre differential.",
+      "n8": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Standard delivered tire per Germany MY2026 price list is 255/55 R19 on 8.5 J  19 5-V-spoke wheel; eTD WLTP reference tire is 255/60 R18 on 8 J × 18 forged aluminium wheel.",
+      "n9": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Drivetrain: quattro permanent AWD with self-locking centre differential.",
+      "n10": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. PHEV-specific ZF 8HP ratio set top gear is 0.667.",
+      "n11": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Q7 4M PHEV final drive ratio is 3.204 (single value front and rear).",
+      "n12": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Standard tire per the official PHEV TD PDF and Germany MY2026 price list is 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel.",
+      "n13": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Q7 4M ICE final drive ratio is 3.204 (single value front and rear)."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf"
-      ],
-      "notes": "Official Audi exact-trim brochure material confirms 8-speed tiptronic wording for the checked Q7 45 TFSI quattro state. The repo keeps the normalized ZF8HP code, but this pass did not recover an exact EU-market 45 TFSI technical-data sheet proving the same transmission mapping across the broad 2016-2026 row.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 50.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 50.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi exact-trim brochure material now confirms that Q7 45 TFSI quattro exists with a 2.0-liter / 185 kW petrol engine, permanent quattro all-wheel drive with self-locking center differential, and 8-speed tiptronic, but the checked exact identity source is a non-EU Audi brochure rather than an EU technical-data sheet. Official Audi MediaCenter model-line material separately bounds the Q7 as an 'until 2023' phase plus a revised 2024-era car, while the official Germany MY2026 price list surfaces only the non-PHEV petrol Q7 as TFSI quattro 250 kW tiptronic and does not list a 45 TFSI gasoline row. This broad EU 2016-2026 row therefore remains contradiction-led: exact EU 45 TFSI ratios, final drive, and exact EU tire packages are still unresolved, and the row should not inherit adjacent 55 TFSI numeric data.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf",
-          "audi_mediacenter_sources:4m-q7-until-2023-model-page",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market Audi Q7 45 TFSI quattro mapping",
-        "reason": "Official Audi exact-trim material confirms Q7 45 TFSI quattro identity in a non-EU market, but the checked official Germany MY2026 price list does not surface a 45 TFSI gasoline row and this pass did not recover an exact EU-market 45 TFSI technical-data sheet proving the row's broad EU 2016-2026 drivetrain, ratio, final-drive, or tire mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf",
-          "audi_mediacenter_sources:4m-q7-until-2023-model-page",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q7 45 TFSI quattro is a non-EU regional variant; not in the Germany MY2026 price list",
-        "reason": "The Audi Germany MY2026 price list (`audi-q7-2026-pricelist-de.pdf`) lists Q7 petrol only as TFSI quattro 250 kW (V6) and TFSI e quattro 290/360 kW. No 45 TFSI gasoline variant appears for Germany. The 45 TFSI 1984 cc 185 kW Q7 is documented only in the Audi Middle East brochure (non-EU). The broad EU 2016-2026 production span for this row is therefore unsupported.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf",
-          "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m-55-tfsi-eu-2016-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2016,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2016-2026)",
-    "variant_name": "55 TFSI",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-revised-2024-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Drivetrain: quattro permanent AWD with self-locking centre differential.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-revised-2024-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2024 and 2026 technical-data PDFs consistently list the full forward gear-ratio set for the exact facelift-era Q7 petrol row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-        "value": 3.204
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-        "value": 3.204
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Standard delivered tire per Germany MY2026 price list is 255/55 R19 on 8.5 J  19 5-V-spoke wheel; eTD WLTP reference tire is 255/60 R18 on 8 J × 18 forged aluminium wheel.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-            "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-            "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf"
-          ],
-          "notes": "Official Audi 2024 and 2026 technical-data PDFs list this as the basic wheel/tire setup for the exact facelift-era Q7 petrol row.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 60.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Basic 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-revised-2024-release",
-            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-          ],
-          "notes": "Official Audi 2024 launch material and the 2026 Germany price list show a square 19-inch sales fitment for the regular Q7 petrol row.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 55.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-          ],
-          "notes": "The official Audi Germany MY2026 price list lists this square 20-inch summer package for the regular Q7 petrol row.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 20\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-          ],
-          "notes": "The official Audi Germany MY2026 price list lists this square 21-inch summer package for the regular Q7 petrol row.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 21\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-          ],
-          "notes": "The official Audi Germany MY2026 price list lists this square 22-inch summer package for the regular Q7 petrol row.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi facelift-era material now resolves the exact Q7 55 TFSI quattro / TFSI quattro 250 kW petrol row across the 2024-2026 slice: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, and a published final-drive value of 3.204. The exact technical-data PDFs keep 255/60 R18 on 8J x 18 as the basic setup, while the official 2024 launch release and 2026 Germany price list show current sales equipment stepping through square 19/20/21/22-inch packages with no recovered staggered regular-Q7 package. This row is therefore narrowed to the exact facelift-era state instead of projecting those values back across the earlier 2016-2023 phase.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-revised-2024-release",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q7 55 TFSI quattro final-drive field semantics in Audi technical-data PDFs",
-        "reason": "The 2024 official technical-data PDF prints the final-drive line as -3.478 / 3.204 / 1.000, while the 2026 official PDFs print -3.478 / 3.204 / -. This pass consistently supports 3.204 as the published final-drive value, but it does not resolve the meaning of the auxiliary trailing field.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI quattro basic-versus-sales-standard wheel baseline",
-        "reason": "Official Audi technical-data PDFs list 255/60 R18 as the exact basic setup, while the official 2024 launch release and 2026 Germany price list show 19-inch wheels as the sales-standard V6 package and additional square 20/21/22-inch offerings. This pass did not recover one single trim-agnostic retail baseline that supersedes the technical-data basic wheel line.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-revised-2024-release",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI quattro explicit supplier-family gearbox naming",
-        "reason": "Official Audi exact sources consistently prove 8-speed tiptronic wording for the facelift-era petrol Q7, but they do not explicitly publish the gearbox supplier-family label `ZF8HP`.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Variant name '55 TFSI' without quattro suffix does not match official Audi badging",
-        "reason": "Audi MediaCenter eTD PDFs and the Q7 facelift launch press release brand the 250 kW V6 ICE Q7 as 'Q7 55 TFSI quattro'. The bare '55 TFSI' is not a real EU badge; the canonical quattro row is `audi-4m-55-tfsi-quattro-eu-2016-zf8hp-awd`.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m-55-tfsi-e-quattro-eu-2016-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2016,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2016-2026)",
-    "variant_name": "55 TFSI e quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Drivetrain: quattro permanent AWD with self-locking centre differential.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. PHEV-specific ZF 8HP ratio set top gear is 0.667.",
-        "value": 0.667,
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Q7 4M PHEV final drive ratio is 3.204 (single value front and rear).",
-        "value": 3.204
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Q7 4M PHEV final drive ratio is 3.204 (single value front and rear).",
-        "value": 3.204
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Standard tire per the official PHEV TD PDF and Germany MY2026 price list is 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 50.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market technical-data sheets now confirm the exact Q7 55 TFSI e quattro mapping for the current facelift-era configuration: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and base tire 255/55 R19. This pass also adds exact current non-PHEV Q7 55 TFSI quattro evidence from official Germany-market material: permanent quattro AWD, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final drive 3.204, and a checked 5-seat basic tire 255/60 R18. Wave 14 checks the exact 45 TFSI quattro target and finds that the sampled Germany-market launch/current Q7 material resolves the petrol SUV to 55 TFSI quattro / 250 kW instead, with no recovered exact Germany 45 TFSI quattro technical-data sheet. The broad Q7 row remains unchanged because this pass did not prove the same values across the full 2016-2026 span or recover one production-safe tire baseline and gearbox-family mapping for all represented non-PHEV and PHEV variants.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
-        "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
-        "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
-        "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
-        "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m-55-tfsi-quattro-eu-2016-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2016,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2016-2026)",
-    "variant_name": "55 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-revised-2024-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Drivetrain: quattro permanent AWD with self-locking centre differential.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-revised-2024-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Q7 4M ICE final drive ratio is 3.204 (single value front and rear).",
-        "value": 3.204
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Q7 4M ICE final drive ratio is 3.204 (single value front and rear).",
-        "value": 3.204
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter eTD PDFs (Germany programme, status 2024-03-27 and 2026-02-04) for the Q7 55 TFSI quattro tiptronic 250 kW MHEV (V6 2995 cc): 8-speed tiptronic (ZF 8HP), gear set 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640, reverse -3.478, final drive 3.204, eTD reference tire 255/60 R18, Germany standard delivered tire 255/55 R19 per the MY2026 price list. Standard delivered tire per Germany MY2026 price list is 255/55 R19 on 8.5 J  19 5-V-spoke wheel; eTD WLTP reference tire is 255/60 R18 on 8 J × 18 forged aluminium wheel.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 50.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market technical-data sheets now confirm the exact Q7 55 TFSI e quattro mapping for the current facelift-era configuration: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and base tire 255/55 R19. This pass also adds exact current non-PHEV Q7 55 TFSI quattro evidence from official Germany-market material: permanent quattro AWD, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final drive 3.204, and a checked 5-seat basic tire 255/60 R18. Wave 14 checks the exact 45 TFSI quattro target and finds that the sampled Germany-market launch/current Q7 material resolves the petrol SUV to 55 TFSI quattro / 250 kW instead, with no recovered exact Germany 45 TFSI quattro technical-data sheet. The broad Q7 row remains unchanged because this pass did not prove the same values across the full 2016-2026 span or recover one production-safe tire baseline and gearbox-family mapping for all represented non-PHEV and PHEV variants.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
-        "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
-        "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
-        "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
-        "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m-45-tfsi-eu-2016-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2024-2026)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:29114921acdf",
+        "legacy_research_sources:2b9d74e8ab56",
         "legacy_research_sources:490c5b8fd0e9",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
         "legacy_research_sources:62c1bbb53e87",
+        "legacy_research_sources:63fd9d7843ad",
+        "legacy_research_sources:8a73434aa4c5",
+        "legacy_research_sources:b248c52777b2",
+        "legacy_research_sources:e6c066ac31ae",
         "legacy_research_sources:ec1f2b5d8fc4",
         "legacy_research_sources:fc63799e6f4d"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.667
+      "e2": [
+        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-revised-2024-release"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf",
+        "audi_mediacenter_sources:4m-q7-until-2023-model-page",
+        "audi_mediacenter_sources:4m-q7-revised-2024-release",
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ],
+      "e9": [
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ],
+      "e10": [
+        "audi_mediacenter_sources:4m-q7-revised-2024-release",
+        "audi_mediacenter_sources:4m-q7-55-tfsi-2024-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-7seat-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ],
+      "e11": [
+        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release",
+        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
+        "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-4m-45-tfsi-quattro-eu-2016-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2016,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2016-2026)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "Official Audi exact-trim brochure material confirms that Q7 45 TFSI quattro uses permanent all-wheel drive with self-locking center differential in the checked 185 kW state. This exact identity source is not EU-market, so EU lifecycle continuity across the broad 2016-2026 row remains unresolved.",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 3.333
+        "evidence_refs_ref": "e7",
+        "notes": "Official Audi exact-trim brochure material confirms 8-speed tiptronic wording for the checked Q7 45 TFSI quattro state. The repo keeps the normalized ZF8HP code, but this pass did not recover an exact EU-market 45 TFSI technical-data sheet proving the same transmission mapping across the broad 2016-2026 row.",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 3.333
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 50.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.333
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.333
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 50.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi exact-trim brochure material now confirms that Q7 45 TFSI quattro exists with a 2.0-liter / 185 kW petrol engine, permanent quattro all-wheel drive with self-locking center differential, and 8-speed tiptronic, but the checked exact identity source is a non-EU Audi brochure rather than an EU technical-data sheet. Official Audi MediaCenter model-line material separately bounds the Q7 as an 'until 2023' phase plus a revised 2024-era car, while the official Germany MY2026 price list surfaces only the non-PHEV petrol Q7 as TFSI quattro 250 kW tiptronic and does not list a 45 TFSI gasoline row. This broad EU 2016-2026 row therefore remains contradiction-led: exact EU 45 TFSI ratios, final drive, and exact EU tire packages are still unresolved, and the row should not inherit adjacent 55 TFSI numeric data.",
+          "evidence_refs_ref": "e8"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market technical-data sheets now confirm the exact Q7 55 TFSI e quattro mapping for the current facelift-era configuration: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and base tire 255/55 R19. This pass also adds exact current non-PHEV Q7 55 TFSI quattro evidence from official Germany-market material: permanent quattro AWD, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final drive 3.204, and a checked 5-seat basic tire 255/60 R18. Wave 14 checks the exact 45 TFSI quattro target and finds that the sampled Germany-market launch/current Q7 material resolves the petrol SUV to 55 TFSI quattro / 250 kW instead, with no recovered exact Germany 45 TFSI quattro technical-data sheet. The broad Q7 row remains unchanged because this pass did not prove the same values across the full 2016-2026 span or recover one production-safe tire baseline and gearbox-family mapping for all represented non-PHEV and PHEV variants.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
-        "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
-        "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
-        "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
-        "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
-        "evidence_refs": [
-          "legacy_research_sources:29114921acdf",
-          "legacy_research_sources:2b9d74e8ab56",
-          "legacy_research_sources:490c5b8fd0e9",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:62c1bbb53e87",
-          "legacy_research_sources:63fd9d7843ad",
-          "legacy_research_sources:8a73434aa4c5",
-          "legacy_research_sources:b248c52777b2",
-          "legacy_research_sources:e6c066ac31ae",
-          "legacy_research_sources:ec1f2b5d8fc4",
-          "legacy_research_sources:fc63799e6f4d"
-        ]
-      },
-      {
-        "item": "Audi Q7 45 TFSI is not offered in the EU/Germany market for the 2024-2026 facelift period",
-        "reason": "The Audi Germany MY2026 price list explicitly lists Q7 petrol only as TFSI quattro 250 kW (V6) and TFSI e quattro 290/360 kW; no 45 TFSI 2.0 TSI EU listing exists for the 2024-2026 facelift phase. The 45 TFSI gasoline Q7 is a non-EU (Middle East) regional variant.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf",
-          "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf",
-          "audi_mediacenter_sources:4m-q7-revised-2024-release"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m-55-tfsi-e-eu-2024-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M",
-    "body_code": "4M",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "Q7 (4M, 2024-2026)",
-    "variant_name": "55 TFSI e",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
       ],
-      "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Drivetrain: quattro permanent AWD with self-locking centre differential.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-        "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-      ],
-      "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. PHEV-specific ZF 8HP ratio set top gear is 0.667.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf"
-        ],
-        "notes": "Official Audi 2025 technical-data PDF lists the forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact facelift-era Q7 55 TFSI e quattro tiptronic state represented by this narrowed 2024-2026 row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V.",
-        "value": 3.204
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V.",
-        "value": 3.204
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ],
-        "notes": "Confirmed by Audi MediaCenter TD PDF (Germany programme, status 2025-12-15) for the Q7 TFSI e quattro tiptronic 290 kW PHEV: 8-speed tiptronic (ZF 8HP, PHEV-specific ratio set), gear set 4.714/3.143/2.106/1.667/1.285/1.000/0.839/0.667, reverse -3.317, final drive 3.204, standard tire 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel. System output 290 kW (394 PS); battery 25.9/22.0 kWh gross/net at 400V. Standard tire per the official PHEV TD PDF and Germany MY2026 price list is 255/55 R19 on 8.5 J × 19 cast aluminium flow-forming wheel.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_exact",
+          "item": "Exact EU-market Audi Q7 45 TFSI quattro mapping",
+          "reason": "Official Audi exact-trim material confirms Q7 45 TFSI quattro identity in a non-EU market, but the checked official Germany MY2026 price list does not surface a 45 TFSI gasoline row and this pass did not recover an exact EU-market 45 TFSI technical-data sheet proving the row's broad EU 2016-2026 drivetrain, ratio, final-drive, or tire mapping.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Audi Q7 45 TFSI quattro is a non-EU regional variant; not in the Germany MY2026 price list",
+          "reason": "The Audi Germany MY2026 price list (`audi-q7-2026-pricelist-de.pdf`) lists Q7 petrol only as TFSI quattro 250 kW (V6) and TFSI e quattro 290/360 kW. No 45 TFSI gasoline variant appears for Germany. The 45 TFSI 1984 cc 185 kW Q7 is documented only in the Audi Middle East brochure (non-EU). The broad EU 2016-2026 production span for this row is therefore unsupported.",
           "evidence_refs": [
-            "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-          ],
-          "notes": "Official Audi 2025 technical-data PDF and MY2026 Germany price list agree on 255/55 R19 as the exact standard 19-inch tire package for the facelift-era Q7 55 TFSI e quattro state represented by this narrowed 2024-2026 row.",
+            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf",
+            "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf"
+          ]
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-4m-55-tfsi-eu-2016-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2016,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2016-2026)",
+      "variant_name": "55 TFSI",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n7",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi 2024 and 2026 technical-data PDFs consistently list the full forward gear-ratio set for the exact facelift-era Q7 petrol row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "value": 3.204
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "value": 3.204
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 55.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "Official Audi 2024 and 2026 technical-data PDFs list this as the basic wheel/tire setup for the exact facelift-era Q7 petrol row.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 60.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Basic 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:29114921acdf",
-            "legacy_research_sources:2b9d74e8ab56",
-            "legacy_research_sources:490c5b8fd0e9",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:62c1bbb53e87",
-            "legacy_research_sources:63fd9d7843ad",
-            "legacy_research_sources:8a73434aa4c5",
-            "legacy_research_sources:b248c52777b2",
-            "legacy_research_sources:e6c066ac31ae",
-            "legacy_research_sources:ec1f2b5d8fc4",
-            "legacy_research_sources:fc63799e6f4d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs": [
+              "audi_mediacenter_sources:4m-q7-revised-2024-release",
+              "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+            ],
+            "notes": "Official Audi 2024 launch material and the 2026 Germany price list show a square 19-inch sales fitment for the regular Q7 petrol row.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 55.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "The official Audi Germany MY2026 price list lists this square 20-inch summer package for the regular Q7 petrol row.",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 20\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "The official Audi Germany MY2026 price list lists this square 21-inch summer package for the regular Q7 petrol row.",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 21\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "The official Audi Germany MY2026 price list lists this square 22-inch summer package for the regular Q7 petrol row.",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi facelift-era material now resolves the exact Q7 55 TFSI quattro / TFSI quattro 250 kW petrol row across the 2024-2026 slice: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, and a published final-drive value of 3.204. The exact technical-data PDFs keep 255/60 R18 on 8J x 18 as the basic setup, while the official 2024 launch release and 2026 Germany price list show current sales equipment stepping through square 19/20/21/22-inch packages with no recovered staggered regular-Q7 package. This row is therefore narrowed to the exact facelift-era state instead of projecting those values back across the earlier 2016-2023 phase.",
+          "evidence_refs_ref": "e10"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q7 55 TFSI quattro final-drive field semantics in Audi technical-data PDFs",
+          "reason": "The 2024 official technical-data PDF prints the final-drive line as -3.478 / 3.204 / 1.000, while the 2026 official PDFs print -3.478 / 3.204 / -. This pass consistently supports 3.204 as the published final-drive value, but it does not resolve the meaning of the auxiliary trailing field.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi Q7 55 TFSI quattro basic-versus-sales-standard wheel baseline",
+          "reason": "Official Audi technical-data PDFs list 255/60 R18 as the exact basic setup, while the official 2024 launch release and 2026 Germany price list show 19-inch wheels as the sales-standard V6 package and additional square 20/21/22-inch offerings. This pass did not recover one single trim-agnostic retail baseline that supersedes the technical-data basic wheel line.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi Q7 55 TFSI quattro explicit supplier-family gearbox naming",
+          "reason": "Official Audi exact sources consistently prove 8-speed tiptronic wording for the facelift-era petrol Q7, but they do not explicitly publish the gearbox supplier-family label `ZF8HP`.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Variant name '55 TFSI' without quattro suffix does not match official Audi badging",
+          "reason": "Audi MediaCenter eTD PDFs and the Q7 facelift launch press release brand the 250 kW V6 ICE Q7 as 'Q7 55 TFSI quattro'. The bare '55 TFSI' is not a real EU badge; the canonical quattro row is `audi-4m-55-tfsi-quattro-eu-2016-zf8hp-awd`.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:4m-q7-tfsi-250kw-2026-5seat-tech-data-pdf",
+            "audi_mediacenter_sources:4m-q7-revised-2024-release"
+          ]
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter Germany material now retimes this row to the first recovered exact Q7 55 TFSI e quattro state: the April 2024 product-upgrade release says the new Q7 TFSI e quattro is available to order from the end of April 2024, and the exact 2025 technical-data PDF plus the MY2026 Germany price list confirm continued 55 TFSI e quattro / 290 kW sale with permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, a single published final-drive ratio 3.204, and basic 255/55 R19 tires. This pass therefore promotes the exact top gear, forward ratios, single final-drive value, and baseline tire into the narrowed 2024-2026 row while leaving full optional-wheel coverage and public gearbox-family naming unresolved.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full retimed 2024-2026 row span",
-        "reason": "The checked exact 2025 technical-data PDF and MY2026 Germany price list agree on the facelift-era 55 TFSI e quattro AWD, 8-speed tiptronic, ratio, final-drive, and 255/55 R19 basic-tire package, but this pass did not recover year-by-year material proving one unchanged mapping across every represented 2024-2026 state.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+    {
+      "id": "audi-4m-55-tfsi-e-quattro-eu-2016-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2016,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2016-2026)",
+      "variant_name": "55 TFSI e quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n9",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n10",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n11",
+          "value": 3.204
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n11",
+          "value": 3.204
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n12",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 55.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
       },
-      {
-        "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
-        "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and the MY2026 Germany price list refines the standard base-model and S line 19-inch packages, but this pass did not recover the full optional wheel/tire matrix or an explicit official gearbox-family code such as ZF 8HP.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2026-price-list-pdf"
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
+          "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
+          "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
+          "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
+          "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-4m-55-tfsi-quattro-eu-2016-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2016,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2016-2026)",
+      "variant_name": "55 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n7",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n13",
+          "value": 3.204
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n13",
+          "value": 3.204
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 55.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
       },
-      {
-        "item": "Variant name '55 TFSI e' without quattro suffix does not match official Audi badging",
-        "reason": "Audi MediaCenter TD PDFs and the 2024 PHEV upgrade press release brand the 290 kW PHEV Q7 as 'Q7 TFSI e quattro' / 'Q7 55 TFSI e quattro'. The bare '55 TFSI e' is not a real EU badge; the canonical quattro row is `audi-4m-55-tfsi-e-quattro-eu-2016-zf8hp-awd`.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf",
-          "audi_mediacenter_sources:4m-q7-2024-tfsi-e-upgrade-release"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
+          "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
+          "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
+          "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
+          "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-4m-45-tfsi-eu-2016-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2024-2026)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs": [
+          "legacy_research_sources:490c5b8fd0e9",
+          "legacy_research_sources:62c1bbb53e87",
+          "legacy_research_sources:ec1f2b5d8fc4",
+          "legacy_research_sources:fc63799e6f4d"
+        ],
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.333
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.333
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 50.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full 4M row span",
+          "reason": "Checked exact official Germany-market evidence resolved the current facelift-era 55 TFSI e quattro values, but this pass did not prove the same ratio and final-drive mapping across the full 2016-2026 row span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
+          "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and 8-speed tiptronic wording, but this pass did not recover the full optional tire matrix or explicit official ZF 8HP naming.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 55 TFSI quattro production-data applicability and tire-baseline continuity across the full 4M row span",
+          "reason": "Checked exact official current-generation 55 TFSI quattro evidence resolves the 250 kW ratio set, final drive 3.204, and a 5-seat 255/60 R18 basic tire, but this pass did not prove the same mapping across the full 2016-2026 non-PHEV row span or recover one uncontested production-safe tire baseline for all represented configurations.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact Germany-market Audi Q7 45 TFSI quattro mapping",
+          "reason": "Checked official Germany launch/current Q7 model pages, press releases, and 2020/2026 price-list material resolve the petrol SUV to 55 TFSI quattro / 250 kW instead, and this pass did not recover an official Germany 45 TFSI quattro technical-data sheet that would justify reusing the 55 TFSI data.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi Q7 45 TFSI is not offered in the EU/Germany market for the 2024-2026 facelift period",
+          "reason": "The Audi Germany MY2026 price list explicitly lists Q7 petrol only as TFSI quattro 250 kW (V6) and TFSI e quattro 290/360 kW; no 45 TFSI 2.0 TSI EU listing exists for the 2024-2026 facelift phase. The 45 TFSI gasoline Q7 is a non-EU (Middle East) regional variant.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:4m-q7-2026-price-list-pdf",
+            "audi_mediacenter_sources:4m-q7-45-tfsi-middle-east-brochure-pdf",
+            "audi_mediacenter_sources:4m-q7-revised-2024-release"
+          ]
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-4m-55-tfsi-e-eu-2024-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M",
+      "body_code": "4M",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "Q7 (4M, 2024-2026)",
+      "variant_name": "55 TFSI e",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n9",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n10",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:4m-q7-55-tfsi-e-2025-tech-data-pdf"
+          ],
+          "notes": "Official Audi 2025 technical-data PDF lists the forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact facelift-era Q7 55 TFSI e quattro tiptronic state represented by this narrowed 2024-2026 row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.204
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.204
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n12",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 55.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes": "Official Audi 2025 technical-data PDF and MY2026 Germany price list agree on 255/55 R19 as the exact standard 19-inch tire package for the facelift-era Q7 55 TFSI e quattro state represented by this narrowed 2024-2026 row.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 55.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter Germany material now retimes this row to the first recovered exact Q7 55 TFSI e quattro state: the April 2024 product-upgrade release says the new Q7 TFSI e quattro is available to order from the end of April 2024, and the exact 2025 technical-data PDF plus the MY2026 Germany price list confirm continued 55 TFSI e quattro / 290 kW sale with permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, a single published final-drive ratio 3.204, and basic 255/55 R19 tires. This pass therefore promotes the exact top gear, forward ratios, single final-drive value, and baseline tire into the narrowed 2024-2026 row while leaving full optional-wheel coverage and public gearbox-family naming unresolved.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q7 55 TFSI e quattro production-data applicability across the full retimed 2024-2026 row span",
+          "reason": "The checked exact 2025 technical-data PDF and MY2026 Germany price list agree on the facelift-era 55 TFSI e quattro AWD, 8-speed tiptronic, ratio, final-drive, and 255/55 R19 basic-tire package, but this pass did not recover year-by-year material proving one unchanged mapping across every represented 2024-2026 state.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Audi Q7 55 TFSI e quattro exact optional tire matrix and gearbox-family naming",
+          "reason": "Official Audi exact sources prove the base 255/55 R19 fitment and the MY2026 Germany price list refines the standard base-model and S line 19-inch packages, but this pass did not recover the full optional wheel/tire matrix or an explicit official gearbox-family code such as ZF 8HP.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Variant name '55 TFSI e' without quattro suffix does not match official Audi badging",
+          "reason": "Audi MediaCenter TD PDFs and the 2024 PHEV upgrade press release brand the 290 kW PHEV Q7 as 'Q7 TFSI e quattro' / 'Q7 55 TFSI e quattro'. The bare '55 TFSI e' is not a real EU badge; the canonical quattro row is `audi-4m-55-tfsi-e-quattro-eu-2016-zf8hp-awd`.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q8/4M8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q8/4M8.json
@@ -1,882 +1,657 @@
-[
-  {
-    "id": "audi-4m8-55-tfsi-eu-2019-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M8",
-    "body_code": "4M8",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Q8 (4M8, 2019-2026)",
-    "variant_name": "55 TFSI",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n4": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
+      "n5": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "secondary_technical_sources:q8-4m8-wikipedia"
+      ],
+      "e2": [
+        "legacy_research_sources:3da53a121d0a",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:834b58fa6ac6",
+        "legacy_research_sources:858568b097e7",
+        "legacy_research_sources:987b02afd090",
+        "legacy_research_sources:9a9f7660e688",
+        "legacy_research_sources:9ac37563abd5",
+        "legacy_research_sources:c6f574693b14",
+        "legacy_research_sources:d13f1c818845"
+      ],
+      "e3": [
         "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
         "secondary_technical_sources:q8-4m8-wikipedia",
         "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
+      "e4": [
         "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-        "secondary_technical_sources:q8-4m8-wikipedia",
         "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e5": [
+        "secondary_technical_sources:zf8hp-wikipedia"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
+        "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
+        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
+        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
+        "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
+        "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
+        "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
+      ],
+      "e9": [
+        "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
+        "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
+        "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-4m8-55-tfsi-eu-2019-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M8",
+      "body_code": "4M8",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Q8 (4M8, 2019-2026)",
+      "variant_name": "55 TFSI",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-        "value": 3.333,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-        "value": 3.333,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 4M8 has never been offered without quattro - Wikipedia confirms layout 'front-engine, four-wheel-drive' for ALL Q8 variants and lists only '55 TFSI quattro' as the petrol ICE variant (no plain '55 TFSI' was ever produced or sold). This row is a duplicate of audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd under an incorrect abbreviated badge. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence and safety gates set to require manual confirmation. Authoritative entry is the '55 TFSI quattro' row.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.333,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.333,
+          "evidence_refs_ref": "e1"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 285.0,
             "aspect_pct": 40.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 22\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 5 exact-source review replaces the stale mixed/PHEV Q8 note with row-specific 55 TFSI evidence. The checked official Audi 02/04/2026 technical-data PDF and current Audi Austria brochure agree on Q8 55 TFSI quattro identity, permanent quattro AWD with self-locking center differential, 8-speed tiptronic, and late-cycle exact 55 TFSI figures including forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final-drive expression 3.504 / -, and 265/55 R19 as the checked technical-sheet basic tire. Official Audi lifecycle pages show that this broad row spans at least two states: a predecessor line bounded as 'until 2023' and the upgraded Q8 launched in September 2023. Production numeric and tire fields therefore remain unchanged here because this pass did not prove one safe exact 2019-2026 mapping or one year-spanning wheel program.",
+          "evidence_refs_ref": "e8"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 22\""
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q8 55 TFSI production-data applicability across the represented 2019-2026 row span",
+          "reason": "The checked official Audi chain proves an earlier predecessor state bounded as 'until 2023' and a later upgraded Q8 launched in September 2023, plus an exact late-cycle 55 TFSI technical-data sheet, but this pass did not recover a year-by-year official chain proving one unchanged exact 55 TFSI mapping across the full broad row.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi Q8 55 TFSI exact gearbox-family naming",
+          "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the late-cycle 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi Q8 55 TFSI exact tire-baseline and wheel-program rewrite across the represented 2019-2026 row span",
+          "reason": "The checked exact technical-data PDF proves a 265/55 R19 basic tire, while the checked current Audi Austria brochure documents square 20-inch through 23-inch summer packages and winter 19-inch through 21-inch packages, so this pass did not prove one production-safe default or full wheel/tire rewrite for the broad row's inherited placeholders.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Batch 5 exact-source review replaces the stale mixed/PHEV Q8 note with row-specific 55 TFSI evidence. The checked official Audi 02/04/2026 technical-data PDF and current Audi Austria brochure agree on Q8 55 TFSI quattro identity, permanent quattro AWD with self-locking center differential, 8-speed tiptronic, and late-cycle exact 55 TFSI figures including forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final-drive expression 3.504 / -, and 265/55 R19 as the checked technical-sheet basic tire. Official Audi lifecycle pages show that this broad row spans at least two states: a predecessor line bounded as 'until 2023' and the upgraded Q8 launched in September 2023. Production numeric and tire fields therefore remain unchanged here because this pass did not prove one safe exact 2019-2026 mapping or one year-spanning wheel program.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
-          "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
+    {
+      "id": "audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M8",
+      "body_code": "4M8",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Q8 (4M8, 2019-2026)",
+      "variant_name": "55 TFSI quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Exact official Audi technical-data and Austria brochure evidence confirm permanent quattro AWD with self-locking center differential for the checked Q8 55 TFSI quattro state, while early-row continuity and row-wide numeric/tire applicability remain unresolved across the broad 2019-2026 row. Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
+        "value": "AWD"
       },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "transmission": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
+          "secondary_technical_sources:zf8hp-wikipedia",
           "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
           "secondary_technical_sources:q8-4m8-wikipedia",
           "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
+        ],
+        "notes": "Exact official Audi technical-data and Austria brochure evidence confirm 8-speed tiptronic wording for the checked Q8 55 TFSI quattro state, while early-row continuity and row-wide numeric/tire applicability remain unresolved across the broad 2019-2026 row. Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
+          "value": 0.667,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.333
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.333
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 285.0,
+            "aspect_pct": 40.0,
+            "rim_in": 21.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 22\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
         ]
       },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "verification_notes": [
+        {
+          "note": "Batch 5 exact-source review strengthens this row with row-specific 55 TFSI evidence and removes the stale mixed 55/60 note. The checked official Audi 02/04/2026 technical-data PDF and current Audi Austria brochure agree on Q8 55 TFSI quattro identity, permanent quattro AWD with self-locking center differential, 8-speed tiptronic, and late-cycle exact 55 TFSI figures including forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final-drive expression 3.504 / -, and 265/55 R19 as the checked technical-sheet basic tire. Official Audi lifecycle pages show that this broad row spans at least two states: a predecessor line bounded as 'until 2023' and the upgraded Q8 launched in September 2023. Production numeric and tire fields therefore remain unchanged here because this pass did not prove one safe exact 2019-2026 mapping or one year-spanning wheel program.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q8 55 TFSI quattro production-data applicability across the represented 2019-2026 row span",
+          "reason": "The checked official Audi chain proves an earlier predecessor state bounded as 'until 2023' and a later upgraded Q8 launched in September 2023, plus an exact late-cycle 55 TFSI technical-data sheet, but this pass did not recover a year-by-year official chain proving one unchanged exact 55 TFSI quattro mapping across the full broad row.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi Q8 55 TFSI quattro exact gearbox-family naming",
+          "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the late-cycle 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi Q8 55 TFSI quattro exact tire-baseline and wheel-program rewrite across the represented 2019-2026 row span",
+          "reason": "The checked exact technical-data PDF proves a 265/55 R19 basic tire, while the checked current Audi Austria brochure documents square 20-inch through 23-inch summer packages and winter 19-inch through 21-inch packages, so this pass did not prove one production-safe default or full wheel/tire rewrite for the broad row's inherited placeholders.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-4m8-60-tfsi-e-eu-2019-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M8",
+      "body_code": "4M8",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Q8 (4M8, 2019-2026)",
+      "variant_name": "60 TFSI e",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "value": "AWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.333,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.333,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 285.0,
+            "aspect_pct": 40.0,
+            "rim_in": 21.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 22\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 review replaces the mixed Q8 55/60 family note with row-specific Audi MediaCenter evidence for the exact Q8 60 TFSI e quattro tiptronic state. The checked 11/20/2020 and 12/15/2025 technical-data PDFs agree on permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and basic 265/55 R19 tires. The 2024 product-upgrade release confirms a later 360 kW facelift state under the same 60 TFSI e quattro badge, but production JSON remains unchanged because this pass did not prove one exact 2019-2026 mapping or one year-spanning tire baseline.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi Q8 60 TFSI e quattro production-data applicability across the represented 2019-2026 row span",
+          "reason": "The checked late-2020 and 2025 Audi MediaCenter technical-data PDFs prove later exact 60 TFSI e quattro states, but this pass did not recover a year-by-year official chain proving the current 2019 start or one unchanged exact mapping across the full broad row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Schema-safe promotion of Audi Q8 60 TFSI e quattro exact transmission naming and final-drive mapping",
+          "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording and a single 3.204 final-drive value, but the current broad row still carries normalized ZF8HP and split-final-drive placeholders and this pass did not prove a safer coordinated row reshaping across the adjacent Q8 aliases.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi Q8 60 TFSI e quattro tire-baseline and optional wheel matrix continuity",
+          "reason": "The checked technical-data PDFs prove a 265/55 R19 basic tire, while later official market material documents a different later standard-equipment package, so this pass did not close one representative default or optional wheel/tire chain for the full broad row.",
+          "evidence_refs": [
+            "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
+            "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
+            "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
+          ]
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd",
+      "brand": "Audi",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "4M8",
+      "body_code": "4M8",
+      "production_start_year": 2020,
+      "production_end_year": 2026,
+      "model_name": "Q8 (4M8, 2020-2026)",
+      "variant_name": "60 TFSI e quattro",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L V6 TFSI Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
+          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf",
           "secondary_technical_sources:q8-4m8-wikipedia",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q8 55 TFSI production-data applicability across the represented 2019-2026 row span",
-        "reason": "The checked official Audi chain proves an earlier predecessor state bounded as 'until 2023' and a later upgraded Q8 launched in September 2023, plus an exact late-cycle 55 TFSI technical-data sheet, but this pass did not recover a year-by-year official chain proving one unchanged exact 55 TFSI mapping across the full broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
-          "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 55 TFSI exact gearbox-family naming",
-        "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the late-cycle 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 55 TFSI exact tire-baseline and wheel-program rewrite across the represented 2019-2026 row span",
-        "reason": "The checked exact technical-data PDF proves a 265/55 R19 basic tire, while the checked current Audi Austria brochure documents square 20-inch through 23-inch summer packages and winter 19-inch through 21-inch packages, so this pass did not prove one production-safe default or full wheel/tire rewrite for the broad row's inherited placeholders.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m8-55-tfsi-quattro-eu-2019-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M8",
-    "body_code": "4M8",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Q8 (4M8, 2019-2026)",
-    "variant_name": "55 TFSI quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-        "secondary_technical_sources:q8-4m8-wikipedia",
-        "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-      ],
-      "notes": "Exact official Audi technical-data and Austria brochure evidence confirm permanent quattro AWD with self-locking center differential for the checked Q8 55 TFSI quattro state, while early-row continuity and row-wide numeric/tire applicability remain unresolved across the broad 2019-2026 row. Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:zf8hp-wikipedia",
-        "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-        "secondary_technical_sources:q8-4m8-wikipedia",
-        "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-      ],
-      "notes": "Exact official Audi technical-data and Austria brochure evidence confirm 8-speed tiptronic wording for the checked Q8 55 TFSI quattro state, while early-row continuity and row-wide numeric/tire applicability remain unresolved across the broad 2019-2026 row. Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): Q8 55 TFSI quattro confirmed by Wikipedia engine table - 3.0 L V6 TFSI 250 kW (340 PS) / 500 Nm, AWD quattro 40:60 split, ZF 8-speed Tiptronic. Production started June 2018 (MY2019). ZF sub-variant likely 8HP76/I (2018 3rd-gen, 8th-gear 0.640) but the repo's inherited 0.667 8th-gear ratio is the older 8HP75/I value (2014, 1st iteration). Top gear ratio downgraded to no_confidence pending Audi MediaCenter Q8 tech-data PDF.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:zf8hp-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3da53a121d0a",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:834b58fa6ac6",
-          "legacy_research_sources:858568b097e7",
-          "legacy_research_sources:987b02afd090",
-          "legacy_research_sources:9a9f7660e688",
-          "legacy_research_sources:9ac37563abd5",
-          "legacy_research_sources:c6f574693b14",
-          "legacy_research_sources:d13f1c818845"
+          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf"
         ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes": "Exact official Audi MediaCenter 2020 and 2025 Q8 60 TFSI e quattro technical-data material confirms permanent quattro AWD for the checked launch and facelift-era PHEV states, while row-wide tire-program continuity remains unresolved across the retimed 2020-2026 row. Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf",
+          "secondary_technical_sources:zf8hp-wikipedia",
+          "secondary_technical_sources:q8-4m8-wikipedia",
+          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf"
+        ],
+        "notes": "Exact official Audi MediaCenter 2020 and 2025 Q8 60 TFSI e quattro technical-data material confirms the 8-speed tiptronic transmission wording for the checked launch and facelift-era PHEV states, while row-wide tire-program continuity remains unresolved across the retimed 2020-2026 row. Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
+          "value": 0.667,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 3.333
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.333
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 285.0,
             "aspect_pct": 40.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 22\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Exact official Audi MediaCenter Q8 60 TFSI e quattro material now supports a safe numeric promotion on this retimed 2020-2026 row. The checked 11/20/2020 and 12/15/2025 technical-data PDFs agree on permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, one published final-drive value 3.204, and 265/55 R19 basic tires. The checked 2024 upgrade release confirms the later 360 kW facelift handover inside the same 60 TFSI e quattro line. This pass still did not recover any earlier 2019 Germany-market 60 TFSI e sheet or a production-safe full wheel-program rewrite.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 22\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 5 exact-source review strengthens this row with row-specific 55 TFSI evidence and removes the stale mixed 55/60 note. The checked official Audi 02/04/2026 technical-data PDF and current Audi Austria brochure agree on Q8 55 TFSI quattro identity, permanent quattro AWD with self-locking center differential, 8-speed tiptronic, and late-cycle exact 55 TFSI figures including forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, final-drive expression 3.504 / -, and 265/55 R19 as the checked technical-sheet basic tire. Official Audi lifecycle pages show that this broad row spans at least two states: a predecessor line bounded as 'until 2023' and the upgraded Q8 launched in September 2023. Production numeric and tire fields therefore remain unchanged here because this pass did not prove one safe exact 2019-2026 mapping or one year-spanning wheel program.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
-          "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:zf8hp-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q8 55 TFSI quattro production-data applicability across the represented 2019-2026 row span",
-        "reason": "The checked official Audi chain proves an earlier predecessor state bounded as 'until 2023' and a later upgraded Q8 launched in September 2023, plus an exact late-cycle 55 TFSI technical-data sheet, but this pass did not recover a year-by-year official chain proving one unchanged exact 55 TFSI quattro mapping across the full broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-until-2023-model-page",
-          "audi_mediacenter_sources:4m8-q8-2023-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 55 TFSI quattro exact gearbox-family naming",
-        "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the late-cycle 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 55 TFSI quattro exact tire-baseline and wheel-program rewrite across the represented 2019-2026 row span",
-        "reason": "The checked exact technical-data PDF proves a 265/55 R19 basic tire, while the checked current Audi Austria brochure documents square 20-inch through 23-inch summer packages and winter 19-inch through 21-inch packages, so this pass did not prove one production-safe default or full wheel/tire rewrite for the broad row's inherited placeholders.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-55-tfsi-2026-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2026-austria-brochure-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m8-60-tfsi-e-eu-2019-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M8",
-    "body_code": "4M8",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Q8 (4M8, 2019-2026)",
-    "variant_name": "60 TFSI e",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-      "value": "AWD",
-      "evidence_refs": [
-        "secondary_technical_sources:q8-4m8-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:q8-4m8-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-        "value": 3.333,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-        "value": 3.333,
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. Audi Q8 60 TFSI e has only ever been sold as '60 TFSI e quattro' (always AWD), and EU PHEV pre-sales began in 2020 - not 2019. This row duplicates audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd under an incorrect badge AND wrong production_start_year. Drivetrain, transmission, ratios, and tires are downgraded to no_confidence with safety gates requiring manual confirmation. Authoritative entry is the '60 TFSI e quattro' (2020) row.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 22\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 review replaces the mixed Q8 55/60 family note with row-specific Audi MediaCenter evidence for the exact Q8 60 TFSI e quattro tiptronic state. The checked 11/20/2020 and 12/15/2025 technical-data PDFs agree on permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, final drive 3.204, and basic 265/55 R19 tires. The 2024 product-upgrade release confirms a later 360 kW facelift state under the same 60 TFSI e quattro badge, but production JSON remains unchanged because this pass did not prove one exact 2019-2026 mapping or one year-spanning tire baseline.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:q8-4m8-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q8 60 TFSI e quattro production-data applicability across the represented 2019-2026 row span",
-        "reason": "The checked late-2020 and 2025 Audi MediaCenter technical-data PDFs prove later exact 60 TFSI e quattro states, but this pass did not recover a year-by-year official chain proving the current 2019 start or one unchanged exact mapping across the full broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe promotion of Audi Q8 60 TFSI e quattro exact transmission naming and final-drive mapping",
-        "reason": "The checked official source chain proves market-facing 8-speed tiptronic wording and a single 3.204 final-drive value, but the current broad row still carries normalized ZF8HP and split-final-drive placeholders and this pass did not prove a safer coordinated row reshaping across the adjacent Q8 aliases.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 60 TFSI e quattro tire-baseline and optional wheel matrix continuity",
-        "reason": "The checked technical-data PDFs prove a 265/55 R19 basic tire, while later official market material documents a different later standard-equipment package, so this pass did not close one representative default or optional wheel/tire chain for the full broad row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-4m8-60-tfsi-e-quattro-eu-2020-zf8hp-awd",
-    "brand": "Audi",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "4M8",
-    "body_code": "4M8",
-    "production_start_year": 2020,
-    "production_end_year": 2026,
-    "model_name": "Q8 (4M8, 2020-2026)",
-    "variant_name": "60 TFSI e quattro",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L V6 TFSI Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf",
-        "secondary_technical_sources:q8-4m8-wikipedia",
-        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf"
       ],
-      "notes": "Exact official Audi MediaCenter 2020 and 2025 Q8 60 TFSI e quattro technical-data material confirms permanent quattro AWD for the checked launch and facelift-era PHEV states, while row-wide tire-program continuity remains unresolved across the retimed 2020-2026 row. Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf",
-        "secondary_technical_sources:zf8hp-wikipedia",
-        "secondary_technical_sources:q8-4m8-wikipedia",
-        "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf"
-      ],
-      "notes": "Exact official Audi MediaCenter 2020 and 2025 Q8 60 TFSI e quattro technical-data material confirms the 8-speed tiptronic transmission wording for the checked launch and facelift-era PHEV states, while row-wide tire-program continuity remains unresolved across the retimed 2020-2026 row. Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): Q8 60 TFSI e quattro confirmed by Wikipedia: 3.0 L V6 TFSI + AC e-motor + 17.3 kWh battery, 335 kW (456 PS) / 700 Nm system output, AWD quattro, ZF 8-speed Tiptronic. EU pre-sales 2020. The same 8HP75/I-vs-8HP76/I ratio uncertainty applies as for the ICE 55 TFSI quattro - top gear 0.667 downgraded to no_confidence pending Audi MediaCenter PDF.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:zf8hp-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.333
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3da53a121d0a",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:834b58fa6ac6",
-          "legacy_research_sources:858568b097e7",
-          "legacy_research_sources:987b02afd090",
-          "legacy_research_sources:9a9f7660e688",
-          "legacy_research_sources:9ac37563abd5",
-          "legacy_research_sources:c6f574693b14",
-          "legacy_research_sources:d13f1c818845"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "item": "Audi Q8 60 TFSI e quattro exact tire-baseline and option continuity across the retimed 2020-2026 row span",
+          "reason": "The checked 2020 and 2025 technical-data sheets both prove a 265/55 R19 basic tire, but this pass did not recover production-safe market material for the full wheel and tire program carried by the row's inherited 21-inch and 22-inch placeholders.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 22\""
+          "item": "Audi Q8 60 TFSI e quattro exact gearbox-family naming",
+          "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the consistent 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3da53a121d0a",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:834b58fa6ac6",
-            "legacy_research_sources:858568b097e7",
-            "legacy_research_sources:987b02afd090",
-            "legacy_research_sources:9a9f7660e688",
-            "legacy_research_sources:9ac37563abd5",
-            "legacy_research_sources:c6f574693b14",
-            "legacy_research_sources:d13f1c818845"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 22\""
+          "item": "Audi Q8 60 TFSI e quattro production-data applicability across the full retimed 2020-2026 row span",
+          "reason": "The checked 2020 and 2025 technical-data sheets agree on the exact Q8 60 TFSI e quattro AWD, 8-speed tiptronic, ratio, final-drive, and 265/55 R19 basic-tire package, but this pass did not recover year-by-year material proving one unchanged mapping across every represented year.",
+          "evidence_refs_ref": "e6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Exact official Audi MediaCenter Q8 60 TFSI e quattro material now supports a safe numeric promotion on this retimed 2020-2026 row. The checked 11/20/2020 and 12/15/2025 technical-data PDFs agree on permanent quattro AWD, 8-speed tiptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, one published final-drive value 3.204, and 265/55 R19 basic tires. The checked 2024 upgrade release confirms the later 360 kW facelift handover inside the same 60 TFSI e quattro line. This pass still did not recover any earlier 2019 Germany-market 60 TFSI e sheet or a production-safe full wheel-program rewrite.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:zf8hp-wikipedia"
-        ]
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi Q8 60 TFSI e quattro exact tire-baseline and option continuity across the retimed 2020-2026 row span",
-        "reason": "The checked 2020 and 2025 technical-data sheets both prove a 265/55 R19 basic tire, but this pass did not recover production-safe market material for the full wheel and tire program carried by the row's inherited 21-inch and 22-inch placeholders.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 60 TFSI e quattro exact gearbox-family naming",
-        "reason": "Official Audi exact sources prove 8-speed tiptronic wording and the consistent 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 ratio block, but they do not publish an explicit gearbox-family code such as ZF 8HP.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi Q8 60 TFSI e quattro production-data applicability across the full retimed 2020-2026 row span",
-        "reason": "The checked 2020 and 2025 technical-data sheets agree on the exact Q8 60 TFSI e quattro AWD, 8-speed tiptronic, ratio, final-drive, and 265/55 R19 basic-tire package, but this pass did not recover year-by-year material proving one unchanged mapping across every represented year.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2020-tech-data-pdf",
-          "audi_mediacenter_sources:4m8-q8-2024-tfsi-e-upgrade-release",
-          "audi_mediacenter_sources:4m8-q8-60-tfsi-e-2025-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/r8/4S.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/r8/4S.json
@@ -1,304 +1,240 @@
-[
-  {
-    "id": "audi-4s-v10-rwd-eu-2015-dct7-rwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "4S",
-    "body_code": "4S",
-    "production_start_year": 2015,
-    "production_end_year": 2024,
-    "model_name": "R8 (4S, 2015-2024)",
-    "variant_name": "V10 RWD",
-    "engine_code": "5.2L",
-    "engine_name": "5.2L V10 NA",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "RWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL800)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.714
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.538
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:2eabd1ad6f42",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:71e8284cbff9",
-          "legacy_research_sources:9a27d8aef08c",
-          "legacy_research_sources:f3ff6ea4bfe6",
-          "legacy_research_sources:f40ffef80c9d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 295.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2eabd1ad6f42",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:71e8284cbff9",
-            "legacy_research_sources:9a27d8aef08c",
-            "legacy_research_sources:f3ff6ea4bfe6",
-            "legacy_research_sources:f40ffef80c9d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2eabd1ad6f42",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:71e8284cbff9",
-            "legacy_research_sources:9a27d8aef08c",
-            "legacy_research_sources:f3ff6ea4bfe6",
-            "legacy_research_sources:f40ffef80c9d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
-        }
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:2eabd1ad6f42",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:71e8284cbff9",
+        "legacy_research_sources:9a27d8aef08c",
+        "legacy_research_sources:f3ff6ea4bfe6",
+        "legacy_research_sources:f40ffef80c9d"
+      ],
+      "e2": [
+        "legacy_research_sources:a1a7fdd8c2e4"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 10 checked an official Audi 01/2023 Germany technical-data PDF for the later R8 Coupé V10 performance RWD. That later source confirms rear-wheel drive, 7-speed S tronic wording, Audi-form transmission ratios ending with 0.653 top gear, final-drive values 4.458 / 3.588, and staggered 245/35 R19 front plus 295/35 R19 rear base tires, but this pass still did not recover an official launch-era document proving one exact RWD mapping across the represented row span.",
-        "evidence_refs": [
-          "legacy_research_sources:a1a7fdd8c2e4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi R8 V10 RWD production-data applicability across the full represented row span",
-        "reason": "Checked official 01/2023 Germany technical data proves a later R8 Coupé V10 performance RWD program, but this pass did not recover an official launch-era RWD technical-data document proving one exact 2015-2024 mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:a1a7fdd8c2e4"
-        ]
-      },
-      {
-        "item": "Schema-safe encoding of exact Audi R8 V10 RWD ratio and tire continuity",
-        "reason": "The checked official 01/2023 RWD technical-data sheet publishes Audi-form ratio/final-drive data and later-program staggered base tires, but this pass did not recover a matching early-span source that would let the current broad row encode one exact cross-span mapping without interpretation.",
-        "evidence_refs": [
-          "legacy_research_sources:a1a7fdd8c2e4"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-4s-v10-quattro-eu-2015-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "4S",
-    "body_code": "4S",
-    "production_start_year": 2015,
-    "production_end_year": 2024,
-    "model_name": "R8 (4S, 2015-2024)",
-    "variant_name": "V10 quattro",
-    "engine_code": "5.2L",
-    "engine_name": "5.2L V10 NA",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DL800)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.714
+  "configurations": [
+    {
+      "id": "audi-4s-v10-rwd-eu-2015-dct7-rwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "4S",
+      "body_code": "4S",
+      "production_start_year": 2015,
+      "production_end_year": 2024,
+      "model_name": "R8 (4S, 2015-2024)",
+      "variant_name": "V10 RWD",
+      "engine_code": "5.2L",
+      "engine_name": "5.2L V10 NA",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.538
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL800)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.538
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:2eabd1ad6f42",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:71e8284cbff9",
-          "legacy_research_sources:9a27d8aef08c",
-          "legacy_research_sources:f3ff6ea4bfe6",
-          "legacy_research_sources:f40ffef80c9d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 295.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2eabd1ad6f42",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:71e8284cbff9",
-            "legacy_research_sources:9a27d8aef08c",
-            "legacy_research_sources:f3ff6ea4bfe6",
-            "legacy_research_sources:f40ffef80c9d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.714
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.538
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 295.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 10 checked an official Audi 01/2023 Germany technical-data PDF for the later R8 Coupé V10 performance RWD. That later source confirms rear-wheel drive, 7-speed S tronic wording, Audi-form transmission ratios ending with 0.653 top gear, final-drive values 4.458 / 3.588, and staggered 245/35 R19 front plus 295/35 R19 rear base tires, but this pass still did not recover an official launch-era document proving one exact RWD mapping across the represented row span.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2eabd1ad6f42",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:71e8284cbff9",
-            "legacy_research_sources:9a27d8aef08c",
-            "legacy_research_sources:f3ff6ea4bfe6",
-            "legacy_research_sources:f40ffef80c9d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 305.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
+          "note_ref": "n2"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi R8 V10 RWD production-data applicability across the full represented row span",
+          "reason": "Checked official 01/2023 Germany technical data proves a later R8 Coupé V10 performance RWD program, but this pass did not recover an official launch-era RWD technical-data document proving one exact 2015-2024 mapping.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Schema-safe encoding of exact Audi R8 V10 RWD ratio and tire continuity",
+          "reason": "The checked official 01/2023 RWD technical-data sheet publishes Audi-form ratio/final-drive data and later-program staggered base tires, but this pass did not recover a matching early-span source that would let the current broad row encode one exact cross-span mapping without interpretation.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market material now confirms the exact 2019+ R8 Coupé V10 quattro mapping: quattro AWD, 7-speed S tronic, a standard staggered 245/35 R19 front + 295/35 R19 rear tire setup, and Audi-form transmission data showing ratio values 13.969 / 9.287 / 6.746 / 5.080 / 4.003 / 3.171 / 2.343 with final-drive values 1.848 / 1.488. The broad R8 row remains unchanged because the exact V10 quattro badge is only cleanly evidenced from the 2019 facelift onward, accessible pre-facelift AWD documentation is contradictory, and the current schema cannot safely encode the dual final-drive and Audi-form ratio data.",
-        "evidence_refs": [
-          "legacy_research_sources:2eabd1ad6f42",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:71e8284cbff9",
-          "legacy_research_sources:9a27d8aef08c",
-          "legacy_research_sources:f3ff6ea4bfe6",
-          "legacy_research_sources:f40ffef80c9d"
+    {
+      "id": "audi-4s-v10-quattro-eu-2015-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "4S",
+      "body_code": "4S",
+      "production_start_year": 2015,
+      "production_end_year": 2024,
+      "model_name": "R8 (4S, 2015-2024)",
+      "variant_name": "V10 quattro",
+      "engine_code": "5.2L",
+      "engine_name": "5.2L V10 NA",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DL800)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.714
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.538
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.538
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 295.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 305.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany-market material now confirms the exact 2019+ R8 Coupé V10 quattro mapping: quattro AWD, 7-speed S tronic, a standard staggered 245/35 R19 front + 295/35 R19 rear tire setup, and Audi-form transmission data showing ratio values 13.969 / 9.287 / 6.746 / 5.080 / 4.003 / 3.171 / 2.343 with final-drive values 1.848 / 1.488. The broad R8 row remains unchanged because the exact V10 quattro badge is only cleanly evidenced from the 2019 facelift onward, accessible pre-facelift AWD documentation is contradictory, and the current schema cannot safely encode the dual final-drive and Audi-form ratio data.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi R8 V10 quattro production-data applicability across the full 2015-2024 row span",
+          "reason": "Checked official material cleanly proves the V10 quattro naming and exact mapping from the 2019 facelift onward, but this pass did not recover a non-contradictory official pre-facelift AWD technical-data sheet proving the same package across the full represented span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Schema-safe encoding of exact Audi R8 V10 quattro final-drive and ratio data",
+          "reason": "The checked official 2019+ V10 quattro technical-data sheet publishes dual final-drive values 1.848 / 1.488 and Audi-form ratio data that do not map safely into the current single final_drive_ratio and top_gear_ratio fields without interpretation.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi R8 V10 quattro production-data applicability across the full 2015-2024 row span",
-        "reason": "Checked official material cleanly proves the V10 quattro naming and exact mapping from the 2019 facelift onward, but this pass did not recover a non-contradictory official pre-facelift AWD technical-data sheet proving the same package across the full represented span.",
-        "evidence_refs": [
-          "legacy_research_sources:2eabd1ad6f42",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:71e8284cbff9",
-          "legacy_research_sources:9a27d8aef08c",
-          "legacy_research_sources:f3ff6ea4bfe6",
-          "legacy_research_sources:f40ffef80c9d"
-        ]
-      },
-      {
-        "item": "Schema-safe encoding of exact Audi R8 V10 quattro final-drive and ratio data",
-        "reason": "The checked official 2019+ V10 quattro technical-data sheet publishes dual final-drive values 1.848 / 1.488 and Audi-form ratio data that do not map safely into the current single final_drive_ratio and top_gear_ratio fields without interpretation.",
-        "evidence_refs": [
-          "legacy_research_sources:2eabd1ad6f42",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:71e8284cbff9",
-          "legacy_research_sources:9a27d8aef08c",
-          "legacy_research_sources:f3ff6ea4bfe6",
-          "legacy_research_sources:f40ffef80c9d"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8V.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8V.json
@@ -1,123 +1,125 @@
-[
-  {
-    "id": "audi-8v-rs3-sedan-eu-2017-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8V",
-    "body_code": "8V",
-    "production_start_year": 2017,
-    "production_end_year": 2020,
-    "model_name": "RS 3 Sedan (8V, 2017-2020)",
-    "variant_name": "RS 3",
-    "engine_code": "2.5L",
-    "engine_name": "2.5L I5 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:cb8e49d17f26",
-        "legacy_research_sources:cd4f372ab981"
-      ],
-      "notes": "Official Audi MediaCenter launch and archived Audi Germany model-page material confirm the exact 8V RS 3 Sedan uses quattro AWD in the EU launch-era state.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:cd4f372ab981"
-      ],
-      "notes": "The archived official Audi Germany RS 3 Limousine page explicitly says the exact 8V sedan uses a seven-speed S tronic. The repo keeps DCT7 as the canonical transmission-family mapping, but no checked official source publishes a gearbox family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
+{
+  "definitions": {
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:ce71a24f5b83",
+        "secondary_technical_sources:rs3-8v-sedan-brochure-mirror",
+        "secondary_technical_sources:rs3-8v-sedan-carfolio",
+        "secondary_technical_sources:rs3-8v-sedan-carspecs"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-8v-rs3-sedan-eu-2017-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8V",
+      "body_code": "8V",
+      "production_start_year": 2017,
+      "production_end_year": 2020,
+      "model_name": "RS 3 Sedan (8V, 2017-2020)",
+      "variant_name": "RS 3",
+      "engine_code": "2.5L",
+      "engine_name": "2.5L I5 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "secondary_technical_sources:rs3-8v-sedan-carfolio",
-          "secondary_technical_sources:rs3-8v-sedan-carspecs"
+          "legacy_research_sources:cb8e49d17f26",
+          "legacy_research_sources:cd4f372ab981"
         ],
-        "notes": "Independent secondary exact sedan pages agree on a 0.640 top gear for the 8V RS 3 Sedan, while the checked official Audi launch-era sources do not publish a gear-by-gear ratio table.",
-        "value": 0.64
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:ce71a24f5b83",
-          "secondary_technical_sources:rs3-8v-sedan-brochure-mirror",
-          "secondary_technical_sources:rs3-8v-sedan-carfolio",
-          "secondary_technical_sources:rs3-8v-sedan-carspecs"
-        ],
-        "notes": "Independent secondary exact sedan pages agree on square 235/35 R19 tires for the 8V RS 3 Sedan, and the March 2017 German-market brochure mirror with archived Audi Austria provenance independently lists 235/35 R19 in the brochure tire table. The same brochure also lists 255/30 R19 without a clean axle or package mapping, so production JSON keeps only the cross-checked 235/35 R19 baseline.",
-        "front": {
-          "width_mm": 235.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes": "Official Audi MediaCenter launch and archived Audi Germany model-page material confirm the exact 8V RS 3 Sedan uses quattro AWD in the EU launch-era state.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "legacy_research_sources:cd4f372ab981"
+        ],
+        "notes": "The archived official Audi Germany RS 3 Limousine page explicitly says the exact 8V sedan uses a seven-speed S tronic. The repo keeps DCT7 as the canonical transmission-family mapping, but no checked official source publishes a gearbox family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "reputable_secondary_crosschecked",
           "evidence_refs": [
-            "legacy_research_sources:ce71a24f5b83",
-            "secondary_technical_sources:rs3-8v-sedan-brochure-mirror",
             "secondary_technical_sources:rs3-8v-sedan-carfolio",
             "secondary_technical_sources:rs3-8v-sedan-carspecs"
           ],
-          "notes": "Independent secondary exact sedan pages agree on square 235/35 R19 tires for the 8V RS 3 Sedan, and the March 2017 German-market brochure mirror with archived Audi Austria provenance independently lists 235/35 R19 in the brochure tire table.",
+          "notes": "Independent secondary exact sedan pages agree on a 0.640 top gear for the 8V RS 3 Sedan, while the checked official Audi launch-era sources do not publish a gear-by-gear ratio table.",
+          "value": 0.64
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e1",
+          "notes": "Independent secondary exact sedan pages agree on square 235/35 R19 tires for the 8V RS 3 Sedan, and the March 2017 German-market brochure mirror with archived Audi Austria provenance independently lists 235/35 R19 in the brochure tire table. The same brochure also lists 255/30 R19 without a clean axle or package mapping, so production JSON keeps only the cross-checked 235/35 R19 baseline.",
           "front": {
             "width_mm": 235.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 8 review replaces the mixed 8V/8Y RS 3 placeholder with an exact 8V sedan row. Official Audi MediaCenter and archived Audi Germany launch-era material confirm the distinct 8V RS 3 Limousine identity, 294 kW / 400 PS, 480 Nm, 4.1-second launch performance state, quattro AWD, and seven-speed S tronic wording for the EU launch-era sedan. An archived Audi Austria brochure index proves provenance for the March 2017 German-market RS 3 brochure mirror, and the checked secondary cross-checks support top gear 0.640 plus a square 235/35 R19 baseline tire while the final-drive story remains unresolved.",
-        "evidence_refs": [
-          "legacy_research_sources:cb8e49d17f26",
-          "legacy_research_sources:cd4f372ab981",
-          "legacy_research_sources:ce71a24f5b83",
-          "secondary_technical_sources:rs3-8v-sedan-brochure-mirror",
-          "secondary_technical_sources:rs3-8v-sedan-carfolio",
-          "secondary_technical_sources:rs3-8v-sedan-carspecs"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 3 Sedan (8V) exact official gear-ratio and final-drive table",
-        "reason": "The checked official Audi launch-era sources prove quattro AWD and seven-speed S tronic wording for the 8V sedan, but they do not publish an exact gear-by-gear or final-drive table. Secondary sources conflict on the final-drive figure and only the weaker source exposes a full gear stack.",
-        "evidence_refs": [
-          "legacy_research_sources:cb8e49d17f26",
-          "legacy_research_sources:cd4f372ab981",
-          "secondary_technical_sources:rs3-8v-sedan-carfolio",
-          "secondary_technical_sources:rs3-8v-sedan-carspecs"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes": "Independent secondary exact sedan pages agree on square 235/35 R19 tires for the 8V RS 3 Sedan, and the March 2017 German-market brochure mirror with archived Audi Austria provenance independently lists 235/35 R19 in the brochure tire table.",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          }
         ]
       },
-      {
-        "item": "Audi RS 3 Sedan (8V) exact axle assignment and package mapping for the 255/30 R19 brochure tire size",
-        "reason": "The March 2017 German-market brochure mirror lists both 235/35 R19 and 255/30 R19 tire sizes, but it does not cleanly assign 255/30 R19 to an axle or an exact orderable wheel package for the 8V sedan.",
-        "evidence_refs": [
-          "legacy_research_sources:ce71a24f5b83",
-          "secondary_technical_sources:rs3-8v-sedan-brochure-mirror"
-        ]
+      "verification_notes": [
+        {
+          "note": "Batch 8 review replaces the mixed 8V/8Y RS 3 placeholder with an exact 8V sedan row. Official Audi MediaCenter and archived Audi Germany launch-era material confirm the distinct 8V RS 3 Limousine identity, 294 kW / 400 PS, 480 Nm, 4.1-second launch performance state, quattro AWD, and seven-speed S tronic wording for the EU launch-era sedan. An archived Audi Austria brochure index proves provenance for the March 2017 German-market RS 3 brochure mirror, and the checked secondary cross-checks support top gear 0.640 plus a square 235/35 R19 baseline tire while the final-drive story remains unresolved.",
+          "evidence_refs": [
+            "legacy_research_sources:cb8e49d17f26",
+            "legacy_research_sources:cd4f372ab981",
+            "legacy_research_sources:ce71a24f5b83",
+            "secondary_technical_sources:rs3-8v-sedan-brochure-mirror",
+            "secondary_technical_sources:rs3-8v-sedan-carfolio",
+            "secondary_technical_sources:rs3-8v-sedan-carspecs"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 3 Sedan (8V) exact official gear-ratio and final-drive table",
+          "reason": "The checked official Audi launch-era sources prove quattro AWD and seven-speed S tronic wording for the 8V sedan, but they do not publish an exact gear-by-gear or final-drive table. Secondary sources conflict on the final-drive figure and only the weaker source exposes a full gear stack.",
+          "evidence_refs": [
+            "legacy_research_sources:cb8e49d17f26",
+            "legacy_research_sources:cd4f372ab981",
+            "secondary_technical_sources:rs3-8v-sedan-carfolio",
+            "secondary_technical_sources:rs3-8v-sedan-carspecs"
+          ]
+        },
+        {
+          "item": "Audi RS 3 Sedan (8V) exact axle assignment and package mapping for the 255/30 R19 brochure tire size",
+          "reason": "The March 2017 German-market brochure mirror lists both 235/35 R19 and 255/30 R19 tire sizes, but it does not cleanly assign 255/30 R19 to an axle or an exact orderable wheel package for the 8V sedan.",
+          "evidence_refs": [
+            "legacy_research_sources:ce71a24f5b83",
+            "secondary_technical_sources:rs3-8v-sedan-brochure-mirror"
+          ]
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8Y.json
@@ -1,169 +1,161 @@
-[
-  {
-    "id": "audi-8y-rs3-sedan-eu-2021-dct7-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "RS 3 Sedan (8Y, 2021-2026)",
-    "variant_name": "RS 3",
-    "engine_code": "2.5L",
-    "engine_name": "2.5L I5 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:c34943178335",
+{
+  "definitions": {
+    "evidence_ref_sets": {
+      "e1": [
         "legacy_research_sources:c71437bb1b44"
       ],
-      "notes": "Official Audi MediaCenter launch and exact Sedan technical-data material confirm the 8Y RS 3 Sedan uses quattro AWD with torque splitter.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
+      "e2": [
         "legacy_research_sources:c34943178335",
         "legacy_research_sources:c71437bb1b44",
         "legacy_research_sources:e52a1c74b8d3"
       ],
-      "notes": "Official Audi MediaCenter launch material, the exact Sedan technical-data PDF, and the Audi Switzerland price list consistently use 7-speed / 7-Gang S tronic wording for the 8Y RS 3 Sedan. The repo keeps DCT7 as the canonical transmission-family mapping, but the checked official sources do not publish a gearbox family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:c71437bb1b44"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF lists 0.630 as the top-gear ratio for the exact 8Y RS 3 Sedan.",
-        "value": 0.63
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:c71437bb1b44"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF lists the full forward ratio set for the exact 8Y RS 3 Sedan.",
-        "value": [
-          3.56,
-          2.53,
-          1.68,
-          1.02,
-          0.79,
-          0.76,
-          0.63
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:c71437bb1b44"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sedan. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
-        "value": 4.059
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:c71437bb1b44"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sedan. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
-        "value": 4.059
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:c71437bb1b44",
-          "legacy_research_sources:e52a1c74b8d3"
-        ],
-        "notes": "The official Audi MediaCenter Sedan technical-data PDF and the Audi Switzerland price list confirm the exact 8Y RS 3 Sedan's basic staggered 19-inch setup.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 30.0,
-          "rim_in": 19.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:c71437bb1b44",
-            "legacy_research_sources:e52a1c74b8d3"
-          ],
-          "notes": "The official Audi MediaCenter Sedan technical-data PDF and the Audi Switzerland price list confirm this as the basic staggered 19-inch setup for the exact 8Y RS 3 Sedan.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:e52a1c74b8d3"
-          ],
-          "notes": "The official Audi Switzerland price list confirms optional Pirelli P Zero Trofeo R tires for the exact 8Y RS 3 Sedan in the same staggered 19-inch sizes.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Pirelli P Zero Trofeo R 19\""
-        }
+      "e3": [
+        "legacy_research_sources:c71437bb1b44",
+        "legacy_research_sources:e52a1c74b8d3"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 8 review splits the mixed RS 3 row and promotes the exact 8Y RS 3 Sedan into production data. The official Audi MediaCenter launch article and exact Sedan technical-data PDF confirm quattro AWD with torque splitter, 7-speed S tronic wording, forward ratios 3.560 / 2.530 / 1.680 / 1.020 / 0.790 / 0.760 / 0.630, one published final-drive value 4.059, and the basic staggered 19-inch 265/30 front plus 245/35 rear setup. The official Audi Switzerland price list independently confirms the EU-market Sedan identity, the same staggered base fitment, optional Pirelli P Zero Trofeo R tires in the same sizes, and the 280 / 290 km/h top-speed option packages.",
-        "evidence_refs": [
-          "legacy_research_sources:c34943178335",
-          "legacy_research_sources:c71437bb1b44",
-          "legacy_research_sources:e52a1c74b8d3"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 3 Sedan (8Y) exact gearbox family code and full optional wheel/tire matrix beyond the checked 19-inch packages",
-        "reason": "The checked exact Audi sources prove the 7-speed S tronic ratio set, one published final-drive value, the basic staggered 19-inch setup, and the same-size Trofeo R option, but they do not publish a gearbox family code or a complete wheel and tire matrix for every exact 8Y Sedan package.",
-        "evidence_refs": [
-          "legacy_research_sources:c34943178335",
-          "legacy_research_sources:c71437bb1b44",
-          "legacy_research_sources:e52a1c74b8d3"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  },
+  "configurations": [
+    {
+      "id": "audi-8y-rs3-sedan-eu-2021-dct7-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "RS 3 Sedan (8Y, 2021-2026)",
+      "variant_name": "RS 3",
+      "engine_code": "2.5L",
+      "engine_name": "2.5L I5 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "legacy_research_sources:c34943178335",
+          "legacy_research_sources:c71437bb1b44"
+        ],
+        "notes": "Official Audi MediaCenter launch and exact Sedan technical-data material confirm the 8Y RS 3 Sedan uses quattro AWD with torque splitter.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "Official Audi MediaCenter launch material, the exact Sedan technical-data PDF, and the Audi Switzerland price list consistently use 7-speed / 7-Gang S tronic wording for the 8Y RS 3 Sedan. The repo keeps DCT7 as the canonical transmission-family mapping, but the checked official sources do not publish a gearbox family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official Audi MediaCenter technical-data PDF lists 0.630 as the top-gear ratio for the exact 8Y RS 3 Sedan.",
+          "value": 0.63
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official Audi MediaCenter technical-data PDF lists the full forward ratio set for the exact 8Y RS 3 Sedan.",
+          "value": [
+            3.56,
+            2.53,
+            1.68,
+            1.02,
+            0.79,
+            0.76,
+            0.63
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sedan. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
+          "value": 4.059
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sedan. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
+          "value": 4.059
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official Audi MediaCenter Sedan technical-data PDF and the Audi Switzerland price list confirm the exact 8Y RS 3 Sedan's basic staggered 19-inch setup.",
+          "front": {
+            "width_mm": 265.0,
+            "aspect_pct": 30.0,
+            "rim_in": 19.0
+          },
+          "rear": {
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "The official Audi MediaCenter Sedan technical-data PDF and the Audi Switzerland price list confirm this as the basic staggered 19-inch setup for the exact 8Y RS 3 Sedan.",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs": [
+              "legacy_research_sources:e52a1c74b8d3"
+            ],
+            "notes": "The official Audi Switzerland price list confirms optional Pirelli P Zero Trofeo R tires for the exact 8Y RS 3 Sedan in the same staggered 19-inch sizes.",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Pirelli P Zero Trofeo R 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 8 review splits the mixed RS 3 row and promotes the exact 8Y RS 3 Sedan into production data. The official Audi MediaCenter launch article and exact Sedan technical-data PDF confirm quattro AWD with torque splitter, 7-speed S tronic wording, forward ratios 3.560 / 2.530 / 1.680 / 1.020 / 0.790 / 0.760 / 0.630, one published final-drive value 4.059, and the basic staggered 19-inch 265/30 front plus 245/35 rear setup. The official Audi Switzerland price list independently confirms the EU-market Sedan identity, the same staggered base fitment, optional Pirelli P Zero Trofeo R tires in the same sizes, and the 280 / 290 km/h top-speed option packages.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 3 Sedan (8Y) exact gearbox family code and full optional wheel/tire matrix beyond the checked 19-inch packages",
+          "reason": "The checked exact Audi sources prove the 7-speed S tronic ratio set, one published final-drive value, the basic staggered 19-inch setup, and the same-size Trofeo R option, but they do not publish a gearbox family code or a complete wheel and tire matrix for every exact 8Y Sedan package.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    }
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sportback/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sportback/8Y.json
@@ -1,107 +1,85 @@
-[
-  {
-    "id": "audi-8y-rs3-sportback-eu-2021-dct7-awd",
-    "brand": "Audi",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "8Y",
-    "body_code": "8Y",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "RS 3 Sportback (8Y, 2021-2026)",
-    "variant_name": "RS 3",
-    "engine_code": "2.5L",
-    "engine_name": "2.5L I5 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official Audi MediaCenter launch and exact Sportback technical-data material confirm the basic staggered 19-inch setup for the 8Y RS 3 Sportback."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "legacy_research_sources:c34943178335",
         "legacy_research_sources:dae61be0efdf"
       ],
-      "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material confirm the 8Y RS 3 Sportback uses quattro AWD with torque splitter.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:c34943178335",
+      "e2": [
         "legacy_research_sources:dae61be0efdf"
-      ],
-      "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material consistently use 7-speed S tronic wording for the 8Y RS 3 Sportback. The repo keeps DCT7 as the canonical transmission-family mapping, but the checked official sources do not publish a gearbox family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-8y-rs3-sportback-eu-2021-dct7-awd",
+      "brand": "Audi",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "8Y",
+      "body_code": "8Y",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "RS 3 Sportback (8Y, 2021-2026)",
+      "variant_name": "RS 3",
+      "engine_code": "2.5L",
+      "engine_name": "2.5L I5 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:dae61be0efdf"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF lists 0.630 as the top-gear ratio for the exact 8Y RS 3 Sportback.",
-        "value": 0.63
+        "evidence_refs_ref": "e1",
+        "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material confirm the 8Y RS 3 Sportback uses quattro AWD with torque splitter.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:dae61be0efdf"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF lists the full forward ratio set for the exact 8Y RS 3 Sportback.",
-        "value": [
-          3.56,
-          2.53,
-          1.68,
-          1.02,
-          0.79,
-          0.76,
-          0.63
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:dae61be0efdf"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sportback. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
-        "value": 4.059
+        "evidence_refs_ref": "e1",
+        "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material consistently use 7-speed S tronic wording for the 8Y RS 3 Sportback. The repo keeps DCT7 as the canonical transmission-family mapping, but the checked official sources do not publish a gearbox family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:dae61be0efdf"
-        ],
-        "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sportback. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
-        "value": 4.059
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:c34943178335",
-          "legacy_research_sources:dae61be0efdf"
-        ],
-        "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material confirm the basic staggered 19-inch setup for the 8Y RS 3 Sportback.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 30.0,
-          "rim_in": 19.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:c34943178335",
-            "legacy_research_sources:dae61be0efdf"
-          ],
-          "notes": "Official Audi MediaCenter launch and exact Sportback technical-data material confirm the basic staggered 19-inch setup for the 8Y RS 3 Sportback.",
+          "evidence_refs_ref": "e2",
+          "notes": "The official Audi MediaCenter technical-data PDF lists 0.630 as the top-gear ratio for the exact 8Y RS 3 Sportback.",
+          "value": 0.63
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official Audi MediaCenter technical-data PDF lists the full forward ratio set for the exact 8Y RS 3 Sportback.",
+          "value": [
+            3.56,
+            2.53,
+            1.68,
+            1.02,
+            0.79,
+            0.76,
+            0.63
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sportback. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
+          "value": 4.059
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official Audi MediaCenter technical-data PDF publishes one final-drive value of 4.059 for the exact 8Y RS 3 Sportback. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
+          "value": 4.059
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 30.0,
@@ -112,36 +90,48 @@
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 8 review splits the mixed RS 3 row and promotes the exact 8Y RS 3 Sportback into production data. The official Audi MediaCenter launch article and exact Sportback technical-data PDF confirm quattro AWD with torque splitter, 7-speed S tronic wording, forward ratios 3.560 / 2.530 / 1.680 / 1.020 / 0.790 / 0.760 / 0.630, one published final-drive value 4.059, and the basic staggered 19-inch 265/30 front plus 245/35 rear setup.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 8 review splits the mixed RS 3 row and promotes the exact 8Y RS 3 Sportback into production data. The official Audi MediaCenter launch article and exact Sportback technical-data PDF confirm quattro AWD with torque splitter, 7-speed S tronic wording, forward ratios 3.560 / 2.530 / 1.680 / 1.020 / 0.790 / 0.760 / 0.630, one published final-drive value 4.059, and the basic staggered 19-inch 265/30 front plus 245/35 rear setup.",
-        "evidence_refs": [
-          "legacy_research_sources:c34943178335",
-          "legacy_research_sources:dae61be0efdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 3 Sportback (8Y) exact gearbox family code and full optional wheel/tire matrix",
+          "reason": "The checked exact Audi sources prove the 7-speed S tronic ratio set, one published final-drive value, and the basic staggered 19-inch setup, but they do not publish a gearbox family code or one complete optional wheel and tire matrix for the exact Sportback row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 3 Sportback (8Y) exact gearbox family code and full optional wheel/tire matrix",
-        "reason": "The checked exact Audi sources prove the 7-speed S tronic ratio set, one published final-drive value, and the basic staggered 19-inch setup, but they do not publish a gearbox family code or one complete optional wheel and tire matrix for the exact Sportback row.",
-        "evidence_refs": [
-          "legacy_research_sources:c34943178335",
-          "legacy_research_sources:dae61be0efdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_4_avant/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_4_avant/B9.json
@@ -1,160 +1,130 @@
-[
-  {
-    "id": "audi-b9-rs-4-eu-2018-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Wagon",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "RS 4 Avant (B9, 2018-2024)",
-    "variant_name": "RS 4",
-    "engine_code": "2.9L",
-    "engine_name": "2.9L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:03e33032d1fd",
+        "legacy_research_sources:40b7eea7495e",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:9e97ecf68724",
+        "legacy_research_sources:a3af81211686"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-b9-rs-4-eu-2018-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Wagon",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "RS 4 Avant (B9, 2018-2024)",
+      "variant_name": "RS 4",
+      "engine_code": "2.9L",
+      "engine_name": "2.9L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:03e33032d1fd",
-          "legacy_research_sources:40b7eea7495e",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:9e97ecf68724",
-          "legacy_research_sources:a3af81211686"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:03e33032d1fd",
-            "legacy_research_sources:40b7eea7495e",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9e97ecf68724",
-            "legacy_research_sources:a3af81211686"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany technical-data material now confirms the exact later-cycle RS 4 Avant mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.204, and a basic square 265/35 R19 tire setup. The broad RS 4 row remains unchanged because this pass did not recover a launch-year 2018 Germany/EU technical-data sheet, and checked official sources do not prove the same optional wheel/tire matrix or gearbox-family naming across the full 2018-2024 span.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:03e33032d1fd",
-            "legacy_research_sources:40b7eea7495e",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9e97ecf68724",
-            "legacy_research_sources:a3af81211686"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany technical-data material now confirms the exact later-cycle RS 4 Avant mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.204, and a basic square 265/35 R19 tire setup. The broad RS 4 row remains unchanged because this pass did not recover a launch-year 2018 Germany/EU technical-data sheet, and checked official sources do not prove the same optional wheel/tire matrix or gearbox-family naming across the full 2018-2024 span.",
-        "evidence_refs": [
-          "legacy_research_sources:03e33032d1fd",
-          "legacy_research_sources:40b7eea7495e",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:9e97ecf68724",
-          "legacy_research_sources:a3af81211686"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 4 Avant exact production-data applicability across the full 2018-2024 row span",
+          "reason": "The checked official RS 4 Avant technical-data material resolves the later-cycle mapping, but this pass did not recover a launch-year 2018 Germany/EU sheet that proves the same ratio and tire package across the full represented span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi RS 4 Avant exact transmission-code and non-basic tire-option coverage",
+          "reason": "Official Audi exact material proves 8-speed tiptronic wording, the full ratio set, final drive 3.204, and the 265/35 R19 basic tire, but it does not publish a gearbox-family code or a full optional wheel/tire matrix for the plain RS 4 Avant.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 4 Avant exact production-data applicability across the full 2018-2024 row span",
-        "reason": "The checked official RS 4 Avant technical-data material resolves the later-cycle mapping, but this pass did not recover a launch-year 2018 Germany/EU sheet that proves the same ratio and tire package across the full represented span.",
-        "evidence_refs": [
-          "legacy_research_sources:03e33032d1fd",
-          "legacy_research_sources:40b7eea7495e",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:9e97ecf68724",
-          "legacy_research_sources:a3af81211686"
-        ]
-      },
-      {
-        "item": "Audi RS 4 Avant exact transmission-code and non-basic tire-option coverage",
-        "reason": "Official Audi exact material proves 8-speed tiptronic wording, the full ratio set, final drive 3.204, and the 265/35 R19 basic tire, but it does not publish a gearbox-family code or a full optional wheel/tire matrix for the plain RS 4 Avant.",
-        "evidence_refs": [
-          "legacy_research_sources:03e33032d1fd",
-          "legacy_research_sources:40b7eea7495e",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:9e97ecf68724",
-          "legacy_research_sources:a3af81211686"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_5/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_5/B9.json
@@ -1,166 +1,150 @@
-[
-  {
-    "id": "audi-b9-rs-5-eu-2019-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "B9",
-    "body_code": "B9",
-    "production_start_year": 2019,
-    "production_end_year": 2024,
-    "model_name": "RS 5 (B9, 2019-2024)",
-    "variant_name": "RS 5",
-    "engine_code": "2.9L",
-    "engine_name": "2.9L V6 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official Audi 2019 and 2024 technical-data PDFs publish a single 3.204 final-drive ratio for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n2": "Official Audi 2019 and 2024 technical-data PDFs agree on a square 265/35 R19 basic tire setup for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "legacy_research_sources:0ccc83cfa474",
         "legacy_research_sources:9b59acace271"
-      ],
-      "notes": "Official Audi 2019 and 2024 technical-data PDFs confirm permanent quattro all-wheel drive with self-locking center differential for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:0ccc83cfa474",
-        "legacy_research_sources:9b59acace271"
-      ],
-      "notes": "Official Audi 2019 and 2024 technical-data PDFs confirm 8-speed tiptronic wording for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row. The repo keeps ZF8HP as the canonical gearbox-family mapping because the official Audi PDFs do not publish the gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-b9-rs-5-eu-2019-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "B9",
+      "body_code": "B9",
+      "production_start_year": 2019,
+      "production_end_year": 2024,
+      "model_name": "RS 5 (B9, 2019-2024)",
+      "variant_name": "RS 5",
+      "engine_code": "2.9L",
+      "engine_name": "2.9L V6 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ],
-        "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on 0.640 top gear for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
-        "value": 0.64
+        "evidence_refs_ref": "e1",
+        "notes": "Official Audi 2019 and 2024 technical-data PDFs confirm permanent quattro all-wheel drive with self-locking center differential for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ],
-        "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on the forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ],
-        "notes": "Official Audi 2019 and 2024 technical-data PDFs publish a single 3.204 final-drive ratio for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.204
+        "evidence_refs_ref": "e1",
+        "notes": "Official Audi 2019 and 2024 technical-data PDFs confirm 8-speed tiptronic wording for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row. The repo keeps ZF8HP as the canonical gearbox-family mapping because the official Audi PDFs do not publish the gearbox-family code.",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ],
-        "notes": "Official Audi 2019 and 2024 technical-data PDFs publish a single 3.204 final-drive ratio for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.204
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ],
-        "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on a square 265/35 R19 basic tire setup for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:0ccc83cfa474",
-            "legacy_research_sources:9b59acace271"
-          ],
-          "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on a square 265/35 R19 basic tire setup for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on 0.640 top gear for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official Audi 2019 and 2024 technical-data PDFs agree on the forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact RS 5 Coupé state represented by this narrowed 2019-2024 row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 3.204
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 3.204
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0ccc83cfa474",
-            "legacy_research_sources:40b7eea7495e",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:59390d64c606",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:9b59acace271",
-            "legacy_research_sources:b5bb7c63c3d1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi 2019 and 2024 technical-data PDFs now confirm the exact RS 5 Coupé mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published final-drive ratio 3.204, and a basic square 265/35 R19 tire setup. Production JSON narrows the broad row to the supported 2019-2024 state because this pass still did not recover a launch-year 2018 technical-data sheet proving the same package.",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
+          {
+            "confidence": "family_default",
+            "evidence_refs": [
+              "legacy_research_sources:0ccc83cfa474",
+              "legacy_research_sources:40b7eea7495e",
+              "legacy_research_sources:4b4b833b364a",
+              "legacy_research_sources:4b8ab423f879",
+              "legacy_research_sources:59390d64c606",
+              "legacy_research_sources:5e252f7f436b",
+              "legacy_research_sources:9b59acace271",
+              "legacy_research_sources:b5bb7c63c3d1"
+            ],
+            "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "Official Audi 2019 and 2024 technical-data PDFs now confirm the exact RS 5 Coupé mapping: permanent quattro AWD with self-locking center differential, 8-speed tiptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published final-drive ratio 3.204, and a basic square 265/35 R19 tire setup. Production JSON narrows the broad row to the supported 2019-2024 state because this pass still did not recover a launch-year 2018 technical-data sheet proving the same package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 5 exact transmission-code and non-basic tire-option coverage",
+          "reason": "Official Audi 2019 and 2024 technical-data PDFs prove 8-speed tiptronic wording, the full ratio set, a single published final-drive ratio 3.204, and the 265/35 R19 basic tire, but they do not publish the gearbox-family code or the exact optional 20-inch tire dimensions for the plain RS 5 Coupé.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 5 exact transmission-code and non-basic tire-option coverage",
-        "reason": "Official Audi 2019 and 2024 technical-data PDFs prove 8-speed tiptronic wording, the full ratio set, a single published final-drive ratio 3.204, and the 265/35 R19 basic tire, but they do not publish the gearbox-family code or the exact optional 20-inch tire dimensions for the plain RS 5 Coupé.",
-        "evidence_refs": [
-          "legacy_research_sources:0ccc83cfa474",
-          "legacy_research_sources:9b59acace271"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_6_avant/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_6_avant/C8.json
@@ -1,182 +1,137 @@
-[
-  {
-    "id": "audi-c8-rs-6-eu-2020-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Wagon",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2020,
-    "production_end_year": 2026,
-    "model_name": "RS 6 Avant (C8, 2020-2026)",
-    "variant_name": "RS 6",
-    "engine_code": "4.0L",
-    "engine_name": "4.0L V8 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:07cc5dc911b9",
+        "legacy_research_sources:0a24f01e0a95",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
         "legacy_research_sources:655c83e80527",
-        "legacy_research_sources:ee23956fe3cd"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
+        "legacy_research_sources:876c20c63603",
+        "legacy_research_sources:b225154c654e",
+        "legacy_research_sources:ee23956fe3cd",
+        "legacy_research_sources:f6365cece15e"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-c8-rs-6-eu-2020-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Wagon",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2020,
+      "production_end_year": 2026,
+      "model_name": "RS 6 Avant (C8, 2020-2026)",
+      "variant_name": "RS 6",
+      "engine_code": "4.0L",
+      "engine_name": "4.0L V8 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:0a24f01e0a95",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
           "legacy_research_sources:655c83e80527",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:b225154c654e",
-          "legacy_research_sources:ee23956fe3cd",
-          "legacy_research_sources:f6365cece15e"
+          "legacy_research_sources:ee23956fe3cd"
         ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:0a24f01e0a95",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:655c83e80527",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:b225154c654e",
-            "legacy_research_sources:ee23956fe3cd",
-            "legacy_research_sources:f6365cece15e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 285.0,
             "aspect_pct": 30.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany technical-data sheets now confirm the exact RS 6 Avant drivetrain mapping, full gear ratios, final drive 3.204, basic 275/35 R21 tires, and optional 285/30 R22 tires for 2023-2025 Germany-market documents. The broad row remains unchanged because this pass did not prove the same mapping across the full 2020-2026 span represented in production data.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:0a24f01e0a95",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:655c83e80527",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:b225154c654e",
-            "legacy_research_sources:ee23956fe3cd",
-            "legacy_research_sources:f6365cece15e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 22\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany technical-data sheets now confirm the exact RS 6 Avant drivetrain mapping, full gear ratios, final drive 3.204, basic 275/35 R21 tires, and optional 285/30 R22 tires for 2023-2025 Germany-market documents. The broad row remains unchanged because this pass did not prove the same mapping across the full 2020-2026 span represented in production data.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:0a24f01e0a95",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:655c83e80527",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:b225154c654e",
-          "legacy_research_sources:ee23956fe3cd",
-          "legacy_research_sources:f6365cece15e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 6 Avant exact production-data applicability across the full 2020-2026 row span",
+          "reason": "This pass found exact Germany-market proof for 2023-2025 documents, but it did not retrieve matching official launch-year and full-span documents that prove one unchanged ratio and tire package across the entire row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi RS 6 Avant public gearbox-family naming beyond '8-speed tiptronic'",
+          "reason": "Official Audi exact sources confirm the transmission as 8-speed tiptronic but do not explicitly name the gearbox family as ZF 8HP.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 6 Avant exact production-data applicability across the full 2020-2026 row span",
-        "reason": "This pass found exact Germany-market proof for 2023-2025 documents, but it did not retrieve matching official launch-year and full-span documents that prove one unchanged ratio and tire package across the entire row.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:0a24f01e0a95",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:655c83e80527",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:b225154c654e",
-          "legacy_research_sources:ee23956fe3cd",
-          "legacy_research_sources:f6365cece15e"
-        ]
-      },
-      {
-        "item": "Audi RS 6 Avant public gearbox-family naming beyond '8-speed tiptronic'",
-        "reason": "Official Audi exact sources confirm the transmission as 8-speed tiptronic but do not explicitly name the gearbox family as ZF 8HP.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:0a24f01e0a95",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:655c83e80527",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:b225154c654e",
-          "legacy_research_sources:ee23956fe3cd",
-          "legacy_research_sources:f6365cece15e"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_7_sportback/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_7_sportback/C8.json
@@ -1,182 +1,137 @@
-[
-  {
-    "id": "audi-c8-rs-7-eu-2020-zf8hp-awd",
-    "brand": "Audi",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "C8",
-    "body_code": "C8",
-    "production_start_year": 2020,
-    "production_end_year": 2026,
-    "model_name": "RS 7 Sportback (C8, 2020-2026)",
-    "variant_name": "RS 7",
-    "engine_code": "4.0L",
-    "engine_name": "4.0L V8 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:07cc5dc911b9",
         "legacy_research_sources:32f63bff9841",
-        "legacy_research_sources:d63fb6ea66e8"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed tiptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:876c20c63603",
+        "legacy_research_sources:8d27cb10445a",
+        "legacy_research_sources:d63fb6ea66e8",
+        "legacy_research_sources:e0e3c0af8330",
+        "legacy_research_sources:f328feae7002"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-c8-rs-7-eu-2020-zf8hp-awd",
+      "brand": "Audi",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "C8",
+      "body_code": "C8",
+      "production_start_year": 2020,
+      "production_end_year": 2026,
+      "model_name": "RS 7 Sportback (C8, 2020-2026)",
+      "variant_name": "RS 7",
+      "engine_code": "4.0L",
+      "engine_name": "4.0L V8 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
           "legacy_research_sources:32f63bff9841",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8d27cb10445a",
-          "legacy_research_sources:d63fb6ea66e8",
-          "legacy_research_sources:e0e3c0af8330",
-          "legacy_research_sources:f328feae7002"
+          "legacy_research_sources:d63fb6ea66e8"
         ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed tiptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:32f63bff9841",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:8d27cb10445a",
-            "legacy_research_sources:d63fb6ea66e8",
-            "legacy_research_sources:e0e3c0af8330",
-            "legacy_research_sources:f328feae7002"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 285.0,
             "aspect_pct": 30.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi Germany technical-data sheets now confirm the exact RS 7 Sportback drivetrain mapping, full gear ratios, final drive 3.204, and standard 275/35 R21 tires from launch-era 2020 and later 2024 Germany-market documents. The broad row remains unchanged because exact official proof for the base RS 7 22-inch option and safe mapping across the full 2020-2026 span is still incomplete.",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:07cc5dc911b9",
-            "legacy_research_sources:32f63bff9841",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:876c20c63603",
-            "legacy_research_sources:8d27cb10445a",
-            "legacy_research_sources:d63fb6ea66e8",
-            "legacy_research_sources:e0e3c0af8330",
-            "legacy_research_sources:f328feae7002"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 22\""
+          "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany technical-data sheets now confirm the exact RS 7 Sportback drivetrain mapping, full gear ratios, final drive 3.204, and standard 275/35 R21 tires from launch-era 2020 and later 2024 Germany-market documents. The broad row remains unchanged because exact official proof for the base RS 7 22-inch option and safe mapping across the full 2020-2026 span is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:32f63bff9841",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8d27cb10445a",
-          "legacy_research_sources:d63fb6ea66e8",
-          "legacy_research_sources:e0e3c0af8330",
-          "legacy_research_sources:f328feae7002"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "Audi RS 7 Sportback exact 22-inch base-variant tire-option proof",
+          "reason": "Checked official Audi family and supplier sources point to 285/30 R22, but this pass did not retrieve a base-RS7 Germany-market technical-data sheet that explicitly lists the optional 22-inch size.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi RS 7 Sportback production-data applicability across the full 2020-2026 row span",
+          "reason": "This pass found matching launch-era 2020 and later 2024 Germany-market ratio documents, but the current Audi MediaCenter model hub labels the model family through 2025, so the repo's full 2020-2026 span still is not fully closed.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi RS 7 Sportback exact 22-inch base-variant tire-option proof",
-        "reason": "Checked official Audi family and supplier sources point to 285/30 R22, but this pass did not retrieve a base-RS7 Germany-market technical-data sheet that explicitly lists the optional 22-inch size.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:32f63bff9841",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8d27cb10445a",
-          "legacy_research_sources:d63fb6ea66e8",
-          "legacy_research_sources:e0e3c0af8330",
-          "legacy_research_sources:f328feae7002"
-        ]
-      },
-      {
-        "item": "Audi RS 7 Sportback production-data applicability across the full 2020-2026 row span",
-        "reason": "This pass found matching launch-era 2020 and later 2024 Germany-market ratio documents, but the current Audi MediaCenter model hub labels the model family through 2025, so the repo's full 2020-2026 span still is not fully closed.",
-        "evidence_refs": [
-          "legacy_research_sources:07cc5dc911b9",
-          "legacy_research_sources:32f63bff9841",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:876c20c63603",
-          "legacy_research_sources:8d27cb10445a",
-          "legacy_research_sources:d63fb6ea66e8",
-          "legacy_research_sources:e0e3c0af8330",
-          "legacy_research_sources:f328feae7002"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8J.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8J.json
@@ -1,707 +1,580 @@
-[
-  {
-    "id": "audi-8j-2-0-tfsi-eu-2011-dct6-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8J",
-    "body_code": "8J",
-    "production_start_year": 2011,
-    "production_end_year": 2014,
-    "model_name": "TT (8J, 2011-2014)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
+      "n3": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
+      "n4": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921.",
+      "n6": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded.",
+      "n7": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:3b8a9657b4b7",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:5e252f7f436b",
+        "legacy_research_sources:bc25c256657b"
+      ],
+      "e2": [
+        "legacy_research_sources:fa2ecfeb2ce9"
+      ],
+      "e3": [
+        "legacy_research_sources:efeaede27b61"
+      ],
+      "e4": [
         "secondary_technical_sources:tt-8j-wikipedia",
         "legacy_research_sources:efeaede27b61",
         "legacy_research_sources:fa2ecfeb2ce9"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
-        "legacy_research_sources:efeaede27b61",
-        "legacy_research_sources:fa2ecfeb2ce9"
+      "e5": [
+        "legacy_research_sources:fa2ecfeb2ce9",
+        "legacy_research_sources:ac68dd8bebb2",
+        "legacy_research_sources:b3806add936a"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921.",
-      "code": "DCT6",
-      "name": "6-speed S tronic (DQ250)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921.",
-        "value": 0.921,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921. Encodes sub-trans 1 (odd gears 1/3/5) output ratio.",
-        "value": 4.059,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3b8a9657b4b7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:bc25c256657b"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi UK TT Coupé pricing/specification and technical-sheet URLs now close the FWD 6-speed S tronic mapping for this row. The indexed official technical-sheet extract also reports top gear 0.921 with split final drives 4.059 / 3.136, which contradicts the inherited 0.742 and single 3.444 placeholders, so those numeric fields remain advisory until the repo can encode them from a directly captured or schema-safe official artifact.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:efeaede27b61"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of official Audi TT Coupé 2.0 TFSI S tronic split final-drive values",
-        "reason": "The checked official TT Coupé technical-sheet extract reports top gear 0.921 and split final drives 4.059 / 3.136 for the exact FWD S tronic slice, but the current row has only one final_drive_front field and this pass did not promote indexed-extract ratio data into production values without a directly captured official artifact.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      },
-      {
-        "item": "Audi TT 2.0 TFSI generic EU Coupé baseline tire mapping",
-        "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:ac68dd8bebb2",
-          "legacy_research_sources:b3806add936a"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8j-2-0-tfsi-eu-2011-mt6-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8J",
-    "body_code": "8J",
-    "production_start_year": 2011,
-    "production_end_year": 2014,
-    "model_name": "TT (8J, 2011-2014)",
-    "variant_name": "2.0 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
-        "legacy_research_sources:efeaede27b61",
-        "legacy_research_sources:fa2ecfeb2ce9"
+      "e6": [
+        "legacy_research_sources:ac68dd8bebb2"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
-        "legacy_research_sources:efeaede27b61",
-        "legacy_research_sources:fa2ecfeb2ce9"
+      "e7": [
+        "legacy_research_sources:fa2ecfeb2ce9",
+        "legacy_research_sources:efeaede27b61"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded.",
-      "code": "MT6",
-      "name": "6-speed manual (MQ250 / GQQ)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded.",
-        "value": 0.975,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded. Encodes first MQ250 output FD ratio.",
-        "value": 3.944,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3b8a9657b4b7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:bc25c256657b"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi UK TT Coupé pricing/specification and technical-sheet URLs now close the FWD 6-speed manual mapping for this row. The indexed official technical-sheet extract also reports top gear 0.975 with split final drives 3.944 / 3.087, which contradicts the inherited 0.84 and single 3.462 placeholders, so those numeric fields remain advisory until the repo can encode them from a directly captured or schema-safe official artifact.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:efeaede27b61"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of official Audi TT Coupé 2.0 TFSI manual split final-drive values",
-        "reason": "The checked official TT Coupé technical-sheet extract reports top gear 0.975 and split final drives 3.944 / 3.087 for the exact FWD manual slice, but the current row has only one final_drive_front field and this pass did not promote indexed-extract ratio data into production values without a directly captured official artifact.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9"
-        ]
-      },
-      {
-        "item": "Audi TT 2.0 TFSI generic EU Coupé baseline tire mapping",
-        "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:ac68dd8bebb2",
-          "legacy_research_sources:b3806add936a"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8j-2-0-tfsi-quattro-eu-2011-dct6-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8J",
-    "body_code": "8J",
-    "production_start_year": 2011,
-    "production_end_year": 2014,
-    "model_name": "TT (8J, 2011-2014)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
+      "e8": [
         "secondary_technical_sources:tt-8j-wikipedia",
         "legacy_research_sources:efeaede27b61",
         "legacy_research_sources:ac68dd8bebb2"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
+      "e9": [
         "legacy_research_sources:efeaede27b61",
         "legacy_research_sources:ac68dd8bebb2"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-      "code": "DCT6",
-      "name": "6-speed S tronic (DQ250) with Haldex"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 0.921,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:ac68dd8bebb2",
-          "secondary_technical_sources:tt-8j-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 3.444,
-        "evidence_refs": [
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro DQ250 internal gear ratios match the FWD Coupe (same DQ250 box). Top gear 0.921 retained from FWD analogy. Final drive for the quattro Coupe is not directly published in any source recovered this run; the closest proxy is the Audi UK TT Roadster 2.0 TFSI quattro Technical sheet (legacy_research_sources:ac68dd8bebb2). Quattro uses a Haldex coupling on the rear axle - the front-axle FD likely follows the FWD split (4.059/3.136) but the published quattro-specific value is not yet confirmed. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 3.444,
-        "evidence_refs": [
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3b8a9657b4b7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:bc25c256657b"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
-        }
+      "e10": [
+        "secondary_technical_sources:tt-8j-wikipedia",
+        "legacy_research_sources:efeaede27b61"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi UK TT Coupé pricing/specification material now closes TT Coupé 2.0 TFSI quattro plus 6-speed S tronic availability for this row. A nearby official TT Roadster quattro technical-sheet extract gives close AWD S tronic powertrain evidence with top gear 0.686 and split final drives 3.264 / 4.769, but because that numeric sheet is Roadster-based rather than exact Coupé proof, the inherited AWD S tronic numeric fields remain advisory placeholders in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61",
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Direct official Audi TT Coupé 2.0 TFSI quattro S tronic ratio and final-drive capture",
-        "reason": "The checked official pricing/specification guide proves Coupé quattro S tronic availability, but the best recovered AWD ratio and split final-drive evidence is still from an official Roadster quattro technical-sheet URL rather than a direct Coupé technical-data artifact.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61",
-          "legacy_research_sources:ac68dd8bebb2"
-        ]
-      },
-      {
-        "item": "Audi TT 2.0 TFSI quattro generic EU Coupé baseline tire mapping",
-        "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:ac68dd8bebb2",
-          "legacy_research_sources:b3806add936a"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "audi-8j-2-0-tfsi-quattro-eu-2011-mt6-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8J",
-    "body_code": "8J",
-    "production_start_year": 2011,
-    "production_end_year": 2014,
-    "model_name": "TT (8J, 2011-2014)",
-    "variant_name": "2.0 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
-        "legacy_research_sources:efeaede27b61"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "secondary_technical_sources:tt-8j-wikipedia",
-        "legacy_research_sources:efeaede27b61"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-      "code": "MT6",
-      "name": "6-speed manual (MQ250 / GQQ) with Haldex"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 0.975,
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "secondary_technical_sources:tt-8j-wikipedia"
-        ]
+  "configurations": [
+    {
+      "id": "audi-8j-2-0-tfsi-eu-2011-dct6-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8J",
+      "body_code": "8J",
+      "production_start_year": 2011,
+      "production_end_year": 2014,
+      "model_name": "TT (8J, 2011-2014)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n5",
+        "value": "FWD"
       },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 3.462,
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
-        ]
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n5",
+        "code": "DCT6",
+        "name": "6-speed S tronic (DQ250)"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 8J quattro 6-speed manual internal gear ratios match the FWD Coupe (same MQ250 box). Top gear 0.975 retained from FWD analogy. Quattro Coupe-specific FD values are not directly confirmed in this run; FWD split-FD 3.944/3.087 is the best proxy. Single-FD placeholder values retained at no_confidence pending Coupe-quattro-specific tech sheet.",
-        "value": 3.462,
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:3b8a9657b4b7",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:bc25c256657b"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "notes_ref": "n5",
+          "value": 0.921,
+          "evidence_refs_ref": "e2"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD S tronic (DQ250) ratios: top gear 0.921; split final drive 4.059 (sub-trans 1, odd gears 1/3/5) / 3.136 (sub-trans 2, even gears 2/4/6). Both feed the same FWD axle. Repo schema convention: final_drive_front encodes sub-trans 1 (odd) ratio, final_drive_rear encodes sub-trans 2 (even) ratio (NOT a physical rear axle on FWD cars). Prior single-FD 3.444 placeholder superseded. Top gear 0.742 was incorrect (likely DQ200-style placeholder); DQ250 8J 6th gear is 0.921. Encodes sub-trans 1 (odd gears 1/3/5) output ratio.",
+          "value": 4.059,
+          "evidence_refs_ref": "e2"
+        }
       },
-      "options": [
-        {
+      "tires": {
+        "default": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi UK TT Coupé pricing/specification and technical-sheet URLs now close the FWD 6-speed S tronic mapping for this row. The indexed official technical-sheet extract also reports top gear 0.921 with split final drives 4.059 / 3.136, which contradicts the inherited 0.742 and single 3.444 placeholders, so those numeric fields remain advisory until the repo can encode them from a directly captured or schema-safe official artifact.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3b8a9657b4b7",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:bc25c256657b"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 20\""
+          "note_ref": "n4"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of official Audi TT Coupé 2.0 TFSI S tronic split final-drive values",
+          "reason": "The checked official TT Coupé technical-sheet extract reports top gear 0.921 and split final drives 4.059 / 3.136 for the exact FWD S tronic slice, but the current row has only one final_drive_front field and this pass did not promote indexed-extract ratio data into production values without a directly captured official artifact.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi TT 2.0 TFSI generic EU Coupé baseline tire mapping",
+          "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official Audi UK TT Coupé pricing/specification material now closes TT Coupé 2.0 TFSI quattro plus 6-speed manual availability for this row, but no direct official manual-quattro technical sheet was recovered. The inherited AWD manual numeric and tire fields therefore remain advisory placeholders in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
+    {
+      "id": "audi-8j-2-0-tfsi-eu-2011-mt6-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8J",
+      "body_code": "8J",
+      "production_start_year": 2011,
+      "production_end_year": 2014,
+      "model_name": "TT (8J, 2011-2014)",
+      "variant_name": "2.0 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n6",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n6",
+        "code": "MT6",
+        "name": "6-speed manual (MQ250 / GQQ)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "notes_ref": "n6",
+          "value": 0.975,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes": "Sonnet redo research (2026-04 v2): Audi UK TT Coupe 2.0 TFSI Technical sheet (legacy_research_sources:fa2ecfeb2ce9) confirms 8J facelift FWD 6-speed manual (MQ250 / GQQ) ratios: top gear 0.975; split final drive 3.944 (sub-trans 1) / 3.087 (sub-trans 2). The MQ250 manual gearbox uses two output pinions feeding the differential, similar to the DCT split-FD architecture. Repo schema convention: final_drive_front = first FD ratio, final_drive_rear = second FD ratio (NOT a physical rear axle on FWD). Prior single-FD 3.462 and top gear 0.840 are placeholders inherited from a generic family default and are superseded. Encodes first MQ250 output FD ratio.",
+          "value": 3.944,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
-        ]
+      "verification_notes": [
+        {
+          "note": "Official Audi UK TT Coupé pricing/specification and technical-sheet URLs now close the FWD 6-speed manual mapping for this row. The indexed official technical-sheet extract also reports top gear 0.975 with split final drives 3.944 / 3.087, which contradicts the inherited 0.84 and single 3.462 placeholders, so those numeric fields remain advisory until the repo can encode them from a directly captured or schema-safe official artifact.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of official Audi TT Coupé 2.0 TFSI manual split final-drive values",
+          "reason": "The checked official TT Coupé technical-sheet extract reports top gear 0.975 and split final drives 3.944 / 3.087 for the exact FWD manual slice, but the current row has only one final_drive_front field and this pass did not promote indexed-extract ratio data into production values without a directly captured official artifact.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi TT 2.0 TFSI generic EU Coupé baseline tire mapping",
+          "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Direct official Audi TT Coupé 2.0 TFSI quattro manual ratio and final-drive capture",
-        "reason": "The checked official pricing/specification guide proves Coupé quattro manual availability, but this pass did not recover a direct official manual-quattro technical sheet or homologation source with ratios and final drives.",
-        "evidence_refs": [
-          "legacy_research_sources:efeaede27b61"
+    },
+    {
+      "id": "audi-8j-2-0-tfsi-quattro-eu-2011-dct6-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8J",
+      "body_code": "8J",
+      "production_start_year": 2011,
+      "production_end_year": 2014,
+      "model_name": "TT (8J, 2011-2014)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n2",
+        "code": "DCT6",
+        "name": "6-speed S tronic (DQ250) with Haldex"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n2",
+          "value": 0.921,
+          "evidence_refs": [
+            "legacy_research_sources:fa2ecfeb2ce9",
+            "legacy_research_sources:ac68dd8bebb2",
+            "secondary_technical_sources:tt-8j-wikipedia"
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.444,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.444,
+          "evidence_refs_ref": "e6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
         ]
       },
-      {
-        "item": "Audi TT 2.0 TFSI quattro generic EU Coupé baseline tire mapping",
-        "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
-        "evidence_refs": [
-          "legacy_research_sources:fa2ecfeb2ce9",
-          "legacy_research_sources:ac68dd8bebb2",
-          "legacy_research_sources:b3806add936a"
-        ]
+      "verification_notes": [
+        {
+          "note": "Official Audi UK TT Coupé pricing/specification material now closes TT Coupé 2.0 TFSI quattro plus 6-speed S tronic availability for this row. A nearby official TT Roadster quattro technical-sheet extract gives close AWD S tronic powertrain evidence with top gear 0.686 and split final drives 3.264 / 4.769, but because that numeric sheet is Roadster-based rather than exact Coupé proof, the inherited AWD S tronic numeric fields remain advisory placeholders in this pass.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Direct official Audi TT Coupé 2.0 TFSI quattro S tronic ratio and final-drive capture",
+          "reason": "The checked official pricing/specification guide proves Coupé quattro S tronic availability, but the best recovered AWD ratio and split final-drive evidence is still from an official Roadster quattro technical-sheet URL rather than a direct Coupé technical-data artifact.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi TT 2.0 TFSI quattro generic EU Coupé baseline tire mapping",
+          "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "audi-8j-2-0-tfsi-quattro-eu-2011-mt6-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8J",
+      "body_code": "8J",
+      "production_start_year": 2011,
+      "production_end_year": 2014,
+      "model_name": "TT (8J, 2011-2014)",
+      "variant_name": "2.0 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n3",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n3",
+        "code": "MT6",
+        "name": "6-speed manual (MQ250 / GQQ) with Haldex"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.975,
+          "evidence_refs": [
+            "legacy_research_sources:fa2ecfeb2ce9",
+            "secondary_technical_sources:tt-8j-wikipedia"
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.462,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.462,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi UK TT Coupé pricing/specification material now closes TT Coupé 2.0 TFSI quattro plus 6-speed manual availability for this row, but no direct official manual-quattro technical sheet was recovered. The inherited AWD manual numeric and tire fields therefore remain advisory placeholders in this pass.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Direct official Audi TT Coupé 2.0 TFSI quattro manual ratio and final-drive capture",
+          "reason": "The checked official pricing/specification guide proves Coupé quattro manual availability, but this pass did not recover a direct official manual-quattro technical sheet or homologation source with ratios and final drives.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Audi TT 2.0 TFSI quattro generic EU Coupé baseline tire mapping",
+          "reason": "Checked official Audi UK slices disagree between 225/55 R16, 245/45 R17, and 245/40 R18 depending on trim, body, and year context, so the current 245/40 R18 placeholder was not treated as a proven generic EU Coupé baseline.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
@@ -1,2129 +1,1757 @@
-[
-  {
-    "id": "audi-8s-40-tfsi-eu-2015-mt6-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2015,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2015-2023)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n3": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+      "n4": "Official Audi Germany-market material now confirms the exact late-cycle TT Coupé 45 TFSI quattro S tronic 180 kW mapping: quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, reverse 2.900, dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. The broad TT row remains unchanged because the current schema stores only one final_drive_ratio, the checked exact evidence is late-cycle only, and this pass did not prove one production-safe mapping across the full 2015-2023 row.",
+      "n5": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
+      "n6": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+      "n7": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+      "n8": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+      "n9": "Official Audi MediaCenter 11/2022 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+      "n10": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+      "n11": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+      "n12": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+      "n13": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Coupe state represented by this 2022-only row.",
+      "n14": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Roadster state represented by this 2022-only row."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi TT/TTS product-information material shows the facelift-era 40 TFSI only with 7-speed S tronic rather than a manual gearbox, and this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet for a 40 TFSI manual coupe. The broad legacy manual row therefore remains only as an unresolved placeholder rather than a supported exact configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi TT 40 TFSI exact manual applicability across the represented row",
-        "reason": "Official Audi TT/TTS product information shows the facelift-era 40 TFSI only with 7-speed S tronic, and this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet for a 40 TFSI manual coupe.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 40 TFSI legacy manual row replacement evidence",
-        "reason": "Accessible public historical analogue evidence suggests an early front-wheel-drive manual TT coupe existed under older naming, but this run did not recover accepted official Audi source material that maps that analogue cleanly onto a 40 TFSI manual row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-eu-2015-mt6-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2015,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2015-2023)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi TT/TTS product-information material confirms that the facelift-era 45 TFSI program includes a 6-speed manual coupe, but this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet with the manual row's ratios, final drive, and basic tire. The broad legacy manual row therefore remains unresolved rather than promoted to an exact early-cycle mapping.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi TT 45 TFSI exact manual ratio and final-drive mapping across the represented row",
-        "reason": "Official Audi TT/TTS product information confirms 45 TFSI manual availability, but this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet with the manual row's ratios or final-drive publication.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI exact wheel/tire coverage across the represented manual row",
-        "reason": "Official Audi TT/TTS product information closes the broader TT/TTS family 17/18/19/20-inch wheel ladder, but this run did not recover one accepted exact official wheel/tire matrix for the manual 45 TFSI coupe row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-eu-2015-dct7-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2015,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2015-2023)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.725
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market material now confirms the exact late-cycle TT Coupé 45 TFSI quattro S tronic 180 kW mapping: quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, reverse 2.900, dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. The broad TT row remains unchanged because the current schema stores only one final_drive_ratio, the checked exact evidence is late-cycle only, and this pass did not prove one production-safe mapping across the full 2015-2023 row.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro production-data applicability across the full 2015-2023 row span",
-        "reason": "The checked exact 2023 Germany-market technical-data PDF resolves the late-cycle 45 TFSI quattro mapping, but this pass did not recover enough year-specific official ratio sheets to prove one unchanged package across the full represented span.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire, but they do not publish the gearbox code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-quattro-eu-2015-mt6-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2015,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2015-2023)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.84
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi TT/TTS product-information material and the exact 01/2023 TT Coupe 45 TFSI quattro technical-data PDF support quattro AWD only alongside 7-speed S tronic wording; this run did not recover any accepted official evidence for a manual 45 TFSI quattro coupe row. The broad legacy manual row therefore remains only as an unresolved placeholder rather than a supported exact configuration.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf",
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro exact manual applicability across the represented row",
-        "reason": "Official Audi TT/TTS product information lists 45 TFSI manual availability and 45 TFSI quattro availability separately, while the checked exact quattro technical-data PDF is S tronic only; this run did not recover any accepted official evidence for a manual 45 TFSI quattro coupe row.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf",
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the late-cycle dual-final-drive label, and the 225/50 R17 basic tire, while TT/TTS product information only closes the broader 17/18/19/20-inch family wheel ladder rather than one exact manual-quattro option matrix or gearbox-family code.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf",
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-quattro-eu-2015-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2015,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2015-2023)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:002d355a3a6c",
+        "legacy_research_sources:4b4b833b364a",
+        "legacy_research_sources:4b8ab423f879",
+        "legacy_research_sources:593c29d5ab5f",
+        "legacy_research_sources:5e252f7f436b",
         "legacy_research_sources:a66ead086a49",
         "legacy_research_sources:f46299570461"
       ],
-      "notes": "Exact official Audi MediaCenter TT Coupe model-page and technical-data PDF evidence confirm quattro AWD with electronically controlled multi-plate clutch for the checked 180 kW coupe state, while full-row numeric continuity remains unresolved.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e2": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "e3": [
+        "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
+      ],
+      "e4": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+      ],
+      "e5": [
+        "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+      ],
+      "e6": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+      ],
+      "e7": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "e8": [
+        "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+      ],
+      "e9": [
+        "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+      ],
+      "e10": [
+        "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf"
+      ],
+      "e11": [
+        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+      ],
+      "e12": [
+        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+      ],
+      "e13": [
+        "audi_mediacenter_sources:8s-tt-tts-until-2023-product-info-pdf",
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "e14": [
+        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "e15": [
+        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "e16": [
         "legacy_research_sources:a66ead086a49",
         "legacy_research_sources:f46299570461"
       ],
-      "notes": "Exact official Audi MediaCenter TT Coupe model-page and technical-data PDF evidence confirm the 7-speed S tronic transmission wording for the checked 180 kW coupe state, while full-row numeric continuity remains unresolved.",
-      "code": "DCT7",
-      "name": "7-speed S tronic (DQ381)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 0.725
+      "e17": [
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "audi-8s-40-tfsi-eu-2015-mt6-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2015,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2015-2023)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 4.769
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi TT/TTS product-information material shows the facelift-era 40 TFSI only with 7-speed S tronic rather than a manual gearbox, and this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet for a 40 TFSI manual coupe. The broad legacy manual row therefore remains only as an unresolved placeholder rather than a supported exact configuration.",
+          "evidence_refs_ref": "e10"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "note_ref": "n3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi Germany-market material now confirms the exact late-cycle TT Coupé 45 TFSI quattro S tronic 180 kW mapping: quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, reverse 2.900, dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. The broad TT row remains unchanged because the current schema stores only one final_drive_ratio, the checked exact evidence is late-cycle only, and this pass did not prove one production-safe mapping across the full 2015-2023 row.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro production-data applicability across the full 2015-2023 row span",
-        "reason": "The checked exact 2023 Germany-market technical-data PDF resolves the late-cycle 45 TFSI quattro mapping, but this pass did not recover enough year-specific official ratio sheets to prove one unchanged package across the full represented span.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire, but they do not publish the gearbox code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "legacy_research_sources:002d355a3a6c",
-          "legacy_research_sources:4b4b833b364a",
-          "legacy_research_sources:4b8ab423f879",
-          "legacy_research_sources:593c29d5ab5f",
-          "legacy_research_sources:5e252f7f436b",
-          "legacy_research_sources:a66ead086a49",
-          "legacy_research_sources:f46299570461"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-40-tfsi-eu-2023-dct7-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2023)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
       ],
-      "notes": "Official Audi MediaCenter TT Coupé model-page and 01/2023 technical-data PDF evidence confirm front-wheel drive for the exact late-cycle TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
+      "unresolved": [
+        {
+          "item": "Audi TT 40 TFSI exact manual applicability across the represented row",
+          "reason": "Official Audi TT/TTS product information shows the facelift-era 40 TFSI only with 7-speed S tronic, and this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet for a 40 TFSI manual coupe.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi TT 40 TFSI legacy manual row replacement evidence",
+          "reason": "Accessible public historical analogue evidence suggests an early front-wheel-drive manual TT coupe existed under older naming, but this run did not recover accepted official Audi source material that maps that analogue cleanly onto a 40 TFSI manual row.",
+          "evidence_refs_ref": "e10"
+        }
       ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact TT Coupé 40 TFSI 145 kW state represented by this narrowed 2023-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish the gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
-        "value": 0.635
+    {
+      "id": "audi-8s-45-tfsi-eu-2015-mt6-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2015,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2015-2023)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Retained conservative placeholder because the official Audi MediaCenter 01/2023 technical-data PDF publishes split final-drive values 4.471 / 3.304 for the exact TT Coupé 40 TFSI S tronic state, and the current single final_drive_front field cannot safely encode both values without losing fidelity.",
-        "value": 4.769
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual"
       },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "notes_ref": "n2",
+          "value": 0.84
         },
-        {
+        "final_drive_front": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:002d355a3a6c",
-            "legacy_research_sources:4b4b833b364a",
-            "legacy_research_sources:4b8ab423f879",
-            "legacy_research_sources:593c29d5ab5f",
-            "legacy_research_sources:5e252f7f436b",
-            "legacy_research_sources:a66ead086a49",
-            "legacy_research_sources:f46299570461"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as Audi press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "S line 21\""
+          "notes_ref": "n2",
+          "value": 3.462
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter TT Coupé model-page and 01/2023 technical-data PDF evidence now confirm the exact late-cycle TT Coupé 40 TFSI S tronic 145 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, reverse 2.900, dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON narrows the broad row to the supported 2023-only state because this pass did not recover an earlier official exact 40 TFSI ratio sheet.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as Audi press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 40 TFSI dual final-drive values",
-        "reason": "The checked exact Audi MediaCenter 01/2023 technical-data PDF publishes two final-drive values 4.471 / 3.304 for the exact TT Coupé 40 TFSI S tronic state, but the current row stores only one final_drive_front field.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 40 TFSI exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi MediaCenter sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-40-tfsi-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-eu-2023-dct7-fwd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2023)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-quattro-eu-2023-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TT (8S, 2023)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "note": "Official Audi TT/TTS product-information material confirms that the facelift-era 45 TFSI program includes a 6-speed manual coupe, but this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet with the manual row's ratios, final drive, and basic tire. The broad legacy manual row therefore remains unresolved rather than promoted to an exact early-cycle mapping.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi TT 45 TFSI exact manual ratio and final-drive mapping across the represented row",
+          "reason": "Official Audi TT/TTS product information confirms 45 TFSI manual availability, but this run did not recover an accepted exact official 2014/2015 Audi technical-data sheet with the manual row's ratios or final-drive publication.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Audi TT 45 TFSI exact wheel/tire coverage across the represented manual row",
+          "reason": "Official Audi TT/TTS product information closes the broader TT/TTS family 17/18/19/20-inch wheel ladder, but this run did not recover one accepted exact official wheel/tire matrix for the manual 45 TFSI coupe row.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-eu-2015-dct7-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2015,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2015-2023)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-40-tfsi-roadster-eu-2023-dct7-fwd",
-    "brand": "Audi",
-    "type": "Roadster",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TT Roadster (8S, 2023)",
-    "variant_name": "40 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 40 TFSI 145 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro production-data applicability across the full 2015-2023 row span",
+          "reason": "The checked exact 2023 Germany-market technical-data PDF resolves the late-cycle 45 TFSI quattro mapping, but this pass did not recover enough year-specific official ratio sheets to prove one unchanged package across the full represented span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire, but they do not publish the gearbox code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-quattro-eu-2015-mt6-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2015,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2015-2023)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.84
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT Roadster 40 TFSI dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT Roadster 40 TFSI exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-roadster-eu-2022-dct7-fwd",
-    "brand": "Audi",
-    "type": "Roadster",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2022,
-    "production_end_year": 2022,
-    "model_name": "TT Roadster (8S, 2022)",
-    "variant_name": "45 TFSI",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms front-wheel drive for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms 7-speed S tronic wording for the exact TT Roadster 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+          "note": "Official Audi TT/TTS product-information material and the exact 01/2023 TT Coupe 45 TFSI quattro technical-data PDF support quattro AWD only alongside 7-speed S tronic wording; this run did not recover any accepted official evidence for a manual 45 TFSI quattro coupe row. The broad legacy manual row therefore remains only as an unresolved placeholder rather than a supported exact configuration.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro exact manual applicability across the represented row",
+          "reason": "Official Audi TT/TTS product information lists 45 TFSI manual availability and 45 TFSI quattro availability separately, while the checked exact quattro technical-data PDF is S tronic only; this run did not recover any accepted official evidence for a manual 45 TFSI quattro coupe row.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the late-cycle dual-final-drive label, and the 225/50 R17 basic tire, while TT/TTS product information only closes the broader 17/18/19/20-inch family wheel ladder rather than one exact manual-quattro option matrix or gearbox-family code.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-quattro-eu-2015-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2015,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2015-2023)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e16",
+        "notes": "Exact official Audi MediaCenter TT Coupe model-page and technical-data PDF evidence confirm quattro AWD with electronically controlled multi-plate clutch for the checked 180 kW coupe state, while full-row numeric continuity remains unresolved.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e16",
+        "notes": "Exact official Audi MediaCenter TT Coupe model-page and technical-data PDF evidence confirm the 7-speed S tronic transmission wording for the checked 180 kW coupe state, while full-row numeric continuity remains unresolved.",
+        "code": "DCT7",
+        "name": "7-speed S tronic (DQ381)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.725
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.769
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 11/2022 technical-data PDF confirms the exact TT Roadster 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT Roadster 45 TFSI exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2022 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-45-tfsi-quattro-roadster-eu-2023-dct7-awd",
-    "brand": "Audi",
-    "type": "Roadster",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TT Roadster (8S, 2023)",
-    "variant_name": "45 TFSI quattro",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "value": [
-          3.4,
-          2.75,
-          1.767,
-          0.925,
-          0.705,
-          0.755,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 for the target, but the current row stores only one final_drive_ratio field.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro production-data applicability across the full 2015-2023 row span",
+          "reason": "The checked exact 2023 Germany-market technical-data PDF resolves the late-cycle 45 TFSI quattro mapping, but this pass did not recover enough year-specific official ratio sheets to prove one unchanged package across the full represented span.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro exact transmission-code and non-basic tire-option coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire, but they do not publish the gearbox code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-40-tfsi-eu-2023-dct7-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2023)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Official Audi MediaCenter TT Coupé model-page and 01/2023 technical-data PDF evidence confirm front-wheel drive for the exact late-cycle TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact TT Coupé 40 TFSI 145 kW state represented by this narrowed 2023-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish the gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "evidence_refs_ref": "e3",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact TT Coupé 40 TFSI S tronic 145 kW state represented by this narrowed 2023-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes": "Retained conservative placeholder because the official Audi MediaCenter 01/2023 technical-data PDF publishes split final-drive values 4.471 / 3.304 for the exact TT Coupé 40 TFSI S tronic state, and the current single final_drive_front field cannot safely encode both values without losing fidelity.",
+          "value": 4.769
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI quattro dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TT Roadster 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-tts-coupe-eu-2023-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TTS Coupe (8S, 2023)",
-    "variant_name": "TTS",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Coupe state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
-        "value": 0.661
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
-        "value": [
-          3.19,
-          2.75,
-          1.897,
-          1.04,
-          0.793,
-          0.86,
-          0.661
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "S line 21\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official Audi MediaCenter TT Coupé model-page and 01/2023 technical-data PDF evidence now confirm the exact late-cycle TT Coupé 40 TFSI S tronic 145 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, reverse 2.900, dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON narrows the broad row to the supported 2023-only state because this pass did not recover an earlier official exact 40 TFSI ratio sheet.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 40 TFSI dual final-drive values",
+          "reason": "The checked exact Audi MediaCenter 01/2023 technical-data PDF publishes two final-drive values 4.471 / 3.304 for the exact TT Coupé 40 TFSI S tronic state, but the current row stores only one final_drive_front field.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Audi TT 40 TFSI exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi MediaCenter sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-eu-2023-dct7-fwd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2023)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 45 TFSI dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Audi TT 45 TFSI exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-quattro-eu-2023-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TT (8S, 2023)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Audi TT 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-40-tfsi-roadster-eu-2023-dct7-fwd",
+      "brand": "Audi",
+      "type": "Roadster",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TT Roadster (8S, 2023)",
+      "variant_name": "40 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e5",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 40 TFSI 145 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT Roadster 40 TFSI dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Audi TT Roadster 40 TFSI exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-roadster-eu-2022-dct7-fwd",
+      "brand": "Audi",
+      "type": "Roadster",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2022,
+      "production_end_year": 2022,
+      "model_name": "TT Roadster (8S, 2022)",
+      "variant_name": "45 TFSI",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms front-wheel drive for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e6",
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms 7-speed S tronic wording for the exact TT Roadster 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n9",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 11/2022 technical-data PDF confirms the exact TT Roadster 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "Audi TT Roadster 45 TFSI exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2022 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-45-tfsi-quattro-roadster-eu-2023-dct7-awd",
+      "brand": "Audi",
+      "type": "Roadster",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TT Roadster (8S, 2023)",
+      "variant_name": "45 TFSI quattro",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e7",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "value": [
+            3.4,
+            2.75,
+            1.767,
+            0.925,
+            0.705,
+            0.755,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI quattro dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Audi TT Roadster 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-tts-coupe-eu-2023-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TTS Coupe (8S, 2023)",
+      "variant_name": "TTS",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Coupe state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+          "value": 0.661
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+          "value": [
+            3.19,
+            2.75,
+            1.897,
+            1.04,
+            0.793,
+            0.86,
+            0.661
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n11",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Coupe mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TTS dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TTS exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-tts-roadster-eu-2023-dct7-awd",
-    "brand": "Audi",
-    "type": "Roadster",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2023,
-    "production_end_year": 2023,
-    "model_name": "TTS Roadster (8S, 2023)",
-    "variant_name": "TTS",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-      ],
-      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Roadster state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
-        "value": 0.661
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
-        "value": [
-          3.19,
-          2.75,
-          1.897,
-          1.04,
-          0.793,
-          0.86,
-          0.661
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Coupe mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TTS dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "Audi TTS exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-tts-roadster-eu-2023-dct7-awd",
+      "brand": "Audi",
+      "type": "Roadster",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2023,
+      "production_end_year": 2023,
+      "model_name": "TTS Roadster (8S, 2023)",
+      "variant_name": "TTS",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e9",
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Roadster state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+          "evidence_refs_ref": "e9",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+          "value": 0.661
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+          "value": [
+            3.19,
+            2.75,
+            1.897,
+            1.04,
+            0.793,
+            0.86,
+            0.661
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Roadster mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Schema-safe encoding of the exact Audi TTS Roadster dual final-drive values",
-        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ]
-      },
-      {
-        "item": "Audi TTS Roadster exact transmission-code and optional wheel/tire coverage",
-        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-tt-rs-coupe-eu-2022-dct7-awd",
-    "brand": "Audi",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2022,
-    "production_end_year": 2022,
-    "model_name": "TT RS Coupe (8S, 2022)",
-    "variant_name": "TT RS",
-    "engine_code": "2.5L",
-    "engine_name": "2.5L I5 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
-        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-      ],
-      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Coupe state represented by this 2022-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
-        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-      ],
-      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Coupe state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Coupe state represented by this 2022-only row.",
-        "value": 0.635
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Coupe state represented by this 2022-only row.",
-        "value": [
-          3.563,
-          2.526,
-          1.679,
-          1.022,
-          0.788,
-          0.761,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Coupe state represented by this 2022-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Roadster mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Schema-safe encoding of the exact Audi TTS Roadster dual final-drive values",
+          "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Audi TTS Roadster exact transmission-code and optional wheel/tire coverage",
+          "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-tt-rs-coupe-eu-2022-dct7-awd",
+      "brand": "Audi",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2022,
+      "production_end_year": 2022,
+      "model_name": "TT RS Coupe (8S, 2022)",
+      "variant_name": "TT RS",
+      "engine_code": "2.5L",
+      "engine_name": "2.5L I5 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e14",
+        "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Coupe state represented by this 2022-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e14",
+        "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Coupe state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Coupe state represented by this 2022-only row.",
+          "evidence_refs_ref": "e11",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Coupe state represented by this 2022-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Coupe state represented by this 2022-only row.",
+          "value": [
+            3.563,
+            2.526,
+            1.679,
+            1.022,
+            0.788,
+            0.761,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n13",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-          ],
-          "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Coupe is optionally available with 255/30 R20 tires.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e11",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Coupe mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
-          "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e17",
+            "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Coupe is optionally available with 255/30 R20 tires.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 20\""
+          }
         ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi TT RS Coupe exact final-drive value",
-        "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Coupe.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "audi-8s-tt-rs-roadster-eu-2022-dct7-awd",
-    "brand": "Audi",
-    "type": "Roadster",
-    "market": "EU",
-    "model_code": "8S",
-    "body_code": "8S",
-    "production_start_year": 2022,
-    "production_end_year": 2022,
-    "model_name": "TT RS Roadster (8S, 2022)",
-    "variant_name": "TT RS",
-    "engine_code": "2.5L",
-    "engine_name": "2.5L I5 TFSI Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
-        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-      ],
-      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Roadster state represented by this 2022-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
-        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-      ],
-      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Roadster state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
-      "code": "DCT7",
-      "name": "7-speed S tronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Roadster state represented by this 2022-only row.",
-        "value": 0.635
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Roadster state represented by this 2022-only row.",
-        "value": [
-          3.563,
-          2.526,
-          1.679,
-          1.022,
-          0.788,
-          0.761,
-          0.635
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
-        ],
-        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Roadster state represented by this 2022-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Coupe mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Audi TT RS Coupe exact final-drive value",
+          "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Coupe.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "audi-8s-tt-rs-roadster-eu-2022-dct7-awd",
+      "brand": "Audi",
+      "type": "Roadster",
+      "market": "EU",
+      "model_code": "8S",
+      "body_code": "8S",
+      "production_start_year": 2022,
+      "production_end_year": 2022,
+      "model_name": "TT RS Roadster (8S, 2022)",
+      "variant_name": "TT RS",
+      "engine_code": "2.5L",
+      "engine_name": "2.5L I5 TFSI Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e15",
+        "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Roadster state represented by this 2022-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e15",
+        "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Roadster state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
+        "code": "DCT7",
+        "name": "7-speed S tronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
-          ],
-          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Roadster state represented by this 2022-only row.",
+          "evidence_refs_ref": "e12",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Roadster state represented by this 2022-only row.",
+          "value": 0.635
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Roadster state represented by this 2022-only row.",
+          "value": [
+            3.563,
+            2.526,
+            1.679,
+            1.022,
+            0.788,
+            0.761,
+            0.635
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n14",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-          ],
-          "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Roadster is optionally available with 255/30 R20 tires.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e12",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 20\""
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e17",
+            "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Roadster is optionally available with 255/30 R20 tires.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Roadster mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
+          "evidence_refs_ref": "e15"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Roadster mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
-          "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Audi TT RS Roadster exact final-drive value",
+          "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Roadster.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Audi TT RS Roadster exact final-drive value",
-        "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Roadster.",
-        "evidence_refs": [
-          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F20.json
@@ -1,2837 +1,2428 @@
-[
-  {
-    "id": "bmw-f20-114i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "114i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d launch-state.",
+      "n3": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i launch-state.",
+      "n4": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d launch-state.",
+      "n5": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118i launch-state.",
+      "n6": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 120d launch-state.",
+      "n7": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
+      "n8": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
+      "n9": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+      "n10": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
+      "n11": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 116d launch-state.",
+      "n12": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116d launch-state.",
+      "n13": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116d launch-state.",
+      "n14": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116d launch-state.",
+      "n15": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116d launch-state.",
+      "n16": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
+      "n17": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 116i launch-state.",
+      "n18": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116i launch-state.",
+      "n19": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116i launch-state.",
+      "n20": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116i launch-state.",
+      "n21": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116i launch-state.",
+      "n22": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
+      "n23": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 118d launch-state.",
+      "n24": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118d launch-state.",
+      "n25": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118d launch-state.",
+      "n26": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118d launch-state.",
+      "n27": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118d launch-state.",
+      "n28": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
+      "n29": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 118i launch-state.",
+      "n30": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118i launch-state.",
+      "n31": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118i launch-state.",
+      "n32": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118i launch-state.",
+      "n33": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118i launch-state.",
+      "n34": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 120d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
+      "n35": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 120d launch-state.",
+      "n36": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 120d launch-state.",
+      "n37": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 120d launch-state.",
+      "n38": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 120d launch-state.",
+      "n39": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
+      "n40": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
+      "n41": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch M135i and confirms the rear-wheel-drive configuration."
     },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 114i MT6 row is not a supported exact 2011 production state under its current id.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:17bbee7ba639",
-          "legacy_research_sources:3687a455cefb",
-          "legacy_research_sources:38987808b4bf",
-          "legacy_research_sources:7dcd6cc94ab9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:db448ae320f5",
-          "legacy_research_sources:eae8f6c35d1a"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 114i MT6 entry remains contradicted for the exact 2011 launch state. A later official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a separate manual-only 114i F20 5-door row exists later, but it does not rescue this current 2011 id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2012-114i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F20 114i exact 2011 launch-state row",
-        "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 114i row is contradicted for the exact 2011 launch-state under its current id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F20 114i later-introduction exact row replacement",
-        "reason": "The official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a later manual-only F20 5-door 114i row exists, but that later source must stay on its own supported 2012+ year chain rather than being conflated with this disproved 2011 id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2012-114i-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f20-114i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "114i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 114i ZF8HP row is not a supported exact 2011 production state under its current id.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:17bbee7ba639",
-          "legacy_research_sources:3687a455cefb",
-          "legacy_research_sources:38987808b4bf",
-          "legacy_research_sources:7dcd6cc94ab9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:db448ae320f5",
-          "legacy_research_sources:eae8f6c35d1a"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 114i ZF8HP entry remains contradicted for the exact 2011 launch state. A later official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a separate manual-only 114i F20 5-door row exists later, and no saved official source in this run proved an automatic 114i row for this body.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2012-114i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F20 114i exact 2011 launch-state row",
-        "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 114i row is contradicted for the exact 2011 launch-state under its current id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F20 114i later-introduction exact row replacement",
-        "reason": "The official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a later manual-only F20 5-door 114i row exists, but this run did not recover any saved official evidence for an automatic 114i row or for a supported 2011 start year, so this disproved 2011 id should not inherit that later source.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2012-114i-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f20-116d-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "116d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
       ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 116d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d manual launch-state.",
-        "value": 0.645
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 116d manual launch-state.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 116d manual launch-state row. The official BMW technical-data PDF confirms the 116d with six-speed manual, sixth gear 0.645, differential ratio 3.077, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-116d-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "116d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 116d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 116d automatic launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 116d automatic launch-state.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 116d automatic launch-state row. The official BMW technical-data PDF confirms the 116d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-116i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "116i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e2": [
         "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
       ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
+      "e3": [
+        "legacy_research_sources:17bbee7ba639",
+        "legacy_research_sources:3687a455cefb",
+        "legacy_research_sources:38987808b4bf",
+        "legacy_research_sources:7dcd6cc94ab9",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:db448ae320f5",
+        "legacy_research_sources:eae8f6c35d1a"
       ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 116i manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.830 as the sixth gear for the exact 116i manual launch-state.",
-        "value": 0.83
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 2.813 as the differential ratio for the exact 116i manual launch-state.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 116i manual launch-state row. The official BMW technical-data PDF confirms the 116i with six-speed manual, sixth gear 0.830, differential ratio 2.813, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-116i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "116i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 116i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 116i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 116i automatic launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 116i automatic launch-state.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 116i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 116i automatic launch-state row. The official BMW technical-data PDF confirms the 116i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-118d-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "118d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 118d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.645 as the sixth gear for the exact 118d manual launch-state.",
-        "value": 0.645
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118d manual launch-state.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 118d manual launch-state row. The official BMW technical-data PDF confirms the 118d with six-speed manual, sixth gear 0.645, differential ratio 3.077, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-118d-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "118d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 118d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 118d automatic launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 118d automatic launch-state.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF explicitly adds the 205/55 R16 square upgrade for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 118d automatic launch-state row. The official BMW technical-data PDF confirms the 118d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-118i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "118i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 118i manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.830 as the sixth gear for the exact 118i manual launch-state.",
-        "value": 0.83
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118i manual launch-state.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118i launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 13 narrows the broad 118i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the 118i with six-speed manual, sixth gear 0.830, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-118i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "118i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 118i in the petrol launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 118i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 118i automatic launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118i automatic launch-state.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118i launch-state.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 16-inch square 205-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "16\" square upgrade"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 118i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 13 narrows the broad 118i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the 118i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-120d-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "120d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 120d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 120d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.659 as the sixth gear for the exact 120d manual launch-state.",
-        "value": 0.659
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.154 as the differential ratio for the exact 120d manual launch-state.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 120d launch-state.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 120d manual launch-state row. The official BMW technical-data PDF confirms the 120d with six-speed manual, sixth gear 0.659, differential ratio 3.154, standard 205/55 R16 tires, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-120d-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "120d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF lists the 120d in the diesel launch-state table for the new F20 1 Series and confirms the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 120d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 120d automatic launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 120d automatic launch-state.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 120d launch-state.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 16-inch square tire setup for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 205-section tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 205"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 17-inch square 225-section tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" square 225"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 17-inch tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "17\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch tire package for the exact 120d launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 14 adds the exact 09/2011 F20 120d automatic launch-state row. The official BMW technical-data PDF confirms the 120d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 205/55 R16 tires, and the 17-inch and 18-inch option ladders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-120i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "120i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 120i MT6 row is not a supported exact 2011 production state under its current id.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:17bbee7ba639",
-          "legacy_research_sources:3687a455cefb",
-          "legacy_research_sources:38987808b4bf",
-          "legacy_research_sources:7dcd6cc94ab9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:db448ae320f5",
-          "legacy_research_sources:eae8f6c35d1a"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 120i MT6 entry remains contradicted for the exact 2011 launch state. A later official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a separate later 120i F20 5-door row exists, but it does not prove this current 2011 id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2016-120i-125i-m140i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F20 120i exact 2011 launch-state row",
-        "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 120i row is contradicted for the exact 2011 launch-state under its current id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F20 120i later-introduction exact row replacement",
-        "reason": "The official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a later exact F20 5-door 120i row exists, but this run did not recover a saved official source proving the first supported year or any pre-LCI exact ratio sheet, so this disproved 2011 id should not inherit the later data.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2016-120i-125i-m140i-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f20-120i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "1 Series (F20, 2011)",
-    "variant_name": "120i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-      ],
-      "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 120i ZF8HP row is not a supported exact 2011 production state under its current id.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:17bbee7ba639",
-          "legacy_research_sources:3687a455cefb",
-          "legacy_research_sources:38987808b4bf",
-          "legacy_research_sources:7dcd6cc94ab9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:db448ae320f5",
-          "legacy_research_sources:eae8f6c35d1a"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:17bbee7ba639",
-            "legacy_research_sources:3687a455cefb",
-            "legacy_research_sources:38987808b4bf",
-            "legacy_research_sources:7dcd6cc94ab9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:db448ae320f5",
-            "legacy_research_sources:eae8f6c35d1a"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 120i ZF8HP entry remains contradicted for the exact 2011 launch state. A later official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a separate later 120i F20 5-door row exists with automatic availability, but it does not prove this current 2011 id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2016-120i-125i-m140i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F20 120i exact 2011 launch-state row",
-        "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 120i row is contradicted for the exact 2011 launch-state under its current id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F20 120i later-introduction exact row replacement",
-        "reason": "The official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a later exact F20 5-door 120i row with automatic availability exists, but this run did not recover a saved official source proving the first supported year for that automatic state, so this disproved 2011 id should not inherit the later data.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
-          "bmw_pressclub_sources:f20-2016-120i-125i-m140i-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f20-125d-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "125d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e4": [
         "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
       ],
-      "notes": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF directly publishes the exact 125d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 0.659 as the sixth gear for the exact 125d manual row.",
-        "value": 0.659
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 3.385 as the differential ratio for the exact 125d manual row.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 17 adds the exact 03/2012 F20 125d manual row. The official BMW technical-data PDF confirms the 125d with six-speed manual, sixth gear 0.659, differential ratio 3.385, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-125d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "125d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF publishes the 125d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125d automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 125d automatic row.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 17 adds the exact 03/2012 F20 125d automatic row. The official BMW technical-data PDF confirms the 125d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125d-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-125i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "125i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e5": [
         "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
       ],
-      "notes": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF directly publishes the exact 125i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 0.677 as the sixth gear for the exact 125i manual row.",
-        "value": 0.677
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 3.909 as the differential ratio for the exact 125i manual row.",
-        "value": 3.909
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 17 adds the exact 03/2012 F20 125i manual row. The official BMW technical-data PDF confirms the 125i with six-speed manual, sixth gear 0.677, differential ratio 3.909, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-125i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "125i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2012 technical-data PDF publishes the 125i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125i automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 125i automatic row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 17 adds the exact 03/2012 F20 125i automatic row. The official BMW technical-data PDF confirms the 125i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-125i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-m135i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "M135i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e6": [
         "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
       ],
-      "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch M135i and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
+      "e7": [
+        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
+        "bmw_pressclub_sources:f20-2012-114i-spec-pdf"
       ],
-      "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF directly publishes the exact M135i row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.846 as the sixth gear for the exact M135i manual row.",
-        "value": 0.846
+      "e8": [
+        "bmw_pressclub_sources:f20-2011-petrol-spec-pdf",
+        "bmw_pressclub_sources:f20-2016-120i-125i-m140i-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f20-114i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "114i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i manual row.",
-        "value": 3.077
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 114i MT6 row is not a supported exact 2011 production state under its current id.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 114i MT6 entry remains contradicted for the exact 2011 launch state. A later official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a separate manual-only 114i F20 5-door row exists later, but it does not rescue this current 2011 id.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F20 114i exact 2011 launch-state row",
+          "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 114i row is contradicted for the exact 2011 launch-state under its current id.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW F20 114i later-introduction exact row replacement",
+          "reason": "The official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a later manual-only F20 5-door 114i row exists, but that later source must stay on its own supported 2012+ year chain rather than being conflated with this disproved 2011 id.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f20-114i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "114i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 114i ZF8HP row is not a supported exact 2011 production state under its current id.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 114i ZF8HP entry remains contradicted for the exact 2011 launch state. A later official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a separate manual-only 114i F20 5-door row exists later, and no saved official source in this run proved an automatic 114i row for this body.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F20 114i exact 2011 launch-state row",
+          "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 114i row is contradicted for the exact 2011 launch-state under its current id.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW F20 114i later-introduction exact row replacement",
+          "reason": "The official BMW 05/2012 valid-from-07/2012 114i technical-data PDF proves a later manual-only F20 5-door 114i row exists, but this run did not recover any saved official evidence for an automatic 114i row or for a supported 2011 start year, so this disproved 2011 id should not inherit that later source.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f20-116d-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "116d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n10",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 116d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d manual launch-state.",
+          "value": 0.645
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 116d manual launch-state.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 116d manual launch-state row. The official BMW technical-data PDF confirms the 116d with six-speed manual, sixth gear 0.645, differential ratio 3.077, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-116d-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "116d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n10",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 116d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 116d automatic launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 116d automatic launch-state.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 116d automatic launch-state row. The official BMW technical-data PDF confirms the 116d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-116i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "116i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n16",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 116i manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.830 as the sixth gear for the exact 116i manual launch-state.",
+          "value": 0.83
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 2.813 as the differential ratio for the exact 116i manual launch-state.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n19",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n20",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n21",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 116i manual launch-state row. The official BMW technical-data PDF confirms the 116i with six-speed manual, sixth gear 0.830, differential ratio 2.813, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-116i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "116i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n16",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 116i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 116i automatic launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 116i automatic launch-state.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n19",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n20",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n21",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 116i automatic launch-state row. The official BMW technical-data PDF confirms the 116i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-118d-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "118d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n22",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 118d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.645 as the sixth gear for the exact 118d manual launch-state.",
+          "value": 0.645
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118d manual launch-state.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n23",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n24",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n25",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n26",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n27",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 118d manual launch-state row. The official BMW technical-data PDF confirms the 118d with six-speed manual, sixth gear 0.645, differential ratio 3.077, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-118d-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "118d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n22",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 118d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 118d automatic launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 118d automatic launch-state.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n23",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n24",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n25",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n26",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n27",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 118d automatic launch-state row. The official BMW technical-data PDF confirms the 118d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 195/55 R16 tires, the 205/55 R16 square upgrade, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-118i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "118i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n28",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 118i manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.830 as the sixth gear for the exact 118i manual launch-state.",
+          "value": 0.83
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118i manual launch-state.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n29",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n31",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n32",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n33",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 13 narrows the broad 118i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the 118i with six-speed manual, sixth gear 0.830, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-118i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "118i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n28",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 118i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 118i automatic launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the differential ratio for the exact 118i automatic launch-state.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n29",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "16\" square upgrade"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n31",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n32",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n33",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 13 narrows the broad 118i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the 118i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, standard 195/55 R16 tires, and 16-inch, 17-inch square, 17-inch staggered, and 18-inch staggered option ladders.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-120d-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "120d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n34",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF directly publishes the exact 120d manual row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.659 as the sixth gear for the exact 120d manual launch-state.",
+          "value": 0.659
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.154 as the differential ratio for the exact 120d manual launch-state.",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n35",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n36",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n37",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n38",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 120d manual launch-state row. The official BMW technical-data PDF confirms the 120d with six-speed manual, sixth gear 0.659, differential ratio 3.154, standard 205/55 R16 tires, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-120d-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "120d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n34",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2011 valid-from-09/2011 technical-data PDF publishes the 120d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 120d automatic launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 2.647 as the differential ratio for the exact 120d automatic launch-state.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n35",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 205"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n36",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" square 225"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n37",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "17\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n38",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 14 adds the exact 09/2011 F20 120d automatic launch-state row. The official BMW technical-data PDF confirms the 120d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, standard 205/55 R16 tires, and the 17-inch and 18-inch option ladders.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-120i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "120i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 120i MT6 row is not a supported exact 2011 production state under its current id.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 120i MT6 entry remains contradicted for the exact 2011 launch state. A later official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a separate later 120i F20 5-door row exists, but it does not prove this current 2011 id.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F20 120i exact 2011 launch-state row",
+          "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 120i row is contradicted for the exact 2011 launch-state under its current id.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW F20 120i later-introduction exact row replacement",
+          "reason": "The official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a later exact F20 5-door 120i row exists, but this run did not recover a saved official source proving the first supported year or any pre-LCI exact ratio sheet, so this disproved 2011 id should not inherit the later data.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f20-120i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "1 Series (F20, 2011)",
+      "variant_name": "120i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes": "Contradicted placeholder. The official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF publishes only 116i and 118i launch rows, so this represented 120i ZF8HP row is not a supported exact 2011 production state under its current id.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run rechecked the official BMW 07/2011 valid-from-09/2011 F20 petrol technical-data PDF and confirmed it publishes only 116i and 118i launch-state rows, so this represented 120i ZF8HP entry remains contradicted for the exact 2011 launch state. A later official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a separate later 120i F20 5-door row exists with automatic availability, but it does not prove this current 2011 id.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F20 120i exact 2011 launch-state row",
+          "reason": "The checked official BMW 09/2011 petrol launch sheet contains only 116i and 118i, so this represented 120i row is contradicted for the exact 2011 launch-state under its current id.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW F20 120i later-introduction exact row replacement",
+          "reason": "The official BMW 06/2016 valid-from-07/2016 120i technical-data PDF proves a later exact F20 5-door 120i row with automatic availability exists, but this run did not recover a saved official source proving the first supported year for that automatic state, so this disproved 2011 id should not inherit the later data.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f20-125d-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "125d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n39",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2012 technical-data PDF directly publishes the exact 125d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 0.659 as the sixth gear for the exact 125d manual row.",
+          "value": 0.659
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 3.385 as the differential ratio for the exact 125d manual row.",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 17 adds the exact 03/2012 F20 125d manual row. The official BMW technical-data PDF confirms the 125d with six-speed manual, sixth gear 0.659, differential ratio 3.385, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-125d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "125d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n39",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2012 technical-data PDF publishes the 125d as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125d automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 125d automatic row.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 17 adds the exact 03/2012 F20 125d automatic row. The official BMW technical-data PDF confirms the 125d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-125i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "125i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n40",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 03/2012 technical-data PDF directly publishes the exact 125i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 0.677 as the sixth gear for the exact 125i manual row.",
+          "value": 0.677
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 3.909 as the differential ratio for the exact 125i manual row.",
+          "value": 3.909
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 17 adds the exact 03/2012 F20 125i manual row. The official BMW technical-data PDF confirms the 125i with six-speed manual, sixth gear 0.677, differential ratio 3.909, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-125i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "125i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n40",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 03/2012 technical-data PDF publishes the 125i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125i automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 125i automatic row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 17 adds the exact 03/2012 F20 125i automatic row. The official BMW technical-data PDF confirms the 125i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-m135i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "M135i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n41",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF directly publishes the exact M135i row as a six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.846 as the sixth gear for the exact M135i manual row.",
+          "value": 0.846
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i manual row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
@@ -2842,103 +2433,89 @@
             "aspect_pct": 35.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 adds the exact 07/2012 F20 M135i manual row. The official BMW technical-data PDF confirms the M135i with six-speed manual, sixth gear 0.846, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\" staggered"
+          }
         ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f20-m135i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F20",
-    "body_code": "F20",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F20, 2012)",
-    "variant_name": "M135i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-      ],
-      "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF lists the exact F20 1 Series 5 Door Hatch M135i and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-      ],
-      "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF publishes the M135i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact M135i automatic row.",
-        "value": 0.667
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i automatic row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Batch 15 adds the exact 07/2012 F20 M135i manual row. The official BMW technical-data PDF confirms the M135i with six-speed manual, sixth gear 0.846, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f20-m135i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F20",
+      "body_code": "F20",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F20, 2012)",
+      "variant_name": "M135i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n41",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 05/2012 valid-from-07/2012 technical-data PDF publishes the M135i as six-speed manual with optional eight-speed automatic figures in brackets, which directly support this exact automatic row.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+          "evidence_refs_ref": "e6",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact M135i automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i automatic row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
@@ -2949,26 +2526,42 @@
             "aspect_pct": 35.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 adds the exact 07/2012 F20 M135i automatic row. The official BMW technical-data PDF confirms the M135i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f20-2012-m135i-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\" staggered"
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 15 adds the exact 07/2012 F20 M135i automatic row. The official BMW technical-data PDF confirms the M135i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F21.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F21.json
@@ -1,1243 +1,1083 @@
-[
-  {
-    "id": "bmw-f21-114i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "114i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
+      "n2": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d row.",
+      "n3": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i row.",
+      "n4": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d row.",
+      "n5": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
+      "n6": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
+      "n7": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+      "n8": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 114i row.",
+      "n9": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116d row and confirms the rear-wheel-drive configuration.",
+      "n10": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d EfficientDynamics Edition row.",
+      "n11": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116i row and confirms the rear-wheel-drive configuration.",
+      "n12": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 118d row and confirms the rear-wheel-drive configuration.",
+      "n13": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
+      "n14": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
+      "n15": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch M135i row and confirms the rear-wheel-drive configuration."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
+      ],
+      "e2": [
         "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
       ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 114i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF publishes the exact 114i row as six-speed manual only, without any bracketed automatic alternative.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.830 as the sixth gear for the exact 114i manual row.",
-        "value": 0.83
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.813 as the differential ratio for the exact 114i manual row.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 114i row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 114i row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 114i manual row. The official BMW technical-data PDF confirms the 114i with six-speed manual, sixth gear 0.830, differential ratio 2.813, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-116d-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "116d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d manual row.",
-        "value": 0.645
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 116d manual row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 116d manual row. The official BMW technical-data PDF confirms the 116d with six-speed manual, sixth gear 0.645, differential ratio 3.077, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-116d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "116d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 116d automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 116d automatic row.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 116d automatic row. The official BMW technical-data PDF confirms the 116d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-116d-efficientdynamics-edition-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "116d EfficientDynamics Edition",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116d EfficientDynamics Edition row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116d EfficientDynamics Edition row as six-speed manual transmission.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d EfficientDynamics Edition row.",
-        "value": 0.645
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.929 as the differential ratio for the exact 116d EfficientDynamics Edition row.",
-        "value": 2.929
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d EfficientDynamics Edition row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116d EfficientDynamics Edition row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 116d EfficientDynamics Edition manual row. The official BMW technical-data PDF confirms the variant with six-speed manual, sixth gear 0.645, differential ratio 2.929, and standard 205/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-116i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "116i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.830 as the sixth gear for the exact 116i manual row.",
-        "value": 0.83
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.813 as the differential ratio for the exact 116i manual row.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 116i manual row. The official BMW technical-data PDF confirms the 116i with six-speed manual, sixth gear 0.830, differential ratio 2.813, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-116i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "116i",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 116i automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 116i automatic row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 116i row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 116i automatic row. The official BMW technical-data PDF confirms the 116i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-petrol-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-118d-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "118d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 118d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 118d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 118d manual row.",
-        "value": 0.645
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 118d manual row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 118d manual row. The official BMW technical-data PDF confirms the 118d with six-speed manual, sixth gear 0.645, differential ratio 3.077, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-118d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "118d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 118d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 118d automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 118d automatic row.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d row.",
-        "front": {
-          "width_mm": 195.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 16-inch square tire setup for the exact 118d row.",
-          "front": {
-            "width_mm": 195.0,
-            "aspect_pct": 55.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 118d automatic row. The official BMW technical-data PDF confirms the 118d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 195/55 R16 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-125d-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "125d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 125d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.659 as the sixth gear for the exact 125d manual row.",
-        "value": 0.659
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.385 as the differential ratio for the exact 125d manual row.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 125d manual row. The official BMW technical-data PDF confirms the 125d with six-speed manual, sixth gear 0.659, differential ratio 3.385, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-125d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "125d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125d row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125d automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 125d automatic row.",
-        "value": 2.647
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125d row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 125d automatic row. The official BMW technical-data PDF confirms the 125d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-diesel-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-125i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "125i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
         "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
       ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 125i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.677 as the sixth gear for the exact 125i manual row.",
-        "value": 0.677
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.909 as the differential ratio for the exact 125i manual row.",
-        "value": 3.909
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 125i manual row. The official BMW technical-data PDF confirms the 125i with six-speed manual, sixth gear 0.677, differential ratio 3.909, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-125i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "125i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 125i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125i automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 125i automatic row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard 17-inch square tire setup for the exact 125i row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 125i automatic row. The official BMW technical-data PDF confirms the 125i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 205/50 R17 tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-125i-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-m135i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "M135i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e4": [
         "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
       ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch M135i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact M135i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e5": [
+        "bmw_pressclub_sources:f21-2012-116d-ed-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f21-114i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "114i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.846 as the sixth gear for the exact M135i manual row.",
-        "value": 0.846
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 114i row and confirms the rear-wheel-drive configuration.",
+        "value": "RWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i manual row.",
-        "value": 3.077
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2012 technical-data PDF publishes the exact 114i row as six-speed manual only, without any bracketed automatic alternative.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.830 as the sixth gear for the exact 114i manual row.",
+          "value": 0.83
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.813 as the differential ratio for the exact 114i manual row.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 114i manual row. The official BMW technical-data PDF confirms the 114i with six-speed manual, sixth gear 0.830, differential ratio 2.813, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f21-116d-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "116d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n9",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d manual row.",
+          "value": 0.645
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 116d manual row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 116d manual row. The official BMW technical-data PDF confirms the 116d with six-speed manual, sixth gear 0.645, differential ratio 3.077, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-116d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "116d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n9",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 116d automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 116d automatic row.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 116d automatic row. The official BMW technical-data PDF confirms the 116d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-116d-efficientdynamics-edition-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "116d EfficientDynamics Edition",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch 116d EfficientDynamics Edition row and confirms the rear-wheel-drive configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116d EfficientDynamics Edition row as six-speed manual transmission.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 116d EfficientDynamics Edition row.",
+          "value": 0.645
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.929 as the differential ratio for the exact 116d EfficientDynamics Edition row.",
+          "value": 2.929
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 116d EfficientDynamics Edition manual row. The official BMW technical-data PDF confirms the variant with six-speed manual, sixth gear 0.645, differential ratio 2.929, and standard 205/55 R16 tires.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-116i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "116i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n11",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 116i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.830 as the sixth gear for the exact 116i manual row.",
+          "value": 0.83
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.813 as the differential ratio for the exact 116i manual row.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 116i manual row. The official BMW technical-data PDF confirms the 116i with six-speed manual, sixth gear 0.830, differential ratio 2.813, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-116i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "116i",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n11",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 116i automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 116i automatic row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 116i automatic row. The official BMW technical-data PDF confirms the 116i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-118d-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "118d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n12",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 118d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.645 as the sixth gear for the exact 118d manual row.",
+          "value": 0.645
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 118d manual row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 118d manual row. The official BMW technical-data PDF confirms the 118d with six-speed manual, sixth gear 0.645, differential ratio 3.077, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-118d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "118d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n12",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 118d automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 118d automatic row.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 195.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 195.0,
+              "aspect_pct": 55.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 118d automatic row. The official BMW technical-data PDF confirms the 118d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 195/55 R16 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-125d-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "125d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n13",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 125d manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.659 as the sixth gear for the exact 125d manual row.",
+          "value": 0.659
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.385 as the differential ratio for the exact 125d manual row.",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 125d manual row. The official BMW technical-data PDF confirms the 125d with six-speed manual, sixth gear 0.659, differential ratio 3.385, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-125d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "125d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n13",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125d automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 2.647 as the differential ratio for the exact 125d automatic row.",
+          "value": 2.647
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 125d automatic row. The official BMW technical-data PDF confirms the 125d with optional eight-speed automatic, eighth gear 0.667, differential ratio 2.647, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-125i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "125i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n14",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact 125i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.677 as the sixth gear for the exact 125i manual row.",
+          "value": 0.677
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.909 as the differential ratio for the exact 125i manual row.",
+          "value": 3.909
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 125i manual row. The official BMW technical-data PDF confirms the 125i with six-speed manual, sixth gear 0.677, differential ratio 3.909, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-125i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "125i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n14",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact 125i automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact 125i automatic row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 125i automatic row. The official BMW technical-data PDF confirms the 125i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard 205/50 R17 tires.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-m135i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "M135i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n15",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 07/2012 technical-data PDF directly publishes the exact M135i manual row as six-speed manual with optional eight-speed automatic figures shown in brackets.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.846 as the sixth gear for the exact M135i manual row.",
+          "value": 0.846
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i manual row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
@@ -1248,103 +1088,89 @@
             "aspect_pct": 35.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 M135i manual row. The official BMW technical-data PDF confirms the M135i with six-speed manual, sixth gear 0.846, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\" staggered"
+          }
         ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f21-m135i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F21",
-    "body_code": "F21",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "1 Series (F21, 2012)",
-    "variant_name": "M135i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2012 technical-data PDF lists the exact F21 1 Series 3 Door Hatch M135i row and confirms the rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-      ],
-      "notes": "Official BMW F21 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact automatic ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact M135i automatic row.",
-        "value": 0.667
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i automatic row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-        ],
-        "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Batch 16 adds the exact 07/2012 F21 M135i manual row. The official BMW technical-data PDF confirms the M135i with six-speed manual, sixth gear 0.846, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f21-m135i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F21",
+      "body_code": "F21",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "1 Series (F21, 2012)",
+      "variant_name": "M135i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n15",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
-          ],
-          "notes": "Official BMW 07/2012 technical-data PDF confirms the standard staggered 18-inch tire package for the exact M135i row.",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 0.667 as the eighth gear for the exact M135i automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 07/2012 technical-data PDF publishes 3.077 as the differential ratio for the exact M135i automatic row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
@@ -1355,26 +1181,42 @@
             "aspect_pct": 35.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 adds the exact 07/2012 F21 M135i automatic row. The official BMW technical-data PDF confirms the M135i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f21-2012-m135i-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\" staggered"
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 adds the exact 07/2012 F21 M135i automatic row. The official BMW technical-data PDF confirms the M135i with optional eight-speed automatic, eighth gear 0.667, differential ratio 3.077, and standard staggered 225/40 R18 front plus 245/35 R18 rear tires.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F40.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F40.json
@@ -1,1278 +1,929 @@
-[
-  {
-    "id": "bmw-f40-118i-eu-2019-dct7-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "118i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n3": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
+      "n4": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n5": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. Standard SE-trim tire is 205/55 R16 91W (7Jx16) per BMW UK Jan 2020 tech data; 225/40 R18 92Y is the M Sport fitment option. 0–62 mph 8.5s manual / 8.9s 'Steptronic'.",
+      "n14": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. 120i is EU-continental only (UK lineup sold the 128ti instead, per BMW UK Nov 2021 model list). Engine and tire data not retrievable from accessed BMW UK sources.",
+      "n15": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. BMW UK Aug 2021 M135i xDrive page confirms B48 4-cyl 1998 cc TwinPower Turbo, 225 kW/306 hp @ 5000-6250, 450 Nm @ 1800-4500, 9.5:1 compression, 1600 kg DIN unladen, 0-62 mph 4.8 s, top speed 155 mph (limited), tires 225/40 R18 92Y XL on 8Jx18."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_market_pages:f40-1series-uk-inform-2019",
+        "bmw_market_pages:f40-1series-uk-tech-data-2020"
+      ],
+      "e2": [
         "legacy_research_sources:091077d8a451",
         "legacy_research_sources:16c091e6cfd6",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020",
-        "bmw_market_pages:f40-1series-uk-inform-2019"
+        "legacy_research_sources:18deedec2c15",
+        "legacy_research_sources:82e045fca148",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:eca9fb0d3e74"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. Standard SE-trim tire is 205/55 R16 91W (7Jx16) per BMW UK Jan 2020 tech data; 225/40 R18 92Y is the M Sport fitment option. 0–62 mph 8.5s manual / 8.9s 'Steptronic'.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. Standard SE-trim tire is 205/55 R16 91W (7Jx16) per BMW UK Jan 2020 tech data; 225/40 R18 92Y is the M Sport fitment option. 0–62 mph 8.5s manual / 8.9s 'Steptronic'.",
-      "code": "DCT7",
-      "name": "7-speed Steptronic dual-clutch transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-tech-data-2020",
-        "bmw_market_pages:f40-1series-uk-inform-2019"
+      "e3": [
+        "bmw_market_pages:f40-1series-uk-tech-data-2020"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f40-118i-eu-2019-dct7-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "118i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "legacy_research_sources:091077d8a451",
+          "legacy_research_sources:16c091e6cfd6",
+          "bmw_market_pages:f40-1series-uk-tech-data-2020",
+          "bmw_market_pages:f40-1series-uk-inform-2019"
+        ],
+        "notes_ref": "n13",
+        "value": "FWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.684
+        "notes_ref": "n13",
+        "code": "DCT7",
+        "name": "7-speed Steptronic dual-clutch transmission",
+        "evidence_refs": [
+          "bmw_market_pages:f40-1series-uk-tech-data-2020",
+          "bmw_market_pages:f40-1series-uk-inform-2019"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.684
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e3",
+          "notes": "Sonnet redo research (2026-04 v2): BMW UK F40 Jan 2020 technical data publishes 118i SE wheel/tyre as 7Jx16 LM, 205/55 R16 91W. The previous 225/40 R18 default appeared to be the M Sport fitment, retained as an option below.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e3",
+            "notes": "BMW UK F40 Jan 2020 technical data lists 8Jx18 LM 225/40 R18 92Y for M Sport-trim 118i.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
+    {
+      "id": "bmw-f40-118i-eu-2019-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "118i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic Sport transmission",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.673,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.075,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f40-120i-eu-2019-dct7-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "120i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
+          "legacy_research_sources:091077d8a451",
+          "legacy_research_sources:16c091e6cfd6",
           "bmw_market_pages:f40-1series-uk-tech-data-2020"
         ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW UK F40 Jan 2020 technical data publishes 118i SE wheel/tyre as 7Jx16 LM, 205/55 R16 91W. The previous 225/40 R18 default appeared to be the M Sport fitment, retained as an option below.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n14",
+        "value": "FWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n14",
+        "code": "DCT7",
+        "name": "7-speed Steptronic dual-clutch transmission",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.684
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f40-120i-eu-2019-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "120i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic Sport transmission",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.673,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.075,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f40-m135i-xdrive-eu-2019-dct7-awd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "M135i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "legacy_research_sources:091077d8a451",
+          "legacy_research_sources:16c091e6cfd6",
+          "bmw_market_pages:f40-1series-uk-m135i-2021",
+          "bmw_market_pages:f40-1series-uk-tech-data-2020"
+        ],
+        "notes_ref": "n15",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n15",
+        "code": "DCT7",
+        "name": "7-speed Steptronic dual-clutch transmission",
+        "evidence_refs": [
+          "bmw_market_pages:f40-1series-uk-m135i-2021",
+          "bmw_market_pages:f40-1series-uk-tech-data-2020"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.684
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.684
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "reputable_secondary_crosschecked",
           "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
+            "legacy_research_sources:091077d8a451",
+            "legacy_research_sources:16c091e6cfd6",
+            "legacy_research_sources:18deedec2c15",
+            "legacy_research_sources:82e045fca148",
+            "legacy_research_sources:95b9bf2bf0cf",
+            "legacy_research_sources:eca9fb0d3e74",
+            "bmw_market_pages:f40-1series-uk-m135i-2021"
           ],
-          "notes": "BMW UK F40 Jan 2020 technical data lists 8Jx18 LM 225/40 R18 92Y for M Sport-trim 118i.",
+          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK Aug 2021 M135i xDrive page confirms 225/40 R18 92Y XL on 8Jx18 alloy.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f40-118i-eu-2019-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "118i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic Sport transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.075,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f40-120i-eu-2019-dct7-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "120i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:091077d8a451",
-        "legacy_research_sources:16c091e6cfd6",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. 120i is EU-continental only (UK lineup sold the 128ti instead, per BMW UK Nov 2021 model list). Engine and tire data not retrievable from accessed BMW UK sources.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. 120i is EU-continental only (UK lineup sold the 128ti instead, per BMW UK Nov 2021 model list). Engine and tire data not retrievable from accessed BMW UK sources.",
-      "code": "DCT7",
-      "name": "7-speed Steptronic dual-clutch transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.684
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f40-m135i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F40",
+      "body_code": "F40",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "1 Series (F40, 2019-2025)",
+      "variant_name": "M135i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic Sport transmission",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.673,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.075,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.075,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f40-120i-eu-2019-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "120i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic Sport transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.075,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "item": "7-speed DCT top_gear_ratio",
+          "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "item": "Per-variant transmission mapping for 118i",
+          "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
+          "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f40-m135i-xdrive-eu-2019-dct7-awd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "M135i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:091077d8a451",
-        "legacy_research_sources:16c091e6cfd6",
-        "bmw_market_pages:f40-1series-uk-m135i-2021",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. BMW UK Aug 2021 M135i xDrive page confirms B48 4-cyl 1998 cc TwinPower Turbo, 225 kW/306 hp @ 5000-6250, 450 Nm @ 1800-4500, 9.5:1 compression, 1600 kg DIN unladen, 0-62 mph 4.8 s, top speed 155 mph (limited), tires 225/40 R18 92Y XL on 8Jx18.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK F40 launch tech-data pages confirm engine and tires but do NOT publish gearbox family. F40 is a transverse FWD/UKL2 platform; the actual gearboxes are widely understood to be the Aisin GA8F22AW (8-speed 'Steptronic' transverse stepped automatic) for non-sport variants and the Getrag GD7F23 7DCT for sport variants. The repo's DCT7 + 'Steptronic' naming is internally inconsistent. Transmission family for this row is not officially confirmed and should be treated as low-confidence pending a BMW PressClub PDF or BMW DE/AT spec sheet. Forward gear ratio and final-drive numbers remain family_default and unverified. BMW UK Aug 2021 M135i xDrive page confirms B48 4-cyl 1998 cc TwinPower Turbo, 225 kW/306 hp @ 5000-6250, 450 Nm @ 1800-4500, 9.5:1 compression, 1600 kg DIN unladen, 0-62 mph 4.8 s, top speed 155 mph (limited), tires 225/40 R18 92Y XL on 8Jx18.",
-      "code": "DCT7",
-      "name": "7-speed Steptronic dual-clutch transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-m135i-2021",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.684
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.684
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74",
-          "bmw_market_pages:f40-1series-uk-m135i-2021"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo research (2026-04 v2): BMW UK Aug 2021 M135i xDrive page confirms 225/40 R18 92Y XL on 8Jx18 alloy.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:091077d8a451",
-            "legacy_research_sources:16c091e6cfd6",
-            "legacy_research_sources:18deedec2c15",
-            "legacy_research_sources:82e045fca148",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:eca9fb0d3e74"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  },
-  {
-    "id": "bmw-f40-m135i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F40",
-    "body_code": "F40",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "1 Series (F40, 2019-2025)",
-    "variant_name": "M135i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic Sport transmission",
-      "evidence_refs": [
-        "bmw_market_pages:f40-1series-uk-inform-2019",
-        "bmw_market_pages:f40-1series-uk-tech-data-2020"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.075,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.075,
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_market_pages:f40-1series-uk-inform-2019",
-            "bmw_market_pages:f40-1series-uk-tech-data-2020"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F40 uses transverse-engine UKL2/FAAR FWD platform (BMW UK launch inform page A3 confirms 'new front-wheel drive system'). ZF 8HP is a longitudinal RWD-platform gearbox — physically incompatible with transverse F40. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Updated only officially confirmed EU-market F40 ratio-relevant values: M135i xDrive 8-speed Steptronic Sport final/top ratio and 120i 7-speed DCT final drive; later official M135i xDrive PDFs also confirm the full 8-speed ratio set and the standard 225/40 R18 tire, but the broad row still cannot encode exact variant-only gearbox and tire mapping without mixing other F40 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_market_pages:f40-1series-uk-inform-2019",
-          "bmw_market_pages:f40-1series-uk-tech-data-2020"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "7-speed DCT top_gear_ratio",
-        "reason": "Official PDF transmission table extraction exposes ratio formatting that is not unambiguous for direct top-gear mapping in this workflow; existing top_gear_ratio kept unchanged per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Per-variant transmission mapping for 118i",
-        "reason": "Official specs show 118i can be manual or 7-speed DCT, but current schema in this entry does not model transmission per variant; no schema expansion applied.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      },
-      {
-        "item": "Exact M135i xDrive variant-only gearbox and tire mapping in the broad F40 row",
-        "reason": "Official BMW PressClub PDFs confirm the exact M135i xDrive 8-speed ratios and 225/40 R18 standard tire, but the current broad row still mixes other F40 gearbox and wheel/tire combinations.",
-        "evidence_refs": [
-          "legacy_research_sources:091077d8a451",
-          "legacy_research_sources:16c091e6cfd6",
-          "legacy_research_sources:18deedec2c15",
-          "legacy_research_sources:82e045fca148",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:eca9fb0d3e74"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_active_tourer/F45.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_active_tourer/F45.json
@@ -1,1996 +1,1456 @@
-[
-  {
-    "id": "bmw-f45-214d-eu-2014-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2014,
-    "production_end_year": 2015,
-    "model_name": "2 Series Active Tourer (F45, 2014-2015)",
-    "variant_name": "214d",
-    "engine_code": "B37C15",
-    "engine_name": "B37C15 I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-        "bmw_pressclub_sources:f45-214d-2015-launch-article",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n3": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
+      "n4": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n5": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n6": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n7": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n8": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n9": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence.",
+      "n14": "BMW 2AT F45 225i FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec PDF) and T0203608EN/325506 (03/2015 spec PDF): engine B48A20O0 (170 kW / 231 hp), gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.075, default tyre 205/55 R17. Plain FWD 225i was discontinued at the LCI changeover and replaced by the 225i xDrive AWD; production_end_year corrected to 2017. NOTE: shard's transmission code 'ZF8HP' is a misnomer - the actual unit is the Aisin AWF8F35 (transverse 8AT). ZF 8HP is longitudinal-only and physically impossible on UKL2. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
+      "n15": "BMW 2AT F45 218d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF): engine B47C20 110 kW, optional Aisin AWF8F35 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (was a data entry error - this row is the LCI 8AT state which ran from 03/2018 to F45 production end 03/2021). Final drive 4.398 was a family_default and was not directly extracted from the spec PDF in this research run; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35 (transverse 8AT). Code retained; transmission.name corrected.",
+      "n16": "BMW 2AT F45 220d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF) and T0277458EN press kit ('220d with the eight-speed Steptronic' as standard fit): engine B47C20 140 kW, Aisin AWF8F35 8AT standard, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (data entry error). Final drive 4.398 family_default not directly extracted; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
+      "n17": "BMW 2AT F45 220i FWD with 7-speed dual-clutch Steptronic (Magna 7DCT300). Confirmed by BMW PressClub T0277458EN press kit ('the 220i is fitted as standard with the seven-speed dual-clutch Steptronic transmission') and T0277458EN/401747 (01/2018 LCI spec PDF). Engine B48A20M0 141 kW (192 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final drive) values; FD 3.231 published separately as family_default but not directly extracted from the spec PDF in this research run, so the per-gear individual ratios remain unset and FD remains at no_confidence. production_end_year corrected: 2018 -> 2021 (data entry error). DCT7 = Magna 7DCT300 (also called Getrag 7DCI300 in some Borg-Warner / Magna PT documents).",
+      "n18": "BMW 2AT F45 225xe iPerformance plug-in hybrid: B38A15M0 1.5L turbo petrol driving front axle via 6-speed Aisin TF-60SN Steptronic; 65 kW electric motor driving rear axle (through-the-road AWD). Confirmed by BMW PressClub T0299792EN release (225xe drivetrain layout) and T0299792EN/436732 (225xe 2019 spec PDF). Production START year corrected: 2014 -> 2016 (225xe entered production in 03/2016, not at 2014 launch). Wikipedia and BMW PressClub confirm Aisin TF-60SN as the 6AT unit (NOT a ZF gearbox; '6-SPEED-STEP' code retained as shard label). Per-gear ratios and individual final drive not exposed in the BMW PressClub spec PDFs cross-checked in this run and remain at no_confidence pending direct text extraction; transmission identity, drivetrain, and configuration are well-evidenced.",
+      "n19": "225xe per-gear ratios and final drive not extracted from BMW PressClub T0299792EN/436732 in this run; remain unverified pending direct PDF text extraction.",
+      "n20": "Final drive value 4.398 was a family_default; the 218d-specific FD was not directly extracted from BMW PressClub T0277458EN/401747 in this research run.",
+      "n21": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
     },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-        "bmw_pressclub_sources:f45-214d-2015-launch-article",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 4.398,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 214d (B37C15 70 kW diesel) was offered exclusively with the 6-speed manual transmission in the EU - no automatic gearbox was ever fitted to this variant. Confirmed by BMW PressClub T0203608EN/325505 (03/2015 214d spec PDF) which lists MT6 only. Additionally the production_start_year of 2014 is wrong: the 214d entered production in 03/2015. The inherited 8AT gear set (5.250...0.673) belongs to the 225i Aisin AWF8F35 and does not apply to the 214d. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW spring 2015 launch material and the exact 03/2015 214d specifications PDF directly. That exact F45 sheet introduces the 214d from 03/2015 and publishes only a six-speed manual state with forward ratios 3.615 / 1.952 / 1.241 / 0.969 / 0.806 / 0.683, final drive 3.632, and 205/60 R16 baseline tires. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 214d exact automatic technical-data row",
-        "reason": "Checked official BMW 03/2015 specifications PDF publishes the 214d only with six-speed manual and does not surface any automatic 214d row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F45 214d exact represented ZF8HP configuration",
-        "reason": "Official BMW spring 2015 launch material introduces the 214d only from 03/2015, and the exact 03/2015 specifications PDF shows six-speed manual with 205/60 R16 baseline tires rather than the inherited 8-speed, 4.398, and 17-inch placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-214d-2015-launch-article",
-          "bmw_pressclub_sources:f45-214d-2015-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '214d'",
-        "reason": "Official BMW PressClub 03/2015 214d specifications PDF (T0203608EN/325505) documents the 214d only as FWD six-speed manual with top gear 0.683, final drive 3.632, and 205/60 R16 default tire, introduced in March 2015. No saved official 214d 8-speed automatic source exists; this row's automatic transmission is contradicted. Driveshaft and wheel-order analysis remain disabled."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-216d-eu-2014-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
-    "variant_name": "216d",
-    "engine_code": "B37C15",
-    "engine_name": "B37C15 I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 4.398,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216d (B37C15 85 kW diesel) was offered with the 6-speed manual at launch and gained the 7-speed dual-clutch Steptronic (Magna 7DCT300) at LCI - it was never fitted with the Aisin AWF8F35 8-speed automatic. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec) which list 216d as MT6 or DCT7 only. The repo's 'ZF8HP' label is a misnomer (ZF 8HP is longitudinal-only on UKL2). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave extends the earlier contradiction note with start-year evidence from the official 02/2014 BMW F45 launch article. That launch article lists only 218i, 225i, and 218d as the launch engine set, so it does not support a 2014 216d row. The checked 01/2018 and 11/2020 specifications PDFs then publish the later 216d only with six-speed manual or optional seven-speed Steptronic with double clutch and 205/60 R16 baseline tires, never with eight-speed Steptronic. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-launch-article",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 216d exact 2014 launch applicability",
-        "reason": "The checked official 02/2014 BMW F45 launch article lists only 218i, 225i, and 218d in the launch engine set, so it does not close a 2014 launch-state 216d row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-launch-article"
-        ]
-      },
-      {
-        "item": "BMW F45 216d exact represented ZF8HP configuration",
-        "reason": "The checked official 2018 and 2020 BMW sheets publish the later 216d only with six-speed manual or optional seven-speed Steptronic with double clutch and 205/60 R16 baseline tires, not with eight-speed Steptronic, so this pass cannot promote the inherited ZF8HP transmission, ratio, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '216d'",
-        "reason": "Official 03/2014 launch packet (T0165875EN/312197) lists only 218i, 225i, and 218d, not 216d. Official 01/2018 LCI spec (T0277458EN/401747) and 11/2020 spec (T0322634EN/468203) document 216d as six-speed manual with optional 7-speed dual-clutch Steptronic, never an 8-speed automatic. This row's broad 2014-2021 8-speed automatic claim is contradicted across all saved official F45 specifications."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-216i-eu-2014-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
-    "variant_name": "216i",
-    "engine_code": "B38A15U0",
-    "engine_name": "B38A15U0 I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 4.398,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 216i (B38A15M0 75 kW petrol) was offered with the 6-speed manual only - no automatic gearbox was ever fitted to this base petrol variant. Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec) and T0322634EN/468203 (11/2020 final spec). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave extends the earlier contradiction note with start-year evidence from the official 02/2014 BMW F45 launch article. That launch article lists only 218i, 225i, and 218d as the launch engine set, so it does not support a 2014 216i row. The checked 01/2018 and 11/2020 specifications PDFs then publish the later 216i only with six-speed manual and 205/60 R16 baseline tires, with no automatic row at all. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-launch-article",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 216i exact 2014 launch applicability",
-        "reason": "The checked official 02/2014 BMW F45 launch article lists only 218i, 225i, and 218d in the launch engine set, so it does not close a 2014 launch-state 216i row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-launch-article"
-        ]
-      },
-      {
-        "item": "BMW F45 216i exact represented ZF8HP configuration",
-        "reason": "The checked official 2018 and 2020 BMW sheets publish the later 216i only with six-speed manual and 205/60 R16 baseline tires, with no automatic row at all, so this pass cannot promote the inherited ZF8HP transmission, ratio, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '216i'",
-        "reason": "Official 03/2014 launch packet excludes 216i. Official 01/2018 and 11/2020 specifications list 216i as six-speed manual only with 205/60 R16. No 8-speed automatic 216i row appears in any saved official F45 source; current row is contradicted across the lifecycle."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-218i-eu-2014-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
-    "variant_name": "218i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2014-spec-pdf",
-        "bmw_pressclub_sources:f45-2015-spec-pdf",
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2014-spec-pdf",
-        "bmw_pressclub_sources:f45-2015-spec-pdf",
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2020-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.673,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 4.398,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW 218i (B38A15M0 100 kW petrol) automatic was the 6-speed Aisin TF-60SN Steptronic in pre-LCI era and the Magna 7DCT300 7-speed dual-clutch in LCI era - it was never fitted with the Aisin AWF8F35 8-speed. Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec, 6AT optional), T0203608EN/325506 (03/2015 spec, 6AT optional), T0277458EN/401747 (01/2018 LCI spec, DCT7 optional), and T0322634EN/468203 (11/2020). Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 3 validation strengthens the contradiction on this exact row with a four-step official BMW ACEA-market chain. The checked 02/2014 and 03/2015 specification PDFs show the 218i Active Tourer with six-speed manual or optional six-speed Steptronic, 205/60 R16 baseline tires, and no eight-speed row. The checked 01/2018 and 11/2020 specification PDFs then show the facelift/late 218i with six-speed manual or optional seven-speed DCT / seven-speed Steptronic with double clutch, again with no eight-speed row, while the same official PDFs explicitly publish Eight-speed Steptronic on 225i xDrive. This represented ZF8HP configuration therefore remains a contradicted advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 218i exact eight-speed Steptronic row",
-        "reason": "Checked official BMW 2014, 2015, 2018, and 2020 F45 ACEA-market specification PDFs show the 218i only with six-speed manual plus optional six-speed Steptronic early or optional seven-speed DCT / seven-speed Steptronic with double clutch later, never with eight-speed Steptronic.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F45 218i exact represented ZF8HP configuration",
-        "reason": "Without any official eight-speed 218i row, this pass cannot promote the inherited transmission, ratio, or tire placeholders for the represented automatic state. The official source chain instead shows an unresolved early six-speed automatic state and a later seven-speed DCT state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F45 218i exact automatic switchover from six-speed Steptronic to seven-speed DCT",
-        "reason": "The checked official BMW source chain proves the early 218i automatic as six-speed Steptronic and the facelift/late 218i automatic as seven-speed DCT / seven-speed Steptronic with double clutch, but this pass did not recover the exact official switchover month or model-year boundary between those two supported automatic states.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-2020-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '218i'",
-        "reason": "Official 2014/2015 specifications document 218i as six-speed manual with optional six-speed Steptronic; 01/2018 and 11/2020 LCI specs document 218i as manual with optional seven-speed dual-clutch. No saved official source documents an 8-speed automatic 218i in any F45 year. Current row's transmission claim is contradicted."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-225i-eu-2014-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2014,
-    "production_end_year": 2017,
-    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
-    "variant_name": "225i",
-    "engine_code": "B48A20O0",
-    "engine_name": "B48A20O0 I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-        "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-      ],
-      "notes": "BMW 2AT F45 225i FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec PDF) and T0203608EN/325506 (03/2015 spec PDF): engine B48A20O0 (170 kW / 231 hp), gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.075, default tyre 205/55 R17. Plain FWD 225i was discontinued at the LCI changeover and replaced by the 225i xDrive AWD; production_end_year corrected to 2017. NOTE: shard's transmission code 'ZF8HP' is a misnomer - the actual unit is the Aisin AWF8F35 (transverse 8AT). ZF 8HP is longitudinal-only and physically impossible on UKL2. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-        "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-      ],
-      "notes": "BMW 2AT F45 225i FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec PDF) and T0203608EN/325506 (03/2015 spec PDF): engine B48A20O0 (170 kW / 231 hp), gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.075, default tyre 205/55 R17. Plain FWD 225i was discontinued at the LCI changeover and replaced by the 225i xDrive AWD; production_end_year corrected to 2017. NOTE: shard's transmission code 'ZF8HP' is a misnomer - the actual unit is the Aisin AWF8F35 (transverse 8AT). ZF 8HP is longitudinal-only and physically impossible on UKL2. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 8th gear from BMW PressClub T0165875EN/312197 (02/2014 launch spec).",
-        "value": 0.673
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 gear set per BMW PressClub T0165875EN/312197 (02/2014) and T0203608EN/325506 (03/2015).",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 final drive (FWD) per BMW PressClub T0165875EN/312197.",
-        "value": 3.075
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-        ],
-        "notes": "BMW 2AT F45 225i FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0165875EN/312197 (02/2014 launch spec PDF) and T0203608EN/325506 (03/2015 spec PDF): engine B48A20O0 (170 kW / 231 hp), gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.075, default tyre 205/55 R17. Plain FWD 225i was discontinued at the LCI changeover and replaced by the 225i xDrive AWD; production_end_year corrected to 2017. NOTE: shard's transmission code 'ZF8HP' is a misnomer - the actual unit is the Aisin AWF8F35 (transverse 8AT). ZF 8HP is longitudinal-only and physically impossible on UKL2. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-            "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-          ],
-          "notes": "Official BMW 02/2014 and 03/2015 technical-data PDFs consistently list the standard square 205/55 R17 setup for the exact plain F45 225i Active Tourer row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 8 review narrows the broad unsupported F45 225i row to the exact early plain front-wheel-drive state supported by official BMW launch-era evidence. The checked 02/2014 technical-data PDF publishes a plain 225i Active Tourer row with Eight-speed Steptronic, forward ratios 5.250 / 3.029 / 1.950 / 1.457 / 1.221 / 1.000 / 0.809 / 0.673, final drive 3.075, top speed 240 km/h, and a square 205/55 R17 baseline setup. The official launch article independently states the launch car uses a front-wheel-drive system, the 225i Active Tourer tops the launch range with a standard-fitted eight-speed Steptronic gearbox, and xDrive variants are added later. The checked March 2015 wrapper corroborates that the plain 225i specification attachment still exists in 2015, while the later 11/2014 225i xDrive specification PDF confirms the later all-wheel-drive row must stay separate.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-2014-launch-article",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-xdrive-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.015",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 225i exact optional wheel-package coverage beyond the standard 17-inch setup",
-        "reason": "The checked official BMW 02/2014 and 03/2015 technical-data PDFs close the square 205/55 R17 standard setup for the exact plain F45 225i row, but this pass did not recover a launch-era official optional wheel matrix for the same exact configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-2014-launch-article"
-        ]
-      },
-      {
-        "item": "BMW F45 225i exact continuation after the checked March 2015 plain-FWD carryover",
-        "reason": "The checked official BMW source chain proves the plain front-wheel-drive 225i Active Tourer at launch and confirms the same plain-spec attachment still exists in the March 2015 wrapper, but this pass did not recover a later official ACEA-market plain-225i row proving how long that exact front-wheel-drive state persisted before the published 225i xDrive-only material takes over.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2014-launch-article",
-          "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
-          "bmw_pressclub_sources:f45-225i-xdrive-2014-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '225i'",
-        "reason": "Official 03/2014 (T0165875EN/312197) and 03/2015 (T0203608EN/325506) specs document plain-FWD 225i with 8-speed Steptronic, top gear 0.673, final drive 3.075, and 205/55 R17 default. Official 01/2018 (T0277458EN/401747) and 11/2020 (T0322634EN/468203) specs document 225i only as 225i xDrive (AWD), not plain-FWD 225i. Therefore the broad 2014-2021 FWD scope is unsupported beyond the 2014-2015 launch slice. Top-gear, final-drive, and default-tire values match official launch evidence; ZF8HP is `official_derived` from BMW's 8-speed Steptronic wording."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-225xe-eu-2014-6-speed-step-awd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2016,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
-    "variant_name": "225xe",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-225xe-launch-release",
-        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ],
-      "notes": "BMW 2AT F45 225xe iPerformance plug-in hybrid: B38A15M0 1.5L turbo petrol driving front axle via 6-speed Aisin TF-60SN Steptronic; 65 kW electric motor driving rear axle (through-the-road AWD). Confirmed by BMW PressClub T0299792EN release (225xe drivetrain layout) and T0299792EN/436732 (225xe 2019 spec PDF). Production START year corrected: 2014 -> 2016 (225xe entered production in 03/2016, not at 2014 launch). Wikipedia and BMW PressClub confirm Aisin TF-60SN as the 6AT unit (NOT a ZF gearbox; '6-SPEED-STEP' code retained as shard label). Per-gear ratios and individual final drive not exposed in the BMW PressClub spec PDFs cross-checked in this run and remain at no_confidence pending direct text extraction; transmission identity, drivetrain, and configuration are well-evidenced.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "BMW 2AT F45 225xe iPerformance plug-in hybrid: B38A15M0 1.5L turbo petrol driving front axle via 6-speed Aisin TF-60SN Steptronic; 65 kW electric motor driving rear axle (through-the-road AWD). Confirmed by BMW PressClub T0299792EN release (225xe drivetrain layout) and T0299792EN/436732 (225xe 2019 spec PDF). Production START year corrected: 2014 -> 2016 (225xe entered production in 03/2016, not at 2014 launch). Wikipedia and BMW PressClub confirm Aisin TF-60SN as the 6AT unit (NOT a ZF gearbox; '6-SPEED-STEP' code retained as shard label). Per-gear ratios and individual final drive not exposed in the BMW PressClub spec PDFs cross-checked in this run and remain at no_confidence pending direct text extraction; transmission identity, drivetrain, and configuration are well-evidenced.",
-      "code": "6-SPEED-STEP",
-      "name": "6-speed Steptronic (Aisin TF-60SN) + electric rear axle",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-225xe-launch-release",
-        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-        "secondary_technical_sources:bmw-f45-2at-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "225xe per-gear ratios and final drive not extracted from BMW PressClub T0299792EN/436732 in this run; remain unverified pending direct PDF text extraction.",
-        "value": 0.672,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive value 4.398 was a family_default; the 218d-specific FD was not directly extracted from BMW PressClub T0277458EN/401747 in this research run.",
-        "value": 3.944,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.944
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf"
-        ],
-        "notes": "225xe default tyre size not extracted from BMW PressClub T0299792EN/436732 in this run; family_default 205/55 R17 unverified - pending direct PDF text extraction.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Issue #1034 official-source review kept the retained 8-speed family baseline for the non-overridden F45 variants, moved the documented 225xe 6-speed Steptronic ratio pair onto the 225xe variant explicitly, and added an explicit 220i 7-speed dual-clutch override so the documented 220i/225xe transmissions no longer rely on shared gearbox rows. Wave 20 re-check confirms from the official 01/2018 BMW specifications PDF that the exact 220i ACEA-market baseline tire is 205/60 R16 and that BMW publishes overall 7-speed DCT ratio figures in that sheet, but those figures still do not expose a safe standalone final-drive/top-gear mapping. Wave 21 extends the exact official 01/2018 ACEA evidence to the 218i: the same BMW specifications PDF proves the 218i 6-speed manual state with ratios 3.615 / 1.952 / 1.241 / 0.969 / 0.806 / 0.683, reverse 3.538, and baseline 205/60 R16 tires, while the optional 7-speed DCT appears only as overall parenthesized ratios 17.348 / 10.232 / 6.593 / 4.615 / 3.572 / 2.819 / 2.285 with reverse 15.982, still without a safely separable final-drive/top-gear mapping. The 225xe official 07/2019 specifications PDF also confirms the exact 205/55 R17 baseline tire alongside the full 6-speed ratio set, final drive 3.944, and top gear 0.672.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-220i-2018-press-kit",
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "bmw_pressclub_sources:f45-225xe-launch-release",
-          "legacy_research_sources:4bcbbab016e3",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b385759b36d8",
-          "legacy_research_sources:ede0bc1c6aee",
-          "secondary_technical_sources:f45-220i-dct-autodata",
-          "secondary_technical_sources:f45-220i-dct-carfolio"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Remaining non-overridden F45 variant gearbox mapping",
-        "reason": "Issue #1034 made the documented 220i and 225xe transmission mappings explicit, but the other listed variants still inherit the retained family baseline until authoritative variant-specific ratio tables are confirmed.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-220i-2018-press-kit",
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "bmw_pressclub_sources:f45-225xe-launch-release",
-          "legacy_research_sources:4bcbbab016e3",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b385759b36d8",
-          "legacy_research_sources:ede0bc1c6aee",
-          "secondary_technical_sources:f45-220i-dct-autodata",
-          "secondary_technical_sources:f45-220i-dct-carfolio"
-        ]
-      },
-      {
-        "item": "Official BMW numeric confirmation for the 220i DCT ratio pair",
-        "reason": "BMW official materials confirm the 220i uses the 7-speed dual-clutch Steptronic transmission, but the public PressClub documents retrieved for this fix do not expose an unambiguous final-drive field mapping, so the numeric ratio pair remains backed by reputable secondary references.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-220i-2018-press-kit",
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "bmw_pressclub_sources:f45-225xe-launch-release",
-          "legacy_research_sources:4bcbbab016e3",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b385759b36d8",
-          "legacy_research_sources:ede0bc1c6aee",
-          "secondary_technical_sources:f45-220i-dct-autodata",
-          "secondary_technical_sources:f45-220i-dct-carfolio"
-        ]
-      },
-      {
-        "item": "Official BMW numeric confirmation for the 218i optional 7-speed DCT ratio pair",
-        "reason": "The official 01/2018 ACEA-market BMW specifications PDF proves the 218i optional 7-speed DCT exists and publishes only overall parenthesized ratios rather than a safely separable final-drive/top-gear mapping, so no exact standalone numeric gearbox override is yet safe for the automatic 218i state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "bmw_pressclub_sources:f45-220i-2018-press-kit",
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "bmw_pressclub_sources:f45-225xe-launch-release",
-          "legacy_research_sources:4bcbbab016e3",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b385759b36d8",
-          "legacy_research_sources:ede0bc1c6aee",
-          "secondary_technical_sources:f45-220i-dct-autodata",
-          "secondary_technical_sources:f45-220i-dct-carfolio"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '225xe'",
-        "reason": "Official BMW PressClub Asia 225xe iPerformance specifications PDF (T0274617EN/394439) and the 2019 update launch article (T0299792EN) plus 2019 spec PDF (T0299792EN/436732) and 11/2020 spec (T0322634EN/468203) all document the 225xe as a plug-in hybrid xDrive with combustion engine driving the front wheels through a six-speed Steptronic and electric motor on the rear axle, with top gear 0.672, final drive 3.944, and 205/55 R17 default tire. None of these saved official sources document a 2014 launch availability; production start at 2014 is unproven. Powertrain/tire values match official evidence; production-year scope remains unresolved."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-218d-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2018,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2018)",
-    "variant_name": "218d",
-    "engine_code": "B47C20",
-    "engine_name": "B47C20 I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-220i-2018-press-kit"
-      ],
-      "notes": "BMW 2AT F45 218d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF): engine B47C20 110 kW, optional Aisin AWF8F35 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (was a data entry error - this row is the LCI 8AT state which ran from 03/2018 to F45 production end 03/2021). Final drive 4.398 was a family_default and was not directly extracted from the spec PDF in this research run; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35 (transverse 8AT). Code retained; transmission.name corrected.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-220i-2018-press-kit"
-      ],
-      "notes": "BMW 2AT F45 218d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF): engine B47C20 110 kW, optional Aisin AWF8F35 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (was a data entry error - this row is the LCI 8AT state which ran from 03/2018 to F45 production end 03/2021). Final drive 4.398 was a family_default and was not directly extracted from the spec PDF in this research run; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35 (transverse 8AT). Code retained; transmission.name corrected.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "225xe per-gear ratios and final drive not extracted from BMW PressClub T0299792EN/436732 in this run; remain unverified pending direct PDF text extraction.",
-        "value": 0.672,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive value 4.398 was a family_default; the 218d-specific FD was not directly extracted from BMW PressClub T0277458EN/401747 in this research run.",
-        "value": 3.944,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ],
-        "notes": "BMW 2AT F45 218d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF): engine B47C20 110 kW, optional Aisin AWF8F35 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (was a data entry error - this row is the LCI 8AT state which ran from 03/2018 to F45 production end 03/2021). Final drive 4.398 was a family_default and was not directly extracted from the spec PDF in this research run; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35 (transverse 8AT). Code retained; transmission.name corrected.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf"
-          ],
-          "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 218d Active Tourer automatic state represented by this narrowed 2018-only row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 60.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 01/2018 specifications PDF now confirms the exact 218d Active Tourer automatic state with front-wheel drive, optional Eight-speed Steptronic wording, bracketed automatic forward ratios 5.519 / 3.184 / 2.050 / 1.492 / 1.235 / 1.000 / 0.801 / 0.673, reverse 4.221, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state because this pass did not recover a year-by-year official source chain proving the same package across the original 2014-2021 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-          "secondary_technical_sources:bmw-f45-2at-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 218d exact standalone final-drive value",
-        "reason": "The official BMW 01/2018 specifications PDF closes the bracketed automatic gear ratios for the exact 218d state but does not expose a standalone final-drive field.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F45 218d exact optional wheel-package coverage beyond the baseline tire",
-        "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 218d automatic state, but this pass did not recover a row-specific optional wheel matrix for the narrowed 2018-only row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '218d'",
-        "reason": "Official 01/2018 LCI spec (T0277458EN/401747) supports FWD, optional 8-speed Steptronic, top gear 0.673, and 205/60 R16 default. 11/2020 spec (T0322634EN/468203) documents the same 218d FWD with 8-speed Steptronic, top 0.673, final drive 2.774, and same default tire. Final drive remains unresolved as an exact 2018-only value because the 01/2018 PDF extraction did not surface that line; optional tire matrix is not exhaustively documented."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-220d-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2018,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2018)",
-    "variant_name": "220d",
-    "engine_code": "B47C20",
-    "engine_name": "B47C20 I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-220i-2018-press-kit"
-      ],
-      "notes": "BMW 2AT F45 220d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF) and T0277458EN press kit ('220d with the eight-speed Steptronic' as standard fit): engine B47C20 140 kW, Aisin AWF8F35 8AT standard, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (data entry error). Final drive 4.398 family_default not directly extracted; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-220i-2018-press-kit"
-      ],
-      "notes": "BMW 2AT F45 220d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF) and T0277458EN press kit ('220d with the eight-speed Steptronic' as standard fit): engine B47C20 140 kW, Aisin AWF8F35 8AT standard, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (data entry error). Final drive 4.398 family_default not directly extracted; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 8th gear per BMW PressClub T0277458EN/401747.",
-        "value": 0.673
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 (diesel calibration) gear set per BMW PressClub T0277458EN/401747.",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 4.398 was a family_default; not directly extracted from BMW PressClub T0277458EN/401747 in this research run.",
-        "value": 4.398,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ],
-        "notes": "BMW 2AT F45 220d FWD with 8-speed Aisin Steptronic (AWF8F35). Confirmed by BMW PressClub T0277458EN/401747 (01/2018 LCI spec PDF) and T0277458EN press kit ('220d with the eight-speed Steptronic' as standard fit): engine B47C20 140 kW, Aisin AWF8F35 8AT standard, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, default tyre 205/60 R16. production_end_year corrected: 2018 -> 2021 (data entry error). Final drive 4.398 family_default not directly extracted; left at no_confidence. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf"
-          ],
-          "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 220d Active Tourer state represented by this narrowed 2018-only row.",
-          "front": {
-            "width_mm": 205.0,
-            "aspect_pct": 60.0,
-            "rim_in": 16.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 01/2018 specifications PDF now confirms the exact 220d Active Tourer front-wheel-drive state with Eight-speed Steptronic wording, forward ratios 5.519 / 3.184 / 2.050 / 1.492 / 1.235 / 1.000 / 0.801 / 0.673, reverse 4.221, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state because this pass did not recover a year-by-year official source chain proving the same package across the original 2014-2021 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 220d exact standalone final-drive value",
-        "reason": "The official BMW 01/2018 specifications PDF for the exact 220d Active Tourer publishes the full forward-ratio and reverse-ratio set but does not expose a standalone final-drive field for the front-wheel-drive state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW F45 220d exact optional wheel-package coverage beyond the baseline tire",
-        "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 220d Active Tourer state, but this pass did not recover a row-specific optional wheel matrix spanning the broader original row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '220d'",
-        "reason": "Official 01/2018 LCI spec supports FWD, 8-speed Steptronic, top gear 0.673, and 205/60 R16. 11/2020 spec confirms top 0.673 and final drive 2.774 for 220d. Final drive remains unresolved as an exact 2018-only value; optional tire matrix is not exhaustively documented."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f45-220i-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "Hatchback",
-    "market": "EU",
-    "model_code": "F45",
-    "body_code": "F45",
-    "production_start_year": 2018,
-    "production_end_year": 2021,
-    "model_name": "2 Series Active Tourer (F45, 2018)",
-    "variant_name": "220i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
         "bmw_pressclub_sources:f45-220i-2018-press-kit",
-        "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
-        "bmw_pressclub_sources:f45-2018-spec-pdf",
-        "secondary_technical_sources:f45-220i-dct-autodata"
+        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
+        "bmw_pressclub_sources:f45-225xe-launch-release",
+        "legacy_research_sources:4bcbbab016e3",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:b385759b36d8",
+        "legacy_research_sources:ede0bc1c6aee",
+        "secondary_technical_sources:f45-220i-dct-autodata",
+        "secondary_technical_sources:f45-220i-dct-carfolio"
       ],
-      "notes": "BMW 2AT F45 220i FWD with 7-speed dual-clutch Steptronic (Magna 7DCT300). Confirmed by BMW PressClub T0277458EN press kit ('the 220i is fitted as standard with the seven-speed dual-clutch Steptronic transmission') and T0277458EN/401747 (01/2018 LCI spec PDF). Engine B48A20M0 141 kW (192 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final drive) values; FD 3.231 published separately as family_default but not directly extracted from the spec PDF in this research run, so the per-gear individual ratios remain unset and FD remains at no_confidence. production_end_year corrected: 2018 -> 2021 (data entry error). DCT7 = Magna 7DCT300 (also called Getrag 7DCI300 in some Borg-Warner / Magna PT documents).",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f45-220i-2018-press-kit",
-        "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
+      "e2": [
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-2020-spec-pdf",
+        "secondary_technical_sources:bmw-f45-2at-wikipedia"
+      ],
+      "e3": [
         "bmw_pressclub_sources:f45-2018-spec-pdf"
       ],
-      "notes": "BMW 2AT F45 220i FWD with 7-speed dual-clutch Steptronic (Magna 7DCT300). Confirmed by BMW PressClub T0277458EN press kit ('the 220i is fitted as standard with the seven-speed dual-clutch Steptronic transmission') and T0277458EN/401747 (01/2018 LCI spec PDF). Engine B48A20M0 141 kW (192 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final drive) values; FD 3.231 published separately as family_default but not directly extracted from the spec PDF in this research run, so the per-gear individual ratios remain unset and FD remains at no_confidence. production_end_year corrected: 2018 -> 2021 (data entry error). DCT7 = Magna 7DCT300 (also called Getrag 7DCI300 in some Borg-Warner / Magna PT documents).",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch Steptronic (Magna 7DCT300)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Retained conservative secondary-backed mapping because the official BMW 01/2018 specifications PDF publishes only overall Seven-speed DCT ratios 15.304 / 9.026 / 5.735 / 4.015 / 3.108 / 2.487 / 2.016 and reverse 13.825, which do not safely separate a standalone top-gear field for the exact 220i automatic state.",
-        "value": 0.698
-      },
-      "final_drive_front": {
+      "e4": [
+        "bmw_pressclub_sources:f45-214d-2015-spec-pdf",
+        "bmw_pressclub_sources:f45-214d-2015-launch-article",
+        "secondary_technical_sources:bmw-f45-2at-wikipedia"
+      ],
+      "e5": [
+        "bmw_pressclub_sources:f45-2014-spec-pdf",
+        "bmw_pressclub_sources:f45-2015-spec-pdf",
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-2020-spec-pdf",
+        "secondary_technical_sources:bmw-f45-2at-wikipedia"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
+        "bmw_pressclub_sources:f45-225i-2015-spec-pdf"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:f45-2014-spec-pdf",
+        "bmw_pressclub_sources:f45-2015-spec-pdf",
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-2020-spec-pdf"
+      ],
+      "e8": [
+        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
+        "secondary_technical_sources:bmw-f45-2at-wikipedia"
+      ],
+      "e9": [
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-220i-2018-press-kit"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:f45-214d-2015-launch-article",
+        "bmw_pressclub_sources:f45-214d-2015-spec-pdf"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f45-2014-launch-article",
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-2020-spec-pdf"
+      ],
+      "e12": [
+        "bmw_pressclub_sources:f45-2014-launch-article"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:f45-2018-spec-pdf",
+        "bmw_pressclub_sources:f45-2020-spec-pdf"
+      ],
+      "e14": [
+        "bmw_pressclub_sources:f45-225xe-launch-release",
+        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
+        "secondary_technical_sources:bmw-f45-2at-wikipedia"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf"
+      ],
+      "e16": [
+        "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
+        "secondary_technical_sources:f45-220i-dct-autodata"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f45-214d-eu-2014-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2014,
+      "production_end_year": 2015,
+      "model_name": "2 Series Active Tourer (F45, 2014-2015)",
+      "variant_name": "214d",
+      "engine_code": "B37C15",
+      "engine_name": "B37C15 I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Final drive 3.231 was a family_default; not directly extracted from BMW PressClub T0277458EN/401747 in this research run. Auto-data secondary cross-check listed; promotion to official_derived requires direct PDF text extraction.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
-          "secondary_technical_sources:f45-220i-dct-autodata"
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n3",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.673,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ],
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 4.398,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW spring 2015 launch material and the exact 03/2015 214d specifications PDF directly. That exact F45 sheet introduces the 214d from 03/2015 and publishes only a six-speed manual state with forward ratios 3.615 / 1.952 / 1.241 / 0.969 / 0.806 / 0.683, final drive 3.632, and 205/60 R16 baseline tires. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 214d exact automatic technical-data row",
+          "reason": "Checked official BMW 03/2015 specifications PDF publishes the 214d only with six-speed manual and does not surface any automatic 214d row.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f45-214d-2015-spec-pdf"
+          ]
+        },
+        {
+          "item": "BMW F45 214d exact represented ZF8HP configuration",
+          "reason": "Official BMW spring 2015 launch material introduces the 214d only from 03/2015, and the exact 03/2015 specifications PDF shows six-speed manual with 205/60 R16 baseline tires rather than the inherited 8-speed, 4.398, and 17-inch placeholders.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "F45 official-source assessment for '214d'",
+          "reason": "Official BMW PressClub 03/2015 214d specifications PDF (T0203608EN/325505) documents the 214d only as FWD six-speed manual with top gear 0.683, final drive 3.632, and 205/60 R16 default tire, introduced in March 2015. No saved official 214d 8-speed automatic source exists; this row's automatic transmission is contradicted. Driveshaft and wheel-order analysis remain disabled."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf",
-          "secondary_technical_sources:f45-220i-dct-autodata"
-        ],
-        "notes": "BMW 2AT F45 220i FWD with 7-speed dual-clutch Steptronic (Magna 7DCT300). Confirmed by BMW PressClub T0277458EN press kit ('the 220i is fitted as standard with the seven-speed dual-clutch Steptronic transmission') and T0277458EN/401747 (01/2018 LCI spec PDF). Engine B48A20M0 141 kW (192 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final drive) values; FD 3.231 published separately as family_default but not directly extracted from the spec PDF in this research run, so the per-gear individual ratios remain unset and FD remains at no_confidence. production_end_year corrected: 2018 -> 2021 (data entry error). DCT7 = Magna 7DCT300 (also called Getrag 7DCI300 in some Borg-Warner / Magna PT documents).",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f45-216d-eu-2014-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+      "variant_name": "216d",
+      "engine_code": "B37C15",
+      "engine_name": "B37C15 I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n5",
+        "value": "FWD"
       },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf"
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 0.673,
+          "evidence_refs_ref": "e2"
+        },
+        "gear_ratios": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
           ],
-          "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 220i Active Tourer Seven-speed DCT state represented by this narrowed 2018-only row.",
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 4.398,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave extends the earlier contradiction note with start-year evidence from the official 02/2014 BMW F45 launch article. That launch article lists only 218i, 225i, and 218d as the launch engine set, so it does not support a 2014 216d row. The checked 01/2018 and 11/2020 specifications PDFs then publish the later 216d only with six-speed manual or optional seven-speed Steptronic with double clutch and 205/60 R16 baseline tires, never with eight-speed Steptronic. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 216d exact 2014 launch applicability",
+          "reason": "The checked official 02/2014 BMW F45 launch article lists only 218i, 225i, and 218d in the launch engine set, so it does not close a 2014 launch-state 216d row.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "BMW F45 216d exact represented ZF8HP configuration",
+          "reason": "The checked official 2018 and 2020 BMW sheets publish the later 216d only with six-speed manual or optional seven-speed Steptronic with double clutch and 205/60 R16 baseline tires, not with eight-speed Steptronic, so this pass cannot promote the inherited ZF8HP transmission, ratio, or tire placeholders.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "F45 official-source assessment for '216d'",
+          "reason": "Official 03/2014 launch packet (T0165875EN/312197) lists only 218i, 225i, and 218d, not 216d. Official 01/2018 LCI spec (T0277458EN/401747) and 11/2020 spec (T0322634EN/468203) document 216d as six-speed manual with optional 7-speed dual-clutch Steptronic, never an 8-speed automatic. This row's broad 2014-2021 8-speed automatic claim is contradicted across all saved official F45 specifications."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-216i-eu-2014-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+      "variant_name": "216i",
+      "engine_code": "B38A15U0",
+      "engine_name": "B38A15U0 I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n6",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 0.673,
+          "evidence_refs_ref": "e2"
+        },
+        "gear_ratios": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ],
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 4.398,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave extends the earlier contradiction note with start-year evidence from the official 02/2014 BMW F45 launch article. That launch article lists only 218i, 225i, and 218d as the launch engine set, so it does not support a 2014 216i row. The checked 01/2018 and 11/2020 specifications PDFs then publish the later 216i only with six-speed manual and 205/60 R16 baseline tires, with no automatic row at all. This represented 2014 ZF8HP configuration therefore remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 216i exact 2014 launch applicability",
+          "reason": "The checked official 02/2014 BMW F45 launch article lists only 218i, 225i, and 218d in the launch engine set, so it does not close a 2014 launch-state 216i row.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "BMW F45 216i exact represented ZF8HP configuration",
+          "reason": "The checked official 2018 and 2020 BMW sheets publish the later 216i only with six-speed manual and 205/60 R16 baseline tires, with no automatic row at all, so this pass cannot promote the inherited ZF8HP transmission, ratio, or tire placeholders.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "F45 official-source assessment for '216i'",
+          "reason": "Official 03/2014 launch packet excludes 216i. Official 01/2018 and 11/2020 specifications list 216i as six-speed manual only with 205/60 R16. No 8-speed automatic 216i row appears in any saved official F45 source; current row is contradicted across the lifecycle."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-218i-eu-2014-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+      "variant_name": "218i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n7",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.673,
+          "evidence_refs_ref": "e5"
+        },
+        "gear_ratios": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ],
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 4.398,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 3 validation strengthens the contradiction on this exact row with a four-step official BMW ACEA-market chain. The checked 02/2014 and 03/2015 specification PDFs show the 218i Active Tourer with six-speed manual or optional six-speed Steptronic, 205/60 R16 baseline tires, and no eight-speed row. The checked 01/2018 and 11/2020 specification PDFs then show the facelift/late 218i with six-speed manual or optional seven-speed DCT / seven-speed Steptronic with double clutch, again with no eight-speed row, while the same official PDFs explicitly publish Eight-speed Steptronic on 225i xDrive. This represented ZF8HP configuration therefore remains a contradicted advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW 01/2018 specifications PDF / press release with Medium confidence."
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 218i exact eight-speed Steptronic row",
+          "reason": "Checked official BMW 2014, 2015, 2018, and 2020 F45 ACEA-market specification PDFs show the 218i only with six-speed manual plus optional six-speed Steptronic early or optional seven-speed DCT / seven-speed Steptronic with double clutch later, never with eight-speed Steptronic.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW F45 218i exact represented ZF8HP configuration",
+          "reason": "Without any official eight-speed 218i row, this pass cannot promote the inherited transmission, ratio, or tire placeholders for the represented automatic state. The official source chain instead shows an unresolved early six-speed automatic state and a later seven-speed DCT state.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW F45 218i exact automatic switchover from six-speed Steptronic to seven-speed DCT",
+          "reason": "The checked official BMW source chain proves the early 218i automatic as six-speed Steptronic and the facelift/late 218i automatic as seven-speed DCT / seven-speed Steptronic with double clutch, but this pass did not recover the exact official switchover month or model-year boundary between those two supported automatic states.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "F45 official-source assessment for '218i'",
+          "reason": "Official 2014/2015 specifications document 218i as six-speed manual with optional six-speed Steptronic; 01/2018 and 11/2020 LCI specs document 218i as manual with optional seven-speed dual-clutch. No saved official source documents an 8-speed automatic 218i in any F45 year. Current row's transmission claim is contradicted."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-225i-eu-2014-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2014,
+      "production_end_year": 2017,
+      "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+      "variant_name": "225i",
+      "engine_code": "B48A20O0",
+      "engine_name": "B48A20O0 I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n14",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n14",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 8th gear from BMW PressClub T0165875EN/312197 (02/2014 launch spec).",
+          "value": 0.673
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 gear set per BMW PressClub T0165875EN/312197 (02/2014) and T0203608EN/325506 (03/2015).",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 final drive (FWD) per BMW PressClub T0165875EN/312197.",
+          "value": 3.075
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n14",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW 02/2014 and 03/2015 technical-data PDFs consistently list the standard square 205/55 R17 setup for the exact plain F45 225i Active Tourer row.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 8 review narrows the broad unsupported F45 225i row to the exact early plain front-wheel-drive state supported by official BMW launch-era evidence. The checked 02/2014 technical-data PDF publishes a plain 225i Active Tourer row with Eight-speed Steptronic, forward ratios 5.250 / 3.029 / 1.950 / 1.457 / 1.221 / 1.000 / 0.809 / 0.673, final drive 3.075, top speed 240 km/h, and a square 205/55 R17 baseline setup. The official launch article independently states the launch car uses a front-wheel-drive system, the 225i Active Tourer tops the launch range with a standard-fitted eight-speed Steptronic gearbox, and xDrive variants are added later. The checked March 2015 wrapper corroborates that the plain 225i specification attachment still exists in 2015, while the later 11/2014 225i xDrive specification PDF confirms the later all-wheel-drive row must stay separate.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
+            "bmw_pressclub_sources:f45-2014-launch-article",
+            "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
+            "bmw_pressclub_sources:f45-225i-xdrive-2014-spec-pdf"
+          ]
+        },
+        {
+          "note": "Reverse gear ratio (research note): 4.015",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 225i exact optional wheel-package coverage beyond the standard 17-inch setup",
+          "reason": "The checked official BMW 02/2014 and 03/2015 technical-data PDFs close the square 205/55 R17 standard setup for the exact plain F45 225i row, but this pass did not recover a launch-era official optional wheel matrix for the same exact configuration.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
+            "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
+            "bmw_pressclub_sources:f45-2014-launch-article"
+          ]
+        },
+        {
+          "item": "BMW F45 225i exact continuation after the checked March 2015 plain-FWD carryover",
+          "reason": "The checked official BMW source chain proves the plain front-wheel-drive 225i Active Tourer at launch and confirms the same plain-spec attachment still exists in the March 2015 wrapper, but this pass did not recover a later official ACEA-market plain-225i row proving how long that exact front-wheel-drive state persisted before the published 225i xDrive-only material takes over.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f45-2014-launch-article",
+            "bmw_pressclub_sources:f45-225i-2014-spec-pdf",
+            "bmw_pressclub_sources:f45-225i-2015-spec-pdf",
+            "bmw_pressclub_sources:f45-225i-xdrive-2014-spec-pdf"
+          ]
+        },
+        {
+          "item": "F45 official-source assessment for '225i'",
+          "reason": "Official 03/2014 (T0165875EN/312197) and 03/2015 (T0203608EN/325506) specs document plain-FWD 225i with 8-speed Steptronic, top gear 0.673, final drive 3.075, and 205/55 R17 default. Official 01/2018 (T0277458EN/401747) and 11/2020 (T0322634EN/468203) specs document 225i only as 225i xDrive (AWD), not plain-FWD 225i. Therefore the broad 2014-2021 FWD scope is unsupported beyond the 2014-2015 launch slice. Top-gear, final-drive, and default-tire values match official launch evidence; ZF8HP is `official_derived` from BMW's 8-speed Steptronic wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-225xe-eu-2014-6-speed-step-awd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2016,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+      "variant_name": "225xe",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e14",
+        "notes_ref": "n18",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n18",
+        "code": "6-SPEED-STEP",
+        "name": "6-speed Steptronic (Aisin TF-60SN) + electric rear axle",
+        "evidence_refs_ref": "e14"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n19",
+          "value": 0.672,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n20",
+          "value": 3.944,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n8",
+          "value": 3.944
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e15",
+          "notes": "225xe default tyre size not extracted from BMW PressClub T0299792EN/436732 in this run; family_default 205/55 R17 unverified - pending direct PDF text extraction.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Issue #1034 official-source review kept the retained 8-speed family baseline for the non-overridden F45 variants, moved the documented 225xe 6-speed Steptronic ratio pair onto the 225xe variant explicitly, and added an explicit 220i 7-speed dual-clutch override so the documented 220i/225xe transmissions no longer rely on shared gearbox rows. Wave 20 re-check confirms from the official 01/2018 BMW specifications PDF that the exact 220i ACEA-market baseline tire is 205/60 R16 and that BMW publishes overall 7-speed DCT ratio figures in that sheet, but those figures still do not expose a safe standalone final-drive/top-gear mapping. Wave 21 extends the exact official 01/2018 ACEA evidence to the 218i: the same BMW specifications PDF proves the 218i 6-speed manual state with ratios 3.615 / 1.952 / 1.241 / 0.969 / 0.806 / 0.683, reverse 3.538, and baseline 205/60 R16 tires, while the optional 7-speed DCT appears only as overall parenthesized ratios 17.348 / 10.232 / 6.593 / 4.615 / 3.572 / 2.819 / 2.285 with reverse 15.982, still without a safely separable final-drive/top-gear mapping. The 225xe official 07/2019 specifications PDF also confirms the exact 205/55 R17 baseline tire alongside the full 6-speed ratio set, final drive 3.944, and top gear 0.672.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n21"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Remaining non-overridden F45 variant gearbox mapping",
+          "reason": "Issue #1034 made the documented 220i and 225xe transmission mappings explicit, but the other listed variants still inherit the retained family baseline until authoritative variant-specific ratio tables are confirmed.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Official BMW numeric confirmation for the 220i DCT ratio pair",
+          "reason": "BMW official materials confirm the 220i uses the 7-speed dual-clutch Steptronic transmission, but the public PressClub documents retrieved for this fix do not expose an unambiguous final-drive field mapping, so the numeric ratio pair remains backed by reputable secondary references.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Official BMW numeric confirmation for the 218i optional 7-speed DCT ratio pair",
+          "reason": "The official 01/2018 ACEA-market BMW specifications PDF proves the 218i optional 7-speed DCT exists and publishes only overall parenthesized ratios rather than a safely separable final-drive/top-gear mapping, so no exact standalone numeric gearbox override is yet safe for the automatic 218i state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F45 official-source assessment for '225xe'",
+          "reason": "Official BMW PressClub Asia 225xe iPerformance specifications PDF (T0274617EN/394439) and the 2019 update launch article (T0299792EN) plus 2019 spec PDF (T0299792EN/436732) and 11/2020 spec (T0322634EN/468203) all document the 225xe as a plug-in hybrid xDrive with combustion engine driving the front wheels through a six-speed Steptronic and electric motor on the rear axle, with top gear 0.672, final drive 3.944, and 205/55 R17 default tire. None of these saved official sources document a 2014 launch availability; production start at 2014 is unproven. Powertrain/tire values match official evidence; production-year scope remains unresolved."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-218d-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2018,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2018)",
+      "variant_name": "218d",
+      "engine_code": "B47C20",
+      "engine_name": "B47C20 I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n15",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n15",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n19",
+          "value": 0.672,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n20",
+          "value": 3.944,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n15",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 60.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 218d Active Tourer automatic state represented by this narrowed 2018-only row.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 01/2018 specifications PDF now confirms the exact 218d Active Tourer automatic state with front-wheel drive, optional Eight-speed Steptronic wording, bracketed automatic forward ratios 5.519 / 3.184 / 2.050 / 1.492 / 1.235 / 1.000 / 0.801 / 0.673, reverse 4.221, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state because this pass did not recover a year-by-year official source chain proving the same package across the original 2014-2021 span.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 215.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 18\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f45-2018-spec-pdf",
-            "bmw_pressclub_sources:f45-220i-2018-press-kit",
-            "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
-            "bmw_pressclub_sources:f45-225xe-launch-release",
-            "legacy_research_sources:4bcbbab016e3",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b385759b36d8",
-            "legacy_research_sources:ede0bc1c6aee",
-            "secondary_technical_sources:f45-220i-dct-autodata",
-            "secondary_technical_sources:f45-220i-dct-carfolio"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 19\""
+          "note_ref": "n2",
+          "evidence_refs_ref": "e3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 218d exact standalone final-drive value",
+          "reason": "The official BMW 01/2018 specifications PDF closes the bracketed automatic gear ratios for the exact 218d state but does not expose a standalone final-drive field.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW F45 218d exact optional wheel-package coverage beyond the baseline tire",
+          "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 218d automatic state, but this pass did not recover a row-specific optional wheel matrix for the narrowed 2018-only row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "F45 official-source assessment for '218d'",
+          "reason": "Official 01/2018 LCI spec (T0277458EN/401747) supports FWD, optional 8-speed Steptronic, top gear 0.673, and 205/60 R16 default. 11/2020 spec (T0322634EN/468203) documents the same 218d FWD with 8-speed Steptronic, top 0.673, final drive 2.774, and same default tire. Final drive remains unresolved as an exact 2018-only value because the 01/2018 PDF extraction did not surface that line; optional tire matrix is not exhaustively documented."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW 01/2018 specifications PDF now confirms the exact 220i Active Tourer Seven-speed DCT state with front-wheel drive, Seven-speed DCT wording, overall DCT ratios 15.304 / 9.026 / 5.735 / 4.015 / 3.108 / 2.487 / 2.016, reverse 13.825, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state and promotes the exact drivetrain / transmission / baseline-tire evidence while leaving the standalone top-gear and final-drive fields conservative because the official sheet publishes only overall DCT ratios.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
+    {
+      "id": "bmw-f45-220d-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2018,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2018)",
+      "variant_name": "220d",
+      "engine_code": "B47C20",
+      "engine_name": "B47C20 I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n16",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n16",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Aisin AWF8F35 8th gear per BMW PressClub T0277458EN/401747.",
+          "value": 0.673
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Aisin AWF8F35 (diesel calibration) gear set per BMW PressClub T0277458EN/401747.",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 4.398 was a family_default; not directly extracted from BMW PressClub T0277458EN/401747 in this research run.",
+          "value": 4.398,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 220d Active Tourer state represented by this narrowed 2018-only row.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "verification_notes": [
+        {
+          "note": "Official BMW 01/2018 specifications PDF now confirms the exact 220d Active Tourer front-wheel-drive state with Eight-speed Steptronic wording, forward ratios 5.519 / 3.184 / 2.050 / 1.492 / 1.235 / 1.000 / 0.801 / 0.673, reverse 4.221, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state because this pass did not recover a year-by-year official source chain proving the same package across the original 2014-2021 span.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note": "Reverse gear ratio (research note): 4.221",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 220d exact standalone final-drive value",
+          "reason": "The official BMW 01/2018 specifications PDF for the exact 220d Active Tourer publishes the full forward-ratio and reverse-ratio set but does not expose a standalone final-drive field for the front-wheel-drive state.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW F45 220d exact optional wheel-package coverage beyond the baseline tire",
+          "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 220d Active Tourer state, but this pass did not recover a row-specific optional wheel matrix spanning the broader original row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "F45 official-source assessment for '220d'",
+          "reason": "Official 01/2018 LCI spec supports FWD, 8-speed Steptronic, top gear 0.673, and 205/60 R16. 11/2020 spec confirms top 0.673 and final drive 2.774 for 220d. Final drive remains unresolved as an exact 2018-only value; optional tire matrix is not exhaustively documented."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f45-220i-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "Hatchback",
+      "market": "EU",
+      "model_code": "F45",
+      "body_code": "F45",
+      "production_start_year": 2018,
+      "production_end_year": 2021,
+      "model_name": "2 Series Active Tourer (F45, 2018)",
+      "variant_name": "220i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
+          "bmw_pressclub_sources:f45-220i-2018-press-kit",
           "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
+          "bmw_pressclub_sources:f45-2018-spec-pdf",
           "secondary_technical_sources:f45-220i-dct-autodata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F45 220i exact standalone top-gear and final-drive fields",
-        "reason": "The official BMW 01/2018 specifications PDF publishes only overall Seven-speed DCT ratios for the exact 220i automatic state, so this pass cannot safely separate a standalone top-gear or final-drive field from the official source alone.",
+        ],
+        "notes_ref": "n17",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
         "evidence_refs": [
+          "bmw_pressclub_sources:f45-220i-2018-press-kit",
+          "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
           "bmw_pressclub_sources:f45-2018-spec-pdf"
+        ],
+        "notes_ref": "n17",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch Steptronic (Magna 7DCT300)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes": "Retained conservative secondary-backed mapping because the official BMW 01/2018 specifications PDF publishes only overall Seven-speed DCT ratios 15.304 / 9.026 / 5.735 / 4.015 / 3.108 / 2.487 / 2.016 and reverse 13.825, which do not safely separate a standalone top-gear field for the exact 220i automatic state.",
+          "value": 0.698
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.231 was a family_default; not directly extracted from BMW PressClub T0277458EN/401747 in this research run. Auto-data secondary cross-check listed; promotion to official_derived requires direct PDF text extraction.",
+          "value": 3.231,
+          "evidence_refs_ref": "e16"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f45-2018-spec-pdf",
+            "secondary_technical_sources:f45-220i-dct-autodata"
+          ],
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 01/2018 specifications PDF lists 205/60 R16 as the baseline tire for the exact 220i Active Tourer Seven-speed DCT state represented by this narrowed 2018-only row.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 215.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 19\""
+          }
         ]
       },
-      {
-        "item": "BMW F45 220i exact optional wheel-package coverage beyond the baseline tire",
-        "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 220i Seven-speed DCT state, but this pass did not recover a row-specific optional wheel matrix for the narrowed 2018-only row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f45-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "F45 official-source assessment for '220i'",
-        "reason": "Official 01/2018 LCI press kit (T0277458EN) and spec PDF (T0277458EN/401747) document the 220i LCI as FWD with seven-speed dual-clutch Steptronic standard and 205/60 R16 default tire. The official PDF publishes DCT overall-ratio values but the saved extraction did not surface a separated top-gear/final-drive pair. Secondary mirrors (Auto-Data, Carfolio) confirm body/drivetrain/transmission identity but their saved pages have blank ratio cells. Driveshaft order analysis remains disabled until separated top-gear and final-drive values are sourced."
+      "verification_notes": [
+        {
+          "note": "Official BMW 01/2018 specifications PDF now confirms the exact 220i Active Tourer Seven-speed DCT state with front-wheel drive, Seven-speed DCT wording, overall DCT ratios 15.304 / 9.026 / 5.735 / 4.015 / 3.108 / 2.487 / 2.016, reverse 13.825, and 205/60 R16 baseline tires. Production JSON narrows the broad row to the supported 2018-only state and promotes the exact drivetrain / transmission / baseline-tire evidence while leaving the standalone top-gear and final-drive fields conservative because the official sheet publishes only overall DCT ratios.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n21"
+        },
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F45 220i exact standalone top-gear and final-drive fields",
+          "reason": "The official BMW 01/2018 specifications PDF publishes only overall Seven-speed DCT ratios for the exact 220i automatic state, so this pass cannot safely separate a standalone top-gear or final-drive field from the official source alone.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW F45 220i exact optional wheel-package coverage beyond the baseline tire",
+          "reason": "The official BMW 01/2018 specifications PDF closes the 205/60 R16 baseline tire for the exact 220i Seven-speed DCT state, but this pass did not recover a row-specific optional wheel matrix for the narrowed 2018-only row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "F45 official-source assessment for '220i'",
+          "reason": "Official 01/2018 LCI press kit (T0277458EN) and spec PDF (T0277458EN/401747) document the 220i LCI as FWD with seven-speed dual-clutch Steptronic standard and 205/60 R16 default tire. The official PDF publishes DCT overall-ratio values but the saved extraction did not surface a separated top-gear/final-drive pair. Secondary mirrors (Auto-Data, Carfolio) confirm body/drivetrain/transmission identity but their saved pages have blank ratio cells. Driveshaft order analysis remains disabled until separated top-gear and final-drive values are sourced."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/F22.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/F22.json
@@ -1,1952 +1,1484 @@
-[
-  {
-    "id": "bmw-f22-220i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "220i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 220i 6-speed manual RWD. The row spans two engine eras: pre-LCI 2014-2016 with N20B20 (top 0.830 / FD 3.077 per BMW PressClub T0165234EN/250293) and post-LCI 2016 onwards with B48 (top 0.668 / FD 3.385 per T0260233EN/359752). Repo retains a single row covering the full generation; primary ratio values reflect the LCI B48 era because (a) it covers the larger share of production years and (b) the 220i MT6 with B48 was the variant carried into the 2017+ refresh. MT6 was retired before the 2021 packet (T0327248EN/473311 lists 220i automatic-only), so MT6 production_end is approximately 2019. Default tyre 205/55 R16 per both ACEA packets. Transmission code 'GS6-17BG' (Getrag 285) confirmed via sibling F32 420i tech sheet.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
-        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-      ]
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n3": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
+      "n4": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
+      "n6": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
+      "n7": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
+      "n8": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
+      "n9": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "BMW F22 220i 6-speed manual RWD. The row spans two engine eras: pre-LCI 2014-2016 with N20B20 (top 0.830 / FD 3.077 per BMW PressClub T0165234EN/250293) and post-LCI 2016 onwards with B48 (top 0.668 / FD 3.385 per T0260233EN/359752). Repo retains a single row covering the full generation; primary ratio values reflect the LCI B48 era because (a) it covers the larger share of production years and (b) the 220i MT6 with B48 was the variant carried into the 2017+ refresh. MT6 was retired before the 2021 packet (T0327248EN/473311 lists 220i automatic-only), so MT6 production_end is approximately 2019. Default tyre 205/55 R16 per both ACEA packets. Transmission code 'GS6-17BG' (Getrag 285) confirmed via sibling F32 420i tech sheet.",
+      "n15": "BMW F22 220i 8-speed Steptronic (ZF GA8HP45Z) RWD. Era-split: pre-LCI 2014-2016 N20 with 8HP old set (top 0.667 / FD 3.077, T0165234EN/250293) and post-LCI 2016-2021 B48 with 8HP new set (top 0.640 / FD 2.813, T0260233EN/359752 + T0327248EN/473311 confirms 2021 still uses new set). Repo single row holds post-LCI primary values; pre-LCI documented in notes. ZF GA8HP45Z is BMW-published as '8-speed Steptronic'; specific ZF code derived. Default tyre 205/55 R16.",
+      "n16": "Reverse gear ratio (research note): 3.712",
+      "n17": "BMW F22 228i 6-speed manual RWD. The 228i was a narrow EU market (UK + select ACEA) variant only produced 2014-2016 (discontinued at 07/2016 LCI; absent from T0260233EN/359752 facelift packet). production_end_year corrected 2021 -> 2016. Engine N20B20B (180 kW / 245 hp / 350 Nm). Transmission Getrag GS6-17BG. Top gear 0.701 and FD 3.909 per ACEA packet T0179544EN/267610. Default tyre 205/50 R17.",
+      "n18": "BMW F22 228i 8-speed Steptronic (ZF GA8HP45Z) RWD. Production 2014-2016 only. Engine N20B20B. ZF GA8HP45Z old ratio set: [4.714, 3.143, 2.106, 1.667, 1.285, 1.000, 0.839, 0.667], reverse 3.295, FD 3.077 per ACEA T0179544EN/267610 cross-confirmed via sibling F32 428i 2013 launch packet. Default tyre 205/50 R17.",
+      "n19": "BMW F22 230i 6-speed manual RWD. CRITICAL DATE FIX: 230i first appears in the 07/2016 LCI packet (T0260233EN/359752); it did not exist in 2014. production_start_year corrected 2014 -> 2016. MT6 is absent from the 2021 packet (T0327248EN/473311 lists 230i automatic-only); MT6 production_end approx 2019. Engine B48 (high-output tune). Top gear 0.677 / FD 3.909 per LCI ACEA packet. Default tyre 205/50 R17.",
+      "n20": "BMW F22 230i 8-speed Steptronic (ZF GA8HP45Z) RWD. DATE FIX: 230i started 07/2016 (LCI), not 2014. Production through 2021 confirmed by T0327248EN/473311. Engine B48 high-output tune. ZF GA8HP45Z new ratio set: [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, FD 2.813 per T0260233EN/359752 + T0327248EN/473311. Default tyre 205/50 R17."
     },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 220i 6-speed manual RWD. The row spans two engine eras: pre-LCI 2014-2016 with N20B20 (top 0.830 / FD 3.077 per BMW PressClub T0165234EN/250293) and post-LCI 2016 onwards with B48 (top 0.668 / FD 3.385 per T0260233EN/359752). Repo retains a single row covering the full generation; primary ratio values reflect the LCI B48 era because (a) it covers the larger share of production years and (b) the 220i MT6 with B48 was the variant carried into the 2017+ refresh. MT6 was retired before the 2021 packet (T0327248EN/473311 lists 220i automatic-only), so MT6 production_end is approximately 2019. Default tyre 205/55 R16 per both ACEA packets. Transmission code 'GS6-17BG' (Getrag 285) confirmed via sibling F32 420i tech sheet.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
-        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Post-LCI B48 era 6th gear from BMW PressClub T0260233EN/359752; pre-LCI N20 era was 0.830 (T0165234EN/250293) - era-split documented in row notes.",
-        "value": 0.668,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Post-LCI B48 final drive from T0260233EN/359752; pre-LCI N20 era was 3.077.",
-        "value": 3.385,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ],
-        "notes": "Standard 220i tyre 205/55 R16 per both pre-LCI and post-LCI ACEA tech-data PDFs. Repo placeholder 225/40 R18 was a Sport-trim option, not the catalogue baseline.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '220i' across 2014-2021",
-        "reason": "Broad 2014-2021 220i MT6 row spans at least two distinct exact technical states: 03/2014 ACEA packet (T0165234EN/250293) shows MT6 with top gear 0.830, final drive 3.077, standard 205/55 R16, and 270 Nm; 07/2016 ACEA packet (T0260233EN/359752) shows the B48 220i MT6 with top gear 0.668, final drive 3.385, standard 205/55 R16, and 290 Nm. The 2021 packet (T0327248EN/473311) is automatic-only, so broad MT6 continuity to 2021 is unsupported. Default tire 225/40 R18 is contradicted by official 205/55 R16 standard."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-220i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "220i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 220i 8-speed Steptronic (ZF GA8HP45Z) RWD. Era-split: pre-LCI 2014-2016 N20 with 8HP old set (top 0.667 / FD 3.077, T0165234EN/250293) and post-LCI 2016-2021 B48 with 8HP new set (top 0.640 / FD 2.813, T0260233EN/359752 + T0327248EN/473311 confirms 2021 still uses new set). Repo single row holds post-LCI primary values; pre-LCI documented in notes. ZF GA8HP45Z is BMW-published as '8-speed Steptronic'; specific ZF code derived. Default tyre 205/55 R16.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1af3f514e4a4",
+        "legacy_research_sources:224120e311f3",
+        "legacy_research_sources:60f36b6f8878",
+        "legacy_research_sources:7e0213853a41",
+        "legacy_research_sources:95b9bf2bf0cf"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
+      ],
+      "e4": [
         "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
         "bmw_pressclub_sources:f22-2021-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 220i 8-speed Steptronic (ZF GA8HP45Z) RWD. Era-split: pre-LCI 2014-2016 N20 with 8HP old set (top 0.667 / FD 3.077, T0165234EN/250293) and post-LCI 2016-2021 B48 with 8HP new set (top 0.640 / FD 2.813, T0260233EN/359752 + T0327248EN/473311 confirms 2021 still uses new set). Repo single row holds post-LCI primary values; pre-LCI documented in notes. ZF GA8HP45Z is BMW-published as '8-speed Steptronic'; specific ZF code derived. Default tyre 205/55 R16.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP45Z)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
+      ],
+      "e5": [
+        "bmw_pressclub_sources:f22-2014-spec-article",
         "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
         "bmw_pressclub_sources:f22-2021-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Post-LCI B48 ZF GA8HP45Z new ratio set 8th gear; pre-LCI N20 era was 0.667 (old set).",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Post-LCI ZF GA8HP45Z final drive; pre-LCI was 3.077.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ],
-        "notes": "Post-LCI ZF GA8HP45Z new ratio set per F22 2016 ACEA packet, cross-confirmed via sibling F32 2016 packet. Pre-LCI old set was [4.714, 3.143, 2.106, 1.667, 1.285, 1.000, 0.839, 0.667]."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ],
-        "notes": "Standard 220i tyre 205/55 R16 per ACEA packets. Repo placeholder 225/40 R18 was an option.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '220i' across 2014-2021",
-        "reason": "Broad 2014-2021 220i 8-speed Steptronic row spans three official exact states with different ratio/final-drive sets: 03/2014 (top 0.667, FD 3.077), 07/2016 (top 0.640, FD 2.813), 03/2021 (top 0.640, FD 2.813). One row cannot be exact across this span. Default tire 225/40 R18 is contradicted; official standard is 205/55 R16. ZF8HP transmission code is `official_derived` because BMW publishes only `8-speed Steptronic` wording, not the supplier code."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-228i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "228i",
-    "engine_code": "B48B20",
-    "engine_name": "B48B20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 228i 6-speed manual RWD. The 228i was a narrow EU market (UK + select ACEA) variant only produced 2014-2016 (discontinued at 07/2016 LCI; absent from T0260233EN/359752 facelift packet). production_end_year corrected 2021 -> 2016. Engine N20B20B (180 kW / 245 hp / 350 Nm). Transmission Getrag GS6-17BG. Top gear 0.701 and FD 3.909 per ACEA packet T0179544EN/267610. Default tyre 205/50 R17.",
-      "value": "RWD",
-      "evidence_refs": [
+      ],
+      "e6": [
         "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 228i 6-speed manual RWD. The 228i was a narrow EU market (UK + select ACEA) variant only produced 2014-2016 (discontinued at 07/2016 LCI; absent from T0260233EN/359752 facelift packet). production_end_year corrected 2021 -> 2016. Engine N20B20B (180 kW / 245 hp / 350 Nm). Transmission Getrag GS6-17BG. Top gear 0.701 and FD 3.909 per ACEA packet T0179544EN/267610. Default tyre 205/50 R17.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "BMW PressClub T0179544EN/267610 (07/2014 ACEA F22 228i tech-data PDF).",
-        "value": 0.701,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "BMW PressClub T0179544EN/267610.",
-        "value": 3.909,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-        ],
-        "notes": "Standard 228i tyre 205/50 R17 per ACEA packet T0179544EN/267610.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Follow-up official BMW packet review still does not recover any EU F22 228i row. The saved 03/2014 launch article anchors 220i and M235i petrol launch material, the saved 07/2016 packet publishes the later 220i, 230i, and M240i lineup, and the saved 03/2021 packet still shows only 220i and 230i. This row should therefore be treated as an unsupported EU placeholder, not as a verified 2014-2021 configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F22 228i exact EU applicability within the recovered official packet set",
-        "reason": "The saved official BMW launch, facelift, and late-cycle packets recover 220i, 230i, and M235i/M240i states but do not recover an EU 228i row, so this stored EU placeholder remains unsupported.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe replacement for the unsupported F22 228i EU manual row",
-        "reason": "This pass proves the stored EU 228i manual row is not backed by the recovered official packet sequence, but it does not prove whether the right fix is deletion, market narrowing, or a broader petrol-row refactor.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '228i' across 2014-2021",
-        "reason": "Official 07/2014 ACEA 228i packet (T0179544EN/267610) supports MT6 with 180 kW/245 hp, 350 Nm, top gear 0.701, final drive 3.909, and standard 205/50 R17. No saved official source supports 228i continuity into 2021; the 2016/2021 packets do not include 228i. Broad 2014-2021 row should be narrowed; default 225/40 R18 contradicted."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-228i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "228i",
-    "engine_code": "B48B20",
-    "engine_name": "B48B20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 228i 8-speed Steptronic (ZF GA8HP45Z) RWD. Production 2014-2016 only. Engine N20B20B. ZF GA8HP45Z old ratio set: [4.714, 3.143, 2.106, 1.667, 1.285, 1.000, 0.839, 0.667], reverse 3.295, FD 3.077 per ACEA T0179544EN/267610 cross-confirmed via sibling F32 428i 2013 launch packet. Default tyre 205/50 R17.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 228i 8-speed Steptronic (ZF GA8HP45Z) RWD. Production 2014-2016 only. Engine N20B20B. ZF GA8HP45Z old ratio set: [4.714, 3.143, 2.106, 1.667, 1.285, 1.000, 0.839, 0.667], reverse 3.295, FD 3.077 per ACEA T0179544EN/267610 cross-confirmed via sibling F32 428i 2013 launch packet. Default tyre 205/50 R17.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP45Z)",
-      "evidence_refs": [
+      ],
+      "e7": [
+        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
+      ],
+      "e8": [
         "bmw_pressclub_sources:f22-2014-228i-spec-pdf",
         "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "ZF GA8HP45Z old set 8th gear.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf",
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "ZF GA8HP45Z final drive (old set).",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf",
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf",
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ],
-        "notes": "ZF GA8HP45Z old (pre-2016 facelift) ratio set per F22 228i ACEA packet T0179544EN/267610 cross-confirmed via F32 428i 2013 launch packet."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf"
-        ],
-        "notes": "Standard 228i tyre 205/50 R17.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Follow-up official BMW packet review still does not recover any EU F22 228i row. The saved 03/2014 launch article anchors 220i and M235i petrol launch material, the saved 07/2016 packet publishes the later 220i, 230i, and M240i lineup, and the saved 03/2021 packet still shows only 220i and 230i. This stored automatic row should therefore be treated as an unsupported EU placeholder, not as a verified 2014-2021 configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.295",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-228i-spec-pdf",
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F22 228i exact EU applicability within the recovered official packet set",
-        "reason": "The saved official BMW launch, facelift, and late-cycle packets recover 220i, 230i, and M235i/M240i states but do not recover an EU 228i row, so this stored EU placeholder remains unsupported.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe replacement for the unsupported F22 228i EU automatic row",
-        "reason": "This pass proves the stored EU 228i automatic row is not backed by the recovered official packet sequence, but it does not prove whether the right fix is deletion, market narrowing, or a broader petrol-row refactor.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '228i' across 2014-2021",
-        "reason": "Official 07/2014 228i packet supports the optional 8-speed Steptronic with top gear 0.667, final drive 3.077, and standard 205/50 R17. No saved official source documents 228i continuity past the 07/2014 ACEA window. Broad 2014-2021 span is unsupported; default 225/40 R18 contradicted; ZF8HP code is `official_derived`."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-230i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2016,
-    "production_end_year": 2019,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "230i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 230i 6-speed manual RWD. CRITICAL DATE FIX: 230i first appears in the 07/2016 LCI packet (T0260233EN/359752); it did not exist in 2014. production_start_year corrected 2014 -> 2016. MT6 is absent from the 2021 packet (T0327248EN/473311 lists 230i automatic-only); MT6 production_end approx 2019. Engine B48 (high-output tune). Top gear 0.677 / FD 3.909 per LCI ACEA packet. Default tyre 205/50 R17.",
-      "value": "RWD",
-      "evidence_refs": [
+      ],
+      "e9": [
+        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
+        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
+        "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f22-2014-220i-spec-pdf",
         "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
         "bmw_pressclub_sources:f22-2021-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 230i 6-speed manual RWD. CRITICAL DATE FIX: 230i first appears in the 07/2016 LCI packet (T0260233EN/359752); it did not exist in 2014. production_start_year corrected 2014 -> 2016. MT6 is absent from the 2021 packet (T0327248EN/473311 lists 230i automatic-only); MT6 production_end approx 2019. Engine B48 (high-output tune). Top gear 0.677 / FD 3.909 per LCI ACEA packet. Default tyre 205/50 R17.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)",
-      "evidence_refs": [
+      ],
+      "e12": [
+        "bmw_pressclub_sources:f22-2014-spec-article",
         "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "BMW PressClub T0260233EN/359752 (07/2016 F22 LCI 230i tech-data).",
-        "value": 0.677,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "BMW PressClub T0260233EN/359752.",
-        "value": 3.909,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ],
-        "notes": "Standard 230i tyre 205/50 R17 per LCI ACEA packet.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW packet review shows that the F22 230i appears only in the recovered 07/2016 facelift technical-data packet, not in the 03/2014 launch packet, and the recovered 03/2021 packet keeps 230i only as a late automatic state. This broad 2014-2021 manual row therefore mixes a too-early start year with a later manual state that does not span the stored range.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F22 230i exact EU start-year applicability",
-        "reason": "The recovered official BMW packet sequence first supports 230i in the 07/2016 facelift packet rather than in the stored 2014 start year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe split between later F22 230i manual and late-cycle automatic-only states",
-        "reason": "The saved 07/2016 packet publishes 230i as manual with optional eight-speed automatic, while the saved 03/2021 packet keeps 230i only as a later automatic state, so the broad 2014-2021 manual row is not one exact production-safe configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '230i' across 2014-2021",
-        "reason": "230i MT6 is not supported as a 2014 launch row: the official 230i packet (T0260233EN/359752) starts in 07/2016 with MT6, top gear 0.677, final drive 3.909, standard 205/50 R17, and 252 hp. The 2021 packet (T0327248EN/473311) is automatic-only, so manual continuity to 2021 is unsupported. Production start year should be 2016 if the row is retained, and end year for MT6 is unresolved. Default 225/40 R18 contradicted by official 205/50 R17 standard."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f22-230i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2016,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "230i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW F22 230i 8-speed Steptronic (ZF GA8HP45Z) RWD. DATE FIX: 230i started 07/2016 (LCI), not 2014. Production through 2021 confirmed by T0327248EN/473311. Engine B48 high-output tune. ZF GA8HP45Z new ratio set: [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, FD 2.813 per T0260233EN/359752 + T0327248EN/473311. Default tyre 205/50 R17.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-        "bmw_pressclub_sources:f22-2021-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "BMW F22 230i 8-speed Steptronic (ZF GA8HP45Z) RWD. DATE FIX: 230i started 07/2016 (LCI), not 2014. Production through 2021 confirmed by T0327248EN/473311. Engine B48 high-output tune. ZF GA8HP45Z new ratio set: [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, FD 2.813 per T0260233EN/359752 + T0327248EN/473311. Default tyre 205/50 R17.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP45Z)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-        "bmw_pressclub_sources:f22-2021-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "bmw-f22-220i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "220i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "notes": "ZF GA8HP45Z new set 8th gear.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
+        "notes_ref": "n14",
+        "value": "RWD",
+        "evidence_refs_ref": "e9"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "ZF GA8HP45Z new final drive.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n14",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)",
+        "evidence_refs_ref": "e9"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ],
-        "notes": "ZF GA8HP45Z new (post-2016) ratio set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ],
-        "notes": "Standard 230i tyre 205/50 R17.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "Post-LCI B48 era 6th gear from BMW PressClub T0260233EN/359752; pre-LCI N20 era was 0.830 (T0165234EN/250293) - era-split documented in row notes.",
+          "value": 0.668,
+          "evidence_refs_ref": "e7"
         },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "Post-LCI B48 final drive from T0260233EN/359752; pre-LCI N20 era was 3.077.",
+          "value": 3.385,
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW packet review shows that the F22 230i appears only in the recovered 07/2016 facelift technical-data packet, not in the 03/2014 launch packet, and the recovered 03/2021 packet keeps 230i as a later automatic-only state. This broad 2014-2021 automatic row therefore remains a mixed-era placeholder rather than one exact production-safe automatic configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F22 230i exact EU start-year applicability",
-        "reason": "The recovered official BMW packet sequence first supports 230i in the 07/2016 facelift packet rather than in the stored 2014 start year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2014-spec-article",
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf"
-        ]
-      },
-      {
-        "item": "Schema-safe split between later F22 230i automatic states across facelift and late-cycle packets",
-        "reason": "The saved 07/2016 packet publishes 230i as manual with optional eight-speed automatic, while the saved 03/2021 packet keeps 230i only as a later automatic state, so the broad 2014-2021 automatic row is not one exact production-safe configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f22-2016-220i-230i-spec-pdf",
-          "bmw_pressclub_sources:f22-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "F22 broad-row continuity issues for '230i' across 2014-2021",
-        "reason": "230i 8-speed Steptronic is not supported as a 2014 launch row: 07/2016 ACEA packet supports top gear 0.640, final drive 2.813, standard 205/50 R17; 03/2021 packet (8-speed Steptronic Sport) supports the same top gear/final drive and standard 205/50 R17. Production start year should be 2016 if the row is retained. Default 225/40 R18 contradicted; ZF8HP code is `official_derived`."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-m2-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "M2",
-    "engine_code": "B58B30O0",
-    "engine_name": "B58B30O0 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch). The BMW M2 is chassis F87, NOT F22. Per BMW PressClub T0238042EN/368917 (M2 2016 launch tech-data PDF), the M2 launched in 2016 (not 2014) with engine N55B30T0 (NOT B58 as the repo row claims). Default tyres are staggered 245/35 ZR19 front + 265/35 ZR19 rear. This row's chassis placement, engine code, and start year are all wrong. The variant should be re-homed to a dedicated F87 shard. Drivetrain, transmission, ratios, and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Standard 220i tyre 205/55 R16 per both pre-LCI and post-LCI ACEA tech-data PDFs. Repo placeholder 225/40 R18 was a Sport-trim option, not the catalogue baseline.",
           "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Variant 'M2' contradicted by official BMW PressClub evidence",
-        "reason": "Official BMW PressClub article (T0238042EN) and 2016 press kit (T0238042EN/368917) document the M2 Coupe as F87 (not F22), launched in 2016 with the N55-era 272 kW/370 hp 3.0L straight-six, MT6 standard. Current row places M2 in F22 with 2014 start year and B58 engine; both metadata facts are contradicted. Marked no_confidence pending shard relocation to F87."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-m2-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "M2",
-    "engine_code": "B58B30O0",
-    "engine_name": "B58B30O0 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (triple-mismatch). The BMW M2 is chassis F87 not F22; launched 2016 not 2014; engine N55B30T0 not B58. Furthermore the M2 automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0238042EN/368917. Row should be re-homed to F87 shard with corrected gearbox.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-2016-launch-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Variant 'M2' contradicted by official BMW PressClub evidence",
-        "reason": "Official BMW PressClub M2 launch press kit confirms the optional automatic for the M2 Coupe is a 7-speed M Double Clutch Transmission with Drivelogic (M-DCT/DCT7), not ZF8HP. The launch model is also F87, not F22. Current row's transmission code and shard placement are contradicted. Marked no_confidence pending replacement with an F87 DCT7 row."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-m2-competition-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "M2 Competition",
-    "engine_code": "S55B30T0",
-    "engine_name": "S55B30T0 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW (chassis-mismatch + year-error). The BMW M2 Competition is chassis F87 not F22; launched 2018 not 2014. Engine S55B30T0 (carried over from F80 M3 / F82 M4) is correct, but chassis placement and start year are wrong. Per BMW PressClub T0279885EN/415275. Default tyres staggered 245/35 ZR19 front + 265/35 ZR19 rear. Row should be re-homed to F87 shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Variant 'M2 Competition' contradicted by official BMW PressClub evidence",
-        "reason": "Official BMW PressClub M2 Competition article (T0279885EN) and 2018 technical-data PDF (415275) document the M2 Competition as F87, 2018-era, S55-family 2979 cc 302 kW/410 hp, with standard 245/35 ZR19 front and 265/35 ZR19 rear. Current row's 2014 start, F22 placement, and inherited 18-inch default are contradicted. Marked no_confidence pending shard relocation to F87."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f22-m2-competition-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F22",
-    "body_code": "F22",
-    "production_start_year": 2014,
-    "production_end_year": 2021,
-    "model_name": "2 Series Coupe (F22, 2014-2021)",
-    "variant_name": "M2 Competition",
-    "engine_code": "S55B30T0",
-    "engine_name": "S55B30T0 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '220i' across 2014-2021",
+          "reason": "Broad 2014-2021 220i MT6 row spans at least two distinct exact technical states: 03/2014 ACEA packet (T0165234EN/250293) shows MT6 with top gear 0.830, final drive 3.077, standard 205/55 R16, and 270 Nm; 07/2016 ACEA packet (T0260233EN/359752) shows the B48 220i MT6 with top gear 0.668, final drive 3.385, standard 205/55 R16, and 290 Nm. The 2021 packet (T0327248EN/473311) is automatic-only, so broad MT6 continuity to 2021 is unsupported. Default tire 225/40 R18 is contradicted by official 205/55 R16 standard."
+        }
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. M2 Competition is F87 not F22; launched 2018 not 2014. The automatic option is M-DCT 7 (Getrag GS7D36BG / 7DCI600), NOT ZF GA8HP45Z. ZF8HP was never offered in M2/M2C. Per BMW PressClub T0279885EN/415275.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f22-220i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "220i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n15",
+        "value": "RWD",
+        "evidence_refs_ref": "e11"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n15",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP45Z)",
+        "evidence_refs_ref": "e11"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "Post-LCI B48 ZF GA8HP45Z new ratio set 8th gear; pre-LCI N20 era was 0.667 (old set).",
+          "value": 0.64,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "Post-LCI ZF GA8HP45Z final drive; pre-LCI was 3.077.",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "evidence_refs_ref": "e10",
+          "notes": "Post-LCI ZF GA8HP45Z new ratio set per F22 2016 ACEA packet, cross-confirmed via sibling F32 2016 packet. Pre-LCI old set was [4.714, 3.143, 2.106, 1.667, 1.285, 1.000, 0.839, 0.667]."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Standard 220i tyre 205/55 R16 per ACEA packets. Repo placeholder 225/40 R18 was an option.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 55.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '220i' across 2014-2021",
+          "reason": "Broad 2014-2021 220i 8-speed Steptronic row spans three official exact states with different ratio/final-drive sets: 03/2014 (top 0.667, FD 3.077), 07/2016 (top 0.640, FD 2.813), 03/2021 (top 0.640, FD 2.813). One row cannot be exact across this span. Default tire 225/40 R18 is contradicted; official standard is 205/55 R16. ZF8HP transmission code is `official_derived` because BMW publishes only `8-speed Steptronic` wording, not the supplier code."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f22-228i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "228i",
+      "engine_code": "B48B20",
+      "engine_name": "B48B20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n17",
+        "value": "RWD",
+        "evidence_refs_ref": "e6"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n17",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)",
+        "evidence_refs_ref": "e6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "BMW PressClub T0179544EN/267610 (07/2014 ACEA F22 228i tech-data PDF).",
+          "value": 0.701,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "BMW PressClub T0179544EN/267610.",
+          "value": 3.909,
+          "evidence_refs_ref": "e6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Standard 228i tyre 205/50 R17 per ACEA packet T0179544EN/267610.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Follow-up official BMW packet review still does not recover any EU F22 228i row. The saved 03/2014 launch article anchors 220i and M235i petrol launch material, the saved 07/2016 packet publishes the later 220i, 230i, and M240i lineup, and the saved 03/2021 packet still shows only 220i and 230i. This row should therefore be treated as an unsupported EU placeholder, not as a verified 2014-2021 configuration.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F22 228i exact EU applicability within the recovered official packet set",
+          "reason": "The saved official BMW launch, facelift, and late-cycle packets recover 220i, 230i, and M235i/M240i states but do not recover an EU 228i row, so this stored EU placeholder remains unsupported.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Schema-safe replacement for the unsupported F22 228i EU manual row",
+          "reason": "This pass proves the stored EU 228i manual row is not backed by the recovered official packet sequence, but it does not prove whether the right fix is deletion, market narrowing, or a broader petrol-row refactor.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '228i' across 2014-2021",
+          "reason": "Official 07/2014 ACEA 228i packet (T0179544EN/267610) supports MT6 with 180 kW/245 hp, 350 Nm, top gear 0.701, final drive 3.909, and standard 205/50 R17. No saved official source supports 228i continuity into 2021; the 2016/2021 packets do not include 228i. Broad 2014-2021 row should be narrowed; default 225/40 R18 contradicted."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f22-228i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "228i",
+      "engine_code": "B48B20",
+      "engine_name": "B48B20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n18",
+        "value": "RWD",
+        "evidence_refs_ref": "e6"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n18",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP45Z)",
+        "evidence_refs_ref": "e8"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "ZF GA8HP45Z old set 8th gear.",
+          "value": 0.667,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "ZF GA8HP45Z final drive (old set).",
+          "value": 3.077,
+          "evidence_refs_ref": "e8"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ],
+          "evidence_refs_ref": "e8",
+          "notes": "ZF GA8HP45Z old (pre-2016 facelift) ratio set per F22 228i ACEA packet T0179544EN/267610 cross-confirmed via F32 428i 2013 launch packet."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Standard 228i tyre 205/50 R17.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Follow-up official BMW packet review still does not recover any EU F22 228i row. The saved 03/2014 launch article anchors 220i and M235i petrol launch material, the saved 07/2016 packet publishes the later 220i, 230i, and M240i lineup, and the saved 03/2021 packet still shows only 220i and 230i. This stored automatic row should therefore be treated as an unsupported EU placeholder, not as a verified 2014-2021 configuration.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note": "Reverse gear ratio (research note): 3.295",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F22 228i exact EU applicability within the recovered official packet set",
+          "reason": "The saved official BMW launch, facelift, and late-cycle packets recover 220i, 230i, and M235i/M240i states but do not recover an EU 228i row, so this stored EU placeholder remains unsupported.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Schema-safe replacement for the unsupported F22 228i EU automatic row",
+          "reason": "This pass proves the stored EU 228i automatic row is not backed by the recovered official packet sequence, but it does not prove whether the right fix is deletion, market narrowing, or a broader petrol-row refactor.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '228i' across 2014-2021",
+          "reason": "Official 07/2014 228i packet supports the optional 8-speed Steptronic with top gear 0.667, final drive 3.077, and standard 205/50 R17. No saved official source documents 228i continuity past the 07/2014 ACEA window. Broad 2014-2021 span is unsupported; default 225/40 R18 contradicted; ZF8HP code is `official_derived`."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f22-230i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2016,
+      "production_end_year": 2019,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "230i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n19",
+        "value": "RWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n19",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)",
+        "evidence_refs_ref": "e7"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "BMW PressClub T0260233EN/359752 (07/2016 F22 LCI 230i tech-data).",
+          "value": 0.677,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "BMW PressClub T0260233EN/359752.",
+          "value": 3.909,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Standard 230i tyre 205/50 R17 per LCI ACEA packet.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW packet review shows that the F22 230i appears only in the recovered 07/2016 facelift technical-data packet, not in the 03/2014 launch packet, and the recovered 03/2021 packet keeps 230i only as a late automatic state. This broad 2014-2021 manual row therefore mixes a too-early start year with a later manual state that does not span the stored range.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F22 230i exact EU start-year applicability",
+          "reason": "The recovered official BMW packet sequence first supports 230i in the 07/2016 facelift packet rather than in the stored 2014 start year.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Schema-safe split between later F22 230i manual and late-cycle automatic-only states",
+          "reason": "The saved 07/2016 packet publishes 230i as manual with optional eight-speed automatic, while the saved 03/2021 packet keeps 230i only as a later automatic state, so the broad 2014-2021 manual row is not one exact production-safe configuration.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '230i' across 2014-2021",
+          "reason": "230i MT6 is not supported as a 2014 launch row: the official 230i packet (T0260233EN/359752) starts in 07/2016 with MT6, top gear 0.677, final drive 3.909, standard 205/50 R17, and 252 hp. The 2021 packet (T0327248EN/473311) is automatic-only, so manual continuity to 2021 is unsupported. Production start year should be 2016 if the row is retained, and end year for MT6 is unresolved. Default 225/40 R18 contradicted by official 205/50 R17 standard."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f22-230i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2016,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "230i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n20",
+        "value": "RWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n20",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP45Z)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "ZF GA8HP45Z new set 8th gear.",
+          "value": 0.64,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "ZF GA8HP45Z new final drive.",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e10",
+          "notes": "ZF GA8HP45Z new (post-2016) ratio set."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Standard 230i tyre 205/50 R17.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW packet review shows that the F22 230i appears only in the recovered 07/2016 facelift technical-data packet, not in the 03/2014 launch packet, and the recovered 03/2021 packet keeps 230i as a later automatic-only state. This broad 2014-2021 automatic row therefore remains a mixed-era placeholder rather than one exact production-safe automatic configuration.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F22 230i exact EU start-year applicability",
+          "reason": "The recovered official BMW packet sequence first supports 230i in the 07/2016 facelift packet rather than in the stored 2014 start year.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Schema-safe split between later F22 230i automatic states across facelift and late-cycle packets",
+          "reason": "The saved 07/2016 packet publishes 230i as manual with optional eight-speed automatic, while the saved 03/2021 packet keeps 230i only as a later automatic state, so the broad 2014-2021 automatic row is not one exact production-safe configuration.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "F22 broad-row continuity issues for '230i' across 2014-2021",
+          "reason": "230i 8-speed Steptronic is not supported as a 2014 launch row: 07/2016 ACEA packet supports top gear 0.640, final drive 2.813, standard 205/50 R17; 03/2021 packet (8-speed Steptronic Sport) supports the same top gear/final drive and standard 205/50 R17. Production start year should be 2016 if the row is retained. Default 225/40 R18 contradicted; ZF8HP code is `official_derived`."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f22-m2-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "M2",
+      "engine_code": "B58B30O0",
+      "engine_name": "B58B30O0 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "value": "RWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n5",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n5",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1af3f514e4a4",
-            "legacy_research_sources:224120e311f3",
-            "legacy_research_sources:60f36b6f8878",
-            "legacy_research_sources:7e0213853a41",
-            "legacy_research_sources:95b9bf2bf0cf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant 'M2' contradicted by official BMW PressClub evidence",
+          "reason": "Official BMW PressClub article (T0238042EN) and 2016 press kit (T0238042EN/368917) document the M2 Coupe as F87 (not F22), launched in 2016 with the N55-era 272 kW/370 hp 3.0L straight-six, MT6 standard. Current row places M2 in F22 with 2014 start year and B58 engine; both metadata facts are contradicted. Marked no_confidence pending shard relocation to F87."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: accessible official BMW sources in this environment did not provide retrievable F22 technical ratio tables, and secondary sources were insufficient to override existing values without guessing.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
+    {
+      "id": "bmw-f22-m2-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "M2",
+      "engine_code": "B58B30O0",
+      "engine_name": "B58B30O0 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "value": "RWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f87-m2-competition-2018-launch-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant 'M2' contradicted by official BMW PressClub evidence",
+          "reason": "Official BMW PressClub M2 launch press kit confirms the optional automatic for the M2 Coupe is a 7-speed M Double Clutch Transmission with Drivelogic (M-DCT/DCT7), not ZF8HP. The launch model is also F87, not F22. Current row's transmission code and shard placement are contradicted. Marked no_confidence pending replacement with an F87 DCT7 row."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
-        "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
+    },
+    {
+      "id": "bmw-f22-m2-competition-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "M2 Competition",
+      "engine_code": "S55B30T0",
+      "engine_name": "S55B30T0 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "value": "RWD",
+        "evidence_refs_ref": "e3"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n7",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 0.812,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n7",
+          "value": 3.231,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
-        "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
-        "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:1af3f514e4a4",
-          "legacy_research_sources:224120e311f3",
-          "legacy_research_sources:60f36b6f8878",
-          "legacy_research_sources:7e0213853a41",
-          "legacy_research_sources:95b9bf2bf0cf"
-        ]
-      },
-      {
-        "item": "Variant 'M2 Competition' contradicted by official BMW PressClub evidence",
-        "reason": "Same official M2 Competition technical-data PDF documents the optional automatic as 7-speed M DCT, not ZF8HP. Shard placement and transmission family are contradicted. Marked no_confidence pending replacement with an F87 DCT7 row."
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant 'M2 Competition' contradicted by official BMW PressClub evidence",
+          "reason": "Official BMW PressClub M2 Competition article (T0279885EN) and 2018 technical-data PDF (415275) document the M2 Competition as F87, 2018-era, S55-family 2979 cc 302 kW/410 hp, with standard 245/35 ZR19 front and 265/35 ZR19 rear. Current row's 2014 start, F22 placement, and inherited 18-inch default are contradicted. Marked no_confidence pending shard relocation to F87."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "bmw-f22-m2-competition-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F22",
+      "body_code": "F22",
+      "production_start_year": 2014,
+      "production_end_year": 2021,
+      "model_name": "2 Series Coupe (F22, 2014-2021)",
+      "variant_name": "M2 Competition",
+      "engine_code": "S55B30T0",
+      "engine_name": "S55B30T0 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n8",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 0.667,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU F22 variant matrix with drivetrain split (RWD vs xDrive) for 220i/230i/M240i",
+          "reason": "Could not retrieve an official EU F22 technical brochure/spec table in this environment to confirm exact market mapping without ambiguity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Transmission-specific final drive ratios for EU F22 manual/automatic by variant",
+          "reason": "No accessible official source with verifiable ratio tables was obtained; existing values retained per no-guess rule.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Top-gear ratio confirmation by gearbox subtype across EU F22 production years",
+          "reason": "Available sources did not provide directly retrievable official ratio breakdowns for F22 in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant 'M2 Competition' contradicted by official BMW PressClub evidence",
+          "reason": "Same official M2 Competition technical-data PDF documents the optional automatic as 7-speed M DCT, not ZF8HP. Shard placement and transmission family are contradicted. Marked no_confidence pending replacement with an F87 DCT7 row."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/G42.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/G42.json
@@ -1,932 +1,665 @@
-[
-  {
-    "id": "bmw-g42-220i-eu-2022-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G42",
-    "body_code": "G42",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "2 Series Coupe (G42, 2022-2026)",
-    "variant_name": "220i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_market_pages:g42-2-series-price-list-2024",
         "bmw_market_pages:g42-2-series-price-list-current",
         "bmw_market_pages:g42-2-series-technical-data-de",
+        "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
+        "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
+        "legacy_research_sources:27089d2ed61a",
+        "legacy_research_sources:69757924a78e",
+        "legacy_research_sources:95b9bf2bf0cf",
         "legacy_research_sources:d5fc03e7d5f3",
+        "legacy_research_sources:f8299c41e459",
         "legacy_research_sources:fb0ad8a77215"
       ],
-      "notes": "The official BMW launch technical-data PDF and linked Germany market sources already used in this row resolve the exact G42 220i as a rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e2": [
         "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
       ],
-      "notes": "The official BMW technical-data PDF for the exact G42 220i explicitly lists an Eight-speed Steptronic transmission for this launch-state rear-wheel-drive configuration.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW technical-data PDF for the exact G42 220i publishes eighth gear as 0.640.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW technical-data PDF for the exact G42 220i publishes the full forward-ratio set 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW technical-data PDF for the exact G42 220i publishes a single rear final-drive ratio of 2.813.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW technical-data PDF for the exact G42 220i publishes 225/50 R17 as the launch-standard tire size.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Official BMW Germany 2024 and current price lists list 225/45 R18 as the exact standard square wheel/tire package for the current 230i M Sport state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered sport 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of the official BMW G42 220i technical-data PDF confirms the launch-state row values already carried here: rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and 225/50 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Current-market continuity of the launch-state G42 220i mechanical package across the retained 2022-2026 row span",
-        "reason": "This pass directly revalidated the official launch technical-data PDF for the exact 220i row but did not reopen every later market-year continuity source behind the retained 2022-2026 production span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g42-230i-eu-2022-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G42",
-    "body_code": "G42",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "2 Series Coupe (G42, 2022-2026)",
-    "variant_name": "230i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
+        "bmw_market_pages:g42-2-series-price-list-2024",
+        "bmw_market_pages:g42-2-series-price-list-current",
+        "bmw_market_pages:g42-2-series-technical-data-de",
+        "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
+        "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
+        "legacy_research_sources:27089d2ed61a",
+        "legacy_research_sources:69757924a78e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:d5fc03e7d5f3",
+        "legacy_research_sources:fb0ad8a77215"
+      ],
+      "e4": [
+        "bmw_market_pages:g42-2-series-price-list-2024",
         "bmw_market_pages:g42-2-series-price-list-current",
         "bmw_market_pages:g42-2-series-technical-data-de",
         "legacy_research_sources:d5fc03e7d5f3",
         "legacy_research_sources:fb0ad8a77215"
       ],
-      "notes": "The official BMW 07/2021 launch press kit says the G42 four-cylinder lineup is rear-wheel drive and that the 230i joins that rear-drive core in summer 2022, while the current BMW Germany technical-data page and price list surface 230i Coupé M Sport separately from M240i xDrive.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
+      "e5": [
+        "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf"
+      ],
+      "e6": [
         "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
         "bmw_market_pages:g42-2-series-price-list-2024",
+        "bmw_market_pages:g42-2-series-price-list-current",
+        "bmw_market_pages:g42-2-series-technical-data-de"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
         "bmw_market_pages:g42-2-series-price-list-current",
         "bmw_market_pages:g42-2-series-technical-data-de",
         "legacy_research_sources:d5fc03e7d5f3"
-      ],
-      "notes": "Checked official BMW 03/2022 technical-data PDF lists Eight-speed Steptronic transmission for the exact 230i Coupé launch state, while the 2024/current BMW Germany price lists and current technical-data page surface the later 230i M Sport as 8-Gang Steptronic Sport. The repo keeps ZF8HP as the normalized gearbox-family mapping because the checked official BMW sources do not publish a subtype code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf"
-        ],
-        "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists 0.640 as the 8th-gear ratio. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
-        "value": 0.64
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g42-220i-eu-2022-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G42",
+      "body_code": "G42",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "2 Series Coupe (G42, 2022-2026)",
+      "variant_name": "220i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW launch technical-data PDF and linked Germany market sources already used in this row resolve the exact G42 220i as a rear-wheel-drive configuration.",
+        "value": "RWD"
       },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf"
-        ],
-        "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW technical-data PDF for the exact G42 220i explicitly lists an Eight-speed Steptronic transmission for this launch-state rear-wheel-drive configuration.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf"
-        ],
-        "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists 2.813 as the final-drive ratio. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:f8299c41e459",
-          "legacy_research_sources:fb0ad8a77215"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW technical-data PDF for the exact G42 220i publishes eighth gear as 0.640.",
+          "value": 0.64
         },
-        "default_axle_for_speed": "rear"
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW technical-data PDF for the exact G42 220i publishes the full forward-ratio set 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW technical-data PDF for the exact G42 220i publishes a single rear final-drive ratio of 2.813.",
+          "value": 2.813
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW technical-data PDF for the exact G42 220i publishes 225/50 R17 as the launch-standard tire size.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "Official BMW Germany 2024 and current price lists list 225/45 R18 as the exact standard square wheel/tire package for the current 230i M Sport state.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered sport 19\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price lists with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\""
+          "note": "Direct validation of the official BMW G42 220i technical-data PDF confirms the launch-state row values already carried here: rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and 225/50 R17 baseline tires.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 3 validation closes the exact launch-era numeric mapping for the G42 230i row. The official BMW PressClub article and 03/2022 230i Coupé technical-data PDF valid for ACEA markets prove the exact row starts from 03/2022 with rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and a 225/50 R17 launch-standard tire. The checked BMW Germany technical-data page plus the 2024/current price lists confirm that 230i remains a rear-wheel-drive automatic state in later German-market material, but they also show the current 230i M Sport standard tire moved to 225/45 R18 and use Steptronic Sport wording. The row therefore promotes the exact launch ratio package while leaving full-span tire continuity and public gearbox-subtype naming unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-article",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G42 230i production-data applicability across the full 2022-2026 row span",
-        "reason": "The checked official 03/2022 technical-data PDF and the 2024/current BMW Germany material prove exact launch and later 230i rear-wheel-drive automatic states, but this pass did not recover one year-by-year chain proving one unchanged mapping across the full represented row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de"
-        ]
-      },
-      {
-        "item": "BMW G42 230i exact default tire across the represented 2022-2026 row span",
-        "reason": "The checked official 03/2022 technical-data PDF shows a launch-standard 225/50 R17 tire, while the checked 2024 and current BMW Germany price lists show later 230i M Sport standard 225/45 R18 tires plus staggered 18-inch and 19-inch options. The current single default-tire field therefore should not be treated as one exact full-span mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de"
-        ]
-      },
-      {
-        "item": "BMW G42 230i exact public gearbox subtype and trim-specific transmission wording",
-        "reason": "The checked official BMW sources prove launch-era Eight-speed Steptronic wording and later 230i M Sport Steptronic Sport wording, but they do not publish a gearbox subtype code such as ZF8HP or one single public transmission label that applies unchanged across the represented row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g42-230i-xdrive-eu-2022-mt6-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G42",
-    "body_code": "G42",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "2 Series Coupe (G42, 2022-2026)",
-    "variant_name": "230i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_market_pages:g42-2-series-price-list-2024",
-        "bmw_market_pages:g42-2-series-price-list-current",
-        "bmw_market_pages:g42-2-series-technical-data-de",
-        "legacy_research_sources:d5fc03e7d5f3",
-        "legacy_research_sources:fb0ad8a77215"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
+      "unresolved": [
+        {
+          "item": "Current-market continuity of the launch-state G42 220i mechanical package across the retained 2022-2026 row span",
+          "reason": "This pass directly revalidated the official launch technical-data PDF for the exact 220i row but did not reopen every later market-year continuity source behind the retained 2022-2026 production span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
+    {
+      "id": "bmw-g42-230i-eu-2022-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G42",
+      "body_code": "G42",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "2 Series Coupe (G42, 2022-2026)",
+      "variant_name": "230i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
           "bmw_market_pages:g42-2-series-price-list-current",
           "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
           "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:f8299c41e459",
           "legacy_research_sources:fb0ad8a77215"
         ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes": "The official BMW 07/2021 launch press kit says the G42 four-cylinder lineup is rear-wheel drive and that the 230i joins that rear-drive core in summer 2022, while the current BMW Germany technical-data page and price list surface 230i Coupé M Sport separately from M240i xDrive.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
+          "bmw_market_pages:g42-2-series-price-list-2024",
+          "bmw_market_pages:g42-2-series-price-list-current",
+          "bmw_market_pages:g42-2-series-technical-data-de",
+          "legacy_research_sources:d5fc03e7d5f3"
+        ],
+        "notes": "Checked official BMW 03/2022 technical-data PDF lists Eight-speed Steptronic transmission for the exact 230i Coupé launch state, while the 2024/current BMW Germany price lists and current technical-data page surface the later 230i M Sport as 8-Gang Steptronic Sport. The repo keeps ZF8HP as the normalized gearbox-family mapping because the checked official BMW sources do not publish a subtype code.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists 0.640 as the 8th-gear ratio. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes": "Checked official BMW 03/2022 technical-data PDF for the exact 230i Coupé launch state lists 2.813 as the final-drive ratio. Applied as official-derived evidence while full 2022-2026 continuity remains unresolved.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 3 validation closes the exact launch-era numeric mapping for the G42 230i row. The official BMW PressClub article and 03/2022 230i Coupé technical-data PDF valid for ACEA markets prove the exact row starts from 03/2022 with rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and a 225/50 R17 launch-standard tire. The checked BMW Germany technical-data page plus the 2024/current price lists confirm that 230i remains a rear-wheel-drive automatic state in later German-market material, but they also show the current 230i M Sport standard tire moved to 225/45 R18 and use Steptronic Sport wording. The row therefore promotes the exact launch ratio package while leaving full-span tire continuity and public gearbox-subtype naming unresolved.",
           "evidence_refs": [
+            "bmw_pressclub_sources:g42-230i-2022-tech-spec-article",
+            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
             "bmw_market_pages:g42-2-series-price-list-2024",
             "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+            "bmw_market_pages:g42-2-series-technical-data-de"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G42 230i production-data applicability across the full 2022-2026 row span",
+          "reason": "The checked official 03/2022 technical-data PDF and the 2024/current BMW Germany material prove exact launch and later 230i rear-wheel-drive automatic states, but this pass did not recover one year-by-year chain proving one unchanged mapping across the full represented row span.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW G42 230i exact default tire across the represented 2022-2026 row span",
+          "reason": "The checked official 03/2022 technical-data PDF shows a launch-standard 225/50 R17 tire, while the checked 2024 and current BMW Germany price lists show later 230i M Sport standard 225/45 R18 tires plus staggered 18-inch and 19-inch options. The current single default-tire field therefore should not be treated as one exact full-span mapping.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW G42 230i exact public gearbox subtype and trim-specific transmission wording",
+          "reason": "The checked official BMW sources prove launch-era Eight-speed Steptronic wording and later 230i M Sport Steptronic Sport wording, but they do not publish a gearbox subtype code such as ZF8HP or one single public transmission label that applies unchanged across the represented row span.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g42-230i-xdrive-eu-2022-mt6-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G42",
+      "body_code": "G42",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "2 Series Coupe (G42, 2022-2026)",
+      "variant_name": "230i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Wave 11 validation sharpened the official Germany/EU picture for the G42 230i target: the current BMW Germany technical-data page and the checked 2024/2025 Germany price lists list 230i as rear-wheel drive with 8-Gang automatic/Steptronic Sport wording, while the 07/2021 official launch press kit describes the four-cylinder models as rear-wheel drive and reserves xDrive for M240i xDrive. Wave 12 validation recovered exact 220i Coupé evidence, and Wave 13 now does the same for 230i: the official 03/2022 BMW technical-data PDF valid for ACEA markets provides rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and a 225/50 R17 launch-standard tire, while the checked Germany technical-data page and 2024/current price lists confirm the current automatic-only RWD 230i context plus 18/19-inch wheel options. That is sufficient for a variant-scoped 230i production override and exact-row update. Wave 13 also adds exact launch-ratio evidence for M240i xDrive plus current Germany market/tire context, but that variant remains source-ledger-only because the public current-market material is already a later 48V state and this pass did not recover one current exact ratio table proving one unchanged 2022-2026 package.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 11 validation sharpened the official Germany/EU picture for the G42 230i target: the current BMW Germany technical-data page and the checked 2024/2025 Germany price lists list 230i as rear-wheel drive with 8-Gang automatic/Steptronic Sport wording, while the 07/2021 official launch press kit describes the four-cylinder models as rear-wheel drive and reserves xDrive for M240i xDrive. Wave 12 validation recovered exact 220i Coupé evidence, and Wave 13 now does the same for 230i: the official 03/2022 BMW technical-data PDF valid for ACEA markets provides rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and a 225/50 R17 launch-standard tire, while the checked Germany technical-data page and 2024/current price lists confirm the current automatic-only RWD 230i context plus 18/19-inch wheel options. That is sufficient for a variant-scoped 230i production override and exact-row update. Wave 13 also adds exact launch-ratio evidence for M240i xDrive plus current Germany market/tire context, but that variant remains source-ledger-only because the public current-market material is already a later 48V state and this pass did not recover one current exact ratio table proving one unchanged 2022-2026 package.",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:fb0ad8a77215"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether BMW 230i xDrive belongs in the G42 row at all",
-        "reason": "Checked official BMW Germany/EU sources now consistently show 230i as rear-wheel drive and reserve xDrive for M240i xDrive, but this pass did not recover enough official non-Germany market evidence to prove whether the existing AWD 230i variant is an intentional non-EU/global carry-over or simply unsupported library data.",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:fb0ad8a77215"
-        ]
-      },
-      {
-        "item": "BMW M240i xDrive production-data applicability across the full G42 row span",
-        "reason": "Wave 13 now proves the exact launch M240i xDrive ratio set, reverse ratio 3.712, final drive 2.813, and standard staggered 225/40 R19 front + 255/35 R19 rear tires, but the checked current Germany market material is already a later 48V mild-hybrid state and this pass did not recover a current exact numeric ratio table proving one unchanged 2022-2026 package.",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:fb0ad8a77215"
-        ]
-      },
-      {
-        "item": "BMW M240i xDrive exact optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the launch standard 19-inch staggered fitment plus current Germany 18/19-inch options and automatic context, but they do not publish a gearbox subtype code beyond Steptronic wording or one current exact numeric table that closes the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:fb0ad8a77215"
-        ]
-      },
-      {
-        "item": "EU applicability of the existing '6-speed manual' gearbox entry across 2022-2026 range",
-        "reason": "Checked official BMW Germany/EU launch and current-market material now resolves the visible 220i and 230i petrol lineup as automatic-only, but this pass still did not recover one official market-by-market transmission matrix proving when, where, or whether the retained broad-row 6-speed manual entry applies.",
-        "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:fb0ad8a77215"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g42-230i-xdrive-eu-2022-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G42",
-    "body_code": "G42",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "2 Series Coupe (G42, 2022-2026)",
-    "variant_name": "230i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-        "bmw_market_pages:g42-2-series-price-list-current",
-        "bmw_market_pages:g42-2-series-technical-data-de",
-        "legacy_research_sources:d5fc03e7d5f3",
-        "legacy_research_sources:fb0ad8a77215"
       ],
-      "notes": "Checked official BMW 03/2022 230i technical-data material and current Germany market pages now make this exact EU AWD row unsupported rather than confirmed: BMW presents the G42 230i as a rear-drive four-cylinder model with 8-speed automatic, while current Germany market material reserves xDrive for M240i xDrive, so this inherited AWD value is retained only as an advisory placeholder pending exact non-EU proof or row cleanup.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 2.813
+      "unresolved": [
+        {
+          "item": "Whether BMW 230i xDrive belongs in the G42 row at all",
+          "reason": "Checked official BMW Germany/EU sources now consistently show 230i as rear-wheel drive and reserve xDrive for M240i xDrive, but this pass did not recover enough official non-Germany market evidence to prove whether the existing AWD 230i variant is an intentional non-EU/global carry-over or simply unsupported library data.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW M240i xDrive production-data applicability across the full G42 row span",
+          "reason": "Wave 13 now proves the exact launch M240i xDrive ratio set, reverse ratio 3.712, final drive 2.813, and standard staggered 225/40 R19 front + 255/35 R19 rear tires, but the checked current Germany market material is already a later 48V mild-hybrid state and this pass did not recover a current exact numeric ratio table proving one unchanged 2022-2026 package.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW M240i xDrive exact optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the launch standard 19-inch staggered fitment plus current Germany 18/19-inch options and automatic context, but they do not publish a gearbox subtype code beyond Steptronic wording or one current exact numeric table that closes the full represented row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "EU applicability of the existing '6-speed manual' gearbox entry across 2022-2026 range",
+          "reason": "Checked official BMW Germany/EU launch and current-market material now resolves the visible 220i and 230i petrol lineup as automatic-only, but this pass still did not recover one official market-by-market transmission matrix proving when, where, or whether the retained broad-row 6-speed manual entry applies.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
+    {
+      "id": "bmw-g42-230i-xdrive-eu-2022-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G42",
+      "body_code": "G42",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "2 Series Coupe (G42, 2022-2026)",
+      "variant_name": "230i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
         "evidence_refs": [
-          "bmw_market_pages:g42-2-series-price-list-2024",
+          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
           "bmw_market_pages:g42-2-series-price-list-current",
           "bmw_market_pages:g42-2-series-technical-data-de",
-          "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "legacy_research_sources:27089d2ed61a",
-          "legacy_research_sources:69757924a78e",
-          "legacy_research_sources:95b9bf2bf0cf",
           "legacy_research_sources:d5fc03e7d5f3",
-          "legacy_research_sources:f8299c41e459",
           "legacy_research_sources:fb0ad8a77215"
         ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes": "Checked official BMW 03/2022 230i technical-data material and current Germany market pages now make this exact EU AWD row unsupported rather than confirmed: BMW presents the G42 230i as a rear-drive four-cylinder model with 8-speed automatic, while current Germany market material reserves xDrive for M240i xDrive, so this inherited AWD value is retained only as an advisory placeholder pending exact non-EU proof or row cleanup.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g42-2-series-price-list-2024",
-            "bmw_market_pages:g42-2-series-price-list-current",
-            "bmw_market_pages:g42-2-series-technical-data-de",
-            "bmw_pressclub_sources:g42-220i-2021-tech-spec-pdf",
-            "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-            "legacy_research_sources:27089d2ed61a",
-            "legacy_research_sources:69757924a78e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:d5fc03e7d5f3",
-            "legacy_research_sources:f8299c41e459",
-            "legacy_research_sources:fb0ad8a77215"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This pass directly revalidated that the checked official BMW Europe-facing material does not support an exact EU-market G42 230i xDrive row: the 03/2022 exact 230i technical-data sheet publishes the 230i as a rear-wheel-drive 8-speed automatic state with final drive 2.813, the current BMW Germany technical-data page still separates 230i Coupé M Sport from M240i xDrive, and the current Germany price list lists 230i M Sport apart from M240i xDrive. The current AWD 230i row is therefore retained only as an unsupported advisory reference pending exact market-proof or a row cleanup decision.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "legacy_research_sources:d5fc03e7d5f3"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 230i xDrive exact EU-market existence and production span",
-        "reason": "The checked official BMW 03/2022 230i sheet and current Germany market material support 230i as a rear-drive trim and reserve xDrive for M240i xDrive, so this pass did not recover exact OEM proof that an EU-market 230i xDrive row exists at all.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "legacy_research_sources:d5fc03e7d5f3"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "item": "BMW 230i xDrive row cleanup versus likely trim leakage or mis-targeted market mapping",
-        "reason": "Because the checked official BMW sources point to rear-drive 230i with an exact 03/2022 ratio package and separate M240i xDrive instead, this row should not receive guessed AWD drivetrain, transmission, ratio, or wheel promotions without an exact official source proving a true 230i xDrive market variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g42-230i-2022-tech-spec-pdf",
-          "bmw_market_pages:g42-2-series-price-list-current",
-          "bmw_market_pages:g42-2-series-technical-data-de",
-          "legacy_research_sources:d5fc03e7d5f3"
-        ]
+      "verification_notes": [
+        {
+          "note": "This pass directly revalidated that the checked official BMW Europe-facing material does not support an exact EU-market G42 230i xDrive row: the 03/2022 exact 230i technical-data sheet publishes the 230i as a rear-wheel-drive 8-speed automatic state with final drive 2.813, the current BMW Germany technical-data page still separates 230i Coupé M Sport from M240i xDrive, and the current Germany price list lists 230i M Sport apart from M240i xDrive. The current AWD 230i row is therefore retained only as an unsupported advisory reference pending exact market-proof or a row cleanup decision.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 230i xDrive exact EU-market existence and production span",
+          "reason": "The checked official BMW 03/2022 230i sheet and current Germany market material support 230i as a rear-drive trim and reserve xDrive for M240i xDrive, so this pass did not recover exact OEM proof that an EU-market 230i xDrive row exists at all.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW 230i xDrive row cleanup versus likely trim leakage or mis-targeted market mapping",
+          "reason": "Because the checked official BMW sources point to rear-drive 230i with an exact 03/2022 ratio package and separate M240i xDrive instead, this row should not receive guessed AWD drivetrain, transmission, ratio, or wheel promotions without an exact official source proving a true 230i xDrive market variant.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/F30.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/F30.json
@@ -1,1657 +1,1127 @@
-[
-  {
-    "id": "bmw-f30-320i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "320i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n4": "F30 standard base tyre 225/45 R18.",
+      "n5": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "Final drive 3.231 was family_default; 330i xDrive specific FD not directly extracted from PressClub PDF in this run.",
+      "n7": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "Final drive 3.077 family_default; 330i xDrive 8AT specific FD not directly extracted.",
+      "n9": "Stored value inherited from 4-cyl GS6-45BZ family_default; the 340i uses Getrag GS6X53DZ (different ratios). Direct PressClub PDF extraction needed."
     },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 320i MT6 RWD with stored engine code B48. The B48 engine entered F30 production at the LCI changeover in mid-2015 - it was NOT used in the pre-LCI 320i (which used the N20). production_start_year corrected from 2012 to 2015. Transmission is the Getrag/ZF GS6-45BZ 6-speed manual. Per Wikipedia F30 article, 6th-gear 0.812 and final drive 3.231 are the expected values for the GS6-45BZ in 320i applications, but no BMW PressClub spec PDF was directly extracted in this research run; values held at reputable_secondary.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-45BZ)",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1594dc9b0d47",
+        "legacy_research_sources:1c24f5312261",
+        "legacy_research_sources:28b59b0b3030",
+        "legacy_research_sources:32e8742ffbf1",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:ec4f691f5393",
+        "legacy_research_sources:f576994a4890"
+      ],
+      "e2": [
         "secondary_technical_sources:bmw-f30-3series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Getrag GS6-45BZ 6th-gear ratio per Wikipedia F30 manual transmission listing.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Final drive 3.231 typical for F30 320i MT6 (GS6-45BZ); held at reputable_secondary - no BMW PressClub spec PDF directly extracted.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18 (option packs: Sport Line 235/40 R19, M Sport 245/35 R20). Cross-checked against Wikipedia F30 article.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '320i'",
-        "reason": "F30 320i MT6 broad 2012-2019 row spans two engine generations: pre-LCI 320i used the N20 (1997 cc) per the 03/2012 launch press kit (T0122586EN) and 03/2012 update PDF (T0124299EN); LCI 320i used the B48 (1998 cc) per 05/2015 specs (T0234765EN). Current row asserts B48 across the entire span; pre-LCI N20 years are unsupported. Driveshaft and wheel-order analysis disabled until row is split."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-320i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "320i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 320i 8AT RWD with stored engine code B48 (LCI-only). production_start_year corrected from 2012 to 2015. Transmission is ZF 8HP45 (4-cylinder petrol variant of the 8HP family). LCI-era 8HP45 8th-gear ratio is 0.640 (NOT the legacy 0.667 which was the older first-generation 8HP70 value, inherited as family_default). Final drive 3.077 is consistent with secondary cross-checks for B48 8HP45 RWD; held at reputable_secondary.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP45)",
-      "evidence_refs": [
+      "e3": [
         "secondary_technical_sources:bmw-f30-3series-wikipedia",
         "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48 applications. The legacy family_default 0.667 reflects the older first-generation 8HP70 - LCI 8HP45/8HP50 use 0.640.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Final drive 3.077 consistent with B48 8HP45 in 320i applications; reputable_secondary - no BMW PressClub spec PDF directly extracted.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '320i'",
-        "reason": "Same pre-LCI N20 vs LCI B48 split across the broad 2012-2019 320i 8-speed Steptronic row. Per BMW PressClub launch press kit and 2015 specs, ratios and final drives change between pre-LCI and LCI states. ZF8HP transmission code is `official_derived` from BMW's 'Eight-speed Steptronic' wording, not the supplier code. Saved artifacts: launch press kit (T0122586EN, March 2012), 03/2012 update (T0124299EN), 05/2015 specs (T0234765EN), F30 LCI brochure mirror, BMW UK 01/2014 price-list mirror."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-330i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "330i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      ],
+      "e4": [
         "legacy_research_sources:28b59b0b3030",
         "legacy_research_sources:ec4f691f5393"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): The F30 330i nameplate is LCI-only - it was introduced mid-2015 as the replacement for the 328i. production_start_year corrected from 2012 to 2015. Engine B48 (185 kW / 248 hp tune). Transmission Getrag GS6-45BZ 6-speed manual. The pairing 330i + B48 + MT6 + RWD is a real production state for 2015-2019; per-gear and final-drive values not directly extracted from a BMW PressClub spec PDF in this research run, so ratios remain at their stored values but with the configuration year corrected.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-45BZ)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "GS6-45BZ 6th gear value 0.812 retained from family_default; Wikipedia F30 confirms GS6-45BZ as the 4-cyl manual but does not publish the 330i-specific ratio. Reputable_secondary pending PressClub PDF extraction.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.231 was a family_default; 330i may use a different FD than the 320i (BMW typically gives higher-output variants slightly different FDs). No PressClub PDF directly extracted; held at no_confidence pending direct verification.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '330i'",
-        "reason": "F30 330i MT6 was introduced with the F30 LCI in mid-2015 (per 05/2015 specs T0234765EN), not at the 2012 launch. Pre-LCI 320i/328i are documented in the 03/2012 launch press kit (T0122586EN); 330i does not appear there. Production start at 2012 is contradicted; the 330i launch state begins in 2015."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f30-330i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "330i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 330i is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Transmission ZF 8HP45 (4-cyl petrol). 8th-gear corrected from family_default 0.667 to LCI-era 0.640 (the 0.667 reflected the older first-gen 8HP70). Final drive value 3.077 may differ for the 330i (BMW sometimes uses 2.813 for higher-output 4-cyl autos); held at no_confidence pending direct PressClub PDF extraction.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP45)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia",
-        "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48 applications.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
+  "configurations": [
+    {
+      "id": "bmw-f30-320i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "320i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.077 was a family_default; 330i 8AT may use a different FD than the 320i 8AT. No PressClub PDF directly extracted; held at no_confidence pending direct verification.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
+      "transmission": {
         "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
+        "notes": "Sonnet redo (2026-04 v2): F30 320i MT6 RWD with stored engine code B48. The B48 engine entered F30 production at the LCI changeover in mid-2015 - it was NOT used in the pre-LCI 320i (which used the N20). production_start_year corrected from 2012 to 2015. Transmission is the Getrag/ZF GS6-45BZ 6-speed manual. Per Wikipedia F30 article, 6th-gear 0.812 and final drive 3.231 are the expected values for the GS6-45BZ in 320i applications, but no BMW PressClub spec PDF was directly extracted in this research run; values held at reputable_secondary.",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-45BZ)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Getrag GS6-45BZ 6th-gear ratio per Wikipedia F30 manual transmission listing.",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Final drive 3.231 typical for F30 320i MT6 (GS6-45BZ); held at reputable_secondary - no BMW PressClub spec PDF directly extracted.",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes": "F30 standard base tyre 225/45 R18 (option packs: Sport Line 235/40 R19, M Sport 245/35 R20). Cross-checked against Wikipedia F30 article.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '330i'",
-        "reason": "Same 2012 vs 2015 contradiction. 330i 8-speed Steptronic appears in the 05/2015 LCI specs (T0234765EN) and F30 LCI brochure mirror; not present in the 03/2012 launch press kit. Production start at 2012 unsupported; ZF8HP code is `official_derived`."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-330i-xdrive-eu-2012-mt6-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "330i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 330i xDrive is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. AWD via ATC 350 transfer case with Getrag GS6-45BZ 6-speed manual. Per-gear ratio value retained from family_default; FD values held at no_confidence pending direct PressClub PDF extraction.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-45BZ)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "GS6-45BZ 6th-gear 0.812 from family_default; Wikipedia confirms GS6-45BZ for 4-cyl manual.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.231 was family_default; 330i xDrive specific FD not directly extracted from PressClub PDF in this run.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.231 was family_default; 330i xDrive specific FD not directly extracted from PressClub PDF in this run.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '320i'",
+          "reason": "F30 320i MT6 broad 2012-2019 row spans two engine generations: pre-LCI 320i used the N20 (1997 cc) per the 03/2012 launch press kit (T0122586EN) and 03/2012 update PDF (T0124299EN); LCI 320i used the B48 (1998 cc) per 05/2015 specs (T0234765EN). Current row asserts B48 across the entire span; pre-LCI N20 years are unsupported. Driveshaft and wheel-order analysis disabled until row is split."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f30-320i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "320i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 320i 8AT RWD with stored engine code B48 (LCI-only). production_start_year corrected from 2012 to 2015. Transmission is ZF 8HP45 (4-cylinder petrol variant of the 8HP family). LCI-era 8HP45 8th-gear ratio is 0.640 (NOT the legacy 0.667 which was the older first-generation 8HP70 value, inherited as family_default). Final drive 3.077 is consistent with secondary cross-checks for B48 8HP45 RWD; held at reputable_secondary.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP45)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48 applications. The legacy family_default 0.667 reflects the older first-generation 8HP70 - LCI 8HP45/8HP50 use 0.640.",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Final drive 3.077 consistent with B48 8HP45 in 320i applications; reputable_secondary - no BMW PressClub spec PDF directly extracted.",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '330i xDrive'",
-        "reason": "Same LCI introduction issue: 330i xDrive is an LCI-era model. Pre-LCI 328i xDrive existed but the 330i nameplate begins with LCI per the 05/2015 specs and LCI brochure. Production start at 2012 is contradicted."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-330i-xdrive-eu-2012-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "330i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 330i xDrive 8AT is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. AWD via ATC 350 + ZF 8HP45 (4-cyl). 8th-gear corrected to LCI-era 0.640. FD values held at no_confidence pending direct PressClub PDF extraction.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP45)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia",
-        "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.077 family_default; 330i xDrive 8AT specific FD not directly extracted.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.077 family_default; 330i xDrive 8AT specific FD not directly extracted.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '320i'",
+          "reason": "Same pre-LCI N20 vs LCI B48 split across the broad 2012-2019 320i 8-speed Steptronic row. Per BMW PressClub launch press kit and 2015 specs, ratios and final drives change between pre-LCI and LCI states. ZF8HP transmission code is `official_derived` from BMW's 'Eight-speed Steptronic' wording, not the supplier code. Saved artifacts: launch press kit (T0122586EN, March 2012), 03/2012 update (T0124299EN), 05/2015 specs (T0234765EN), F30 LCI brochure mirror, BMW UK 01/2014 price-list mirror."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f30-330i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "330i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): The F30 330i nameplate is LCI-only - it was introduced mid-2015 as the replacement for the 328i. production_start_year corrected from 2012 to 2015. Engine B48 (185 kW / 248 hp tune). Transmission Getrag GS6-45BZ 6-speed manual. The pairing 330i + B48 + MT6 + RWD is a real production state for 2015-2019; per-gear and final-drive values not directly extracted from a BMW PressClub spec PDF in this research run, so ratios remain at their stored values but with the configuration year corrected.",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-45BZ)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "GS6-45BZ 6th gear value 0.812 retained from family_default; Wikipedia F30 confirms GS6-45BZ as the 4-cyl manual but does not publish the 330i-specific ratio. Reputable_secondary pending PressClub PDF extraction.",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.231 was a family_default; 330i may use a different FD than the 320i (BMW typically gives higher-output variants slightly different FDs). No PressClub PDF directly extracted; held at no_confidence pending direct verification.",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '330i xDrive'",
-        "reason": "Same LCI introduction issue. 330i xDrive 8-speed Steptronic is documented from 05/2015 onward; ZF8HP code is `official_derived` from BMW wording."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-340i-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "340i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 340i is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Engine B58 (240 kW). Transmission is Getrag GS6X53DZ 6-speed manual (the 6-cylinder petrol manual gearbox - NOT the GS6-45BZ used for 4-cyl). transmission.name corrected. Stored 6th-gear 0.812 and FD 3.231 are inherited from the 4-cyl GS6-45BZ family default and are NOT applicable to the GS6X53DZ - the 6-cyl manual uses different ratios (typically 6th approximately 0.756, FD approximately 3.154). Held at no_confidence pending direct PressClub PDF extraction.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6X53DZ)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Stored value inherited from 4-cyl GS6-45BZ family_default; the 340i uses Getrag GS6X53DZ (different ratios). Direct PressClub PDF extraction needed.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Stored value inherited from 4-cyl GS6-45BZ family_default; the 340i uses Getrag GS6X53DZ (different ratios). Direct PressClub PDF extraction needed.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '330i'",
+          "reason": "F30 330i MT6 was introduced with the F30 LCI in mid-2015 (per 05/2015 specs T0234765EN), not at the 2012 launch. Pre-LCI 320i/328i are documented in the 03/2012 launch press kit (T0122586EN); 330i does not appear there. Production start at 2012 is contradicted; the 330i launch state begins in 2015."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f30-330i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "330i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 330i is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Transmission ZF 8HP45 (4-cyl petrol). 8th-gear corrected from family_default 0.667 to LCI-era 0.640 (the 0.667 reflected the older first-gen 8HP70). Final drive value 3.077 may differ for the 330i (BMW sometimes uses 2.813 for higher-output 4-cyl autos); held at no_confidence pending direct PressClub PDF extraction.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP45)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48 applications.",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.077 was a family_default; 330i 8AT may use a different FD than the 320i 8AT. No PressClub PDF directly extracted; held at no_confidence pending direct verification.",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '340i'",
-        "reason": "F30 340i was introduced with the LCI in mid-2015 (B58 engine), replacing the pre-LCI 335i (N55). Per 05/2015 specs (T0234765EN) and LCI brochure, 340i begins in 2015. The 2012 launch press kit lists 335i, not 340i. Production start at 2012 is contradicted."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f30-340i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F30",
-    "body_code": "F30",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "3 Series (F30, 2012-2019)",
-    "variant_name": "340i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:28b59b0b3030",
-        "legacy_research_sources:ec4f691f5393"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): F30 340i 8AT is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Engine B58. Transmission is ZF 8HP50 (the 6-cylinder petrol variant of the 8HP family - NOT the 8HP45 used for 4-cyl). transmission.name corrected. 8th-gear corrected from family_default 0.667 to ZF 8HP50 LCI value 0.640. Stored FD 3.077 is the 4-cyl 8HP45 value; the 6-cyl 8HP50 in F30 typically uses FD 2.813. Held at no_confidence pending direct PressClub PDF extraction.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP50)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f30-3series-wikipedia",
-        "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "ZF 8HP50 8th-gear ratio (LCI-era 6-cyl petrol).",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Final drive 3.077 inherited from 4-cyl 8HP45 family_default; the 340i 8HP50 typically uses FD around 2.813. No direct PressClub PDF extraction; held at no_confidence.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '330i'",
+          "reason": "Same 2012 vs 2015 contradiction. 330i 8-speed Steptronic appears in the 05/2015 LCI specs (T0234765EN) and F30 LCI brochure mirror; not present in the 03/2012 launch press kit. Production start at 2012 unsupported; ZF8HP code is `official_derived`."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ],
-        "notes": "F30 standard base tyre 225/45 R18.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f30-330i-xdrive-eu-2012-mt6-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "330i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 330i xDrive is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. AWD via ATC 350 transfer case with Getrag GS6-45BZ 6-speed manual. Per-gear ratio value retained from family_default; FD values held at no_confidence pending direct PressClub PDF extraction.",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-45BZ)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "GS6-45BZ 6th-gear 0.812 from family_default; Wikipedia confirms GS6-45BZ for 4-cyl manual.",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1594dc9b0d47",
-            "legacy_research_sources:1c24f5312261",
-            "legacy_research_sources:28b59b0b3030",
-            "legacy_research_sources:32e8742ffbf1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:ec4f691f5393",
-            "legacy_research_sources:f576994a4890"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '330i xDrive'",
+          "reason": "Same LCI introduction issue: 330i xDrive is an LCI-era model. Pre-LCI 328i xDrive existed but the 330i nameplate begins with LCI per the 05/2015 specs and LCI brochure. Production start at 2012 is contradicted."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official BMW EU-accessible sources confirmed transmission/drivetrain concepts but did not provide unambiguous final-drive/top-gear values for the exact 320i/330i/330i xDrive/340i F30 set in this entry.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
+    {
+      "id": "bmw-f30-330i-xdrive-eu-2012-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "330i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 330i xDrive 8AT is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. AWD via ATC 350 + ZF 8HP45 (4-cyl). 8th-gear corrected to LCI-era 0.640. FD values held at no_confidence pending direct PressClub PDF extraction.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP45)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "ZF 8HP45 8th-gear ratio for LCI-era B48.",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f30-3series-wikipedia"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '330i xDrive'",
+          "reason": "Same LCI introduction issue. 330i xDrive 8-speed Steptronic is documented from 05/2015 onward; ZF8HP code is `official_derived` from BMW wording."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
-        "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
+    },
+    {
+      "id": "bmw-f30-340i-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "340i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 340i is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Engine B58 (240 kW). Transmission is Getrag GS6X53DZ 6-speed manual (the 6-cylinder petrol manual gearbox - NOT the GS6-45BZ used for 4-cyl). transmission.name corrected. Stored 6th-gear 0.812 and FD 3.231 are inherited from the 4-cyl GS6-45BZ family default and are NOT applicable to the GS6X53DZ - the 6-cyl manual uses different ratios (typically 6th approximately 0.756, FD approximately 3.154). Held at no_confidence pending direct PressClub PDF extraction.",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6X53DZ)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
-        "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
-        "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
-        "evidence_refs": [
-          "legacy_research_sources:1594dc9b0d47",
-          "legacy_research_sources:1c24f5312261",
-          "legacy_research_sources:28b59b0b3030",
-          "legacy_research_sources:32e8742ffbf1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:ec4f691f5393",
-          "legacy_research_sources:f576994a4890"
-        ]
-      },
-      {
-        "item": "F30 broad-row 2012-2019 issues for '340i'",
-        "reason": "Same LCI introduction issue. 340i 8-speed Steptronic is documented from 05/2015; ZF8HP code is `official_derived`. The pre-LCI 335i with N55 is the 2012-launch counterpart and is not represented by this 340i row."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '340i'",
+          "reason": "F30 340i was introduced with the LCI in mid-2015 (B58 engine), replacing the pre-LCI 335i (N55). Per 05/2015 specs (T0234765EN) and LCI brochure, 340i begins in 2015. The 2012 launch press kit lists 335i, not 340i. Production start at 2012 is contradicted."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "bmw-f30-340i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F30",
+      "body_code": "F30",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "3 Series (F30, 2012-2019)",
+      "variant_name": "340i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes": "Sonnet redo (2026-04 v2): F30 340i 8AT is LCI-only (mid-2015+); production_start_year corrected from 2012 to 2015. Engine B58. Transmission is ZF 8HP50 (the 6-cylinder petrol variant of the 8HP family - NOT the 8HP45 used for 4-cyl). transmission.name corrected. 8th-gear corrected from family_default 0.667 to ZF 8HP50 LCI value 0.640. Stored FD 3.077 is the 4-cyl 8HP45 value; the 6-cyl 8HP50 in F30 typically uses FD 2.813. Held at no_confidence pending direct PressClub PDF extraction.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP50)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "ZF 8HP50 8th-gear ratio (LCI-era 6-cyl petrol).",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Final drive 3.077 inherited from 4-cyl 8HP45 family_default; the 340i 8HP50 typically uses FD around 2.813. No direct PressClub PDF extraction; held at no_confidence.",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact EU-market final drive ratios for 320i (B48), 330i (B48), 330i xDrive (B48), and 340i (B58) in F30 years covered by this entry",
+          "reason": "Accessible official BMW sources in this run provide launch/model-update transmission context and some model-specific ratio tables, but not a complete, unambiguous mapping for this exact variant set.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Exact top-gear ratios for the 6-speed manual across each listed petrol variant",
+          "reason": "Official F30 press-kit tables show model-dependent manual top gear values; no direct official table was found for the precise listed variant subset, so existing value was preserved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Variant-specific ratio differences between RWD and xDrive within the listed petrol set",
+          "reason": "xDrive drivetrain-layout difference is clear, but authoritative numeric final-drive/gear-ratio deltas for these exact trims were not confirmed from accessible official EU documents in this session.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "F30 broad-row 2012-2019 issues for '340i'",
+          "reason": "Same LCI introduction issue. 340i 8-speed Steptronic is documented from 05/2015; ZF8HP code is `official_derived`. The pre-LCI 335i with N55 is the 2012-launch counterpart and is not represented by this 340i row."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/G20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/G20.json
@@ -1,5613 +1,3772 @@
-[
-  {
-    "id": "bmw-g20-316d-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "316d",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+      "n2": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
+      "n3": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n4": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n5": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n12": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
+      "n13": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
+      "n14": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
+      "n15": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
+      "n16": "Reverse gear ratio (research note): 3.712",
+      "n17": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
+      "n18": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
+      "n19": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
+      "n20": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
+      "n21": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
+      "n22": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
+      "n23": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
+      "n24": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
+      "n25": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
+      "n26": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
+      "n27": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
+      "n28": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
+      "n29": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with High confidence.",
+      "n30": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence.",
+      "n31": "Reverse gear ratio (research note): 3.727",
+      "n32": "Reverse gear ratio (research note): 3.317"
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
+        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e2": [
+        "bmw_market_pages:g20-3-series-de-overview",
+        "bmw_market_pages:g20-3-series-uk-listing",
+        "legacy_research_sources:0bfbe440deb6",
+        "legacy_research_sources:3c7fce849237",
+        "legacy_research_sources:5d6e9b9da00b",
+        "legacy_research_sources:7c9fbfb0e7d2",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:b5d8a7f385c9",
+        "legacy_research_sources:b92080a8b603",
+        "legacy_research_sources:daa8f80dca50",
+        "legacy_research_sources:fc3067f501c7",
+        "legacy_research_sources:ff48a54d62d6"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2024-techdata"
+      ],
+      "e5": [
         "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
         "bmw_pressclub_sources:g20-3series-2022-lci-article",
         "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
+      "e6": [
+        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2024-techdata",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e7": [
         "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2024-techdata",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e8": [
+        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e9": [
+        "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
+        "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
+        "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
+      ],
+      "e10": [
         "bmw_pressclub_sources:g20-3series-2022-lci-article",
         "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2022-lci-article"
+      ],
+      "e12": [
+        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2024-techdata"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata"
+      ],
+      "e14": [
+        "bmw_pressclub_sources:g20-3series-2021-techdata"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-2024-techdata"
+      ],
+      "e16": [
+        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
+        "bmw_pressclub_sources:g20-3series-2021-techdata",
+        "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
+      ],
+      "e17": [
+        "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
+        "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
+      ],
+      "e18": [
+        "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
+      ],
+      "e19": [
+        "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
+        "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
+      ],
+      "e20": [
+        "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
+        "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
+      ],
+      "e21": [
+        "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
+        "bmw_market_pages:g20-3-series-price-list-2024"
+      ],
+      "e22": [
+        "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
+        "bmw_pressclub_sources:g28-in-320ld-diesel-launch-page"
+      ],
+      "e23": [
+        "bmw_market_pages:g28-th-320li-overview-2024",
+        "bmw_market_pages:g28-in-long-wheelbase-overview"
+      ],
+      "e24": [
+        "bmw_market_pages:g28-cn-2024-specsheet"
+      ],
+      "e25": [
+        "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
+        "bmw_market_pages:g28-cn-2024-specsheet"
+      ],
+      "e26": [
+        "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
+        "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
+      ],
+      "e27": [
+        "bmw_pressclub_sources:g20-330e-2019-launch-article-pdf",
+        "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
+        "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
+      ],
+      "e28": [
+        "bmw_pressclub_sources:g20-320d-2019-spec-pdf",
+        "bmw_pressclub_sources:g20-320d-2021-spec-pdf",
+        "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
+      ],
+      "e29": [
+        "bmw_pressclub_sources:g20-318i-2020-spec-pdf",
+        "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
+        "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g20-316d-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "316d",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n12",
+        "value": "RWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n12",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
+          "notes_ref": "n12",
+          "value": 0.812,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n12",
+          "value": 3.077,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW 03/2019 and 03/2021 diesel technical-data PDFs plus the later 05/2024 ACEA technical-data PDF do not surface an exact G20 316d Sedan row. This MT6 row therefore remains an unsupported placeholder rather than a production-backed manual mapping.",
+          "evidence_refs_ref": "e9"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Checked official BMW G20 diesel technical-data PDFs do not surface a 316d manual Sedan row; secondary evidence found by this run supports automatic only.",
+          "evidence_refs_ref": "e9"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA tech-data PDF includes a 316d MT6 variant. The G20 316d existed only 2021-2022 in MHEV form with 8-speed Steptronic (per Auto-Data and UltimateSpecs secondary sources); 316d was discontinued at the 07/2022 LCI per BMW PressClub T0388273EN. Repo's production_start_year of 2019 is also wrong. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW 03/2019 and 03/2021 diesel technical-data PDFs plus the later 05/2024 ACEA technical-data PDF do not surface an exact G20 316d Sedan row. This MT6 row therefore remains an unsupported placeholder rather than a production-backed manual mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "Checked official BMW G20 diesel technical-data PDFs do not surface a 316d manual Sedan row; secondary evidence found by this run supports automatic only.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether any exact G20 316d Sedan source exists for this broad EU manual row",
-        "reason": "The checked official BMW diesel technical-data PDFs surface 318d and 320d rows but no exact 316d Sedan row, so this pass cannot safely promote drivetrain, gearbox, ratio, or tire values for the represented 2019-2025 manual placeholder.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Checked official BMW G20 diesel technical-data PDFs do not surface a 316d manual Sedan row; secondary evidence found by this run supports automatic only.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-316d-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "316d",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2022-lci-article",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2022-lci-article",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022."
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 316d was offered only in 2021-2022 MHEV form with 8-speed Steptronic; discontinued at 07/2022 LCI (per BMW PressClub T0388273EN). No official BMW ACEA tech-data PDF for 316d specifically was located, but the engine (B47D20 122 hp) and ZF 8HP gearbox match the 318d auto, so ratios are official_derived from sibling: I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 2.813. Standard tire 205/60 R16 (UltimateSpecs secondary). Repo year window 2019-2025 should be ~2021-2022.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Whether any exact G20 316d Sedan source exists for this broad EU manual row",
+          "reason": "The checked official BMW diesel technical-data PDFs surface 318d and 320d rows but no exact 316d Sedan row, so this pass cannot safely promote drivetrain, gearbox, ratio, or tire values for the represented 2019-2025 manual placeholder.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Unsupported exact manual configuration",
+          "reason": "Checked official BMW G20 diesel technical-data PDFs do not surface a 316d manual Sedan row; secondary evidence found by this run supports automatic only.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-316d-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "316d",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n17",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n17",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n17",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n17"
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n17",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e17",
+            "notes": "Checked official BMW 03/2019 launch and 03/2021 technical-data PDFs both list 205/60 R16 96W XL tires on 6.5J x 16 wheels as the standard non-staggered setup for the exact G20 318d Sedan automatic state. Applied as official-derived evidence while full 2019-2025 continuity remains unresolved.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 16\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 3 review replaces the copied neighboring G20 petrol note with row-specific BMW evidence for the exact 318d Sedan automatic state. The checked official 03/2019 launch and 03/2021 BMW technical-data PDFs both prove the exact 318d automatic package: BMW 318d Sedan row identity, Eight-speed Steptronic transmission wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 205/60 R16 96W XL tires on 6.5J x 16 wheels. The row now promotes that exact launch-to-03/2021 package while leaving explicit public rear-wheel-drive wording, gearbox subtype naming, and later facelift/current continuity unresolved.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G20 318d production-data applicability across the full 2019-2025 row span",
+          "reason": "The checked official 03/2019 launch and 03/2021 technical-data PDFs prove one exact 318d automatic package through March 2021, but this pass did not recover a later official 318d row proving unchanged drivetrain, tire, and ratio mapping across the full represented span.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "item": "BMW G20 318d exact public drivetrain wording and full-span default-tire continuity",
+          "reason": "The checked official BMW technical-data PDFs prove the exact 318d Sedan automatic row, 205/60 R16 96W XL launch-to-03/2021 standard tires, and separate xDrive naming on AWD rows, but they do not literally print rear-wheel-drive wording for 318d or prove the same standard-tire package continued unchanged through later facelift/current years.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "item": "BMW G20 318d exact public gearbox subtype and full wheel-option matrix",
+          "reason": "The checked official BMW technical-data PDFs prove Eight-speed Steptronic wording, the exact ratio package, and the launch-to-03/2021 standard 16-inch setup, but they do not publish a gearbox subtype code such as ZF8HP or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e17"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-318d-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "318d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e11",
+        "notes_ref": "n19",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n19",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e11"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n19",
+          "value": 0.601,
+          "evidence_refs_ref": "e11"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n19",
+          "value": 3.154,
+          "evidence_refs_ref": "e11"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.11,
+            2.248,
+            1.403,
+            1.0,
+            0.786,
+            0.601
+          ],
+          "evidence_refs_ref": "e11",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022. Forward gear ratios I..VI per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n19",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs show the exact G20 318d Sedan manual state with 0.601 top gear, 3.154 final drive, and 205/60 R16 baseline tires, but the checked 05/2024 ACEA technical-data PDF only shows the later automatic state. This broad 2019-2025 MT6 row therefore needs an early-manual split instead of one inherited package.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n31",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this broad G20 318d manual row should be narrowed to an early exact 2019-2021 row",
+          "reason": "The checked official BMW material proves one early manual package and later automatic-only continuity, so this pass keeps the broad MT6 row only as a split-first placeholder instead of promoting one numeric package across the full represented 2019-2025 span.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-318d-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "318d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n20",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n20",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n20",
+          "value": 0.64
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n20",
+          "value": 2.813
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n20",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2019 launch technical-data shows the exact G20 320d Sedan manual state with 0.601 top gear, 3.154 final drive, and 205/60 R16 baseline tires, but the checked 03/2021 and 05/2024 official BMW technical-data PDFs only show the later automatic state. This broad 2019-2025 MT6 row therefore needs an early-manual split instead of one inherited package.",
+          "evidence_refs_ref": "e28"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this broad G20 320d manual row should be narrowed to an early exact 2019 row",
+          "reason": "The checked official BMW material proves one launch-period manual package and later automatic-only continuity, so this pass keeps the broad MT6 row only as a split-first placeholder instead of promoting one numeric package across the full represented 2019-2025 span.",
+          "evidence_refs_ref": "e28"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-318i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "318i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n13",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n13",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n13",
+          "value": 0.812,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n13",
+          "value": 3.077,
+          "evidence_refs_ref": "e6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n13",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2019, 03/2021, and 05/2024 technical-data PDFs all support the broad G20 318d Sedan automatic row as rear-wheel drive with Eight-speed Steptronic, 0.640 top gear, and 2.813 final drive. This follow-up promotes those stable powertrain values while leaving the tire fields unresolved because the checked official sheets move from 205/60 R16 early in the run to 225/50 R17 later in the run.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note": "Official BMW 2020, 2021, and 2024 G20 318i technical-data PDFs found in this run show the 318i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e29"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G20 318d exact default tire across the full represented 2019-2025 row span",
+          "reason": "The checked official BMW technical-data PDFs move the standard tire from early 205/60 R16 to later 225/50 R17, so the current single default-tire field remains a placeholder until the broad row is time-split or gains explicit year-aware wheel encoding.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "BMW G20 318d exact public gearbox subtype and full optional wheel matrix",
+          "reason": "The checked official BMW sources prove market-facing Eight-speed Steptronic wording and the stable 0.640 / 2.813 powertrain package, but they do not publish a gearbox subtype code or one full optional wheel/tire matrix that safely closes the broad row.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Unsupported exact manual configuration",
+          "reason": "Official BMW 2020, 2021, and 2024 G20 318i technical-data PDFs found in this run show the 318i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e29"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-318i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "318i",
+      "engine_code": "I3",
+      "engine_name": "I3",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n21",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n21",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n21",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e12",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n21",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n21",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 60.0,
+            "rim_in": 16.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs": [
+              "bmw_pressclub_sources:g20-318i-2020-spec-pdf",
+              "bmw_pressclub_sources:g20-318i-2021-spec-pdf"
+            ],
+            "notes": "Official 2020/2021 BMW G20 318i sheets list 205/60 R16 96W XL as the standard tire.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official standard"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 2 review replaces the copied neighboring G20 note with row-specific BMW evidence for the exact 318i Sedan automatic state. The checked official 03/2021 BMW technical-data PDF proves rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 205/60 R16 tires. The checked official 07/2024 Germany price list confirms later rear-wheel-drive 8-Gang Steptronic continuity but shows the standard tire moved to 225/50 R17, so the current single default-tire field remains a placeholder pending row retiming or option encoding.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G20 318i production-data applicability across the full 2019-2025 row span",
+          "reason": "The checked official 03/2021 technical-data PDF and 07/2024 Germany price list prove exact 318i rear-wheel-drive automatic states with the same 0.640 / 2.813 ratio package, but this pass did not recover a launch-era 2019 source or one year-by-year chain proving one unchanged mapping across the full represented row span.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "item": "BMW G20 318i exact default tire across the full represented row span",
+          "reason": "The checked official 03/2021 technical-data PDF shows standard 205/60 R16 tires while the checked official 07/2024 Germany price list shows standard 225/50 R17 tires, so the current single default-tire field should not be promoted as one exact 2019-2025 mapping.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "item": "BMW G20 318i exact public gearbox code and full tire-option matrix",
+          "reason": "The checked official BMW sources prove market-facing Eight-speed Steptronic wording and show two exact standard tire states, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e21"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320ld-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320Ld",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.812,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW India press material places the 320Ld inside the 3 Series Gran Limousine / G28 long-wheelbase family and supports only an 8-speed Steptronic Sport automatic state. This G20 EU manual row is therefore wrong-shard spillover, not a production-backed G20 manual mapping.",
+          "evidence_refs_ref": "e22"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Move the 320Ld family into a dedicated G28 / non-EU shard",
+          "reason": "The saved official BMW India sources place 320Ld in the G28 long-wheelbase family and do not support a manual row, so this G20 EU placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e22"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320ld-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320Ld",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 0.64
+        },
+        "gear_ratios": {
           "confidence": "official_derived",
           "evidence_refs": [
-            "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-            "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
+            "bmw_pressclub_sources:g20-320d-2021-spec-pdf",
+            "bmw_pressclub_sources:g20-320d-2022-spec-pdf"
           ],
-          "notes": "Checked official BMW 03/2019 launch and 03/2021 technical-data PDFs both list 205/60 R16 96W XL tires on 6.5J x 16 wheels as the standard non-staggered setup for the exact G20 318d Sedan automatic state. Applied as official-derived evidence while full 2019-2025 continuity remains unresolved.",
+          "notes": "Checked official BMW 03/2021 and 05/2022 technical-data for the exact G20 320d Sedan automatic state both list the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640. Applied as official-derived evidence while full 2019-2025 continuity remains unresolved.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW India sources place the 320Ld inside the 3 Series Gran Limousine / G28 long-wheelbase family, not the EU-market G20 shard. The automatic transmission is real only on that non-EU G28 row, which also carries a mixed 18-inch tyre package rather than the inherited G20 square default.",
+          "evidence_refs_ref": "e22"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Rebuild 320Ld from exact G28 market-specific sources",
+          "reason": "The saved official BMW India packet proves a non-EU G28 automatic row with different body/market scope and tyre shape, so this G20 EU placeholder should be replaced only after a dedicated G28 shard exists.",
+          "evidence_refs_ref": "e22"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320li-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320Li",
+      "engine_code": "I3",
+      "engine_name": "I3",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.812,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW Thailand and India long-wheelbase pages place the 320Li family in G28 Gran Limousine scope, not the EU-market G20 shard, and no saved official manual evidence was recovered. This G20 EU manual row remains wrong-shard spillover with unsupported gearbox identity.",
+          "evidence_refs_ref": "e23"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Move 320Li into a dedicated G28 / non-EU shard",
+          "reason": "The saved official BMW long-wheelbase sources place 320Li in the G28 family and do not provide manual support, so this G20 EU manual placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e23"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320li-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320Li",
+      "engine_code": "I3",
+      "engine_name": "I3",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 0.64
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW Thailand and India long-wheelbase pages place the 320Li family in G28 Gran Limousine scope rather than the EU-market G20 shard. This automatic row therefore remains a wrong-shard placeholder and should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
+          "evidence_refs_ref": "e23"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Rebuild 320Li from exact G28 market-specific sources",
+          "reason": "The saved official BMW long-wheelbase sources prove the family scope mismatch, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
+          "evidence_refs_ref": "e23"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320d-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e13",
+        "notes_ref": "n22",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n22",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e13"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n22",
+          "value": 0.601,
+          "evidence_refs_ref": "e13"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n22",
+          "value": 3.154,
+          "evidence_refs_ref": "e13"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.11,
+            2.248,
+            1.403,
+            1.0,
+            0.786,
+            0.601
+          ],
+          "evidence_refs_ref": "e13",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only. Forward gear ratios I..VI per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes_ref": "n22",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 60.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 16\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n31",
+          "evidence_refs_ref": "e13"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 3 review replaces the copied neighboring G20 petrol note with row-specific BMW evidence for the exact 318d Sedan automatic state. The checked official 03/2019 launch and 03/2021 BMW technical-data PDFs both prove the exact 318d automatic package: BMW 318d Sedan row identity, Eight-speed Steptronic transmission wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 205/60 R16 96W XL tires on 6.5J x 16 wheels. The row now promotes that exact launch-to-03/2021 package while leaving explicit public rear-wheel-drive wording, gearbox subtype naming, and later facelift/current continuity unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2022-lci-article",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G20 318d production-data applicability across the full 2019-2025 row span",
-        "reason": "The checked official 03/2019 launch and 03/2021 technical-data PDFs prove one exact 318d automatic package through March 2021, but this pass did not recover a later official 318d row proving unchanged drivetrain, tire, and ratio mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G20 318d exact public drivetrain wording and full-span default-tire continuity",
-        "reason": "The checked official BMW technical-data PDFs prove the exact 318d Sedan automatic row, 205/60 R16 96W XL launch-to-03/2021 standard tires, and separate xDrive naming on AWD rows, but they do not literally print rear-wheel-drive wording for 318d or prove the same standard-tire package continued unchanged through later facelift/current years.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G20 318d exact public gearbox subtype and full wheel-option matrix",
-        "reason": "The checked official BMW technical-data PDFs prove Eight-speed Steptronic wording, the exact ratio package, and the launch-to-03/2021 standard 16-inch setup, but they do not publish a gearbox subtype code such as ZF8HP or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-318d-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "318d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
-        "value": 0.601,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.11,
-          2.248,
-          1.403,
-          1.0,
-          0.786,
-          0.601
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022. Forward gear ratios I..VI per ACEA tech-data PDF."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs both publish G20 318d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. MT6 was discontinued for ALL G20 variants at 07/2022 LCI per T0388273EN — row's effective end_year is 2022.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs show the exact G20 318d Sedan manual state with 0.601 top gear, 3.154 final drive, and 205/60 R16 baseline tires, but the checked 05/2024 ACEA technical-data PDF only shows the later automatic state. This broad 2019-2025 MT6 row therefore needs an early-manual split instead of one inherited package.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.727",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this broad G20 318d manual row should be narrowed to an early exact 2019-2021 row",
-        "reason": "The checked official BMW material proves one early manual package and later automatic-only continuity, so this pass keeps the broad MT6 row only as a split-first placeholder instead of promoting one numeric package across the full represented 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-318d-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "318d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 0.64
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 2.813
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-320d-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch, bracketed values), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n23",
+        "value": "RWD"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2019 launch technical-data shows the exact G20 320d Sedan manual state with 0.601 top gear, 3.154 final drive, and 205/60 R16 baseline tires, but the checked 03/2021 and 05/2024 official BMW technical-data PDFs only show the later automatic state. This broad 2019-2025 MT6 row therefore needs an early-manual split instead of one inherited package.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this broad G20 320d manual row should be narrowed to an early exact 2019 row",
-        "reason": "The checked official BMW material proves one launch-period manual package and later automatic-only continuity, so this pass keeps the broad MT6 row only as a split-first placeholder instead of promoting one numeric package across the full represented 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-318i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "318i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The 318i was added to the G20 lineup in 01/2020. BMW PressClub T0304990EN (the 01/2020 318i tech-data PDF) lists Eight-speed Steptronic only — no MT6 was ever offered for the 318i G20. T0325531EN (03/2021) and T0442333EN (2024) likewise show 318i as automatic-only. Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2019, 03/2021, and 05/2024 technical-data PDFs all support the broad G20 318d Sedan automatic row as rear-wheel drive with Eight-speed Steptronic, 0.640 top gear, and 2.813 final drive. This follow-up promotes those stable powertrain values while leaving the tire fields unresolved because the checked official sheets move from 205/60 R16 early in the run to 225/50 R17 later in the run.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official BMW 2020, 2021, and 2024 G20 318i technical-data PDFs found in this run show the 318i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2020-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G20 318d exact default tire across the full represented 2019-2025 row span",
-        "reason": "The checked official BMW technical-data PDFs move the standard tire from early 205/60 R16 to later 225/50 R17, so the current single default-tire field remains a placeholder until the broad row is time-split or gains explicit year-aware wheel encoding.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G20 318d exact public gearbox subtype and full optional wheel matrix",
-        "reason": "The checked official BMW sources prove market-facing Eight-speed Steptronic wording and the stable 0.640 / 2.813 powertrain package, but they do not publish a gearbox subtype code or one full optional wheel/tire matrix that safely closes the broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318d-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-318d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Official BMW 2020, 2021, and 2024 G20 318i technical-data PDFs found in this run show the 318i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2020-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-318i-318d-320d-2024-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-318i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "318i",
-    "engine_code": "I3",
-    "engine_name": "I3",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
-        "value": 0.64
+        "notes_ref": "n23",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0304990EN/445465 (01/2020 318i launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 318i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. production_start_year should be 2020 (not 2019) — 318i not in 03/2019 launch set.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-318i-2020-spec-pdf",
-            "bmw_pressclub_sources:g20-318i-2021-spec-pdf"
+          "notes_ref": "n23",
+          "value": 0.64,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n23",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Official 2020/2021 BMW G20 318i sheets list 205/60 R16 96W XL as the standard tire.",
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n23",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 60.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official standard"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 2 review replaces the copied neighboring G20 note with row-specific BMW evidence for the exact 318i Sedan automatic state. The checked official 03/2021 BMW technical-data PDF proves rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 205/60 R16 tires. The checked official 07/2024 Germany price list confirms later rear-wheel-drive 8-Gang Steptronic continuity but shows the standard tire moved to 225/50 R17, so the current single default-tire field remains a placeholder pending row retiming or option encoding.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_market_pages:g20-3-series-price-list-2024"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2020-318i-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G20 318i production-data applicability across the full 2019-2025 row span",
-        "reason": "The checked official 03/2021 technical-data PDF and 07/2024 Germany price list prove exact 318i rear-wheel-drive automatic states with the same 0.640 / 2.813 ratio package, but this pass did not recover a launch-era 2019 source or one year-by-year chain proving one unchanged mapping across the full represented row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_market_pages:g20-3-series-price-list-2024"
-        ]
-      },
-      {
-        "item": "BMW G20 318i exact default tire across the full represented row span",
-        "reason": "The checked official 03/2021 technical-data PDF shows standard 205/60 R16 tires while the checked official 07/2024 Germany price list shows standard 225/50 R17 tires, so the current single default-tire field should not be promoted as one exact 2019-2025 mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_market_pages:g20-3-series-price-list-2024"
-        ]
-      },
-      {
-        "item": "BMW G20 318i exact public gearbox code and full tire-option matrix",
-        "reason": "The checked official BMW sources prove market-facing Eight-speed Steptronic wording and show two exact standard tire states, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-318i-2021-spec-pdf",
-          "bmw_market_pages:g20-3-series-price-list-2024"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320ld-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320Ld",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320e-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320e",
+      "engine_code": "1.6L",
+      "engine_name": "1.6L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+          "notes_ref": "n2",
+          "value": 0.812,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2021 technical-data PDF shows the G20 320e Sedan only as a rear-wheel-drive full-hybrid row with 8-speed Steptronic transmission, not a 6-speed manual, and the saved packet also places the variant later than the current 2019 start year. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
+          "evidence_refs_ref": "e18"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official BMW 2021 G20 320e technical-data PDF shows the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
+          "evidence_refs_ref": "e18"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW India press material places the 320Ld inside the 3 Series Gran Limousine / G28 long-wheelbase family and supports only an 8-speed Steptronic Sport automatic state. This G20 EU manual row is therefore wrong-shard spillover, not a production-backed G20 manual mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_pressclub_sources:g28-in-320ld-diesel-launch-page"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move the 320Ld family into a dedicated G28 / non-EU shard",
-        "reason": "The saved official BMW India sources place 320Ld in the G28 long-wheelbase family and do not support a manual row, so this G20 EU placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_pressclub_sources:g28-in-320ld-diesel-launch-page"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320ld-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320Ld",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320d-2021-spec-pdf",
-          "bmw_pressclub_sources:g20-320d-2022-spec-pdf"
-        ],
-        "notes": "Checked official BMW 03/2021 and 05/2022 technical-data for the exact G20 320d Sedan automatic state both list the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640. Applied as official-derived evidence while full 2019-2025 continuity remains unresolved.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "item": "Whether this contradicted G20 320e manual row should be replaced by a 2021-on hybrid automatic row",
+          "reason": "Official BMW technical-data material in the saved packet supports the G20 320e only as a 2021-on rear-wheel-drive full-hybrid row with 8-speed Steptronic transmission, but this pass did not split the broad 2019-2025 row model.",
+          "evidence_refs_ref": "e18"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "item": "Unsupported exact manual configuration",
+          "reason": "Official BMW 2021 G20 320e technical-data PDF shows the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
+          "evidence_refs_ref": "e18"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW India sources place the 320Ld inside the 3 Series Gran Limousine / G28 long-wheelbase family, not the EU-market G20 shard. The automatic transmission is real only on that non-EU G28 row, which also carries a mixed 18-inch tyre package rather than the inherited G20 square default.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_pressclub_sources:g28-in-320ld-diesel-launch-page"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Rebuild 320Ld from exact G28 market-specific sources",
-        "reason": "The saved official BMW India packet proves a non-EU G28 automatic row with different body/market scope and tyre shape, so this G20 EU placeholder should be replaced only after a dedicated G28 shard exists.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_pressclub_sources:g28-in-320ld-diesel-launch-page"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320li-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320Li",
-    "engine_code": "I3",
-    "engine_name": "I3",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW Thailand and India long-wheelbase pages place the 320Li family in G28 Gran Limousine scope, not the EU-market G20 shard, and no saved official manual evidence was recovered. This G20 EU manual row remains wrong-shard spillover with unsupported gearbox identity.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-th-320li-overview-2024",
-          "bmw_market_pages:g28-in-long-wheelbase-overview"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move 320Li into a dedicated G28 / non-EU shard",
-        "reason": "The saved official BMW long-wheelbase sources place 320Li in the G28 family and do not provide manual support, so this G20 EU manual placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-th-320li-overview-2024",
-          "bmw_market_pages:g28-in-long-wheelbase-overview"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320li-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320Li",
-    "engine_code": "I3",
-    "engine_name": "I3",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.64
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW Thailand and India long-wheelbase pages place the 320Li family in G28 Gran Limousine scope rather than the EU-market G20 shard. This automatic row therefore remains a wrong-shard placeholder and should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-th-320li-overview-2024",
-          "bmw_market_pages:g28-in-long-wheelbase-overview"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Rebuild 320Li from exact G28 market-specific sources",
-        "reason": "The saved official BMW long-wheelbase sources prove the family scope mismatch, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-th-320li-overview-2024",
-          "bmw_market_pages:g28-in-long-wheelbase-overview"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320d-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
+    {
+      "id": "bmw-g20-320e-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320e",
+      "engine_code": "B48 PHEV",
+      "engine_name": "B48 2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
         "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
-        "value": 0.601,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ]
+        "evidence_refs_ref": "e14",
+        "notes_ref": "n24",
+        "value": "RWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ]
+        "notes_ref": "n24",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP, PHEV-integrated)",
+        "evidence_refs_ref": "e14"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.11,
-          2.248,
-          1.403,
-          1.0,
-          0.786,
-          0.601
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only. Forward gear ratios I..VI per ACEA tech-data PDF."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019 launch) confirms G20 320d 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.154; standard tire 205/60 R16 96W XL. The 03/2021 ACEA PDF (T0325531EN) shows 320d with Steptronic only — MT6 was dropped between 2020 and 03/2021. Row's effective production window is 2019-2020 only.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.727",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320d-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320d ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Top-gear value 0.667 in repo was wrong — corrected to 0.640. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320e-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320e",
-    "engine_code": "1.6L",
-    "engine_name": "1.6L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2021 technical-data PDF shows the G20 320e Sedan only as a rear-wheel-drive full-hybrid row with 8-speed Steptronic transmission, not a 6-speed manual, and the saved packet also places the variant later than the current 2019 start year. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official BMW 2021 G20 320e technical-data PDF shows the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted G20 320e manual row should be replaced by a 2021-on hybrid automatic row",
-        "reason": "Official BMW technical-data material in the saved packet supports the G20 320e only as a 2021-on rear-wheel-drive full-hybrid row with 8-speed Steptronic transmission, but this pass did not split the broad 2019-2025 row model.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Official BMW 2021 G20 320e technical-data PDF shows the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320e-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320e",
-    "engine_code": "B48 PHEV",
-    "engine_name": "B48 2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2021-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP, PHEV-integrated)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2021-techdata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
-        "value": 3.231
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021. Forward gear ratios I..VIII per ACEA tech-data PDF (PHEV-specific set)."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-320e-2021-spec-pdf"
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n24",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n24",
+          "value": 3.231
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "Official BMW 03/2021 G20 320e PHEV technical-data PDF lists 225/50 R17 98Y XL as the standard tire.",
+          "evidence_refs_ref": "e14",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0325531EN/471537 (03/2021) ACEA tech-data PDF publishes G20 320e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231; standard tire 225/50 R17 98Y XL. The 0.667 top gear is the PHEV-specific value, distinct from non-PHEV ZF 8HP top 0.640. 320e was added 2021 (not 2019) — production_start_year should be 2021. Forward gear ratios I..VIII per ACEA tech-data PDF (PHEV-specific set)."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n24",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs both show the EU-market G20 320i Sedan only as a rear-wheel-drive 8-speed Steptronic row, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.317",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2021-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted G20 320i manual row should be deleted or replaced by an exact automatic-only row",
-        "reason": "Official BMW technical-data material in the saved packet supports the G20 320i only as a rear-wheel-drive 8-speed Steptronic row and does not support a 6-speed manual state, but this pass did not restructure the broad row set.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e18",
+            "notes": "Official BMW 03/2021 G20 320e PHEV technical-data PDF lists 225/50 R17 98Y XL as the standard tire.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official standard 17\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs both show the EU-market G20 320i Sedan only as a rear-wheel-drive 8-speed Steptronic row, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
+          "evidence_refs_ref": "e19"
+        },
+        {
+          "note_ref": "n32",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this contradicted G20 320i manual row should be deleted or replaced by an exact automatic-only row",
+          "reason": "Official BMW technical-data material in the saved packet supports the G20 320i only as a rear-wheel-drive 8-speed Steptronic row and does not support a 6-speed manual state, but this pass did not restructure the broad row set.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-320i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n14",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n14",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e7"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
+          "notes_ref": "n14",
+          "value": 0.812,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n14",
+          "value": 3.077,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n14",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 08/2019 launch and 05/2024 technical-data material shows the EU-market G20 330e Sedan as an 8-speed Steptronic full-hybrid row with the electric motor integrated into the transmission, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
+          "evidence_refs_ref": "e27"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official BMW 2019 and 2021 G20 320i technical-data PDFs found in this run show the 320i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e19"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2024-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021, T0442333EN 2024) list 320i with Eight-speed Steptronic only — no MT6 was ever offered for the 320i G20. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 08/2019 launch and 05/2024 technical-data material shows the EU-market G20 330e Sedan as an 8-speed Steptronic full-hybrid row with the electric motor integrated into the transmission, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-launch-article-pdf",
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official BMW 2019 and 2021 G20 320i technical-data PDFs found in this run show the 320i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted G20 330e manual row should be deleted or replaced by the exact hybrid automatic row already evidenced elsewhere in the shard",
-        "reason": "Official BMW launch and technical-data material supports the G20 330e only as an 8-speed Steptronic full-hybrid row and does not support a 6-speed manual state, but this pass did not remove or merge the placeholder row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-launch-article-pdf",
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Official BMW 2019 and 2021 G20 320i technical-data PDFs found in this run show the 320i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-320i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "320i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 0.64
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "value": 2.813
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+      "unresolved": [
+        {
+          "item": "Whether this contradicted G20 330e manual row should be deleted or replaced by the exact hybrid automatic row already evidenced elsewhere in the shard",
+          "reason": "Official BMW launch and technical-data material supports the G20 330e only as an 8-speed Steptronic full-hybrid row and does not support a 6-speed manual state, but this pass did not remove or merge the placeholder row.",
+          "evidence_refs_ref": "e27"
+        },
+        {
+          "item": "Unsupported exact manual configuration",
+          "reason": "Official BMW 2019 and 2021 G20 320i technical-data PDFs found in this run show the 320i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-320i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "320i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 60.0,
-          "rim_in": 16.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n25",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n25",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-320i-2019-spec-pdf",
-            "bmw_pressclub_sources:g20-320i-2021-spec-pdf"
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n25",
+          "value": 0.64
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n25",
+          "value": 2.813
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Official 2019/2021 BMW G20 320i sheets list 205/60 R16 96W XL as the standard tire.",
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 320i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 205/60 R16 96W XL pre-LCI; 225/50 R17 98Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n25",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 60.0,
             "rim_in": 16.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official standard"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs both show the EU-market G20 330i Sedan only as a rear-wheel-drive 8-speed Steptronic row, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted G20 330i manual row should be deleted or replaced by an exact automatic-only row",
-        "reason": "Official BMW technical-data material in the saved packet supports the G20 330i only as a rear-wheel-drive 8-speed Steptronic row and does not support a 6-speed manual state, but this pass did not restructure the broad row set.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-325li-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "325Li",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e19",
+            "notes": "Official 2019/2021 BMW G20 320i sheets list 205/60 R16 96W XL as the standard tire.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 60.0,
+              "rim_in": 16.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official standard"
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official BMW 03/2019 and 03/2021 technical-data PDFs both show the EU-market G20 330i Sedan only as a rear-wheel-drive 8-speed Steptronic row, not a 6-speed manual. This MT6 row remains only as a contradicted placeholder until the broader G20 shard is reshaped.",
+          "evidence_refs_ref": "e20"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this contradicted G20 330i manual row should be deleted or replaced by an exact automatic-only row",
+          "reason": "Official BMW technical-data material in the saved packet supports the G20 330i only as a rear-wheel-drive 8-speed Steptronic row and does not support a 6-speed manual state, but this pass did not restructure the broad row set.",
+          "evidence_refs_ref": "e20"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-325li-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "325Li",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+          "notes_ref": "n1",
+          "value": 0.812,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW China spec data distinguishes G28 long-wheelbase from G20 standard-wheelbase and lists 325Li under the G28 family. No saved official manual evidence was recovered, so this G20 EU manual row remains wrong-shard spillover with unsupported gearbox identity.",
+          "evidence_refs_ref": "e24"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW China spec data distinguishes G28 long-wheelbase from G20 standard-wheelbase and lists 325Li under the G28 family. No saved official manual evidence was recovered, so this G20 EU manual row remains wrong-shard spillover with unsupported gearbox identity.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move 325Li into a dedicated G28 / non-EU shard",
-        "reason": "The saved official BMW China source places 325Li in the G28 long-wheelbase family and does not support a manual row, so this G20 EU placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-325li-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "325Li",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
+      "unresolved": [
+        {
+          "item": "Move 325Li into a dedicated G28 / non-EU shard",
+          "reason": "The saved official BMW China source places 325Li in the G28 long-wheelbase family and does not support a manual row, so this G20 EU placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e24"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-325li-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "325Li",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW China spec data distinguishes G28 long-wheelbase from G20 standard-wheelbase and lists 325Li under the G28 family. This automatic row therefore remains a wrong-shard placeholder and should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
+          "evidence_refs_ref": "e24"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW China spec data distinguishes G28 long-wheelbase from G20 standard-wheelbase and lists 325Li under the G28 family. This automatic row therefore remains a wrong-shard placeholder and should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Rebuild 325Li from exact G28 market-specific sources",
-        "reason": "The saved official BMW China source proves the family-scope mismatch, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
-        "evidence_refs": [
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330li-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330Li",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
+      "unresolved": [
+        {
+          "item": "Rebuild 325Li from exact G28 market-specific sources",
+          "reason": "The saved official BMW China source proves the family-scope mismatch, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
+          "evidence_refs_ref": "e24"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-330li-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330Li",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+          "notes_ref": "n1",
+          "value": 0.812,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW India and China material places the 330Li inside the G28 long-wheelbase family and supports an 8-speed automatic state rather than a manual one. This G20 EU manual row is therefore wrong-shard spillover, not a production-backed G20 manual mapping.",
+          "evidence_refs_ref": "e25"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW India and China material places the 330Li inside the G28 long-wheelbase family and supports an 8-speed automatic state rather than a manual one. This G20 EU manual row is therefore wrong-shard spillover, not a production-backed G20 manual mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move 330Li into a dedicated G28 / non-EU shard",
-        "reason": "The saved official BMW India and China sources place 330Li in the G28 long-wheelbase family and support automatic-only non-EU rows, so this G20 EU manual placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330li-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330Li",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
+      "unresolved": [
+        {
+          "item": "Move 330Li into a dedicated G28 / non-EU shard",
+          "reason": "The saved official BMW India and China sources place 330Li in the G28 long-wheelbase family and support automatic-only non-EU rows, so this G20 EU manual placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e25"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-330li-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330Li",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW India and China material places the 330Li inside the G28 long-wheelbase family rather than the EU-market G20 shard. The saved India technical-data PDF also shows a mixed 18-inch tyre package, so this G20 EU automatic row should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
+          "evidence_refs_ref": "e25"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): 320Ld/320Li/325Li/330Li are exclusively China/India/Thailand G28 LWB Gran Limousine variants — they are NOT EU G20 SWB configurations. BMW India tech-data PDF (T0407338EN/572044), BMW Thailand 2024 brochure, and BMW China 2024 specsheet all place these on the G28 platform with 8-Speed Steptronic Sport (no MT6 anywhere). BMW Germany 2024 price list confirms none of these variants exist in the EU G20 market. Marked no_confidence as a phantom EU configuration; row should be considered for removal or relocation to a G28 China/India shard.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW India and China material places the 330Li inside the G28 long-wheelbase family rather than the EU-market G20 shard. The saved India technical-data PDF also shows a mixed 18-inch tyre package, so this G20 EU automatic row should be rebuilt from exact G28 market sources instead of inheriting G20 defaults.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-india-2023-320ld-330li-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Rebuild 330Li from exact G28 market-specific sources",
-        "reason": "The saved official BMW India and China sources prove the family-scope mismatch and non-G20 tyre package, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g28-in-320ld-330li-2023-spec-pdf",
-          "bmw_market_pages:g28-cn-2024-specsheet"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330e-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330e",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
+      "unresolved": [
+        {
+          "item": "Rebuild 330Li from exact G28 market-specific sources",
+          "reason": "The saved official BMW India and China sources prove the family-scope mismatch and non-G20 tyre package, so this G20 EU automatic placeholder should move to a dedicated G28 shard before any numeric rewrite is attempted.",
+          "evidence_refs_ref": "e25"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-330e-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330e",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
+          "notes_ref": "n2",
+          "value": 0.812,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n29"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): G20 320e and 330e are PHEVs using a PHEV-integrated 8-speed Steptronic transmission with electric motor between engine and gearbox. No MT6 variant exists or was ever offered. BMW PressClub T0298940EN (08/2019 330e launch) and T0325531EN (03/2021 includes 320e and 330e) both list 8-speed Steptronic only. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Official BMW 2019 and 2024 G20 330e technical-data PDFs show the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
+          "evidence_refs_ref": "e26"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with High confidence."
-      },
-      {
-        "note": "Official BMW 2019 and 2024 G20 330e technical-data PDFs show the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Official BMW 2019 and 2024 G20 330e technical-data PDFs show the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330e-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330e",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
+      "unresolved": [
+        {
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Unsupported exact manual configuration",
+          "reason": "Official BMW 2019 and 2024 G20 330e technical-data PDFs show the PHEV row as Eight-speed Steptronic only; no manual PHEV row was recovered.",
+          "evidence_refs_ref": "e26"
+        }
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP, PHEV-integrated)"
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "ratios": {
-      "top_gear_ratio": {
+    {
+      "id": "bmw-g20-330e-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330e",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
-        "value": 0.667
+        "evidence_refs_ref": "e15",
+        "notes_ref": "n26",
+        "value": "RWD"
       },
-      "gear_ratios": {
+      "transmission": {
         "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF (PHEV-specific set)."
+        "evidence_refs_ref": "e15",
+        "notes_ref": "n26",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP, PHEV-integrated)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 08/2019 technical-data PDF lists this as the launch-era standard square setup for the exact G20 330e.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Launch standard 17\""
+          "evidence_refs_ref": "e15",
+          "notes_ref": "n26",
+          "value": 0.667
         },
-        {
+        "gear_ratios": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 05/2024 technical-data PDF lists this as the later standard square setup for the exact G20 330e.",
+          "evidence_refs_ref": "e15",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0298940EN/470771 (08/2019 330e launch), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330e PHEV ratios I 4.714 / II 3.143 / III 2.106 / IV 1.667 / V 1.285 / VI 1.000 / VII 0.839 / VIII 0.667, R 3.317, final drive 3.231. Standard tire 225/50 R17 98Y XL at 2019 launch / 03/2021; changed to 225/45 R18 95Y XL from 07/2022 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF (PHEV-specific set)."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e15",
+          "notes_ref": "n26",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e15",
+          "notes_ref": "n26",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Later standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 08/2019 and 05/2024 technical-data PDFs now confirm the exact G20 330e Sedan as a rear-wheel-drive full-hybrid / plug-in-hybrid state with Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and a launch-era 225/50 R17 baseline that later shifts to a square 225/45 R18 setup. The official BMW 08/2019 launch article also confirms the PHEV architecture, including the electric motor integrated into the transmission, the 12.0 kWh battery under the rear seats, and XtraBoost. This row now carries the corrected hybrid fuel type and exact drivetrain/final-drive evidence, but wheel-order use remains manual because the standard tire baseline changes within the represented 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-launch-article-pdf",
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.317",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-330e-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G20 330e baseline wheel/tire continuity across the full 2019-2025 row span",
-        "reason": "The official BMW 08/2019 technical-data PDF lists a 225/50 R17 launch baseline, while the official 05/2024 technical-data PDF lists a later 225/45 R18 standard setup. This pass did not recover one authoritative official wheel matrix that closes the exact changeover timing across the full represented span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for the G20 330e",
-        "reason": "The checked official BMW PressClub sheets prove the exact Steptronic ratio package plus launch-era and later standard square tire setups, but they do not publish a supplier-family gearbox code or a complete official optional wheel/tire matrix for this exact PHEV row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-        "bmw_pressclub_sources:g20-3series-2022-lci-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs": [
+              "bmw_pressclub_sources:g20-330e-2019-tech-spec-pdf"
+            ],
+            "notes": "The official BMW 08/2019 technical-data PDF lists this as the launch-era standard square setup for the exact G20 330e.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Launch standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs": [
+              "bmw_pressclub_sources:g20-330e-2024-tech-spec-pdf"
+            ],
+            "notes": "The official BMW 05/2024 technical-data PDF lists this as the later standard square setup for the exact G20 330e.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Later standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Official BMW 08/2019 and 05/2024 technical-data PDFs now confirm the exact G20 330e Sedan as a rear-wheel-drive full-hybrid / plug-in-hybrid state with Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and a launch-era 225/50 R17 baseline that later shifts to a square 225/45 R18 setup. The official BMW 08/2019 launch article also confirms the PHEV architecture, including the electric motor integrated into the transmission, the 12.0 kWh battery under the rear seats, and XtraBoost. This row now carries the corrected hybrid fuel type and exact drivetrain/final-drive evidence, but wheel-order use remains manual because the standard tire baseline changes within the represented 2019-2025 span.",
+          "evidence_refs_ref": "e27"
+        },
+        {
+          "note_ref": "n29"
+        },
+        {
+          "note_ref": "n32",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G20 330e baseline wheel/tire continuity across the full 2019-2025 row span",
+          "reason": "The official BMW 08/2019 technical-data PDF lists a 225/50 R17 launch baseline, while the official 05/2024 technical-data PDF lists a later 225/45 R18 standard setup. This pass did not recover one authoritative official wheel matrix that closes the exact changeover timing across the full represented span.",
+          "evidence_refs_ref": "e26"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for the G20 330e",
+          "reason": "The checked official BMW PressClub sheets prove the exact Steptronic ratio package plus launch-era and later standard square tire setups, but they do not publish a supplier-family gearbox code or a complete official optional wheel/tire matrix for this exact PHEV row.",
+          "evidence_refs_ref": "e26"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-330i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n15",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n15",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e8"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
+          "notes_ref": "n15",
+          "value": 0.812,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 3.077,
+          "evidence_refs_ref": "e8"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n15",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n29"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-            "bmw_pressclub_sources:g20-3series-2021-techdata",
-            "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-            "bmw_pressclub_sources:g20-3series-2022-lci-article"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): All official BMW ACEA tech-data PDFs (T0299451EN 03/2019, T0325531EN 03/2021) list 330i with Eight-speed Steptronic only — no MT6 was ever offered for the 330i G20. The plain RWD 330i was also removed from the EU lineup by 2024 (BMW DE 07/2024 price list). Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Official BMW 2019 and 2021 G20 330i technical-data PDFs show the 330i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e20"
+        },
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with High confidence."
-      },
-      {
-        "note": "Official BMW 2019 and 2021 G20 330i technical-data PDFs show the 330i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist",
-          "bmw_pressclub_sources:g20-3series-2022-lci-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Unsupported exact manual configuration",
-        "reason": "Official BMW 2019 and 2021 G20 330i technical-data PDFs show the 330i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
-          "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
-        "value": 0.64
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
-        "value": 2.813
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022. Forward gear ratios I..VIII per ACEA tech-data PDF."
+      "unresolved": [
+        {
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Unsupported exact manual configuration",
+          "reason": "Official BMW 2019 and 2021 G20 330i technical-data PDFs show the 330i Sedan as Eight-speed Steptronic automatic; no exact manual row was recovered.",
+          "evidence_refs_ref": "e20"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g20-330i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e16",
+        "notes_ref": "n27",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n27",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e16"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g20-330i-2019-spec-pdf",
-            "bmw_pressclub_sources:g20-330i-2021-spec-pdf"
+          "evidence_refs_ref": "e16",
+          "notes_ref": "n27",
+          "value": 0.64
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e16",
+          "notes_ref": "n27",
+          "value": 2.813
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Official 2019/2021 BMW G20 330i sheets list 225/50 R17 98Y XL as the standard tire.",
+          "evidence_refs_ref": "e16",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019) and T0325531EN/471537 (03/2021) ACEA tech-data PDFs confirm G20 330i RWD ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 2.813. Standard tire 225/50 R17 98Y XL. The plain RWD 330i was removed from the EU lineup by 2024 (absent from BMW DE 07/2024 price list and from T0442333EN 2024 ACEA PDF) — production_end_year should be ~2022. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e16",
+          "notes_ref": "n27",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official standard"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-de-2024-pricelist"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g20-330i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G20",
-    "body_code": "G20",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "3 Series (G20, 2019-2025)",
-    "variant_name": "330i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-        "bmw_pressclub_sources:g20-3series-2021-techdata",
-        "bmw_pressclub_sources:g20-3series-2024-techdata"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e20",
+            "notes": "Official 2019/2021 BMW G20 330i sheets list 225/50 R17 98Y XL as the standard tire.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official standard"
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n29"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g20-330i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G20",
+      "body_code": "G20",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "3 Series (G20, 2019-2025)",
+      "variant_name": "330i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n28",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n28",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n28",
+          "value": 0.64,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence.",
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0299451EN/437354 (03/2019), T0325531EN/471537 (03/2021), and T0442333EN/620072 (2024) ACEA tech-data PDFs all confirm G20 330i xDrive ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, published final drive 2.813 (BMW lists a single FD value identical to the RWD variant). Standard tire 225/50 R17 98Y XL. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n30",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n28",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n28",
           "front": {
             "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence."
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g20-3-series-de-overview",
-            "bmw_market_pages:g20-3-series-uk-listing",
-            "legacy_research_sources:0bfbe440deb6",
-            "legacy_research_sources:3c7fce849237",
-            "legacy_research_sources:5d6e9b9da00b",
-            "legacy_research_sources:7c9fbfb0e7d2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b5d8a7f385c9",
-            "legacy_research_sources:b92080a8b603",
-            "legacy_research_sources:daa8f80dca50",
-            "legacy_research_sources:fc3067f501c7",
-            "legacy_research_sources:ff48a54d62d6"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n16",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW PressClub technical-data sheets now confirm the G20 330i xDrive 8-speed automatic final-drive ratio at 2.813, top-gear ratio at 0.640, the full 8-speed ratio set, and the standard 225/50 R17 tire from exact 03/2021 and 07/2022 EU-DE documents, so the current 330i xDrive override was corrected. Wave 14 adds the parallel rear-wheel-drive petrol evidence without promoting it into production: official 03/2021 and 07/2022 BMW technical-data sheets prove the exact 320i RWD ratio package, reverse ratio 3.712, final drive 2.813, and baseline tires changing from 205/60 R16 to 225/50 R17, while official 03/2021 BMW technical-data also proves the exact 330i RWD ratio package and 225/50 R17 baseline tire. The broad row remains unchanged because this pass did not recover one current exact numeric BMW Germany table that safely closes plain-RWD 320i and 330i continuity across the full 2019-2025 span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (03/2021, 07/2022) with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g20-3series-2019-launch-techdata",
-          "bmw_pressclub_sources:g20-3series-2021-techdata",
-          "bmw_pressclub_sources:g20-3series-2024-techdata"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
+          "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
+          "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
+          "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
+          "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "EU availability and applicability of 6-speed manual specifically for listed petrol variants",
-        "reason": "Accessible official pages still do not provide one authoritative 2019-2025 matrix covering every listed petrol variant's historical manual-versus-automatic availability.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "Exact public gearbox code and full tire-option matrix for 330i xDrive",
-        "reason": "The checked official BMW PressClub sheets prove the exact 8-speed ratios and the standard 225/50 R17 setup, but they do not publish a gearbox subtype code or the full official optional wheel/tire matrix for this exact variant.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 320i production-data applicability across the full 2019-2025 row span",
-        "reason": "Official 03/2021 and 07/2022 BMW technical-data sheets now prove one exact 320i RWD ratio package and show the baseline tire moving from 205/60 R16 to 225/50 R17, while the checked 2024 Germany price list confirms later automatic-only RWD continuity, but this pass did not recover a current exact numeric table proving one unchanged production mapping across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      },
-      {
-        "item": "BMW G20 330i RWD Germany-market continuity and exact tire-option coverage",
-        "reason": "Official 03/2021 BMW technical-data now proves the exact 330i RWD ratio package and 225/50 R17 baseline tire, but checked current Germany material is split between a 330i technical-data page and an xDrive-led overview, and this pass did not recover an extracted later official price-list or technical-data table closing plain-RWD continuity and wheel options across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g20-3-series-de-overview",
-          "bmw_market_pages:g20-3-series-uk-listing",
-          "legacy_research_sources:0bfbe440deb6",
-          "legacy_research_sources:3c7fce849237",
-          "legacy_research_sources:5d6e9b9da00b",
-          "legacy_research_sources:7c9fbfb0e7d2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b5d8a7f385c9",
-          "legacy_research_sources:b92080a8b603",
-          "legacy_research_sources:daa8f80dca50",
-          "legacy_research_sources:fc3067f501c7",
-          "legacy_research_sources:ff48a54d62d6"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/F32.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/F32.json
@@ -1,2760 +1,2098 @@
-[
-  {
-    "id": "bmw-f32-420i-xdrive-eu-2014-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2015,
-    "model_name": "4 Series (F32, 2014-2015)",
-    "variant_name": "420i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n3": "Sonnet redo (2026-04 v2): The 418i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article. Detail-level transmission/ratio values (gear array, FD) not directly extracted from a BMW PressClub spec PDF in this research run; held at no_confidence.",
+      "n4": "No BMW PressClub spec PDF for the 418i was located in this run; family_default values held at no_confidence pending direct verification.",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 430i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
+      "n6": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 440i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
+      "n7": "Official BMW 03/2014 F82 M4 technical-data PDF lists the standard staggered 255/40 ZR18 front and 275/40 ZR18 rear setup.",
+      "n8": "The official BMW launch-era technical-data PDF publishes a single 3.154 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n9": "The official BMW launch-era technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
+      "n10": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "Sonnet redo (2026-04 v2): This row carries engine_code B48, but the B48 was introduced at the F32 LCI in 03/2016 (the pre-LCI 420i used the N20). production_start_year corrected from 2014 to 2016. The pre-LCI N20 era of the 420i RWD is a separate configuration that is not represented in this row and remains a coverage gap. transmission/ratio values were not directly extracted from a BMW PressClub spec PDF in this research run.",
+      "n13": "The official BMW launch-era and 03/2016 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact F32 420i xDrive manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n14": "The official BMW launch-era and 03/2016 technical-data PDFs agree on 225/50 R17 as the baseline tire for the exact F32 420i xDrive manual configuration.",
+      "n15": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe manual row.",
+      "n16": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe automatic row.",
+      "n17": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 430d Coupe automatic row.",
+      "n18": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435d xDrive Coupe automatic row.",
+      "n19": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe manual row.",
+      "n20": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe automatic row.",
+      "n21": "Added EU-official xDrive drivetrain variants for 420i/430i/440i; retained existing gearbox ratio fields because official BMW specs show engine+drivetrain-specific ratio differences that cannot be safely represented by the current two generic gearbox entries without assumptions.",
+      "n22": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n23": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this top gear.",
+      "n24": "Official BMW 03/2014 F82 M4 technical-data PDF lists final drive 3.462.",
+      "n25": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this full forward gear-ratio set.",
+      "n26": "This run encoded the official staggered rear tire and full transmission ratio set from the BMW 03/2014 F82 M4 technical-data PDF.",
+      "n27": "The official BMW 03/2016 technical-data PDF publishes a single 3.231 final-drive ratio for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n28": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row.",
+      "n29": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n30": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row.",
+      "n31": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n32": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+      "n33": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n34": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:0fe428128ffa",
+        "legacy_research_sources:4ca576983b84",
+        "legacy_research_sources:5a2c34af7aa2",
+        "legacy_research_sources:89441dc61121",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:cf2e1d0043a3",
+        "legacy_research_sources:db56476b60f5",
+        "legacy_research_sources:de2b0611ceb4"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
+      ],
+      "e5": [
+        "secondary_technical_sources:bmw-f32-4series-wikipedia"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
+      ],
+      "e7": [
         "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
       ],
-      "notes": "The official BMW launch-era technical-data PDF confirms xDrive all-wheel drive for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
+      "e8": [
+        "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
+        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
       ],
-      "notes": "The official BMW launch-era technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era technical-data PDF lists the full forward gear-ratio set for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era technical-data PDF publishes a single 3.154 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era technical-data PDF publishes a single 3.154 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-          ],
-          "notes": "The official BMW launch-era technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch-era technical-data PDF confirms the exact F32 420i xDrive automatic launch-state row: AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.154, and 225/50 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 420i xDrive automatic optional wheel/tire matrix for 2014-2015 row",
-        "reason": "The checked official BMW launch-era technical-data PDF closes the baseline 17-inch fitment but does not prove one exact optional wheel/tire matrix for the represented 2014-2015 launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "F32 420i xDrive automatic separate front/rear final-drive publication for 2014-2015 row",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic launch-state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-418i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "418i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
+      "e9": [
+        "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
+        "secondary_technical_sources:bmw-f32-4series-wikipedia"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
+        "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
+      ],
+      "e12": [
         "legacy_research_sources:0fe428128ffa",
         "legacy_research_sources:89441dc61121",
         "legacy_research_sources:db56476b60f5",
         "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "Sonnet redo (2026-04 v2): The 418i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article. Detail-level transmission/ratio values (gear array, FD) not directly extracted from a BMW PressClub spec PDF in this research run; held at no_confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): The 418i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article. Detail-level transmission/ratio values (gear array, FD) not directly extracted from a BMW PressClub spec PDF in this research run; held at no_confidence.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "No BMW PressClub spec PDF for the 418i was located in this run; family_default values held at no_confidence pending direct verification.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "No BMW PressClub spec PDF for the 418i was located in this run; family_default values held at no_confidence pending direct verification.",
-        "value": 3.231,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up removes a copied 430d contradiction note from the F32 418i manual row. No exact official F32 418i technical-data artifact was recovered in the saved packet, so the current engine, ratio, and tyre fields remain inherited placeholders."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Recover an exact official F32 418i manual technical-data sheet",
-        "reason": "The saved official F32 packet still does not include an exact 418i source, so this row cannot safely be rewritten yet and keeps its inherited engine, ratio, and tyre metadata."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-418i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "418i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "reputable_secondary_crosschecked",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
+      "e13": [
+        "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
       ],
-      "notes": "Sonnet redo (2026-04 v2): The 418i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article. Detail-level transmission/ratio values (gear array, FD) not directly extracted from a BMW PressClub spec PDF in this research run; held at no_confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): The 418i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article. Detail-level transmission/ratio values (gear array, FD) not directly extracted from a BMW PressClub spec PDF in this research run; held at no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "No BMW PressClub spec PDF for the 418i was located in this run; family_default values held at no_confidence pending direct verification.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "No BMW PressClub spec PDF for the 418i was located in this run; family_default values held at no_confidence pending direct verification.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up removes a copied 430d contradiction note from the F32 418i automatic row. No exact official F32 418i technical-data artifact was recovered in the saved packet, so the current engine, ratio, and tyre fields remain inherited placeholders."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-f32-4series-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Recover an exact official F32 418i automatic technical-data sheet",
-        "reason": "The saved official F32 packet still does not include an exact 418i source, so this row cannot safely be rewritten yet and keeps its inherited engine, ratio, and tyre metadata."
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-420i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "420i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e14": [
+        "bmw_pressclub_sources:f32-440i-2016-tech-spec-pdf"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
+      ],
+      "e16": [
         "legacy_research_sources:0fe428128ffa",
         "legacy_research_sources:89441dc61121",
         "legacy_research_sources:db56476b60f5"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): This row carries engine_code B48, but the B48 was introduced at the F32 LCI in 03/2016 (the pre-LCI 420i used the N20). production_start_year corrected from 2014 to 2016. The pre-LCI N20 era of the 420i RWD is a separate configuration that is not represented in this row and remains a coverage gap. transmission/ratio values were not directly extracted from a BMW PressClub spec PDF in this research run.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2016 technical-data PDF first proves the F32 430i Coupe as a facelift-era row, not a 2014-start launch-state row. This manual row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this overbroad F32 430i manual row should be re-ranged to the facelift-era start",
-        "reason": "The saved official BMW technical-data packet first proves the F32 430i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-420i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "420i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo (2026-04 v2): This row carries engine_code B48, but the B48 was introduced at the F32 LCI in 03/2016 (the pre-LCI 420i used the N20). production_start_year corrected from 2014 to 2016. The pre-LCI N20 era of the 420i RWD is a separate configuration that is not represented in this row and remains a coverage gap. transmission/ratio values were not directly extracted from a BMW PressClub spec PDF in this research run.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2016 technical-data PDF first proves the F32 430i Coupe as a facelift-era row, not a 2014-start launch-state row. This automatic row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this overbroad F32 430i automatic row should be re-ranged to the facelift-era start",
-        "reason": "The saved official BMW technical-data packet first proves the F32 430i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-430i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-420i-xdrive-eu-2014-mt6-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "420i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on xDrive all-wheel drive for the exact F32 420i xDrive 6-speed manual configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on a 6-speed manual transmission for the exact F32 420i xDrive manual configuration. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on 0.846 as the top-gear ratio for the exact F32 420i xDrive manual configuration.",
-        "value": 0.846
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on the full forward gear-ratio set for the exact F32 420i xDrive manual configuration.",
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact F32 420i xDrive manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact F32 420i xDrive manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on 225/50 R17 as the baseline tire for the exact F32 420i xDrive manual configuration.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-            "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on 225/50 R17 as the baseline tire for the exact F32 420i xDrive manual configuration.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch-era and 03/2016 technical-data PDFs agree on the exact F32 420i xDrive manual state: AWD, 6-speed manual, forward ratios 4.110 / 2.315 / 1.542 / 1.179 / 1.000 / 0.846, a single published final-drive ratio of 3.385, and 225/50 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 420i xDrive manual optional wheel/tire matrix",
-        "reason": "The checked official BMW technical-data PDFs close the baseline 17-inch fitment but do not prove one exact optional wheel/tire matrix across the broader represented row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "F32 420i xDrive manual separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD manual state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-428i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "428i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
+      "e17": [
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
         "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 428i Coupe manual row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
+      "e18": [
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
         "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms a 6-speed manual gearbox for the exact F32 428i Coupe manual row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.701 as the top-gear ratio for the exact F32 428i Coupe manual row.",
-        "value": 0.701,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.909 as the final-drive ratio for the exact F32 428i Coupe manual row.",
-        "value": 3.909,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ],
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe manual row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-          ],
-          "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe manual row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces copied 435d contradiction residue on the F32 428i manual row with the recovered official BMW launch-period values: rear-wheel drive, 6-speed manual, top gear 0.701, final drive 3.909, and standard 225/50 R17 tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 428i manual span",
-        "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-428i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "428i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 428i Coupe automatic row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 428i Coupe automatic row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 428i Coupe automatic row.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.154 as the final-drive ratio for the exact F32 428i Coupe automatic row.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ],
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe automatic row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-          ],
-          "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 428i Coupe automatic row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces copied 435d contradiction residue on the F32 428i automatic row with the recovered official BMW launch-period values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 3.154, and standard 225/50 R17 tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 428i automatic span",
-        "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-430d-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "430d",
-    "engine_code": "N57",
-    "engine_name": "N57 3.0L I6 Diesel Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2013 technical-data PDF confirms rear-wheel drive for the exact F32 430d Coupe automatic row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2013 technical-data PDF confirms the F32 430d Coupe only as an 8-speed automatic with Steptronic. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 11/2013 technical-data PDF lists 0.667 as the eighth gear for the exact F32 430d Coupe automatic row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 technical-data PDF lists 2.563 as the final-drive ratio for the exact F32 430d Coupe automatic row.",
-        "value": 2.563,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 11/2013 technical-data PDF directly publishes the full 8-speed forward ratio set for the exact F32 430d Coupe automatic row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 430d Coupe automatic row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 430d Coupe automatic row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up tightens the F32 430d automatic row to the recovered official BMW 11/2013 values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 2.563, and standard 225/50 R17 tyres. The prior 3.077 final drive and 18-inch default were stale family carryover.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run promoted the exact official 8-speed gear-ratio array for the F32 430d Coupe automatic from the saved BMW 11/2013 technical-data PDF.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 430d automatic span",
-        "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-430d-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-430i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "430i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 430i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 430i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2016 technical-data PDF first proves the F32 440i Coupe as a facelift-era row, not a 2014-start launch-state row. This manual row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this overbroad F32 440i manual row should be re-ranged to the facelift-era start",
-        "reason": "The saved official BMW technical-data packet first proves the F32 440i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-430i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "430i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 430i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 430i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2016 technical-data PDF first proves the F32 440i Coupe as a facelift-era row, not a 2014-start launch-state row. This automatic row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this overbroad F32 440i automatic row should be re-ranged to the facelift-era start",
-        "reason": "The saved official BMW technical-data packet first proves the F32 440i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-435d-xdrive-eu-2014-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "435d xDrive",
-    "engine_code": "N57T",
-    "engine_name": "N57T 3.0L I6 Twin-Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e19": [
         "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-        "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-      ],
-      "notes": "The official BMW launch article and 11/2013 technical-data PDF confirm xDrive all-wheel drive for the exact F32 435d xDrive Coupe automatic row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-        "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-      ],
-      "notes": "The official BMW launch article and 11/2013 technical-data PDF confirm the F32 435d Coupe only as an 8-speed automatic with Steptronic. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
+        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f32-420i-xdrive-eu-2014-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2015,
+      "model_name": "4 Series (F32, 2014-2015)",
+      "variant_name": "420i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 11/2013 technical-data PDF lists 0.667 as the eighth gear for the exact F32 435d xDrive Coupe automatic row.",
-        "value": 0.667
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW launch-era technical-data PDF confirms xDrive all-wheel drive for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
+        "value": "AWD"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 technical-data PDF lists 2.563 as the final-drive ratio for the exact F32 435d xDrive Coupe automatic row.",
-        "value": 2.563,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ]
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW launch-era technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 11/2013 technical-data PDF directly publishes the full 8-speed forward ratio set for the exact F32 435d xDrive Coupe automatic row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435d xDrive Coupe automatic row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-            "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2013 technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435d xDrive Coupe automatic row.",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW launch-era technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW launch-era technical-data PDF lists the full forward gear-ratio set for the exact F32 420i xDrive automatic configuration represented by the 2014-2015 launch-state row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n8",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n8",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch-era technical-data PDF confirms the exact F32 420i xDrive automatic launch-state row: AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.154, and 225/50 R17 baseline tires.",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces the contradicted rear-wheel-drive 435d placeholder with the exact official BMW launch-period 435d xDrive automatic row, including xDrive drivetrain, 8-speed Steptronic automatic, final drive 2.563, and standard 225/50 R17 tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run promoted the exact official 8-speed gear-ratio array for the F32 435d xDrive Coupe automatic from the saved BMW 11/2013 technical-data PDF.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Promote the exact F32 435d xDrive automatic top-gear value",
-        "reason": "The saved official packet cleanly closes drivetrain, transmission family, final drive, and standard-tyre baseline, but this replacement pass did not promote the exact top-gear value into production.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Launch-period exactness across the full stored F32 435d xDrive automatic span",
-        "reason": "The recovered official sources are launch-period material; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-435d-xdrive-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-435i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "435i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 435i Coupe manual row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms a 6-speed manual gearbox for the exact F32 435i Coupe manual row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.846 as the top-gear ratio for the exact F32 435i Coupe manual row.",
-        "value": 0.846,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.231 as the final-drive ratio for the exact F32 435i Coupe manual row.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ],
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe manual row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-          ],
-          "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe manual row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "item": "F32 420i xDrive automatic optional wheel/tire matrix for 2014-2015 row",
+          "reason": "The checked official BMW launch-era technical-data PDF closes the baseline 17-inch fitment but does not prove one exact optional wheel/tire matrix for the represented 2014-2015 launch-state row.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "item": "F32 420i xDrive automatic separate front/rear final-drive publication for 2014-2015 row",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic launch-state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces generic F32 carryover on the 435i manual row with the recovered official BMW launch-period values: rear-wheel drive, 6-speed manual, top gear 0.846, final drive 3.231, and standard 225/50 R17 tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 435i manual span",
-        "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-435i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2016,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "435i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 435i Coupe automatic row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 11/2013 launch technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 435i Coupe automatic row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 435i Coupe automatic row.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.154 as the final-drive ratio for the exact F32 435i Coupe automatic row.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ],
-        "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe automatic row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f32-418i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "418i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n3",
+        "value": "RWD"
       },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-          ],
-          "notes": "The official BMW 11/2013 launch technical-data PDF lists 225/50 R17 94W as the standard tyre package for the exact F32 435i Coupe automatic row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.812,
+          "evidence_refs_ref": "e5"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.231,
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces generic F32 carryover on the 435i automatic row with the recovered official BMW launch-period values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 3.154, and standard 225/50 R17 tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 435i automatic span",
-        "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-428i-435i-2013-launch-tech-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-440i-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "440i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 440i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 440i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "tires": {
+        "default": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up removes a copied 430d contradiction note from the F32 418i manual row. No exact official F32 418i technical-data artifact was recovered in the saved packet, so the current engine, ratio, and tyre fields remain inherited placeholders."
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n10",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n11",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Added EU-official xDrive drivetrain variants for 420i/430i/440i; retained existing gearbox ratio fields because official BMW specs show engine+drivetrain-specific ratio differences that cannot be safely represented by the current two generic gearbox entries without assumptions.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Map precise top_gear_ratio/final_drive_ratio values into current generic `gearboxes` list",
-        "reason": "Official BMW data provides multiple conflicting values by engine (420i/430i/440i), drivetrain (RWD/xDrive), and transmission choice; current schema usage here stores only two generic gearbox entries, so assigning one pair would require assumptions.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      },
-      {
-        "item": "Determine whether current stored gearbox ratios (0.667/3.077 and 0.812/3.231) correspond to specific diesel or non-listed F32 variants",
-        "reason": "Those exact values were not confirmed for the listed petrol variants from the retrieved official EU 420i/430i/440i specification PDFs.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-440i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "440i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0fe428128ffa",
-        "legacy_research_sources:89441dc61121",
-        "legacy_research_sources:db56476b60f5",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 440i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence. Sonnet redo (2026-04 v2): The 440i nameplate is LCI-only (introduced in 03/2016 with the F32 mid-cycle refresh). production_start_year corrected from 2014 to 2016: this badge did not exist in pre-LCI F32 (2013-2015). Engine code clarification per Wikipedia F32 article.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
+      "unresolved": [
+        {
+          "item": "Recover an exact official F32 418i manual technical-data sheet",
+          "reason": "The saved official F32 packet still does not include an exact 418i source, so this row cannot safely be rewritten yet and keeps its inherited engine, ratio, and tyre metadata."
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f32-418i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "418i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "reputable_secondary_crosschecked",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n3",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.667,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.077,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up removes a copied 430d contradiction note from the F32 418i automatic row. No exact official F32 418i technical-data artifact was recovered in the saved packet, so the current engine, ratio, and tyre fields remain inherited placeholders."
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note_ref": "n10",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n11",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Added EU-official xDrive drivetrain variants for 420i/430i/440i; retained existing gearbox ratio fields because official BMW specs show engine+drivetrain-specific ratio differences that cannot be safely represented by the current two generic gearbox entries without assumptions.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Map precise top_gear_ratio/final_drive_ratio values into current generic `gearboxes` list",
-        "reason": "Official BMW data provides multiple conflicting values by engine (420i/430i/440i), drivetrain (RWD/xDrive), and transmission choice; current schema usage here stores only two generic gearbox entries, so assigning one pair would require assumptions.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      },
-      {
-        "item": "Determine whether current stored gearbox ratios (0.667/3.077 and 0.812/3.231) correspond to specific diesel or non-listed F32 variants",
-        "reason": "Those exact values were not confirmed for the listed petrol variants from the retrieved official EU 420i/430i/440i specification PDFs.",
-        "evidence_refs": [
-          "legacy_research_sources:0fe428128ffa",
-          "legacy_research_sources:4ca576983b84",
-          "legacy_research_sources:5a2c34af7aa2",
-          "legacy_research_sources:89441dc61121",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:cf2e1d0043a3",
-          "legacy_research_sources:db56476b60f5",
-          "legacy_research_sources:de2b0611ceb4"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-m4-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "M4",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Twin-Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2014 M4 technical-data PDF confirms rear-wheel drive for the exact F32 M4 Coupe manual row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
+      "unresolved": [
+        {
+          "item": "Recover an exact official F32 418i automatic technical-data sheet",
+          "reason": "The saved official F32 packet still does not include an exact 418i source, so this row cannot safely be rewritten yet and keeps its inherited engine, ratio, and tyre metadata."
+        }
       ],
-      "notes": "The official BMW 03/2014 M4 technical-data PDF confirms a 6-speed manual gearbox for the exact F32 M4 Coupe manual row.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this top gear.",
-        "value": 0.846
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists final drive 3.462.",
-        "value": 3.462
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this full forward gear-ratio set.",
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ]
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f32-420i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "420i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists the standard staggered 255/40 ZR18 front and 275/40 ZR18 rear setup.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+        "evidence_refs_ref": "e16",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.231
         }
       },
-      "options": [
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note": "Official BMW 03/2016 technical-data PDF first proves the F32 430i Coupe as a facelift-era row, not a 2014-start launch-state row. This manual row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this overbroad F32 430i manual row should be re-ranged to the facelift-era start",
+          "reason": "The saved official BMW technical-data packet first proves the F32 430i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-420i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "420i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e16",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n12",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2016 technical-data PDF first proves the F32 430i Coupe as a facelift-era row, not a 2014-start launch-state row. This automatic row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this overbroad F32 430i automatic row should be re-ranged to the facelift-era start",
+          "reason": "The saved official BMW technical-data packet first proves the F32 430i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-420i-xdrive-eu-2014-mt6-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "420i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on xDrive all-wheel drive for the exact F32 420i xDrive 6-speed manual configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on a 6-speed manual transmission for the exact F32 420i xDrive manual configuration. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists the standard staggered 255/40 ZR18 front and 275/40 ZR18 rear setup.",
+          "evidence_refs_ref": "e8",
+          "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on 0.846 as the top-gear ratio for the exact F32 420i xDrive manual configuration.",
+          "value": 0.846
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "The official BMW launch-era and 03/2016 technical-data PDFs agree on the full forward gear-ratio set for the exact F32 420i xDrive manual configuration.",
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n13",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n13",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n14",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch-era and 03/2016 technical-data PDFs agree on the exact F32 420i xDrive manual state: AWD, 6-speed manual, forward ratios 4.110 / 2.315 / 1.542 / 1.179 / 1.000 / 0.846, a single published final-drive ratio of 3.385, and 225/50 R17 baseline tires.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "F32 420i xDrive manual optional wheel/tire matrix",
+          "reason": "The checked official BMW technical-data PDFs close the baseline 17-inch fitment but do not prove one exact optional wheel/tire matrix across the broader represented row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "F32 420i xDrive manual separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD manual state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-428i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "428i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 428i Coupe manual row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms a 6-speed manual gearbox for the exact F32 428i Coupe manual row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.701 as the top-gear ratio for the exact F32 428i Coupe manual row.",
+          "value": 0.701,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.909 as the final-drive ratio for the exact F32 428i Coupe manual row.",
+          "value": 3.909,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n15",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces copied 435d contradiction residue on the F32 428i manual row with the recovered official BMW launch-period values: rear-wheel drive, 6-speed manual, top gear 0.701, final drive 3.909, and standard 225/50 R17 tyres.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 428i manual span",
+          "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-428i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "428i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 428i Coupe automatic row. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 428i Coupe automatic row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 428i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 430i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 428i Coupe automatic row.",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.154 as the final-drive ratio for the exact F32 428i Coupe automatic row.",
+          "value": 3.154,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces copied 435d contradiction residue on the F32 428i automatic row with the recovered official BMW launch-period values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 3.154, and standard 225/50 R17 tyres.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 428i automatic span",
+          "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-430d-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "430d",
+      "engine_code": "N57",
+      "engine_name": "N57 3.0L I6 Diesel Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes": "The official BMW 11/2013 technical-data PDF confirms rear-wheel drive for the exact F32 430d Coupe automatic row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e9",
+        "notes": "The official BMW 11/2013 technical-data PDF confirms the F32 430d Coupe only as an 8-speed automatic with Steptronic. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Official BMW 11/2013 technical-data PDF lists 0.667 as the eighth gear for the exact F32 430d Coupe automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 technical-data PDF lists 2.563 as the final-drive ratio for the exact F32 430d Coupe automatic row.",
+          "value": 2.563,
+          "evidence_refs_ref": "e9"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "Official BMW 11/2013 technical-data PDF directly publishes the full 8-speed forward ratio set for the exact F32 430d Coupe automatic row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up tightens the F32 430d automatic row to the recovered official BMW 11/2013 values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 2.563, and standard 225/50 R17 tyres. The prior 3.077 final drive and 18-inch default were stale family carryover.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note": "This run promoted the exact official 8-speed gear-ratio array for the F32 430d Coupe automatic from the saved BMW 11/2013 technical-data PDF.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 430d automatic span",
+          "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-430i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "430i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n5",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n5",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2016 technical-data PDF first proves the F32 440i Coupe as a facelift-era row, not a 2014-start launch-state row. This manual row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this overbroad F32 440i manual row should be re-ranged to the facelift-era start",
+          "reason": "The saved official BMW technical-data packet first proves the F32 440i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-430i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "430i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n5",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2016 technical-data PDF first proves the F32 440i Coupe as a facelift-era row, not a 2014-start launch-state row. This automatic row remains only as an overbroad placeholder until the broader F32 shard is reshaped.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this overbroad F32 440i automatic row should be re-ranged to the facelift-era start",
+          "reason": "The saved official BMW technical-data packet first proves the F32 440i Coupe from the 03/2016 facelift range, so the current 2014 start year is contradicted, but this pass did not split the row by era.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-435d-xdrive-eu-2014-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "435d xDrive",
+      "engine_code": "N57T",
+      "engine_name": "N57T 3.0L I6 Twin-Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e11",
+        "notes": "The official BMW launch article and 11/2013 technical-data PDF confirm xDrive all-wheel drive for the exact F32 435d xDrive Coupe automatic row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e11",
+        "notes": "The official BMW launch article and 11/2013 technical-data PDF confirm the F32 435d Coupe only as an 8-speed automatic with Steptronic. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e15",
+          "notes": "Official BMW 11/2013 technical-data PDF lists 0.667 as the eighth gear for the exact F32 435d xDrive Coupe automatic row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 technical-data PDF lists 2.563 as the final-drive ratio for the exact F32 435d xDrive Coupe automatic row.",
+          "value": 2.563,
+          "evidence_refs_ref": "e11"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e15",
+          "notes": "Official BMW 11/2013 technical-data PDF directly publishes the full 8-speed forward ratio set for the exact F32 435d xDrive Coupe automatic row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n18",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e11",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces the contradicted rear-wheel-drive 435d placeholder with the exact official BMW launch-period 435d xDrive automatic row, including xDrive drivetrain, 8-speed Steptronic automatic, final drive 2.563, and standard 225/50 R17 tyres.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note": "This run promoted the exact official 8-speed gear-ratio array for the F32 435d xDrive Coupe automatic from the saved BMW 11/2013 technical-data PDF.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Promote the exact F32 435d xDrive automatic top-gear value",
+          "reason": "The saved official packet cleanly closes drivetrain, transmission family, final drive, and standard-tyre baseline, but this replacement pass did not promote the exact top-gear value into production.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "Launch-period exactness across the full stored F32 435d xDrive automatic span",
+          "reason": "The recovered official sources are launch-period material; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-435i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "435i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 435i Coupe manual row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms a 6-speed manual gearbox for the exact F32 435i Coupe manual row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.846 as the top-gear ratio for the exact F32 435i Coupe manual row.",
+          "value": 0.846,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.231 as the final-drive ratio for the exact F32 435i Coupe manual row.",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n19",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n19",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces generic F32 carryover on the 435i manual row with the recovered official BMW launch-period values: rear-wheel drive, 6-speed manual, top gear 0.846, final drive 3.231, and standard 225/50 R17 tyres.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 435i manual span",
+          "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-435i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2016,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "435i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms rear-wheel drive for the exact F32 435i Coupe automatic row. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2013 launch technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 435i Coupe automatic row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 435i nameplate was discontinued at the F32 LCI in 03/2016 (replaced by 440i with the new B-series engine). production_end_year corrected to 2016 to reflect actual production span. Engine code clarified per Wikipedia F32 article.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 0.667 as the top-gear ratio for the exact F32 435i Coupe automatic row.",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "The official BMW 11/2013 launch technical-data PDF lists 3.154 as the final-drive ratio for the exact F32 435i Coupe automatic row.",
+          "value": 3.154,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n20",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n20",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces generic F32 carryover on the 435i automatic row with the recovered official BMW launch-period values: rear-wheel drive, 8-speed Steptronic automatic, top gear 0.667, final drive 3.154, and standard 225/50 R17 tyres.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 435i automatic span",
+          "reason": "The recovered official source is the 11/2013 launch-period sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-440i-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "440i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n6",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n6",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.812
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n21",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n22"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Map precise top_gear_ratio/final_drive_ratio values into current generic `gearboxes` list",
+          "reason": "Official BMW data provides multiple conflicting values by engine (420i/430i/440i), drivetrain (RWD/xDrive), and transmission choice; current schema usage here stores only two generic gearbox entries, so assigning one pair would require assumptions.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Determine whether current stored gearbox ratios (0.667/3.077 and 0.812/3.231) correspond to specific diesel or non-listed F32 variants",
+          "reason": "Those exact values were not confirmed for the listed petrol variants from the retrieved official EU 420i/430i/440i specification PDFs.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-440i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "440i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n6",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n21",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n22"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Map precise top_gear_ratio/final_drive_ratio values into current generic `gearboxes` list",
+          "reason": "Official BMW data provides multiple conflicting values by engine (420i/430i/440i), drivetrain (RWD/xDrive), and transmission choice; current schema usage here stores only two generic gearbox entries, so assigning one pair would require assumptions.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Determine whether current stored gearbox ratios (0.667/3.077 and 0.812/3.231) correspond to specific diesel or non-listed F32 variants",
+          "reason": "Those exact values were not confirmed for the listed petrol variants from the retrieved official EU 420i/430i/440i specification PDFs.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-m4-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "M4",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Twin-Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 03/2014 M4 technical-data PDF confirms rear-wheel drive for the exact F32 M4 Coupe manual row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 03/2014 M4 technical-data PDF confirms a 6-speed manual gearbox for the exact F32 M4 Coupe manual row.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n23",
+          "value": 0.846
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n24",
+          "value": 3.462
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n25",
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
@@ -2765,140 +2103,118 @@
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
-          },
-          "name": "Official standard staggered 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces generic petrol carryover on the F32 M4 manual row with the recovered official BMW 03/2014 values: rear-wheel drive, 6-speed manual, top gear 0.846, final drive 3.462, and launch-period staggered 18-inch tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run encoded the official staggered rear tire and full transmission ratio set from the BMW 03/2014 F82 M4 technical-data PDF.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 M4 manual span",
-        "reason": "The recovered official source is the 03/2014 launch-period M4 sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Explicit rear-tyre encoding for the standard F32 M4 package",
-        "reason": "The official source lists a staggered front/rear tyre package, but the current schema stores only the front baseline plus the rear speed axle marker.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-m4-eu-2014-dct7-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2014-2020)",
-    "variant_name": "M4",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Twin-Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2014 M4 technical-data PDF confirms rear-wheel drive for the exact F32 M4 Coupe double-clutch row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2014 M4 technical-data PDF confirms the optional 7-speed M double-clutch transmission for the exact F32 M4 Coupe automatic row. The repo normalizes that official BMW wording to the canonical DCT7 gearbox family.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (M-DCT)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this top gear.",
-        "value": 0.671
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists final drive 3.462.",
-        "value": 3.462
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF directly publishes this full forward gear-ratio set.",
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists the standard staggered 255/40 ZR18 front and 275/40 ZR18 rear setup.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+          }
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "name": "Official standard staggered 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This follow-up replaces generic petrol carryover on the F32 M4 manual row with the recovered official BMW 03/2014 values: rear-wheel drive, 6-speed manual, top gear 0.846, final drive 3.462, and launch-period staggered 18-inch tyres.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n26",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 M4 manual span",
+          "reason": "The recovered official source is the 03/2014 launch-period M4 sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Explicit rear-tyre encoding for the standard F32 M4 package",
+          "reason": "The official source lists a staggered front/rear tyre package, but the current schema stores only the front baseline plus the rear speed axle marker.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-m4-eu-2014-dct7-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2014-2020)",
+      "variant_name": "M4",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Twin-Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 03/2014 M4 technical-data PDF confirms rear-wheel drive for the exact F32 M4 Coupe double-clutch row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 03/2014 M4 technical-data PDF confirms the optional 7-speed M double-clutch transmission for the exact F32 M4 Coupe automatic row. The repo normalizes that official BMW wording to the canonical DCT7 gearbox family.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (M-DCT)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n23",
+          "value": 0.671
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n24",
+          "value": 3.462
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n25",
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
+          ]
         }
       },
-      "options": [
-        {
+      "tires": {
+        "default": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 03/2014 F82 M4 technical-data PDF lists the standard staggered 255/40 ZR18 front and 275/40 ZR18 rear setup.",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
@@ -2909,739 +2225,583 @@
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
-          },
-          "name": "Official standard staggered 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This follow-up replaces the fake F32 M4 ZF8HP placeholder with the exact official BMW 03/2014 M4 DCT row, including the 7-speed M double-clutch transmission, top gear 0.671, final drive 3.462, and launch-period staggered 18-inch tyres.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run encoded the official staggered rear tire and full transmission ratio set from the BMW 03/2014 F82 M4 technical-data PDF.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Launch-period exactness across the full stored F32 M4 DCT span",
-        "reason": "The recovered official source is the 03/2014 launch-period M4 sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Explicit rear-tyre encoding for the standard F32 M4 package",
-        "reason": "The official source lists a staggered front/rear tyre package, but the current schema stores only the front baseline plus the rear speed axle marker.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-m4-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-440i-xdrive-eu-2016-mt6-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2016-2020)",
-    "variant_name": "440i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 03/2016 specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms a 6-speed manual transmission for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 0.846 as the top-gear ratio for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row.",
-        "value": 0.846
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 3.231 final-drive ratio for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.231
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 3.231 final-drive ratio for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+          }
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "name": "Official standard staggered 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "This follow-up replaces the fake F32 M4 ZF8HP placeholder with the exact official BMW 03/2014 M4 DCT row, including the 7-speed M double-clutch transmission, top gear 0.671, final drive 3.462, and launch-period staggered 18-inch tyres.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n26",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Launch-period exactness across the full stored F32 M4 DCT span",
+          "reason": "The recovered official source is the 03/2014 launch-period M4 sheet; this pass did not recover every later lifecycle table to prove no ratio or standard-tyre drift across the full 2014-2020 row span.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Explicit rear-tyre encoding for the standard F32 M4 package",
+          "reason": "The official source lists a staggered front/rear tyre package, but the current schema stores only the front baseline plus the rear speed axle marker.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-440i-xdrive-eu-2016-mt6-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2016-2020)",
+      "variant_name": "440i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e17",
+        "notes": "The official BMW 03/2016 specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e18",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms a 6-speed manual transmission for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row.",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2016 technical-data PDF lists 0.846 as the top-gear ratio for the exact F32 440i xDrive manual configuration represented by this retimed 2016-only row.",
+          "value": 0.846
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n27",
+          "value": 3.231
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n27",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n28",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n28",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2013 launch-era 4 Series Coupé specifications page does not list 440i xDrive, while the official 03/2016 specifications page and technical-data PDF establish the first checked exact 440i xDrive manual state: AWD, 6-speed manual, 0.846 top gear, a single published 3.231 final-drive ratio, and 225/50 R17 baseline tires. This row is therefore retimed to the supported 2016-only state instead of preserving an unsupported 2014-2020 span.",
+          "evidence_refs_ref": "e19"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2013 launch-era 4 Series Coupé specifications page does not list 440i xDrive, while the official 03/2016 specifications page and technical-data PDF establish the first checked exact 440i xDrive manual state: AWD, 6-speed manual, 0.846 top gear, a single published 3.231 final-drive ratio, and 225/50 R17 baseline tires. This row is therefore retimed to the supported 2016-only state instead of preserving an unsupported 2014-2020 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 440i xDrive manual full forward gear-ratio array",
-        "reason": "The checked official 03/2016 evidence safely resolves the supported 2016-only row span plus top gear, final drive, and baseline tire, but this pass did not extract a full exact forward gear-ratio array for the manual xDrive440i state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "F32 440i xDrive manual exact optional wheel/tire matrix",
-        "reason": "The checked official 03/2016 evidence closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the supported 2016-only row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-440i-xdrive-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2016-2020)",
-    "variant_name": "440i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
       ],
-      "notes": "The official BMW 03/2016 specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
-        "secondary_technical_sources:bmw-f32-4series-wikipedia"
-      ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed Steptronic wording for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "F32 440i xDrive manual full forward gear-ratio array",
+          "reason": "The checked official 03/2016 evidence safely resolves the supported 2016-only row span plus top gear, final drive, and baseline tire, but this pass did not extract a full exact forward gear-ratio array for the manual xDrive440i state.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "F32 440i xDrive manual exact optional wheel/tire matrix",
+          "reason": "The checked official 03/2016 evidence closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the supported 2016-only row.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-440i-xdrive-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2016-2020)",
+      "variant_name": "440i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e17",
+        "notes": "The official BMW 03/2016 specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e18",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed Steptronic wording for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic. Sonnet redo (2026-04 v2): The 440i xDrive remained in production for the full post-LCI F32 era (03/2016 to end of F32 production in 2020). The previous production_end_year of 2016 was a data entry error - it incorrectly captured only the 03/2016 launch documentation date rather than the actual end of production. Corrected to 2020 per Wikipedia F32 production timeline.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row.",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 440i xDrive automatic configuration represented by this retimed 2016-only row.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n29",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n29",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n30",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n30",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2013 launch-era 4 Series Coupé specifications page does not list 440i xDrive, while the official 03/2016 specifications page and technical-data PDF establish the first checked exact 440i xDrive automatic state: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.813 final-drive ratio, and 225/50 R17 baseline tires. This row is therefore retimed to the supported 2016-only state instead of preserving an unsupported 2014-2020 span.",
+          "evidence_refs_ref": "e19"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2013 launch-era 4 Series Coupé specifications page does not list 440i xDrive, while the official 03/2016 specifications page and technical-data PDF establish the first checked exact 440i xDrive automatic state: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.813 final-drive ratio, and 225/50 R17 baseline tires. This row is therefore retimed to the supported 2016-only state instead of preserving an unsupported 2014-2020 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 440i xDrive automatic full forward gear-ratio array",
-        "reason": "The checked official 03/2016 evidence safely resolves the supported 2016-only row span plus top gear, final drive, and baseline tire, but this pass did not extract a full exact forward gear-ratio array for the automatic xDrive440i state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "F32 440i xDrive automatic exact optional wheel/tire matrix",
-        "reason": "The checked official 03/2016 evidence closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the supported 2016-only row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-420i-xdrive-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2016-2020)",
-    "variant_name": "420i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms xDrive all-wheel drive for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists the full forward gear-ratio set for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "F32 440i xDrive automatic full forward gear-ratio array",
+          "reason": "The checked official 03/2016 evidence safely resolves the supported 2016-only row span plus top gear, final drive, and baseline tire, but this pass did not extract a full exact forward gear-ratio array for the automatic xDrive440i state.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "F32 440i xDrive automatic exact optional wheel/tire matrix",
+          "reason": "The checked official 03/2016 evidence closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the supported 2016-only row.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-420i-xdrive-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2016-2020)",
+      "variant_name": "420i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms xDrive all-wheel drive for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 03/2016 technical-data PDF lists the full forward gear-ratio set for the exact F32 420i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n31",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n31",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n32",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n32",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2016 technical-data PDF confirms the exact F32 420i xDrive automatic state represented by the narrowed 2016-2020 row: AWD, 8-speed automatic with Steptronic wording, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, a single published final-drive ratio of 2.813, and 225/50 R17 baseline tires.",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2016 technical-data PDF confirms the exact F32 420i xDrive automatic state represented by the narrowed 2016-2020 row: AWD, 8-speed automatic with Steptronic wording, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, a single published final-drive ratio of 2.813, and 225/50 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 420i xDrive automatic continuity beyond the checked 03/2016 state",
-        "reason": "The row was narrowed to the 2016+ state to avoid mixing the official launch-era automatic ratios with the official 03/2016 update, but this pass did not recover a second later official table proving one unchanged 2016-2020 package.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "F32 420i xDrive automatic separate front/rear final-drive publication for 2016-2020 row",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f32-430i-xdrive-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F32",
-    "body_code": "F32",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "4 Series (F32, 2016-2020)",
-    "variant_name": "430i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms xDrive all-wheel drive for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists the full forward gear-ratio set for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF publishes a single 2.813 final-drive ratio for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "F32 420i xDrive automatic continuity beyond the checked 03/2016 state",
+          "reason": "The row was narrowed to the 2016+ state to avoid mixing the official launch-era automatic ratios with the official 03/2016 update, but this pass did not recover a second later official table proving one unchanged 2016-2020 package.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "F32 420i xDrive automatic separate front/rear final-drive publication for 2016-2020 row",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f32-430i-xdrive-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F32",
+      "body_code": "F32",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "4 Series (F32, 2016-2020)",
+      "variant_name": "430i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms xDrive all-wheel drive for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 03/2016 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2016 technical-data PDF lists 225/50 R17 as the baseline tire for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 03/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 03/2016 technical-data PDF lists the full forward gear-ratio set for the exact F32 430i xDrive automatic configuration represented by the narrowed 2016-2020 row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n33",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n33",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n34",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n34",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fe428128ffa",
-            "legacy_research_sources:4ca576983b84",
-            "legacy_research_sources:5a2c34af7aa2",
-            "legacy_research_sources:89441dc61121",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:cf2e1d0043a3",
-            "legacy_research_sources:db56476b60f5",
-            "legacy_research_sources:de2b0611ceb4"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2016 technical-data PDF confirms the exact F32 430i xDrive automatic state represented by the narrowed 2016-2020 row: AWD, 8-speed automatic with Steptronic wording, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, a single published final-drive ratio of 2.813, and 225/50 R17 baseline tires. The same checked official 03/2016 sheet lists 430i xDrive as automatic-only, so the unsupported manual row was removed instead of preserved as inherited data.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "F32 430i xDrive automatic continuity beyond the checked 03/2016 state",
-        "reason": "The row was narrowed to the 2016+ state because the checked official evidence begins at 03/2016, but this pass did not recover a second later official table proving one unchanged 2016-2020 package.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "item": "F32 430i xDrive automatic separate front/rear final-drive publication for 2016-2020 row",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2016 technical-data PDF confirms the exact F32 430i xDrive automatic state represented by the narrowed 2016-2020 row: AWD, 8-speed automatic with Steptronic wording, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, a single published final-drive ratio of 2.813, and 225/50 R17 baseline tires. The same checked official 03/2016 sheet lists 430i xDrive as automatic-only, so the unsupported manual row was removed instead of preserved as inherited data.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "F32 430i xDrive automatic continuity beyond the checked 03/2016 state",
+          "reason": "The row was narrowed to the 2016+ state because the checked official evidence begins at 03/2016, but this pass did not recover a second later official table proving one unchanged 2016-2020 package.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "F32 430i xDrive automatic separate front/rear final-drive publication for 2016-2020 row",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/G22.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/G22.json
@@ -1,696 +1,439 @@
-[
-  {
-    "id": "bmw-g22-420i-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G22",
-    "body_code": "G22",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "4 Series (G22, 2021-2026)",
-    "variant_name": "420i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
+      "n4": "Issue #1034 official-source review corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Official BMW PressClub DE 07/2021 ACEA technical-data now also confirms the exact M440i xDrive launch mapping: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard staggered 225/45 R18 front + 255/40 R18 rear tires. Later Wave 10 validation adds exact 430i xDrive context: the checked 03/2021 launch technical-data PDF does not list 430i xDrive, but the current BMW Germany technical-data page does list 430i xDrive Coupé / 51HB / Allradantrieb / Steptronic Sport Getriebe, and the 2026 Germany price list confirms standard 225/50 R17 tires, optional 225/45 R18 tires, and optional staggered 225/40 R19 front + 255/35 R19 rear tires. Wave 12 validation now adds exact 420i context from checked 03/2021 and 01/2024 official EU-market technical-data PDFs: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 225/50 R17 tires. The broad 2021-2026 row remains unchanged because the checked official material still does not prove one unchanged 420i, 430i xDrive, or M440i xDrive package across the full represented span."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_market_pages:g22-4-series-technical-data-de",
+        "bmw_market_pages:g22-4-series-technical-data-ie",
+        "legacy_research_sources:03c433610239",
+        "legacy_research_sources:0b510c0af2c9",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:c0c98c38e567",
+        "legacy_research_sources:dbc78803d2a3",
+        "legacy_research_sources:fe5920beed47"
+      ],
+      "e2": [
         "bmw_market_pages:g22-4-series-technical-data-de",
         "bmw_market_pages:g22-4-series-technical-data-ie",
         "legacy_research_sources:c0c98c38e567",
         "legacy_research_sources:dbc78803d2a3"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Issue #1034 official-source review corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Official BMW PressClub DE 07/2021 ACEA technical-data now also confirms the exact M440i xDrive launch mapping: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard staggered 225/45 R18 front + 255/40 R18 rear tires. Later Wave 10 validation adds exact 430i xDrive context: the checked 03/2021 launch technical-data PDF does not list 430i xDrive, but the current BMW Germany technical-data page does list 430i xDrive Coupé / 51HB / Allradantrieb / Steptronic Sport Getriebe, and the 2026 Germany price list confirms standard 225/50 R17 tires, optional 225/45 R18 tires, and optional staggered 225/40 R19 front + 255/35 R19 rear tires. Wave 12 validation now adds exact 420i context from checked 03/2021 and 01/2024 official EU-market technical-data PDFs: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 225/50 R17 tires. The broad 2021-2026 row remains unchanged because the checked official material still does not prove one unchanged 420i, 430i xDrive, or M440i xDrive package across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this row should later expand beyond the supported petrol-family slice",
-        "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 420i production-data applicability across the full G22 row span",
-        "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
-        "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
-        "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-g22-430i-xdrive-eu-2021-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G22",
-    "body_code": "G22",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "4 Series (G22, 2021-2026)",
-    "variant_name": "430i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_market_pages:g22-4-series-technical-data-de",
-        "bmw_market_pages:g22-4-series-technical-data-ie",
-        "legacy_research_sources:c0c98c38e567",
-        "legacy_research_sources:dbc78803d2a3"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-        "value": 0.667
+  "configurations": [
+    {
+      "id": "bmw-g22-420i-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G22",
+      "body_code": "G22",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "4 Series (G22, 2021-2026)",
+      "variant_name": "420i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n3",
+        "value": "RWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-        "value": 2.813
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
+          "notes_ref": "n3",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n3",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 03/2021 + 01/2024 states) with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Issue #1034 official-source review corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Official BMW PressClub DE 07/2021 ACEA technical-data now also confirms the exact M440i xDrive launch mapping: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard staggered 225/45 R18 front + 255/40 R18 rear tires. Later Wave 10 validation adds exact 430i xDrive context: the checked 03/2021 launch technical-data PDF does not list 430i xDrive, but the current BMW Germany technical-data page does list 430i xDrive Coupé / 51HB / Allradantrieb / Steptronic Sport Getriebe, and the 2026 Germany price list confirms standard 225/50 R17 tires, optional 225/45 R18 tires, and optional staggered 225/40 R19 front + 255/35 R19 rear tires. Wave 12 validation now adds exact 420i context from checked 03/2021 and 01/2024 official EU-market technical-data PDFs: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 225/50 R17 tires. The broad 2021-2026 row remains unchanged because the checked official material still does not prove one unchanged 420i, 430i xDrive, or M440i xDrive package across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this row should later expand beyond the supported petrol-family slice",
-        "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 420i production-data applicability across the full G22 row span",
-        "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
-        "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
-        "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g22-m440i-xdrive-eu-2021-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G22",
-    "body_code": "G22",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "4 Series (G22, 2021-2026)",
-    "variant_name": "M440i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_market_pages:g22-4-series-technical-data-de",
-        "bmw_market_pages:g22-4-series-technical-data-ie",
-        "legacy_research_sources:c0c98c38e567",
-        "legacy_research_sources:dbc78803d2a3"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-        "value": 2.813
+      "unresolved": [
+        {
+          "item": "Whether this row should later expand beyond the supported petrol-family slice",
+          "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 420i production-data applicability across the full G22 row span",
+          "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
+          "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
+          "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g22-430i-xdrive-eu-2021-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G22",
+      "body_code": "G22",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "4 Series (G22, 2021-2026)",
+      "variant_name": "430i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_market_pages:g22-4-series-technical-data-de",
-            "bmw_market_pages:g22-4-series-technical-data-ie",
-            "legacy_research_sources:03c433610239",
-            "legacy_research_sources:0b510c0af2c9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:c0c98c38e567",
-            "legacy_research_sources:dbc78803d2a3",
-            "legacy_research_sources:fe5920beed47"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW DE technical data with High confidence."
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this row should later expand beyond the supported petrol-family slice",
+          "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 420i production-data applicability across the full G22 row span",
+          "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
+          "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
+          "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Issue #1034 official-source review corrected the supported EU-facing petrol family to 420i, 430i xDrive, and M440i xDrive, removing the stale RWD-only 430i mapping from the supported row. Official BMW PressClub DE 07/2021 ACEA technical-data now also confirms the exact M440i xDrive launch mapping: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard staggered 225/45 R18 front + 255/40 R18 rear tires. Later Wave 10 validation adds exact 430i xDrive context: the checked 03/2021 launch technical-data PDF does not list 430i xDrive, but the current BMW Germany technical-data page does list 430i xDrive Coupé / 51HB / Allradantrieb / Steptronic Sport Getriebe, and the 2026 Germany price list confirms standard 225/50 R17 tires, optional 225/45 R18 tires, and optional staggered 225/40 R19 front + 255/35 R19 rear tires. Wave 12 validation now adds exact 420i context from checked 03/2021 and 01/2024 official EU-market technical-data PDFs: 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 2.813, and standard 225/50 R17 tires. The broad 2021-2026 row remains unchanged because the checked official material still does not prove one unchanged 420i, 430i xDrive, or M440i xDrive package across the full represented span.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
+    {
+      "id": "bmw-g22-m440i-xdrive-eu-2021-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G22",
+      "body_code": "G22",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "4 Series (G22, 2021-2026)",
+      "variant_name": "M440i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (exact 07/2021 launch state) with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this row should later expand beyond the supported petrol-family slice",
+          "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 420i production-data applicability across the full G22 row span",
+          "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
+          "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
+          "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this row should later expand beyond the supported petrol-family slice",
-        "reason": "BMW Germany technical data confirms additional diesel xDrive variants, but issue #1034 stays narrowly focused on the confirmed petrol-family mismatch rather than broadening the supported row to every current market slice.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 420i production-data applicability across the full G22 row span",
-        "reason": "Checked official 03/2021 and 01/2024 EU-market technical-data PDFs agree on the exact 420i ratio set, reverse ratio 3.712, final drive 2.813, and standard 225/50 R17 tire, but this pass did not recover an official 2025-2026 exact table or one full year-spanning optional wheel matrix proving the same package across the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW 430i xDrive exact numeric ratios and production-data applicability across the full G22 row span",
-        "reason": "Official BMW sources now prove the current Germany-market 430i xDrive naming, model code 51HB, drivetrain, transmission wording, and current 17/18/19-inch tire matrix, but the checked 03/2021 launch technical-data PDF does not list 430i xDrive and this pass did not recover any official exact 430i xDrive final-drive, top-gear, forward-ratio, or reverse-ratio table.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive production-data applicability across the full G22 row span",
-        "reason": "The checked official 07/2021 ACEA sheet resolves the M440i xDrive launch ratios, final drive, top gear, and staggered base tires, but later official Germany-market pages already show a different published output state and this pass did not recover later exact ratio/tire tables proving one unchanged 2021-2026 package.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      },
-      {
-        "item": "BMW M440i xDrive official optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact launch ratio set and standard staggered 18-inch fitment, but they do not publish a gearbox subtype code beyond Steptronic wording or one exact optional wheel/tire matrix for the full represented row.",
-        "evidence_refs": [
-          "bmw_market_pages:g22-4-series-technical-data-de",
-          "bmw_market_pages:g22-4-series-technical-data-ie",
-          "legacy_research_sources:03c433610239",
-          "legacy_research_sources:0b510c0af2c9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:c0c98c38e567",
-          "legacy_research_sources:dbc78803d2a3",
-          "legacy_research_sources:fe5920beed47"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/F10.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/F10.json
@@ -1,1527 +1,1334 @@
-[
-  {
-    "id": "bmw-f10-520i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "520i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n3": "Official BMW 09/2011 technical-data material publishes Eight-speed automatic with Steptronic wording for this exact launch-state. The repo stores normalized code ZF8HP, but the supplier gearbox-family code is not printed in the checked source.",
+      "n4": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 520i manual launch-state.",
+      "n5": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 520i launch-state.",
+      "n6": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 530i manual launch-state.",
+      "n7": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 530i launch-state.",
+      "n8": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 535i manual launch-state.",
+      "n9": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 535i launch-state.",
+      "n10": "Official BMW 09/2011 technical-data PDF confirms the standard 18-inch square tire setup for the exact 550i launch-state.",
+      "n11": "Official BMW 10/2011 M5 technical-data PDF confirms the standard staggered 19-inch tire setup for the exact launch-state M-DCT row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:53f10535a911"
+      ],
+      "e2": [
         "legacy_research_sources:52f10520a911"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 520i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:52f10520a911"
+      "e3": [
+        "legacy_research_sources:55f10550a911"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 520i launch-state.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.677 as sixth gear for the exact 520i manual launch-state.",
-        "value": 0.677
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.909 as the final-drive ratio for the exact 520i manual launch-state.",
-        "value": 3.909
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          3.683,
-          2.062,
-          1.313,
-          1.0,
-          0.809,
-          0.677
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 520i manual launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 520i manual launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 520i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 520i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 520i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 520i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 12 narrows the broad 520i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 520i with six-speed manual, top gear 0.677, final drive 3.909, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-520i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "520i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:52f10520a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 520i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:52f10520a911"
-      ],
-      "notes": "Official BMW 09/2011 technical-data material publishes Eight-speed automatic with Steptronic wording for this exact launch-state. The repo stores normalized code ZF8HP, but the supplier gearbox-family code is not printed in the checked source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic with Steptronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 520i values shown in parentheses.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.231 as the final-drive ratio for the automatic 520i values shown in parentheses.",
-        "value": 3.231
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 520i launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 520i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 520i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 520i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 520i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:52f10520a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 520i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 11 narrows the broad 520i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 520i with optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.231, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:52f10520a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-530i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "530i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 530i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 530i launch-state.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.701 as sixth gear for the exact 530i manual launch-state.",
-        "value": 0.701
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 4.100 as the final-drive ratio for the exact 530i manual launch-state.",
-        "value": 4.1
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          3.498,
-          2.005,
-          1.313,
-          1.0,
-          0.809,
-          0.701
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 530i manual launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 530i manual launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 530i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 530i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 530i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 530i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 12 narrows the broad 530i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 530i with six-speed manual, top gear 0.701, final drive 4.100, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-530i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "530i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 530i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "Official BMW 09/2011 technical-data material publishes Eight-speed automatic with Steptronic wording for this exact launch-state. The repo stores normalized code ZF8HP, but the supplier gearbox-family code is not printed in the checked source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic with Steptronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 530i values shown in parentheses.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.385 as the final-drive ratio for the automatic 530i values shown in parentheses.",
-        "value": 3.385
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 530i launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 530i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 530i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 530i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 530i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 530i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This F10 research wave corrects the automatic 530i engine metadata to match the official 09/2011 530i/535i technical-data PDF and sibling manual row: the 530i is a 2996 cc straight-six launch-state, not an N20 2.0L I4. The same PDF confirms optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.385, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-535i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "535i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 535i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 535i launch-state.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.846 as sixth gear for the exact 535i manual launch-state.",
-        "value": 0.846
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.231 as the final-drive ratio for the exact 535i manual launch-state.",
-        "value": 3.231
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 535i manual launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the exact 535i manual launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 535i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 535i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 535i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 535i manual launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 12 narrows the broad 535i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 535i with six-speed manual, top gear 0.846, final drive 3.231, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-535i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "535i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 535i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:53f10535a911"
-      ],
-      "notes": "Official BMW 09/2011 technical-data material publishes Eight-speed automatic with Steptronic wording for this exact launch-state. The repo stores normalized code ZF8HP, but the supplier gearbox-family code is not printed in the checked source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic with Steptronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 535i values shown in parentheses.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the final-drive ratio for the automatic 535i values shown in parentheses.",
-        "value": 3.077
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 535i launch-state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 17-inch square tire setup for the automatic 535i launch-state.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 535i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" square / winter"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 535i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 535i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:53f10535a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 535i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 11 narrows the broad 535i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 535i with optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.077, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:53f10535a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-550i-eu-2011-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "550i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e4": [
         "bmw_pressclub_sources:f10-550i-2011-spec-article",
         "legacy_research_sources:55f10550a911"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 550i launch-state sheet, so this row represents the exact rear-wheel-drive launch-state family.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f10-550i-2011-spec-article",
-        "legacy_research_sources:55f10550a911"
-      ],
-      "notes": "Contradicted placeholder. The official BMW 09/2011 5 Series Sedan specifications article separates the plain 550i attachment from the 550i xDrive sheet, and the dedicated 550i technical-data PDF then publishes only Eight-speed automatic with Steptronic. This represented MT6 row is therefore not a valid exact production state under its current transmission id.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.812
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:14edf445f865",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:9ec5479fbc04",
-          "legacy_research_sources:d58df4be7646"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:14edf445f865",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:9ec5479fbc04",
-            "legacy_research_sources:d58df4be7646"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:14edf445f865",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:9ec5479fbc04",
-            "legacy_research_sources:d58df4be7646"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:14edf445f865",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:9ec5479fbc04",
-            "legacy_research_sources:d58df4be7646"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This F10 research wave revalidates the official BMW 09/2011 5 Series Sedan specifications article and the dedicated 550i technical-data PDF. Together they confirm the plain rear-wheel-drive 550i launch-state as Eight-speed automatic with Steptronic only, final drive 2.813, and baseline 245/45 R18 tires. This represented MT6 row therefore remains an invalid advisory placeholder rather than a supported exact configuration.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f10-550i-2011-spec-article",
-          "legacy_research_sources:55f10550a911"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F10 550i exact MT6 production row",
-        "reason": "The checked official BMW 09/2011 5 Series Sedan specifications article and dedicated 550i technical-data PDF publish only Eight-speed automatic with Steptronic for the exact launch-state, and this pass did not recover any official F10 550i MT6 row because that represented manual configuration does not exist in the checked source chain.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f10-550i-2011-spec-article",
-          "legacy_research_sources:55f10550a911"
-        ]
-      },
-      {
-        "item": "BMW F10 550i exact 2011 automatic row replacement",
-        "reason": "The checked official BMW 09/2011 550i technical-data PDF is strong enough to seed the exact automatic row, but that valid sibling configuration is already represented by `bmw-f10-550i-eu-2011-zf8hp-rwd` and should not be silently conflated with this disproved MT6 id.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f10-550i-2011-spec-article",
-          "legacy_research_sources:55f10550a911"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f10-550i-eu-2011-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "5 Series (F10, 2011)",
-    "variant_name": "550i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:55f10550a911"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 550i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:55f10550a911"
-      ],
-      "notes": "Official BMW 09/2011 technical-data material publishes Eight-speed automatic with Steptronic wording for this exact launch-state. The repo stores normalized code ZF8HP, but the supplier gearbox-family code is not printed in the checked source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic with Steptronic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:55f10550a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 550i launch-state.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:55f10550a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes 2.813 as the final-drive ratio for the exact 550i launch-state.",
-        "value": 2.813
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:55f10550a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF publishes the complete forward gear-ratio set for this exact launch-state row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:55f10550a911"
-        ],
-        "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 18-inch square tire setup for the exact 550i launch-state.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:55f10550a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the standard 18-inch square tire setup for the exact 550i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:55f10550a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 550i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:55f10550a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 550i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" staggered"
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:55f10550a911"
-          ],
-          "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 550i launch-state.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 11 narrows the broad 550i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 550i with Eight-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 2.813, standard 245/45 R18 tires, and staggered 18-inch, 19-inch, and 20-inch options.",
-        "evidence_refs": [
-          "legacy_research_sources:55f10550a911"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f10-m5-eu-2011-dct7-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F10",
-    "body_code": "F10",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "M5 (F10, 2011)",
-    "variant_name": "M5",
-    "engine_code": "S63B44TU",
-    "engine_name": "S63B44TU V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f10-m5-2011-spec-article",
+      "e5": [
         "legacy_research_sources:f1055dc71011"
       ],
-      "notes": "The official BMW 10/2011 M5 technical-data PDF confirms the exact F10 M5 launch-state is rear-wheel drive.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e6": [
+        "legacy_research_sources:14edf445f865",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:9ac0d28dbf13",
+        "legacy_research_sources:9ec5479fbc04",
+        "legacy_research_sources:d58df4be7646"
+      ],
+      "e7": [
         "bmw_pressclub_sources:f10-m5-2011-spec-article",
         "legacy_research_sources:f1055dc71011"
-      ],
-      "notes": "The official BMW 10/2011 M5 technical-data PDF directly publishes Seven-speed M double-clutch transmission with Drivelogic for the exact launch-state.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (M-DCT)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f10-520i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "520i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:f1055dc71011"
-        ],
-        "notes": "Official BMW 10/2011 M5 technical-data PDF publishes 0.671 as seventh gear for the exact launch-state M-DCT row.",
-        "value": 0.671
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 520i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
+        "value": "RWD"
       },
-      "gear_ratios": {
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:f1055dc71011"
-        ],
-        "notes": "Official BMW 10/2011 M5 technical-data PDF publishes the full M-DCT forward-ratio set for the exact launch-state row.",
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 520i launch-state.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.677 as sixth gear for the exact 520i manual launch-state.",
+          "value": 0.677
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.909 as the final-drive ratio for the exact 520i manual launch-state.",
+          "value": 3.909
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "value": [
+            3.683,
+            2.062,
+            1.313,
+            1.0,
+            0.809,
+            0.677
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 520i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 520i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 520i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 520i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
         ]
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:f1055dc71011"
-        ],
-        "notes": "Official BMW 10/2011 M5 technical-data PDF publishes 3.150 as the final-drive ratio for the exact launch-state M-DCT row.",
-        "value": 3.15
+      "verification_notes": [
+        {
+          "note": "Batch 12 narrows the broad 520i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 520i with six-speed manual, top gear 0.677, final drive 3.909, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f10-520i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "520i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:f1055dc71011"
-        ],
-        "notes": "Official BMW 10/2011 M5 technical-data PDF confirms the standard staggered 19-inch tire setup for the exact launch-state M-DCT row.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "rear": {
-          "width_mm": 295.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 520i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic with Steptronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:f1055dc71011"
-          ],
-          "notes": "Official BMW 10/2011 M5 technical-data PDF confirms the standard staggered 19-inch tire setup for the exact launch-state M-DCT row.",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 520i values shown in parentheses.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.231 as the final-drive ratio for the automatic 520i values shown in parentheses.",
+          "value": 3.231
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 520i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 520i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 520i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 520i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 11 narrows the broad 520i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 520i with optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.231, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-530i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "530i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 530i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 530i launch-state.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.701 as sixth gear for the exact 530i manual launch-state.",
+          "value": 0.701
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 4.100 as the final-drive ratio for the exact 530i manual launch-state.",
+          "value": 4.1
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": [
+            3.498,
+            2.005,
+            1.313,
+            1.0,
+            0.809,
+            0.701
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 530i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 530i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 530i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 530i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 12 narrows the broad 530i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 530i with six-speed manual, top gear 0.701, final drive 4.100, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-530i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "530i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 530i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic with Steptronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 530i values shown in parentheses.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.385 as the final-drive ratio for the automatic 530i values shown in parentheses.",
+          "value": 3.385
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 530i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 530i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 530i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 530i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This F10 research wave corrects the automatic 530i engine metadata to match the official 09/2011 530i/535i technical-data PDF and sibling manual row: the 530i is a 2996 cc straight-six launch-state, not an N20 2.0L I4. The same PDF confirms optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.385, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-535i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "535i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 535i launch-state sheet, so this row represents the exact rear-wheel-drive manual configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF directly publishes the six-speed manual transmission for the exact 535i launch-state.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.846 as sixth gear for the exact 535i manual launch-state.",
+          "value": 0.846
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.231 as the final-drive ratio for the exact 535i manual launch-state.",
+          "value": 3.231
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the exact 535i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 535i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 535i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 535i manual launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 12 narrows the broad 535i manual row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 535i with six-speed manual, top gear 0.846, final drive 3.231, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-535i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "535i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 535i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic with Steptronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the automatic 535i values shown in parentheses.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 3.077 as the final-drive ratio for the automatic 535i values shown in parentheses.",
+          "value": 3.077
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n9",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the 18-inch square winter-compatible option for the automatic 535i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" square / winter"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the automatic 535i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the automatic 535i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the automatic 535i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 11 narrows the broad 535i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 535i with optional eight-speed automatic with Steptronic, top gear 0.667, final drive 3.077, standard 225/55 R17 tires, an 18-inch square winter package, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-550i-eu-2011-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "550i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 550i launch-state sheet, so this row represents the exact rear-wheel-drive launch-state family.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e4",
+        "notes": "Contradicted placeholder. The official BMW 09/2011 5 Series Sedan specifications article separates the plain 550i attachment from the 550i xDrive sheet, and the dedicated 550i technical-data PDF then publishes only Eight-speed automatic with Steptronic. This represented MT6 row is therefore not a valid exact production state under its current transmission id.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.812
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This F10 research wave revalidates the official BMW 09/2011 5 Series Sedan specifications article and the dedicated 550i technical-data PDF. Together they confirm the plain rear-wheel-drive 550i launch-state as Eight-speed automatic with Steptronic only, final drive 2.813, and baseline 245/45 R18 tires. This represented MT6 row therefore remains an invalid advisory placeholder rather than a supported exact configuration.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F10 550i exact MT6 production row",
+          "reason": "The checked official BMW 09/2011 5 Series Sedan specifications article and dedicated 550i technical-data PDF publish only Eight-speed automatic with Steptronic for the exact launch-state, and this pass did not recover any official F10 550i MT6 row because that represented manual configuration does not exist in the checked source chain.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "BMW F10 550i exact 2011 automatic row replacement",
+          "reason": "The checked official BMW 09/2011 550i technical-data PDF is strong enough to seed the exact automatic row, but that valid sibling configuration is already represented by `bmw-f10-550i-eu-2011-zf8hp-rwd` and should not be silently conflated with this disproved MT6 id.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f10-550i-eu-2011-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "5 Series (F10, 2011)",
+      "variant_name": "550i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 09/2011 technical-data PDF is the dedicated non-xDrive 550i launch-state sheet, so this row represents the exact rear-wheel-drive configuration.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic with Steptronic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 0.667 as the eighth gear for the exact 550i launch-state.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 09/2011 technical-data PDF publishes 2.813 as the final-drive ratio for the exact 550i launch-state.",
+          "value": 2.813
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n1",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 18-inch option for the exact 550i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 19-inch option for the exact 550i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" staggered"
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW 09/2011 technical-data PDF confirms the staggered 20-inch option for the exact 550i launch-state.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" staggered"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 11 narrows the broad 550i automatic row to the exact 09/2011 launch-state. The official BMW technical-data PDF confirms the non-xDrive 550i with Eight-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 2.813, standard 245/45 R18 tires, and staggered 18-inch, 19-inch, and 20-inch options.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f10-m5-eu-2011-dct7-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F10",
+      "body_code": "F10",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "M5 (F10, 2011)",
+      "variant_name": "M5",
+      "engine_code": "S63B44TU",
+      "engine_name": "S63B44TU V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 10/2011 M5 technical-data PDF confirms the exact F10 M5 launch-state is rear-wheel drive.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 10/2011 M5 technical-data PDF directly publishes Seven-speed M double-clutch transmission with Drivelogic for the exact launch-state.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (M-DCT)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 10/2011 M5 technical-data PDF publishes 0.671 as seventh gear for the exact launch-state M-DCT row.",
+          "value": 0.671
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 10/2011 M5 technical-data PDF publishes the full M-DCT forward-ratio set for the exact launch-state row.",
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 10/2011 M5 technical-data PDF publishes 3.150 as the final-drive ratio for the exact launch-state M-DCT row.",
+          "value": 3.15
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n11",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 40.0,
@@ -1532,27 +1339,42 @@
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\" staggered"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This F10 research wave replaces the contradicted MT6 and ZF8HP M5 placeholders with the official 10/2011 launch-state M-DCT configuration. The official BMW M5 technical-data PDF confirms rear-wheel drive, Seven-speed M double-clutch transmission with Drivelogic, forward ratios 4.806 / 2.593 / 1.701 / 1.277 / 1.000 / 0.844 / 0.671, final drive 3.150, and standard staggered 265/40 R19 front plus 295/35 R19 rear tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f10-m5-2011-spec-article",
-          "legacy_research_sources:f1055dc71011"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 295.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\" staggered"
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "This F10 research wave replaces the contradicted MT6 and ZF8HP M5 placeholders with the official 10/2011 launch-state M-DCT configuration. The official BMW M5 technical-data PDF confirms rear-wheel drive, Seven-speed M double-clutch transmission with Drivelogic, forward ratios 4.806 / 2.593 / 1.701 / 1.277 / 1.000 / 0.844 / 0.671, final drive 3.150, and standard staggered 265/40 R19 front plus 295/35 R19 rear tires.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G30.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G30.json
@@ -1,1690 +1,61 @@
-[
-  {
-    "id": "bmw-g30-520i-eu-2017-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2017,
-    "model_name": "5 Series (G30, 2017)",
-    "variant_name": "520i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2017 technical-data PDF confirms RWD for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row.",
-      "value": "RWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
+      "n3": "The official BMW 07/2017 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row.",
+      "n4": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row.",
+      "n5": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row.",
+      "n6": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row.",
+      "n7": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row.",
+      "n8": "Wave 14 improved the official Germany picture for the G30 530i without promoting any numeric production changes. Wave 15 adds exact BMW Germany technical-data evidence that the 540i xDrive and 545e xDrive do not belong on the broad-row defaults: 540i xDrive officially uses 8-Gang Steptronic with final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, while 545e xDrive officially uses 8-Gang Steptronic with forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.231, and the same 225/55 R17 baseline. Wave 16 closes the stable exact fields for the rear-wheel-drive 540i in the same way and adds exact official 530i xDrive Germany-market tables proving AWD, 8-Gang Steptronic, top gear 0.640, and a 225/55 R17 baseline tire, but 530i xDrive still stays ledger-only because its final drive and full ratio set split between pre-LCI and LCI documents. Wave 17 adds exact BMW Germany 520i launch and LCI technical-data sheets showing 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but 520i also stays ledger-only because checked 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 documents split the final drive between 2.929 and 2.813 and publish different forward and reverse ratio sets. The row remains low-confidence and unresolved because 520i, 530i, 530i xDrive, and M550i xDrive still lack one safe year-spanning Germany-market mapping."
     },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 07/2017 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 07/2017 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 07/2017 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
-      },
-      "final_drive_rear": {
-        "value": 2.929,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 07/2017 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 07/2017 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 07/2017 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2017 technical-data PDF closes the exact 5 Series Sedan 520i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 5 Series Sedan 520i exact optional wheel/tire matrix beyond the narrowed 2017 row",
-        "reason": "The checked official BMW 07/2017 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-530i-eu-2017-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2017,
-    "model_name": "5 Series (G30, 2017)",
-    "variant_name": "530i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms RWD for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
-      },
-      "final_drive_rear": {
-        "value": 2.929,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 530i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 5 Series Sedan 530i exact optional wheel/tire matrix beyond the narrowed 2017 row",
-        "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-530i-xdrive-eu-2017-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2017,
-    "model_name": "5 Series (G30, 2017)",
-    "variant_name": "530i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms AWD for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row."
-      },
-      "final_drive_front": {
-        "value": 2.929,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF publishes only a 2.929 rear-axle ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
-      },
-      "final_drive_rear": {
-        "value": 2.929,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF publishes a 2.929 rear-axle ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 530i xDrive launch-state mapping: AWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, the published 2.929 rear-axle ratio duplicated across the front and rear axle fields, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 5 Series Sedan 530i xDrive exact optional wheel/tire matrix beyond the narrowed 2017 row",
-        "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 5 Series Sedan 530i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes only a rear-axle ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-540i-eu-2017-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2017,
-    "model_name": "5 Series (G30, 2017)",
-    "variant_name": "540i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms RWD for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
-      },
-      "final_drive_rear": {
-        "value": 2.929,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 540i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 5 Series Sedan 540i exact optional wheel/tire matrix beyond the narrowed 2017 row",
-        "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-540i-xdrive-eu-2017-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2017,
-    "model_name": "5 Series (G30, 2017)",
-    "variant_name": "540i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms AWD for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row."
-      },
-      "final_drive_front": {
-        "value": 2.929,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF publishes only a 2.929 rear-axle ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
-      },
-      "final_drive_rear": {
-        "value": 2.929,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF publishes a 2.929 rear-axle ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2016 technical-data PDF lists 225/55 R17 baseline tires for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 540i xDrive launch-state mapping: AWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, the published 2.929 rear-axle ratio duplicated across the front and rear axle fields, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 5 Series Sedan 540i xDrive exact optional wheel/tire matrix beyond the narrowed 2017 row",
-        "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 5 Series Sedan 540i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes only a rear-axle ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-518d-eu-2018-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "5 Series (G30, 2017-2023)",
-    "variant_name": "518d",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+    "evidence_ref_sets": {
+      "e1": [
         "legacy_research_sources:063169ffdd07",
         "legacy_research_sources:1311432f8826",
         "legacy_research_sources:158e875cffde",
         "legacy_research_sources:344df30613de",
         "legacy_research_sources:4c0796b9f847",
+        "legacy_research_sources:5141df8505c7",
         "legacy_research_sources:55b25acf829a",
         "legacy_research_sources:61b9c053e1b0",
+        "legacy_research_sources:6fb4574da9d1",
         "legacy_research_sources:71623c45be65",
+        "legacy_research_sources:8af93035519b",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:96bea889fe6f",
         "legacy_research_sources:96c5b7290275",
         "legacy_research_sources:9a94972b2802",
+        "legacy_research_sources:9ac0d28dbf13",
+        "legacy_research_sources:b94833fffa01",
         "legacy_research_sources:d15bf307acbd",
         "legacy_research_sources:d2317d3698fe",
+        "legacy_research_sources:f8533e1b6b48",
+        "legacy_research_sources:f89b00916d7f",
         "legacy_research_sources:f9d6f511233d"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW Austria material proves that the exact G30 518d Sedan and Touring first appear from 07/2018 rather than 2017. Official BMW Italy price lists for production 01/2021 and 01/04/2023 both confirm the exact 518d Sedan remains an automatic 110 kW / 150 PS state with `2TE` Eight-speed Steptronic transmission. The same official Italy wheel tables show trim-dependent square and staggered packages rather than one universal wheel baseline, and the checked official technical-data PDFs still do not close the exact ratio or final-drive mapping for the 518d automatic row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-518d-2018-austria-launch-article",
-          "bmw_pressclub_sources:g30-518d-2021-italy-price-list-pdf",
-          "bmw_market_pages:g30-5-series-price-list-2023-it"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact G30 518d automatic ratio and final-drive mapping",
-        "reason": "Checked official BMW Austria and Italy launch/price-list material proves the 518d identity and 2018-on timing, but the recovered official technical-data PDFs still omit an exact 518d automatic ratio or final-drive table.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-518d-2018-austria-launch-article",
-          "bmw_pressclub_sources:g30-518d-2021-italy-price-list-pdf",
-          "bmw_market_pages:g30-5-series-price-list-2023-it"
-        ]
-      },
-      {
-        "item": "Exact G30 518d automatic family code and wheel/tire matrix",
-        "reason": "The checked official BMW sources confirm 518d launch timing and later automatic continuity, but they do not yet close the literal automatic family-code label or one trim-agnostic 518d-specific wheel/tire package safe enough to replace the inherited defaults. Official BMW Italy price lists instead show trim-dependent square and staggered packages across Business, Luxury, and M Sport states.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-518d-2018-austria-launch-article",
-          "bmw_pressclub_sources:g30-518d-2021-italy-price-list-pdf",
-          "bmw_market_pages:g30-5-series-price-list-2023-it"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-520e-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2021,
-    "production_end_year": 2023,
-    "model_name": "5 Series (G30, 2017-2023)",
-    "variant_name": "520e",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
+      "e2": [
+        "bmw_pressclub_sources:g30-530i-and-xdrive-2016-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2021 technical-data PDF lists the exact G30 520e Sedan as a rear-wheel-drive plug-in-hybrid state introduced for this model line from 03/2021.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
+      "e3": [
+        "bmw_pressclub_sources:g30-540i-and-xdrive-2016-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2021 technical-data PDF lists Eight-speed Steptronic transmission for the exact G30 520e Sedan. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2021 technical-data PDF lists 0.667 as the top-gear ratio for the exact G30 520e Sedan.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2021 technical-data PDF lists the full forward gear-ratio set for the exact G30 520e Sedan.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2021 technical-data PDF lists 3.231 as the rear final-drive ratio for the exact G30 520e Sedan.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2021 technical-data PDF lists 225/55 R17 101Y XL as the baseline tire for the exact G30 520e Sedan.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      }
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch and technical-data material shows the exact G30 520e Sedan first appears from 03/2021 rather than 2017. The corrected 2021-on row uses rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and 225/55 R17 101Y XL baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-launch-article",
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact public gearbox family code for the G30 520e 8-speed Steptronic transmission",
-        "reason": "The checked official BMW launch and technical-data material proves Eight-speed Steptronic wording for the exact 520e Sedan, but it does not explicitly publish the supplier-family code ZF8HP.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-launch-article",
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Exact optional wheel-and-tire matrix for the G30 520e Sedan",
-        "reason": "The checked official BMW 03/2021 technical-data PDF proves the standard 225/55 R17 101Y XL package for the exact 520e Sedan, but this pass did not recover a matching official option matrix for later wheel packages.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-523d-eu-2017-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2023,
-    "model_name": "5 Series (G30, 2017-2023)",
-    "variant_name": "523d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "legacy_research_sources:063169ffdd07",
-        "legacy_research_sources:1311432f8826",
-        "legacy_research_sources:158e875cffde",
-        "legacy_research_sources:344df30613de",
-        "legacy_research_sources:4c0796b9f847",
-        "legacy_research_sources:55b25acf829a",
-        "legacy_research_sources:61b9c053e1b0",
-        "legacy_research_sources:71623c45be65",
-        "legacy_research_sources:96c5b7290275",
-        "legacy_research_sources:9a94972b2802",
-        "legacy_research_sources:d15bf307acbd",
-        "legacy_research_sources:d2317d3698fe",
-        "legacy_research_sources:f9d6f511233d"
+      "e4": [
+        "bmw_pressclub_sources:g30-520i-2017-tech-spec-pdf"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 14 improved the official Germany picture for the G30 530i without promoting any numeric production changes. Wave 15 adds exact BMW Germany technical-data evidence that the 540i xDrive and 545e xDrive do not belong on the broad-row defaults: 540i xDrive officially uses 8-Gang Steptronic with final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, while 545e xDrive officially uses 8-Gang Steptronic with forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.231, and the same 225/55 R17 baseline. Wave 16 closes the stable exact fields for the rear-wheel-drive 540i in the same way and adds exact official 530i xDrive Germany-market tables proving AWD, 8-Gang Steptronic, top gear 0.640, and a 225/55 R17 baseline tire, but 530i xDrive still stays ledger-only because its final drive and full ratio set split between pre-LCI and LCI documents. Wave 17 adds exact BMW Germany 520i launch and LCI technical-data sheets showing 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but 520i also stays ledger-only because checked 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 documents split the final drive between 2.929 and 2.813 and publish different forward and reverse ratio sets. The row remains low-confidence and unresolved because 520i, 530i, 530i xDrive, and M550i xDrive still lack one safe year-spanning Germany-market mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Per-variant final drive ratios for the remaining unresolved BMW 5 Series G30 EU-market variants",
-        "reason": "Wave 15 and Wave 16 close the exact 540i, 540i xDrive, and 545e xDrive targets, but this run still does not prove one safe year-spanning final-drive mapping for 520i, 530i, 530i xDrive, or M550i xDrive.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "Per-variant top gear ratios for the remaining unresolved G30 variants",
-        "reason": "Wave 15 through Wave 17 now prove exact top-gear values for 520i, 540i, 540i xDrive, 545e xDrive, and 530i xDrive, but this run still did not recover authoritative EU G30 technical tables for 530i or M550i xDrive.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 530i official tire baseline and later-year continuity",
-        "reason": "The recovered official BMW Germany launch price list proves a 225/55 R17 baseline with 18/19/20-inch options for the 530i, contradicting the current broad-row tire defaults, but this pass did not recover later official archived price lists proving one year-spanning 2017-2023 530i wheel matrix safe enough for a production rewrite.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 520i one exact final-drive and full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 technical-data sheets agree on 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but they split the final drive between 2.929 and 2.813, publish different forward and reverse ratio sets, and this pass did not recover a 2022-2023 Germany sheet to close end-of-span continuity.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 530i xDrive one exact final-drive and full-ratio set across the represented row span",
-        "reason": "Official BMW Germany technical-data sheets now prove 530i xDrive AWD, 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but the 11/2016 sheet publishes final drive 2.929 while the 05/2020, 11/2020, and 03/2021 sheets publish 2.813 and different forward-ratio sets.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 540i one exact full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 11/2016, 05/2020, and 11/2020 technical-data sheets agree on 540i RWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 540i xDrive one exact full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 11/2016 and 11/2020 technical-data sheets agree on 540i xDrive AWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 545e xDrive front-axle/transfer-case detail and full option tire matrix",
-        "reason": "Official BMW Germany 11/2020 technical data and the DE price list prove 545e xDrive AWD, 8-Gang Steptronic, the exact forward ratios, final drive 3.231, and a 225/55 R17 baseline tire, but the checked sources do not publish a separate front final drive, transfer-case ratio, or a full 545e-specific optional wheel/tire matrix.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "No official EU G30 523d evidence located in this source pass",
-        "reason": "Official BMW Italy 2023 G30/G31 price list lists 518d, 520d, 530d, 540d and excludes 523d. No saved official BMW EU PressClub or price-list source documents an EU G30 523d. The only saved 523d evidence is a secondary mirror of a BMW Japan 2023 option list documenting `523d xDrive` (AWD), which contradicts this row's RWD/EU framing. Marked no_confidence pending a real BMW Japan archive PDF or any official BMW EU 523d source."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": false,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-530e-eu-2017-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2017,
-    "production_end_year": 2023,
-    "model_name": "5 Series (G30, 2017-2023)",
-    "variant_name": "530e",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e5": [
         "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
         "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
         "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
       ],
-      "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently place the exact G30 530e Sedan/Limousine on rear-wheel drive while separately listing later 530e xDrive states as different configurations.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-        "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-        "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
+      "e6": [
+        "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
       ],
-      "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 8-Gang/8-speed Steptronic transmission for the exact G30 530e. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 0.667 as the top-gear ratio for the exact G30 530e.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list the full forward gear-ratio set for the exact G30 530e.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 3.231 as the rear final-drive ratio for the exact G30 530e.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 225/55 R17 as the baseline tire size for the exact G30 530e.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2017 technical-data PDF lists this square 18-inch option for the exact G30 530e.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 18-inch option for the exact G30 530e.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Staggered 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2017 technical-data PDF lists this square 19-inch option for the exact G30 530e.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Square 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 19-inch option for the exact G30 530e.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 20-inch option for the exact G30 530e.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data material consistently keeps the exact G30 530e on rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and 225/55 R17 baseline tires. The checked later documents also separate the 530e xDrive as a different configuration, confirming that the corrected 530e row should stay RWD-only. An official BMW launch article adds PHEV architecture detail for the same exact car: the electric motor is mounted upstream of the transmission so the transmission ratios remain usable in EV mode, the system dispenses with a torque converter, and the high-voltage battery sits under the rear seat.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2016-launch-article-pdf",
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact public gearbox family code for the G30 530e 8-speed Steptronic transmission",
-        "reason": "The checked official BMW 530e technical-data PDFs prove 8-Gang/8-speed Steptronic wording for the exact row, but they do not explicitly publish the supplier-family code ZF8HP.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Exact late-cycle optional wheel-and-tire matrix for the G30 530e",
-        "reason": "The checked official BMW 03/2017 technical-data PDF proves the launch 18/19/20-inch option packages for the exact 530e, and later technical-data PDFs keep the same 225/55 R17 baseline, but this pass did not recover a fully exhaustive late-cycle option matrix for every later market state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g30-545e-xdrive-eu-2017-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G30",
-    "body_code": "G30",
-    "production_start_year": 2020,
-    "production_end_year": 2023,
-    "model_name": "5 Series (G30, 2020-2023)",
-    "variant_name": "545e xDrive",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e7": [
+        "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf"
+      ],
+      "e8": [
         "legacy_research_sources:063169ffdd07",
         "legacy_research_sources:1311432f8826",
         "legacy_research_sources:158e875cffde",
@@ -1699,387 +70,1242 @@
         "legacy_research_sources:d2317d3698fe",
         "legacy_research_sources:f9d6f511233d"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-        "value": 0.667
+      "e9": [
+        "bmw_pressclub_sources:g30-518d-2018-austria-launch-article",
+        "bmw_pressclub_sources:g30-518d-2021-italy-price-list-pdf",
+        "bmw_market_pages:g30-5-series-price-list-2023-it"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:g30-520e-2021-launch-article",
+        "bmw_pressclub_sources:g30-520e-2021-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g30-520i-eu-2017-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2017,
+      "model_name": "5 Series (G30, 2017)",
+      "variant_name": "520i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 07/2017 technical-data PDF confirms RWD for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row.",
+        "value": "RWD"
       },
-      "gear_ratios": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 07/2017 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-        "value": 3.231
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 07/2017 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
         },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:063169ffdd07",
-            "legacy_research_sources:1311432f8826",
-            "legacy_research_sources:158e875cffde",
-            "legacy_research_sources:344df30613de",
-            "legacy_research_sources:4c0796b9f847",
-            "legacy_research_sources:5141df8505c7",
-            "legacy_research_sources:55b25acf829a",
-            "legacy_research_sources:61b9c053e1b0",
-            "legacy_research_sources:6fb4574da9d1",
-            "legacy_research_sources:71623c45be65",
-            "legacy_research_sources:8af93035519b",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96bea889fe6f",
-            "legacy_research_sources:96c5b7290275",
-            "legacy_research_sources:9a94972b2802",
-            "legacy_research_sources:9ac0d28dbf13",
-            "legacy_research_sources:b94833fffa01",
-            "legacy_research_sources:d15bf307acbd",
-            "legacy_research_sources:d2317d3698fe",
-            "legacy_research_sources:f8533e1b6b48",
-            "legacy_research_sources:f89b00916d7f",
-            "legacy_research_sources:f9d6f511233d"
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 07/2017 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
+        },
+        "final_drive_rear": {
+          "value": 2.929,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 07/2017 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 520i state represented by this narrowed 2017-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 07/2017 technical-data PDF closes the exact 5 Series Sedan 520i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e4"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 5 Series Sedan 520i exact optional wheel/tire matrix beyond the narrowed 2017 row",
+          "reason": "The checked official BMW 07/2017 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Wave 14 improved the official Germany picture for the G30 530i without promoting any numeric production changes. Wave 15 adds exact BMW Germany technical-data evidence that the 540i xDrive and 545e xDrive do not belong on the broad-row defaults: 540i xDrive officially uses 8-Gang Steptronic with final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, while 545e xDrive officially uses 8-Gang Steptronic with forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.231, and the same 225/55 R17 baseline. Wave 16 closes the stable exact fields for the rear-wheel-drive 540i in the same way and adds exact official 530i xDrive Germany-market tables proving AWD, 8-Gang Steptronic, top gear 0.640, and a 225/55 R17 baseline tire, but 530i xDrive still stays ledger-only because its final drive and full ratio set split between pre-LCI and LCI documents. Wave 17 adds exact BMW Germany 520i launch and LCI technical-data sheets showing 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but 520i also stays ledger-only because checked 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 documents split the final drive between 2.929 and 2.813 and publish different forward and reverse ratio sets. The row remains low-confidence and unresolved because 520i, 530i, 530i xDrive, and M550i xDrive still lack one safe year-spanning Germany-market mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
+    {
+      "id": "bmw-g30-530i-eu-2017-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2017,
+      "model_name": "5 Series (G30, 2017)",
+      "variant_name": "530i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms RWD for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
+        },
+        "final_drive_rear": {
+          "value": 2.929,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 530i state represented by this narrowed 2017-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence."
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 530i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 5 Series Sedan 530i exact optional wheel/tire matrix beyond the narrowed 2017 row",
+          "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Per-variant final drive ratios for the remaining unresolved BMW 5 Series G30 EU-market variants",
-        "reason": "Wave 15 and Wave 16 close the exact 540i, 540i xDrive, and 545e xDrive targets, but this run still does not prove one safe year-spanning final-drive mapping for 520i, 530i, 530i xDrive, or M550i xDrive.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
+    },
+    {
+      "id": "bmw-g30-530i-xdrive-eu-2017-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2017,
+      "model_name": "5 Series (G30, 2017)",
+      "variant_name": "530i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms AWD for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row."
+        },
+        "final_drive_front": {
+          "value": 2.929,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF publishes only a 2.929 rear-axle ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
+        },
+        "final_drive_rear": {
+          "value": 2.929,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 11/2016 technical-data PDF publishes a 2.929 rear-axle ratio for the exact 5 Series Sedan 530i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
         ]
       },
-      {
-        "item": "Per-variant top gear ratios for the remaining unresolved G30 variants",
-        "reason": "Wave 15 through Wave 17 now prove exact top-gear values for 520i, 540i, 540i xDrive, 545e xDrive, and 530i xDrive, but this run still did not recover authoritative EU G30 technical tables for 530i or M550i xDrive.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 530i official tire baseline and later-year continuity",
-        "reason": "The recovered official BMW Germany launch price list proves a 225/55 R17 baseline with 18/19/20-inch options for the 530i, contradicting the current broad-row tire defaults, but this pass did not recover later official archived price lists proving one year-spanning 2017-2023 530i wheel matrix safe enough for a production rewrite.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 520i one exact final-drive and full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 technical-data sheets agree on 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but they split the final drive between 2.929 and 2.813, publish different forward and reverse ratio sets, and this pass did not recover a 2022-2023 Germany sheet to close end-of-span continuity.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 530i xDrive one exact final-drive and full-ratio set across the represented row span",
-        "reason": "Official BMW Germany technical-data sheets now prove 530i xDrive AWD, 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but the 11/2016 sheet publishes final drive 2.929 while the 05/2020, 11/2020, and 03/2021 sheets publish 2.813 and different forward-ratio sets.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 540i one exact full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 11/2016, 05/2020, and 11/2020 technical-data sheets agree on 540i RWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 540i xDrive one exact full-ratio set across the represented row span",
-        "reason": "Official BMW Germany 11/2016 and 11/2020 technical-data sheets agree on 540i xDrive AWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "BMW G30 545e xDrive front-axle/transfer-case detail and full option tire matrix",
-        "reason": "Official BMW Germany 11/2020 technical data and the DE price list prove 545e xDrive AWD, 8-Gang Steptronic, the exact forward ratios, final drive 3.231, and a 225/55 R17 baseline tire, but the checked sources do not publish a separate front final drive, transfer-case ratio, or a full 545e-specific optional wheel/tire matrix.",
-        "evidence_refs": [
-          "legacy_research_sources:063169ffdd07",
-          "legacy_research_sources:1311432f8826",
-          "legacy_research_sources:158e875cffde",
-          "legacy_research_sources:344df30613de",
-          "legacy_research_sources:4c0796b9f847",
-          "legacy_research_sources:5141df8505c7",
-          "legacy_research_sources:55b25acf829a",
-          "legacy_research_sources:61b9c053e1b0",
-          "legacy_research_sources:6fb4574da9d1",
-          "legacy_research_sources:71623c45be65",
-          "legacy_research_sources:8af93035519b",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96bea889fe6f",
-          "legacy_research_sources:96c5b7290275",
-          "legacy_research_sources:9a94972b2802",
-          "legacy_research_sources:9ac0d28dbf13",
-          "legacy_research_sources:b94833fffa01",
-          "legacy_research_sources:d15bf307acbd",
-          "legacy_research_sources:d2317d3698fe",
-          "legacy_research_sources:f8533e1b6b48",
-          "legacy_research_sources:f89b00916d7f",
-          "legacy_research_sources:f9d6f511233d"
-        ]
-      },
-      {
-        "item": "545e xDrive original migration metadata had fuel_type=ICE and 2017-2023 span",
-        "reason": "Official BMW global launch article (T0313447EN) and Germany 11/2020 technical PDF (T0317777DE/461542) document the 545e xDrive as a late-G30 plug-in hybrid xDrive sedan introduced for the 2020/2021 model year, not a 2017 ICE configuration. Engine remains 3.0L I6 turbo paired with an electric motor; fuel_type corrected to PHEV and start year narrowed to 2020. Earlier-year continuity is impossible by definition; later-year continuity through 2023 remains within the published lifecycle of the row."
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 530i xDrive launch-state mapping: AWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, the published 2.929 rear-axle ratio duplicated across the front and rear axle fields, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 5 Series Sedan 530i xDrive exact optional wheel/tire matrix beyond the narrowed 2017 row",
+          "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW 5 Series Sedan 530i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes only a rear-axle ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "bmw-g30-540i-eu-2017-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2017,
+      "model_name": "5 Series (G30, 2017)",
+      "variant_name": "540i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms RWD for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
+        },
+        "final_drive_rear": {
+          "value": 2.929,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 2.929 as the rear final-drive ratio for the exact 5 Series Sedan 540i state represented by this narrowed 2017-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 540i launch-state mapping: RWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, 2.929 rear final drive, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 5 Series Sedan 540i exact optional wheel/tire matrix beyond the narrowed 2017 row",
+          "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-540i-xdrive-eu-2017-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2017,
+      "model_name": "5 Series (G30, 2017)",
+      "variant_name": "540i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms AWD for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 11/2016 technical-data PDF confirms 8-Gang Steptronic wording for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF lists 0.640 as the top-gear ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF lists the full forward gear-ratio set for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row."
+        },
+        "final_drive_front": {
+          "value": 2.929,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF publishes only a 2.929 rear-axle ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
+        },
+        "final_drive_rear": {
+          "value": 2.929,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 11/2016 technical-data PDF publishes a 2.929 rear-axle ratio for the exact 5 Series Sedan 540i xDrive state represented by this narrowed 2017-only row. The repo duplicates that exact published rear-axle ratio across the front and rear final-drive fields for the canonical AWD representation."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2016 technical-data PDF closes the exact 5 Series Sedan 540i xDrive launch-state mapping: AWD, 8-Gang Steptronic/ZF8HP mapping, full forward ratios, the published 2.929 rear-axle ratio duplicated across the front and rear axle fields, and 225/55 R17 baseline tires. This row is narrowed to the supported 2017-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 5 Series Sedan 540i xDrive exact optional wheel/tire matrix beyond the narrowed 2017 row",
+          "reason": "The checked official BMW 11/2016 technical-data PDF closes the 225/55 R17 baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW 5 Series Sedan 540i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes only a rear-axle ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-518d-eu-2018-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "5 Series (G30, 2017-2023)",
+      "variant_name": "518d",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW Austria material proves that the exact G30 518d Sedan and Touring first appear from 07/2018 rather than 2017. Official BMW Italy price lists for production 01/2021 and 01/04/2023 both confirm the exact 518d Sedan remains an automatic 110 kW / 150 PS state with `2TE` Eight-speed Steptronic transmission. The same official Italy wheel tables show trim-dependent square and staggered packages rather than one universal wheel baseline, and the checked official technical-data PDFs still do not close the exact ratio or final-drive mapping for the 518d automatic row.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact G30 518d automatic ratio and final-drive mapping",
+          "reason": "Checked official BMW Austria and Italy launch/price-list material proves the 518d identity and 2018-on timing, but the recovered official technical-data PDFs still omit an exact 518d automatic ratio or final-drive table.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Exact G30 518d automatic family code and wheel/tire matrix",
+          "reason": "The checked official BMW sources confirm 518d launch timing and later automatic continuity, but they do not yet close the literal automatic family-code label or one trim-agnostic 518d-specific wheel/tire package safe enough to replace the inherited defaults. Official BMW Italy price lists instead show trim-dependent square and staggered packages across Business, Luxury, and M Sport states.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-520e-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2021,
+      "production_end_year": 2023,
+      "model_name": "5 Series (G30, 2017-2023)",
+      "variant_name": "520e",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 03/2021 technical-data PDF lists the exact G30 520e Sedan as a rear-wheel-drive plug-in-hybrid state introduced for this model line from 03/2021.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 03/2021 technical-data PDF lists Eight-speed Steptronic transmission for the exact G30 520e Sedan. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2021 technical-data PDF lists 0.667 as the top-gear ratio for the exact G30 520e Sedan.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2021 technical-data PDF lists the full forward gear-ratio set for the exact G30 520e Sedan.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2021 technical-data PDF lists 3.231 as the rear final-drive ratio for the exact G30 520e Sedan.",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 03/2021 technical-data PDF lists 225/55 R17 101Y XL as the baseline tire for the exact G30 520e Sedan.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        }
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW launch and technical-data material shows the exact G30 520e Sedan first appears from 03/2021 rather than 2017. The corrected 2021-on row uses rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and 225/55 R17 101Y XL baseline tires.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact public gearbox family code for the G30 520e 8-speed Steptronic transmission",
+          "reason": "The checked official BMW launch and technical-data material proves Eight-speed Steptronic wording for the exact 520e Sedan, but it does not explicitly publish the supplier-family code ZF8HP.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "Exact optional wheel-and-tire matrix for the G30 520e Sedan",
+          "reason": "The checked official BMW 03/2021 technical-data PDF proves the standard 225/55 R17 101Y XL package for the exact 520e Sedan, but this pass did not recover a matching official option matrix for later wheel packages.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-523d-eu-2017-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2023,
+      "model_name": "5 Series (G30, 2017-2023)",
+      "variant_name": "523d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Per-variant final drive ratios for the remaining unresolved BMW 5 Series G30 EU-market variants",
+          "reason": "Wave 15 and Wave 16 close the exact 540i, 540i xDrive, and 545e xDrive targets, but this run still does not prove one safe year-spanning final-drive mapping for 520i, 530i, 530i xDrive, or M550i xDrive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Per-variant top gear ratios for the remaining unresolved G30 variants",
+          "reason": "Wave 15 through Wave 17 now prove exact top-gear values for 520i, 540i, 540i xDrive, 545e xDrive, and 530i xDrive, but this run still did not recover authoritative EU G30 technical tables for 530i or M550i xDrive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 530i official tire baseline and later-year continuity",
+          "reason": "The recovered official BMW Germany launch price list proves a 225/55 R17 baseline with 18/19/20-inch options for the 530i, contradicting the current broad-row tire defaults, but this pass did not recover later official archived price lists proving one year-spanning 2017-2023 530i wheel matrix safe enough for a production rewrite.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 520i one exact final-drive and full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 technical-data sheets agree on 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but they split the final drive between 2.929 and 2.813, publish different forward and reverse ratio sets, and this pass did not recover a 2022-2023 Germany sheet to close end-of-span continuity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 530i xDrive one exact final-drive and full-ratio set across the represented row span",
+          "reason": "Official BMW Germany technical-data sheets now prove 530i xDrive AWD, 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but the 11/2016 sheet publishes final drive 2.929 while the 05/2020, 11/2020, and 03/2021 sheets publish 2.813 and different forward-ratio sets.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 540i one exact full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 11/2016, 05/2020, and 11/2020 technical-data sheets agree on 540i RWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 540i xDrive one exact full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 11/2016 and 11/2020 technical-data sheets agree on 540i xDrive AWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 545e xDrive front-axle/transfer-case detail and full option tire matrix",
+          "reason": "Official BMW Germany 11/2020 technical data and the DE price list prove 545e xDrive AWD, 8-Gang Steptronic, the exact forward ratios, final drive 3.231, and a 225/55 R17 baseline tire, but the checked sources do not publish a separate front final drive, transfer-case ratio, or a full 545e-specific optional wheel/tire matrix.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "No official EU G30 523d evidence located in this source pass",
+          "reason": "Official BMW Italy 2023 G30/G31 price list lists 518d, 520d, 530d, 540d and excludes 523d. No saved official BMW EU PressClub or price-list source documents an EU G30 523d. The only saved 523d evidence is a secondary mirror of a BMW Japan 2023 option list documenting `523d xDrive` (AWD), which contradicts this row's RWD/EU framing. Marked no_confidence pending a real BMW Japan archive PDF or any official BMW EU 523d source."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": false,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-530e-eu-2017-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2017,
+      "production_end_year": 2023,
+      "model_name": "5 Series (G30, 2017-2023)",
+      "variant_name": "530e",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently place the exact G30 530e Sedan/Limousine on rear-wheel drive while separately listing later 530e xDrive states as different configurations.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e5",
+        "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 8-Gang/8-speed Steptronic transmission for the exact G30 530e. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 0.667 as the top-gear ratio for the exact G30 530e.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list the full forward gear-ratio set for the exact G30 530e.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 3.231 as the rear final-drive ratio for the exact G30 530e.",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data PDFs consistently list 225/55 R17 as the baseline tire size for the exact G30 530e.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 03/2017 technical-data PDF lists this square 18-inch option for the exact G30 530e.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 18-inch option for the exact G30 530e.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Staggered 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 03/2017 technical-data PDF lists this square 19-inch option for the exact G30 530e.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Square 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 19-inch option for the exact G30 530e.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 03/2017 technical-data PDF lists this staggered 20-inch option for the exact G30 530e.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2017, 08/2019, and 11/2020 technical-data material consistently keeps the exact G30 530e on rear-wheel drive, Eight-speed Steptronic transmission, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.231, and 225/55 R17 baseline tires. The checked later documents also separate the 530e xDrive as a different configuration, confirming that the corrected 530e row should stay RWD-only. An official BMW launch article adds PHEV architecture detail for the same exact car: the electric motor is mounted upstream of the transmission so the transmission ratios remain usable in EV mode, the system dispenses with a torque converter, and the high-voltage battery sits under the rear seat.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:g30-530e-2016-launch-article-pdf",
+            "bmw_pressclub_sources:g30-530e-2017-tech-spec-pdf",
+            "bmw_pressclub_sources:g30-530e-2019-tech-spec-pdf",
+            "bmw_pressclub_sources:g30-530e-2020-tech-spec-pdf"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact public gearbox family code for the G30 530e 8-speed Steptronic transmission",
+          "reason": "The checked official BMW 530e technical-data PDFs prove 8-Gang/8-speed Steptronic wording for the exact row, but they do not explicitly publish the supplier-family code ZF8HP.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Exact late-cycle optional wheel-and-tire matrix for the G30 530e",
+          "reason": "The checked official BMW 03/2017 technical-data PDF proves the launch 18/19/20-inch option packages for the exact 530e, and later technical-data PDFs keep the same 225/55 R17 baseline, but this pass did not recover a fully exhaustive late-cycle option matrix for every later market state.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g30-545e-xdrive-eu-2017-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G30",
+      "body_code": "G30",
+      "production_start_year": 2020,
+      "production_end_year": 2023,
+      "model_name": "5 Series (G30, 2020-2023)",
+      "variant_name": "545e xDrive",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.231
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data / DE price list with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Per-variant final drive ratios for the remaining unresolved BMW 5 Series G30 EU-market variants",
+          "reason": "Wave 15 and Wave 16 close the exact 540i, 540i xDrive, and 545e xDrive targets, but this run still does not prove one safe year-spanning final-drive mapping for 520i, 530i, 530i xDrive, or M550i xDrive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Per-variant top gear ratios for the remaining unresolved G30 variants",
+          "reason": "Wave 15 through Wave 17 now prove exact top-gear values for 520i, 540i, 540i xDrive, 545e xDrive, and 530i xDrive, but this run still did not recover authoritative EU G30 technical tables for 530i or M550i xDrive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 530i official tire baseline and later-year continuity",
+          "reason": "The recovered official BMW Germany launch price list proves a 225/55 R17 baseline with 18/19/20-inch options for the 530i, contradicting the current broad-row tire defaults, but this pass did not recover later official archived price lists proving one year-spanning 2017-2023 530i wheel matrix safe enough for a production rewrite.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 520i one exact final-drive and full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 07/2017, 09/2018, 05/2020, 11/2020, and 03/2021 technical-data sheets agree on 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but they split the final drive between 2.929 and 2.813, publish different forward and reverse ratio sets, and this pass did not recover a 2022-2023 Germany sheet to close end-of-span continuity.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 530i xDrive one exact final-drive and full-ratio set across the represented row span",
+          "reason": "Official BMW Germany technical-data sheets now prove 530i xDrive AWD, 8-Gang Steptronic wording, top gear 0.640, and a 225/55 R17 baseline tire, but the 11/2016 sheet publishes final drive 2.929 while the 05/2020, 11/2020, and 03/2021 sheets publish 2.813 and different forward-ratio sets.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 540i one exact full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 11/2016, 05/2020, and 11/2020 technical-data sheets agree on 540i RWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 540i xDrive one exact full-ratio set across the represented row span",
+          "reason": "Official BMW Germany 11/2016 and 11/2020 technical-data sheets agree on 540i xDrive AWD, 8-Gang Steptronic wording, final drive 2.929, top gear 0.640, and a 225/55 R17 baseline tire, but they publish different forward and reverse ratio sets, so this pass promotes only the stable exact fields.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G30 545e xDrive front-axle/transfer-case detail and full option tire matrix",
+          "reason": "Official BMW Germany 11/2020 technical data and the DE price list prove 545e xDrive AWD, 8-Gang Steptronic, the exact forward ratios, final drive 3.231, and a 225/55 R17 baseline tire, but the checked sources do not publish a separate front final drive, transfer-case ratio, or a full 545e-specific optional wheel/tire matrix.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "545e xDrive original migration metadata had fuel_type=ICE and 2017-2023 span",
+          "reason": "Official BMW global launch article (T0313447EN) and Germany 11/2020 technical PDF (T0317777DE/461542) document the 545e xDrive as a late-G30 plug-in hybrid xDrive sedan introduced for the 2020/2021 model year, not a 2017 ICE configuration. Engine remains 3.0L I6 turbo paired with an electric motor; fuel_type corrected to PHEV and start year narrowed to 2020. Earlier-year continuity is impossible by definition; later-year continuity through 2023 remains within the published lifecycle of the row."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G60.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G60.json
@@ -1,221 +1,196 @@
-[
-  {
-    "id": "bmw-g60-520i-eu-2024-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G60",
-    "body_code": "G60",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "5 Series (G60, 2024-2026)",
-    "variant_name": "520i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "The official BMW 05/2023 and 03/2025 technical-data sheets list 225/55 R18 as the standard tire package for the exact 520i.",
+      "n2": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 front and 275/40 R19 rear as the standard tire package for the exact i5 M60 xDrive.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence.",
+      "n4": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 as the standard tire package for the exact i5 eDrive40."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
+        "legacy_research_sources:349959b1860e"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:g60-5-series-launch-press-kit",
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
+        "bmw_pressclub_sources:g60-5-series-launch-press-kit",
+        "legacy_research_sources:0500c1e63e86",
+        "legacy_research_sources:142cdffd456d",
+        "legacy_research_sources:349959b1860e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:e6dcdf409dbe"
+      ],
+      "e5": [
         "bmw_pressclub_sources:g60-5-series-launch-press-kit",
         "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
         "legacy_research_sources:349959b1860e"
-      ],
-      "notes": "The official BMW 05/2023 launch material and the 03/2025 technical-specification PDF both confirm rear-wheel drive for the exact 520i configuration represented by this row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-        "legacy_research_sources:349959b1860e"
-      ],
-      "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets both list an 8-speed Steptronic transmission for the exact 520i. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g60-520i-eu-2024-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G60",
+      "body_code": "G60",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "5 Series (G60, 2024-2026)",
+      "variant_name": "520i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ],
-        "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 0.640 as the top-gear ratio for the exact 520i.",
-        "value": 0.64
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 05/2023 launch material and the 03/2025 technical-specification PDF both confirm rear-wheel drive for the exact 520i configuration represented by this row.",
+        "value": "RWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ],
-        "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 520i.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets both list an 8-speed Steptronic transmission for the exact 520i. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ],
-        "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 3.077 as the final-drive ratio for the exact 520i.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ],
-        "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 225/55 R18 as the standard tire package for the exact 520i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-            "legacy_research_sources:349959b1860e"
-          ],
-          "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 225/55 R18 as the standard tire package for the exact 520i.",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 0.640 as the top-gear ratio for the exact 520i.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 520i.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 05/2023 and 03/2025 technical-data sheets list 3.077 as the final-drive ratio for the exact 520i.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This pass directly revalidated the exact 520i core row from official BMW 05/2023 and 03/2025 technical-data sheets: rear-wheel drive, 8-speed Steptronic transmission wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and a 225/55 R18 standard tire package. Those stable fields are now promoted row-specific instead of inheriting family defaults.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 520i exact optional wheel/tire matrix beyond the standard 18-inch package",
-        "reason": "This pass directly revalidated the standard 225/55 R18 fitment, but it did not re-extract one BMW Germany wheel matrix strong enough to promote the optional 19/20/21-inch packages on this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-          "legacy_research_sources:349959b1860e"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g60-i5-m60-xdrive-eu-2024-ss1-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G60",
-    "body_code": "G60",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "5 Series (G60, 2024-2026)",
-    "variant_name": "i5 M60 xDrive",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-      ],
-      "notes": "The official BMW launch press kit and 03/2025 technical-specification PDF confirm dual-motor xDrive all-wheel drive for the exact i5 M60 xDrive.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 M60 xDrive.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 M60 xDrive. The repo keeps 1.0 as the canonical top-gear value for that single-speed EV mapping.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists 8.774 as the front overall-drive ratio for the exact i5 M60 xDrive.",
-        "value": 8.774
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists 9.374 as the rear overall-drive ratio for the exact i5 M60 xDrive.",
-        "value": 9.374
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 front and 275/40 R19 rear as the standard tire package for the exact i5 M60 xDrive.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
+          "default_axle_for_speed": "rear"
         },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "This pass directly revalidated the exact 520i core row from official BMW 05/2023 and 03/2025 technical-data sheets: rear-wheel drive, 8-speed Steptronic transmission wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and a 225/55 R18 standard tire package. Those stable fields are now promoted row-specific instead of inheriting family defaults.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 520i exact optional wheel/tire matrix beyond the standard 18-inch package",
+          "reason": "This pass directly revalidated the standard 225/55 R18 fitment, but it did not re-extract one BMW Germany wheel matrix strong enough to promote the optional 19/20/21-inch packages on this exact row.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g60-i5-m60-xdrive-eu-2024-ss1-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G60",
+      "body_code": "G60",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "5 Series (G60, 2024-2026)",
+      "variant_name": "i5 M60 xDrive",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW launch press kit and 03/2025 technical-specification PDF confirm dual-motor xDrive all-wheel drive for the exact i5 M60 xDrive.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 M60 xDrive.",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 M60 xDrive. The repo keeps 1.0 as the canonical top-gear value for that single-speed EV mapping.",
+          "value": 1.0
+        },
+        "final_drive_front": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 front and 275/40 R19 rear as the standard tire package for the exact i5 M60 xDrive.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2025 technical-specification PDF lists 8.774 as the front overall-drive ratio for the exact i5 M60 xDrive.",
+          "value": 8.774
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2025 technical-specification PDF lists 9.374 as the rear overall-drive ratio for the exact i5 M60 xDrive.",
+          "value": 9.374
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
@@ -226,209 +201,178 @@
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-            "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-            "legacy_research_sources:0500c1e63e86",
-            "legacy_research_sources:142cdffd456d",
-            "legacy_research_sources:349959b1860e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e6dcdf409dbe"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-            "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-            "legacy_research_sources:0500c1e63e86",
-            "legacy_research_sources:142cdffd456d",
-            "legacy_research_sources:349959b1860e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e6dcdf409dbe"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This pass directly revalidated the exact i5 M60 xDrive core row from the official BMW launch press kit and the 03/2025 technical-specification PDF: dual-motor xDrive AWD, single-speed transmission, front overall-drive ratio 8.774, rear overall-drive ratio 9.374, and a standard 245/45 R19 front + 275/40 R19 rear tire package. The schema can encode those axle-split reducer values and the standard staggered 19-inch setup, so they are now promoted row-specific instead of left as inherited family defaults.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This pass directly revalidated the exact i5 M60 xDrive core row from the official BMW launch press kit and the 03/2025 technical-specification PDF: dual-motor xDrive AWD, single-speed transmission, front overall-drive ratio 8.774, rear overall-drive ratio 9.374, and a standard 245/45 R19 front + 275/40 R19 rear tire package. The schema can encode those axle-split reducer values and the standard staggered 19-inch setup, so they are now promoted row-specific instead of left as inherited family defaults.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW i5 M60 xDrive exact optional 20-inch and 21-inch wheel/tire matrix",
-        "reason": "This pass directly revalidated the standard staggered 19-inch package, but it did not recover one directly readable BMW Germany wheel matrix strong enough to promote the retained 20-inch and 21-inch option packages row-specific.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g60-i5-edrive40-eu-2024-ss1-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G60",
-    "body_code": "G60",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "5 Series (G60, 2024-2026)",
-    "variant_name": "i5 eDrive40",
-    "engine_code": "Electric",
-    "engine_name": "Electric Single Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
       ],
-      "notes": "The official BMW launch press kit and 03/2025 technical-specification PDF confirm rear-wheel drive for the exact i5 eDrive40.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 eDrive40.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 eDrive40. The repo keeps 1.0 as the canonical top-gear value for that single-speed EV mapping.",
-        "value": 1.0
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists 11.115 as the overall-drive ratio for the exact i5 eDrive40.",
-        "value": 11.115
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 as the standard tire package for the exact i5 eDrive40.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW i5 M60 xDrive exact optional 20-inch and 21-inch wheel/tire matrix",
+          "reason": "This pass directly revalidated the standard staggered 19-inch package, but it did not recover one directly readable BMW Germany wheel matrix strong enough to promote the retained 20-inch and 21-inch option packages row-specific.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g60-i5-edrive40-eu-2024-ss1-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G60",
+      "body_code": "G60",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "5 Series (G60, 2024-2026)",
+      "variant_name": "i5 eDrive40",
+      "engine_code": "Electric",
+      "engine_name": "Electric Single Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW launch press kit and 03/2025 technical-specification PDF confirm rear-wheel drive for the exact i5 eDrive40.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 eDrive40.",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2025 technical-specification PDF lists a single-speed transmission for the exact i5 eDrive40. The repo keeps 1.0 as the canonical top-gear value for that single-speed EV mapping.",
+          "value": 1.0
+        },
+        "final_drive_rear": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2025 technical-specification PDF lists 245/45 R19 as the standard tire package for the exact i5 eDrive40.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2025 technical-specification PDF lists 11.115 as the overall-drive ratio for the exact i5 eDrive40.",
+          "value": 11.115
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
-            "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-            "legacy_research_sources:0500c1e63e86",
-            "legacy_research_sources:142cdffd456d",
-            "legacy_research_sources:349959b1860e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e6dcdf409dbe"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\""
+          "note": "This pass directly revalidated the exact i5 eDrive40 core row from the official BMW launch press kit and the 03/2025 technical-specification PDF: rear-wheel drive, single-speed transmission, overall-drive ratio 11.115, and a standard 245/45 R19 tire package. Those stable fields are now promoted row-specific instead of inheriting family defaults.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This pass directly revalidated the exact i5 eDrive40 core row from the official BMW launch press kit and the 03/2025 technical-specification PDF: rear-wheel drive, single-speed transmission, overall-drive ratio 11.115, and a standard 245/45 R19 tire package. Those stable fields are now promoted row-specific instead of inheriting family defaults.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW i5 eDrive40 exact current wheel/tire matrix beyond the standard 19-inch package",
+          "reason": "This pass directly revalidated the standard 245/45 R19 fitment, but it did not independently re-extract one directly readable BMW Germany wheel matrix strong enough to freshly close the retained 21-inch staggered option or the rest of the current wheel matrix.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW i5 eDrive40 exact current wheel/tire matrix beyond the standard 19-inch package",
-        "reason": "This pass directly revalidated the standard 245/45 R19 fitment, but it did not independently re-extract one directly readable BMW Germany wheel matrix strong enough to freshly close the retained 21-inch staggered option or the rest of the current wheel matrix.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g60-5-series-launch-press-kit",
-          "bmw_pressclub_sources:g60-2025-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_coupe/F06.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_coupe/F06.json
@@ -1,1103 +1,920 @@
-[
-  {
-    "id": "bmw-f06-640d-eu-2013-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "640d",
-    "engine_code": "N57",
-    "engine_name": "N57 3.0L I6 Twin-Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
+      "n2": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
+      "n3": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
+      "n4": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
+      "n5": "Official BMW PressClub technical-data PDFs note 245/45 R18 as the Germany-standard six-cylinder F06 tire package.",
+      "n6": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 640d xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
+      "n7": "Official BMW PressClub F06 technical-data PDFs publish a single 3.231 final-drive value for the 640i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
+      "n8": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 650i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
         "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
       ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish 640d separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640d Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640d Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 2.813 for the 640d Gran Coupe.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640d Gran Coupe.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 640d tire package.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs note 245/45 R18 as the Germany-standard six-cylinder F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Germany standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 640d rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f06-640d-xdrive-eu-2013-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "640d xDrive",
-    "engine_code": "N57",
-    "engine_name": "N57 3.0L I6 Twin-Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e2": [
         "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
         "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
       ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs identify the 640d xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640d xDrive Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640d xDrive Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 640d xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 640d xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640d xDrive Gran Coupe.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 640d xDrive tire package.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs note 245/45 R18 as the Germany-standard six-cylinder F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Germany standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 640d xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640d-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f06-640i-eu-2013-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "640i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish 640i separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640i Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640i Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 3.231 for the 640i Gran Coupe.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640i Gran Coupe.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 640i tire package.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs note 245/45 R18 as the Germany-standard six-cylinder F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Germany standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 640i rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f06-640i-xdrive-eu-2013-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "640i xDrive",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
         "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
         "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
       ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs identify the 640i xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
+      "e4": [
+        "bmw_pressclub_sources:f06-640d-2012-spec-pdf",
         "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
       ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640i xDrive Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640i xDrive Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
+      "e5": [
+        "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
+        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f06-640d-eu-2013-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "640d",
+      "engine_code": "N57",
+      "engine_name": "N57 3.0L I6 Twin-Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 3.231 final-drive value for the 640i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 3.231
+        "evidence_refs_ref": "e4",
+        "notes": "Official BMW PressClub F06 technical-data PDFs publish 640d separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
+        "value": "RWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 3.231 final-drive value for the 640i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 3.231
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640i xDrive Gran Coupe.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 640i xDrive tire package.",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640d Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640d Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 2.813 for the 640d Gran Coupe.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640d Gran Coupe.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 640d tire package.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Germany standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 640d rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs note 245/45 R18 as the Germany-standard six-cylinder F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Germany standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 640i xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-xdrive-2013-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f06-650i-eu-2013-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "650i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
       ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish 650i separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 650i Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 650i Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 2.813 for the 650i Gran Coupe.",
-        "value": 2.813
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f06-640d-xdrive-eu-2013-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "640d xDrive",
+      "engine_code": "N57",
+      "engine_name": "N57 3.0L I6 Twin-Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 650i Gran Coupe.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e2",
+        "notes": "Official BMW PressClub F06 technical-data PDFs identify the 640d xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
+        "value": "AWD"
       },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 650i tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 650i rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-640i-650i-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f06-650i-xdrive-eu-2013-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F06",
-    "body_code": "F06",
-    "production_start_year": 2013,
-    "production_end_year": 2018,
-    "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
-    "variant_name": "650i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs identify the 650i xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-        "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-      ],
-      "notes": "Official BMW PressClub F06 technical-data PDFs publish eight-speed automatic/Steptronic wording and exact ratios; the repo keeps ZF8HP as the normalized gearbox-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 650i xDrive Gran Coupe.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 650i xDrive Gran Coupe.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 650i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 2.813
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs publish a single 2.813 final-drive value for the 650i xDrive xDrive Gran Coupe; the repo mirrors it into canonical AWD axle fields.",
-        "value": 2.813
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640d xDrive Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640d xDrive Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n6",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n6",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640d xDrive Gran Coupe.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 640d xDrive tire package.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Germany standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 640d xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 650i xDrive Gran Coupe.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f06-640i-eu-2013-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "640i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW PressClub F06 technical-data PDFs publish 640i separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs publish this F06 650i xDrive tire package.",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640i Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640i Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 3.231 for the 640i Gran Coupe.",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640i Gran Coupe.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 640i tire package.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Germany standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 640i rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f06-640i-xdrive-eu-2013-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "640i xDrive",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Official BMW PressClub F06 technical-data PDFs identify the 640i xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 640i xDrive Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 640i xDrive Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "value": 3.231
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
+          "value": 3.231
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 640i xDrive Gran Coupe.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 640i xDrive tire package.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Germany standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 640i xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f06-650i-eu-2013-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "650i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW PressClub F06 technical-data PDFs publish 650i separately from the xDrive rows; the repo represents that non-xDrive state as RWD.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 650i Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 650i Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list rear final drive 2.813 for the 650i Gran Coupe.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 650i Gran Coupe.",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 19-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 650i tire package.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
           },
-          "name": "Optional staggered 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-            "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDFs list the optional staggered 20-inch F06 tire package.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "name": "Optional staggered 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This run consolidated duplicate F06 650i xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
         ]
       },
-      {
-        "note": "Official 2012/2013 launch and xDrive technical sheets and the 12/2014 LCI model-range technical sheet agree on the F06 ratio/final-drive grouping, closing the previous pre-LCI coverage concern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f06-650i-xdrive-2012-spec-pdf",
-          "bmw_pressclub_sources:f06-lci-2014-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 650i rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
+    },
+    {
+      "id": "bmw-f06-650i-xdrive-eu-2013-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F06",
+      "body_code": "F06",
+      "production_start_year": 2013,
+      "production_end_year": 2018,
+      "model_name": "6 Series Gran Coupe (F06, 2013-2018)",
+      "variant_name": "650i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "Official BMW PressClub F06 technical-data PDFs identify the 650i xDrive Gran Coupe as an xDrive/four-wheel-drive configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list 0.667 as eighth gear for the 650i xDrive Gran Coupe.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW PressClub F06 technical-data PDFs directly publish this full forward ratio set for the 650i xDrive Gran Coupe.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n8",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW PressClub F06 technical-data PDFs list this as the baseline tire for the 650i xDrive Gran Coupe.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes": "Official BMW PressClub technical-data PDFs publish this F06 650i xDrive tire package.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "name": "Optional staggered 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "name": "Optional staggered 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This run consolidated duplicate F06 650i xDrive rows to the single official final-drive group, replaced the unsupported 245/40 R19 default with BMW-published baseline tires, and retained official staggered 19- and 20-inch options.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_turismo/G32.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_turismo/G32.json
@@ -1,1229 +1,987 @@
-[
-  {
-    "id": "bmw-g32-620d-eu-2018-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "620d",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
+      "n3": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 630d xDrive Gran Turismo.",
+      "n4": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 640d xDrive Gran Turismo.",
+      "n5": "Official BMW 11/2020 technical-data PDF lists 245/50 R18 as the standard tire for the exact 640i Gran Turismo state represented by this narrowed 2020-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
         "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
       ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 620d Gran Turismo across the represented row span.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 620d Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 620d Gran Turismo.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 620d Gran Turismo.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 3.077 final drive for the exact 620d Gran Turismo.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 620d Gran Turismo.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 620d Gran Turismo.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 620d uses rear-wheel drive, 8-speed Steptronic wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and 225/60 R17 baseline tires across the represented row span. Production JSON keeps those stable exact fields while leaving the optional wheel matrix unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 620d exact optional wheel-package continuity across the represented row span",
-        "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-630d-eu-2018-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "630d",
-    "engine_code": "B57D30",
-    "engine_name": "B57D30 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 630d Gran Turismo across the represented row span.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630d Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630d Gran Turismo.",
-        "value": 0.64
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 630d Gran Turismo.",
-        "value": 2.563
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630d Gran Turismo.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630d Gran Turismo.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630d uses rear-wheel drive, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires across the represented row span. The row remains a stable-field pass because the checked PDFs publish different forward and reverse ratio sets: 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 with reverse 3.478 in 09/2018 versus 5.500 / 3.520 / 2.200 / 1.720 / 1.317 / 1.000 / 0.823 / 0.640 with reverse 3.993 in 11/2020.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 630d one exact full-ratio and reverse-ratio set across the represented row span",
-        "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on rear-wheel drive, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires, but they publish different 1st-6th and reverse ratios.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G32 630d exact optional wheel-package continuity across the represented row span",
-        "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-630d-xdrive-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "630d xDrive",
-    "engine_code": "B57D30",
-    "engine_name": "B57D30 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm xDrive all-wheel drive for the exact 630d xDrive Gran Turismo across the represented row span.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630d xDrive Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630d xDrive Gran Turismo.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 630d xDrive Gran Turismo.",
-        "value": 2.563
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 630d xDrive Gran Turismo.",
-        "value": 2.563
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630d xDrive Gran Turismo.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630d xDrive Gran Turismo.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630d xDrive uses AWD, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires across the represented row span. The row remains a stable-field pass because the checked PDFs publish different forward and reverse ratio sets: 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 with reverse 3.478 in 09/2018 versus 5.500 / 3.520 / 2.200 / 1.720 / 1.317 / 1.000 / 0.823 / 0.640 with reverse 3.993 in 11/2020.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 630d xDrive one exact full-ratio and reverse-ratio set across the represented row span",
-        "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on xDrive, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive, but they publish different 1st-6th and reverse ratios.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G32 630d xDrive exact optional wheel-package continuity across the represented row span",
-        "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-630i-eu-2018-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "630i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 630i Gran Turismo across the represented row span.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630i Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630i Gran Turismo.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 630i Gran Turismo.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 3.077 final drive for the exact 630i Gran Turismo.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630i Gran Turismo.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-          ],
-          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630i Gran Turismo.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630i uses rear-wheel drive, 8-speed Steptronic wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and 225/60 R17 baseline tires across the represented row span. Production JSON keeps those stable exact fields while leaving the optional wheel matrix unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 630i exact optional wheel-package continuity across the represented row span",
-        "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-630i-xdrive-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "630i xDrive",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-      ],
-      "notes": "Checked official BMW 09/2018 and 11/2020 G32 technical-data PDFs. They publish exact rows for 620d, 630d, 630d xDrive, 630i, 640d xDrive, and 640i xDrive, but they do not publish a 630i xDrive row, so this AWD mapping remains an unsupported advisory placeholder.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:e2ab2042d8b2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27e3d1aa1f09",
-            "legacy_research_sources:5c1b0ad4cf7e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27e3d1aa1f09",
-            "legacy_research_sources:5c1b0ad4cf7e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27e3d1aa1f09",
-            "legacy_research_sources:5c1b0ad4cf7e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 extends the contradiction chain for this represented AWD row across launch and facelift lifecycle evidence. Official BMW global and Netherlands 2017 launch material, the 09/2018 ACEA technical-data PDF, official BMW Netherlands and Italy 2020 facelift articles, and the 11/2020 ACEA technical-data PDF consistently separate 630i Gran Turismo from the distinct AWD petrol row 640i xDrive Gran Turismo. None of the checked official EU / ACEA / local-market sources names an exact 630i xDrive row, so this represented AWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2017-global-launch-article",
-          "bmw_pressclub_sources:g32-2017-netherlands-price-article",
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-netherlands-facelift-article",
-          "bmw_pressclub_sources:g32-2020-italy-facelift-article",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 630i xDrive exact official technical-data row",
-        "reason": "Checked official BMW launch articles, Netherlands launch pricing, 09/2018 and 11/2020 ACEA technical-data PDFs, and Netherlands/Italy facelift articles consistently omit 630i xDrive even while naming adjacent 630i, 640i xDrive, 630d xDrive, and 640d xDrive rows, and this pass did not recover another official EU-market table that contradicts that pattern.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2017-global-launch-article",
-          "bmw_pressclub_sources:g32-2017-netherlands-price-article",
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-netherlands-facelift-article",
-          "bmw_pressclub_sources:g32-2020-italy-facelift-article",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW G32 630i xDrive exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without any checked official exact 630i xDrive row, this pass cannot promote the inherited gearbox, final-drive, or tire values for the represented 2018-2024 AWD row. The saved official ACEA tables instead close 630i RWD and 640i xDrive as separate neighboring configurations with different default tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-640d-xdrive-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "640d xDrive",
-    "engine_code": "B57D30",
-    "engine_name": "B57D30 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:27e3d1aa1f09",
-        "legacy_research_sources:5c1b0ad4cf7e"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm xDrive all-wheel drive for the exact 640d xDrive Gran Turismo across the represented row span.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:27e3d1aa1f09",
-        "legacy_research_sources:5c1b0ad4cf7e"
-      ],
-      "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 640d xDrive Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 640d xDrive Gran Turismo.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 640d xDrive Gran Turismo.",
-        "value": 2.563
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 640d xDrive Gran Turismo.",
-        "value": 2.563
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs disagree on the exact baseline tire for the represented 640d xDrive row (225/60 R17 vs 245/50 R18), so the inherited placeholder remains unresolved until the row is split or one stable across-span mapping is proven.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 10 adds exact official BMW 09/2018 and 11/2020 technical-data evidence that the G32 640d xDrive uses xDrive AWD, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive. Production JSON promotes those stable exact drivetrain and gearbox-ratio fields; the repo keeps ZF8HP as an official-derived gearbox-family mapping, and the inherited default-tire value stays unresolved because the exact BMW baseline tire changes from 225/60 R17 in 09/2018 to 245/50 R18 in 11/2020.",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 640d xDrive one exact full-ratio and reverse-ratio set across the represented row span",
-        "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on xDrive, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive, but they publish different 1st-6th and reverse ratios.",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ]
-      },
-      {
-        "item": "BMW G32 640d xDrive exact baseline-tire continuity across the represented row span",
-        "reason": "Official BMW 09/2018 technical data lists 225/60 R17 baseline tires, while the exact 11/2020 technical-data PDF lists 245/50 R18, so the current broad row still needs a year split before one default tire can be encoded safely.",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-640i-xdrive-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
-    "variant_name": "640i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e2": [
         "legacy_research_sources:27b263e49b0d",
         "legacy_research_sources:5b75597267b1",
+        "legacy_research_sources:95b9bf2bf0cf",
         "legacy_research_sources:b2d556993748",
-        "legacy_research_sources:ca1480e64c12"
+        "legacy_research_sources:ca1480e64c12",
+        "legacy_research_sources:e2ab2042d8b2"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-        "value": 0.64
+      "e3": [
+        "legacy_research_sources:27e3d1aa1f09",
+        "legacy_research_sources:5c1b0ad4cf7e"
+      ],
+      "e4": [
+        "legacy_research_sources:5c1b0ad4cf7e"
+      ],
+      "e5": [
+        "legacy_research_sources:27e3d1aa1f09",
+        "legacy_research_sources:5c1b0ad4cf7e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:e2ab2042d8b2"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:g32-2017-global-launch-article",
+        "bmw_pressclub_sources:g32-2017-netherlands-price-article",
+        "bmw_pressclub_sources:g32-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:g32-2020-netherlands-facelift-article",
+        "bmw_pressclub_sources:g32-2020-italy-facelift-article",
+        "bmw_pressclub_sources:g32-2020-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g32-620d-eu-2018-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "620d",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 620d Gran Turismo across the represented row span.",
+        "value": "RWD"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-        "value": 3.077
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 620d Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-        "value": 3.077
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 620d Gran Turismo.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 620d Gran Turismo.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 3.077 final drive for the exact 620d Gran Turismo.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 620d Gran Turismo.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 620d Gran Turismo.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 620d uses rear-wheel drive, 8-speed Steptronic wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and 225/60 R17 baseline tires across the represented row span. Production JSON keeps those stable exact fields while leaving the optional wheel matrix unresolved.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 620d exact optional wheel-package continuity across the represented row span",
+          "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:27b263e49b0d",
-          "legacy_research_sources:5b75597267b1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b2d556993748",
-          "legacy_research_sources:ca1480e64c12",
-          "legacy_research_sources:e2ab2042d8b2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g32-630d-eu-2018-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "630d",
+      "engine_code": "B57D30",
+      "engine_name": "B57D30 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 630d Gran Turismo across the represented row span.",
+        "value": "RWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630d Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630d Gran Turismo.",
+          "value": 0.64
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 2.563 final drive for the exact 630d Gran Turismo.",
+          "value": 2.563
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630d Gran Turismo.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630d Gran Turismo.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630d uses rear-wheel drive, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires across the represented row span. The row remains a stable-field pass because the checked PDFs publish different forward and reverse ratio sets: 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 with reverse 3.478 in 09/2018 versus 5.500 / 3.520 / 2.200 / 1.720 / 1.317 / 1.000 / 0.823 / 0.640 with reverse 3.993 in 11/2020.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 630d one exact full-ratio and reverse-ratio set across the represented row span",
+          "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on rear-wheel drive, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires, but they publish different 1st-6th and reverse ratios.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G32 630d exact optional wheel-package continuity across the represented row span",
+          "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-630d-xdrive-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "630d xDrive",
+      "engine_code": "B57D30",
+      "engine_name": "B57D30 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm xDrive all-wheel drive for the exact 630d xDrive Gran Turismo across the represented row span.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630d xDrive Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630d xDrive Gran Turismo.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "value": 2.563
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "value": 2.563
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630d xDrive Gran Turismo.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630d xDrive Gran Turismo.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630d xDrive uses AWD, 8-speed Steptronic wording, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires across the represented row span. The row remains a stable-field pass because the checked PDFs publish different forward and reverse ratio sets: 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 with reverse 3.478 in 09/2018 versus 5.500 / 3.520 / 2.200 / 1.720 / 1.317 / 1.000 / 0.823 / 0.640 with reverse 3.993 in 11/2020.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 630d xDrive one exact full-ratio and reverse-ratio set across the represented row span",
+          "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on xDrive, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive, but they publish different 1st-6th and reverse ratios.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW G32 630d xDrive exact optional wheel-package continuity across the represented row span",
+          "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-630i-eu-2018-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "630i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm rear-wheel drive for the exact 630i Gran Turismo across the represented row span.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 630i Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 630i Gran Turismo.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 630i Gran Turismo.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 3.077 final drive for the exact 630i Gran Turismo.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 baseline tires for the exact 630i Gran Turismo.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 225/60 R17 as the standard tire package for the exact 630i Gran Turismo.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 15 directly revalidated official BMW 09/2018 and 11/2020 technical-data PDFs and confirmed that the G32 630i uses rear-wheel drive, 8-speed Steptronic wording, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.077, and 225/60 R17 baseline tires across the represented row span. Production JSON keeps those stable exact fields while leaving the optional wheel matrix unresolved.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 630i exact optional wheel-package continuity across the represented row span",
+          "reason": "Checked BMW 09/2018 and 11/2020 technical-data PDFs close the 225/60 R17 baseline tire, but this pass did not recover one exact optional wheel matrix spanning the full 2018-2024 row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-630i-xdrive-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "630i xDrive",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes": "Checked official BMW 09/2018 and 11/2020 G32 technical-data PDFs. They publish exact rows for 620d, 630d, 630d xDrive, 630i, 640d xDrive, and 640i xDrive, but they do not publish a 630i xDrive row, so this AWD mapping remains an unsupported advisory placeholder.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 extends the contradiction chain for this represented AWD row across launch and facelift lifecycle evidence. Official BMW global and Netherlands 2017 launch material, the 09/2018 ACEA technical-data PDF, official BMW Netherlands and Italy 2020 facelift articles, and the 11/2020 ACEA technical-data PDF consistently separate 630i Gran Turismo from the distinct AWD petrol row 640i xDrive Gran Turismo. None of the checked official EU / ACEA / local-market sources names an exact 630i xDrive row, so this represented AWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 17 now adds exact official BMW technical-data evidence that the G32 640i xDrive uses all-wheel drive, Eight-speed Steptronic transmission wording, final drive 3.077, and top gear 0.640 in checked 11/2020 and later Germany-relevant material. Production JSON promotes only those stable exact gearbox fields because official 2018 and 2020+ documents still disagree on the full forward-ratio and reverse-ratio set, early Germany-market tire continuity is still not closed, and the checked sources do not prove one gearbox-family code across the full 2018-2024 span.",
-        "evidence_refs": [
-          "legacy_research_sources:27b263e49b0d",
-          "legacy_research_sources:5b75597267b1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b2d556993748",
-          "legacy_research_sources:ca1480e64c12",
-          "legacy_research_sources:e2ab2042d8b2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Per-variant final-drive and top-gear ratios for the remaining unresolved EU G32 lineup",
-        "reason": "Wave 17 closes the exact 640i xDrive stable gearbox fields, but this run still did not recover authoritative BMW technical-data tables for the other G32 variants.",
-        "evidence_refs": [
-          "legacy_research_sources:27b263e49b0d",
-          "legacy_research_sources:5b75597267b1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b2d556993748",
-          "legacy_research_sources:ca1480e64c12",
-          "legacy_research_sources:e2ab2042d8b2"
-        ]
-      },
-      {
-        "item": "BMW G32 640i xDrive one exact full-ratio and reverse-ratio set across the represented row span",
-        "reason": "Official BMW 2018 and 11/2020 technical-data sheets for the exact 640i xDrive agree on AWD, Eight-speed Steptronic wording, final drive 3.077, and top gear 0.640, but they publish different 1st-6th and reverse ratios, so this pass promotes only the stable exact fields.",
-        "evidence_refs": [
-          "legacy_research_sources:27b263e49b0d",
-          "legacy_research_sources:5b75597267b1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b2d556993748",
-          "legacy_research_sources:ca1480e64c12",
-          "legacy_research_sources:e2ab2042d8b2"
-        ]
-      },
-      {
-        "item": "BMW G32 640i xDrive exact Germany-market tire continuity across the represented row span",
-        "reason": "Checked 11/2020 technical data and the 11/2022 BMW Germany price list prove a 245/50 R18 baseline tire with 19- and 20-inch options, but this pass did not recover an early Germany-market wheel matrix proving the same package across the full 2018-2024 row span.",
-        "evidence_refs": [
-          "legacy_research_sources:27b263e49b0d",
-          "legacy_research_sources:5b75597267b1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:b2d556993748",
-          "legacy_research_sources:ca1480e64c12",
-          "legacy_research_sources:e2ab2042d8b2"
-        ]
-      },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g32-640i-eu-2020-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G32",
-    "body_code": "G32",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "6 Series Gran Turismo (G32, 2020)",
-    "variant_name": "640i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:5c1b0ad4cf7e"
       ],
-      "notes": "Official BMW 11/2020 technical-data PDF confirms rear-wheel drive for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:5c1b0ad4cf7e"
-      ],
-      "notes": "Official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 640i Gran Turismo state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 11/2020 technical-data PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 11/2020 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ],
-        "notes": "Official BMW 11/2020 technical-data PDF lists 245/50 R18 as the standard tire for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW G32 630i xDrive exact official technical-data row",
+          "reason": "Checked official BMW launch articles, Netherlands launch pricing, 09/2018 and 11/2020 ACEA technical-data PDFs, and Netherlands/Italy facelift articles consistently omit 630i xDrive even while naming adjacent 630i, 640i xDrive, 630d xDrive, and 640d xDrive rows, and this pass did not recover another official EU-market table that contradicts that pattern.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW G32 630i xDrive exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without any checked official exact 630i xDrive row, this pass cannot promote the inherited gearbox, final-drive, or tire values for the represented 2018-2024 AWD row. The saved official ACEA tables instead close 630i RWD and 640i xDrive as separate neighboring configurations with different default tires.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-640d-xdrive-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "640d xDrive",
+      "engine_code": "B57D30",
+      "engine_name": "B57D30 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm xDrive all-wheel drive for the exact 640d xDrive Gran Turismo across the represented row span.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs confirm 8-speed Steptronic wording for the exact 640d xDrive Gran Turismo. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:5c1b0ad4cf7e"
-          ],
-          "notes": "Official BMW 11/2020 technical-data PDF lists 245/50 R18 as the standard tire for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on 0.640 top gear for the exact 640d xDrive Gran Turismo.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n4",
+          "value": 2.563
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n4",
+          "value": 2.563
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes": "Official BMW 09/2018 and 11/2020 technical-data PDFs disagree on the exact baseline tire for the represented 640d xDrive row (225/60 R17 vs 245/50 R18), so the inherited placeholder remains unresolved until the row is split or one stable across-span mapping is proven.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 10 adds exact official BMW 09/2018 and 11/2020 technical-data evidence that the G32 640d xDrive uses xDrive AWD, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive. Production JSON promotes those stable exact drivetrain and gearbox-ratio fields; the repo keeps ZF8HP as an official-derived gearbox-family mapping, and the inherited default-tire value stays unresolved because the exact BMW baseline tire changes from 225/60 R17 in 09/2018 to 245/50 R18 in 11/2020.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 640d xDrive one exact full-ratio and reverse-ratio set across the represented row span",
+          "reason": "Official BMW 09/2018 and 11/2020 technical-data PDFs agree on xDrive, 8-speed Steptronic wording, 0.640 top gear, and 2.563 final drive, but they publish different 1st-6th and reverse ratios.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW G32 640d xDrive exact baseline-tire continuity across the represented row span",
+          "reason": "Official BMW 09/2018 technical data lists 225/60 R17 baseline tires, while the exact 11/2020 technical-data PDF lists 245/50 R18, so the current broad row still needs a year split before one default tire can be encoded safely.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-640i-xdrive-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "6 Series Gran Turismo (G32, 2018-2024)",
+      "variant_name": "640i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "legacy_research_sources:27b263e49b0d",
+          "legacy_research_sources:5b75597267b1",
+          "legacy_research_sources:b2d556993748",
+          "legacy_research_sources:ca1480e64c12"
+        ],
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Wave 17 now adds exact official BMW technical-data evidence that the G32 640i xDrive uses all-wheel drive, Eight-speed Steptronic transmission wording, final drive 3.077, and top gear 0.640 in checked 11/2020 and later Germany-relevant material. Production JSON promotes only those stable exact gearbox fields because official 2018 and 2020+ documents still disagree on the full forward-ratio and reverse-ratio set, early Germany-market tire continuity is still not closed, and the checked sources do not prove one gearbox-family code across the full 2018-2024 span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW technical data / DE price list with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Per-variant final-drive and top-gear ratios for the remaining unresolved EU G32 lineup",
+          "reason": "Wave 17 closes the exact 640i xDrive stable gearbox fields, but this run still did not recover authoritative BMW technical-data tables for the other G32 variants.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G32 640i xDrive one exact full-ratio and reverse-ratio set across the represented row span",
+          "reason": "Official BMW 2018 and 11/2020 technical-data sheets for the exact 640i xDrive agree on AWD, Eight-speed Steptronic wording, final drive 3.077, and top gear 0.640, but they publish different 1st-6th and reverse ratios, so this pass promotes only the stable exact fields.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW G32 640i xDrive exact Germany-market tire continuity across the represented row span",
+          "reason": "Checked 11/2020 technical data and the 11/2022 BMW Germany price list prove a 245/50 R18 baseline tire with 19- and 20-inch options, but this pass did not recover an early Germany-market wheel matrix proving the same package across the full 2018-2024 row span.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g32-640i-eu-2020-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G32",
+      "body_code": "G32",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "6 Series Gran Turismo (G32, 2020)",
+      "variant_name": "640i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Official BMW 11/2020 technical-data PDF confirms rear-wheel drive for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "Official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 640i Gran Turismo state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 11/2020 technical-data PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 11/2020 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 640i Gran Turismo state represented by this narrowed 2020-only row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Retained conservative inherited placeholder for the non-baseline 20-inch wheel package because this pass only closes the exact 245/50 R18 standard tire for the narrowed 2020-only row.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:27b263e49b0d",
-            "legacy_research_sources:5b75597267b1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:b2d556993748",
-            "legacy_research_sources:ca1480e64c12",
-            "legacy_research_sources:e2ab2042d8b2"
-          ],
-          "notes": "Retained conservative inherited placeholder for the non-baseline 21-inch wheel package because this pass only closes the exact 245/50 R18 standard tire for the narrowed 2020-only row.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes": "Retained conservative inherited placeholder for the non-baseline 20-inch wheel package because this pass only closes the exact 245/50 R18 standard tire for the narrowed 2020-only row.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 09/2018 and 11/2020 technical-data PDFs now confirm that the 640i Gran Turismo rear-wheel-drive package changed between the pre-facelift and facelift states: 2018 used forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 with 225/60 R17 standard tires, while 2020 used forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 with 245/50 R18 standard tires, both with rear final drive 3.077. Production JSON therefore narrows this row to the supported 2020-only state instead of overclaiming one exact package across the original broad 2018-2024 span.",
-        "evidence_refs": [
-          "legacy_research_sources:27e3d1aa1f09",
-          "legacy_research_sources:5c1b0ad4cf7e"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G32 640i exact optional wheel/tire matrix for the 2020 facelift state",
-        "reason": "Official BMW 11/2020 technical-data PDF closes the 245/50 R18 standard tire for the exact 640i Gran Turismo row, but this pass did not recover a full row-specific optional wheel/tire matrix for the narrowed 2020-only state.",
-        "evidence_refs": [
-          "legacy_research_sources:5c1b0ad4cf7e"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes": "Retained conservative inherited placeholder for the non-baseline 21-inch wheel package because this pass only closes the exact 245/50 R18 standard tire for the narrowed 2020-only row.",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "item": "G32 source-finding pass status",
-        "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+      "verification_notes": [
+        {
+          "note": "Official BMW 09/2018 and 11/2020 technical-data PDFs now confirm that the 640i Gran Turismo rear-wheel-drive package changed between the pre-facelift and facelift states: 2018 used forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 with 225/60 R17 standard tires, while 2020 used forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 with 245/50 R18 standard tires, both with rear final drive 3.077. Production JSON therefore narrows this row to the supported 2020-only state instead of overclaiming one exact package across the original broad 2018-2024 span.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G32 640i exact optional wheel/tire matrix for the 2020 facelift state",
+          "reason": "Official BMW 11/2020 technical-data PDF closes the 245/50 R18 standard tire for the exact 640i Gran Turismo row, but this pass did not recover a full row-specific optional wheel/tire matrix for the narrowed 2020-only state.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "G32 source-finding pass status",
+          "reason": "G32 source-finding pass collected official BMW PressClub launch (2017 global), 2017 Netherlands price list, 2018 tech-data PDF (T0259...?/419611), 2020 LCI tech-data PDF (463145), 2020 Italy and Netherlands facelift releases, and BMW Germany 11/2022 Preisliste under .tmp/audi-bmw-uncertain-config-research-20260427-1745/sources/bmw-6-series-gran-turismo-g32/. Per official sources the G32 had a 2020 LCI facelift, so the broad 2018-2024 row spans pre-LCI and LCI states with potentially different ratio/final-drive sets. Driveshaft and wheel-order analysis disabled until per-row exact technical data is parsed and added to the source pack. ZF8HP transmission family is `official_derived` from BMW's 'Eight-speed Steptronic' wording."
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/F01.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/F01.json
@@ -1,838 +1,738 @@
-[
-  {
-    "id": "bmw-f01-730i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "730i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
+      "n2": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI.",
+      "n3": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18.",
+      "n4": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18.",
+      "n5": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
+      "n6": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom.",
+      "n7": "Reverse gear ratio (research note): 3.317",
+      "n8": "Reverse gear ratio (research note): 3.295"
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
+      ],
+      "e4": [
         "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
+      "e5": [
+        "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI."
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e6": [
+        "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:f01-730i-2012-tech-spec-pdf"
+      ],
+      "e8": [
+        "bmw_pressclub_sources:f01-750d-xdrive-2012-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f01-730i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "730i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI.",
-        "value": 0.667
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n2",
+        "value": "RWD"
       },
-      "gear_ratios": {
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
         "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.208,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n2"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI.",
-        "value": 3.462
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-730i-2012-tech-spec-pdf"
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.208,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 07/2012 technical-data PDF lists 245/55 R17 baseline tires for the exact F01 730i state represented by this narrowed 2012-only row.",
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207820 (valid from 7/2012) confirms F01 SWB 730i (B58 derivate, 190 kW): ZF 8HP, gear ratios I 4.714/II 3.143/III 2.208/IV 1.667/V 1.285/VI 1.000/VII 0.839/VIII 0.667, R 3.295, final drive 3.462; tires 245/55 R17 102W on 8Jx17. Pre-7/2012 730i used ZF 6HP — this row is scoped to the 2012 LCI. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n2",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 730i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, rear final drive 3.462, and 245/55 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.295",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F01 730i exact optional wheel/tire matrix beyond the narrowed 2012 row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/55 R17 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-730i-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f01-740i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "740i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.208,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "The official BMW 07/2012 technical-data PDF lists 245/55 R17 baseline tires for the exact F01 730i state represented by this narrowed 2012-only row.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 730i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, rear final drive 3.462, and 245/55 R17 baseline tires.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F01 730i exact optional wheel/tire matrix beyond the narrowed 2012 row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/55 R17 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f01-740i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "740i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n3",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.208,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 740i state represented by this narrowed 2012-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 740i (V8, 235 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.295, final drive 3.077; tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 740i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, rear final drive 3.077, and 245/50 R18 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.295",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F01 740i exact optional wheel/tire matrix beyond the narrowed 2012 row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f01-750d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "750d",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-        "value": 3.077,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 740i state represented by this narrowed 2012-only row.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 740i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, rear final drive 3.077, and 245/50 R18 baseline tires.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F01 740i exact optional wheel/tire matrix beyond the narrowed 2012 row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f01-750d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "750d",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.077,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 19 directly revalidated the official BMW 07/2012 F01 diesel technical-data PDF. That checked official BMW sheet publishes an exact 750d xDrive state, but it does not publish an exact 750d RWD row, so this represented 2012 750d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e8"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
+          "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207816 (valid from 7/2012) is the official ACEA spec sheet for the F01 SWB diesel lineup and lists ONLY 730d xDrive, 740d xDrive, and 750d xDrive — every F01 diesel is xDrive-only. There is no RWD 750d in any official BMW publication. The 750d uses the N57S tri-turbo (280 kW/381 hp/740 Nm), distinct from the 740d N57. If the row's intent was the xDrive variant, it should be renamed to 'bmw-f01-750d-xdrive-eu-2012-zf8hp-awd'. Marked no_confidence as a phantom EU configuration (RWD 750d does not exist); row should be considered for removal or rename.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 19 directly revalidated the official BMW 07/2012 F01 diesel technical-data PDF. That checked official BMW sheet publishes an exact 750d xDrive state, but it does not publish an exact 750d RWD row, so this represented 2012 750d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-diesels-2012-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F01 750d exact official 2012 RWD technical-data row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF publishes only 750d xDrive for the represented update window, and this pass did not recover another official 2012 EU technical-data page for a 750d RWD state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750d-xdrive-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f01-750i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "750i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.208,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW F01 750d exact official 2012 RWD technical-data row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF publishes only 750d xDrive for the represented update window, and this pass did not recover another official 2012 EU technical-data page for a 750d RWD state.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f01-750i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "750i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n4",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.208,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 750i state represented by this narrowed 2012-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 (valid from 7/2012) confirms F01 SWB 750i (V8, 330 kW): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 750i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 2.813, and 245/50 R18 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.317",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F01 750i exact optional wheel/tire matrix beyond the narrowed 2012 row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f01-750i-xdrive-eu-2012-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "750i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.208,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 07/2012 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 750i xDrive state represented by this narrowed 2012-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 750i state represented by this narrowed 2012-only row.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 750i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 2.813, and 245/50 R18 baseline tires.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F01 750i exact optional wheel/tire matrix beyond the narrowed 2012 row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f01-750i-xdrive-eu-2012-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "750i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n5",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n5",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.208,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 as the baseline tire for the exact 750i xDrive state represented by this narrowed 2012-only row.",
+          "evidence_refs_ref": "e5",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207819 (valid from 7/2012) confirms F01 SWB 750i xDrive (V8, 330 kW, AWD): ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813 (exact, not derived); tires 245/50 R18 100Y RSC on 8Jx18. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 07/2012 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 750i xDrive state represented by this narrowed 2012-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n5",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2012 technical-data PDF establishes the exact 750i xDrive launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2012-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.317",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series 750i xDrive exact optional wheel/tire matrix beyond the narrowed 2012 row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF closes the 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 7 Series 750i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f01-760i-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F01",
-    "body_code": "F01",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "7 Series (F01, 2012)",
-    "variant_name": "760i",
-    "engine_code": "6.0L",
-    "engine_name": "6.0L V12 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.714,
-          3.143,
-          2.208,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 as the baseline tire for the exact 750i xDrive state represented by this narrowed 2012-only row.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW 07/2012 technical-data PDF establishes the exact 750i xDrive launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2012-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series 750i xDrive exact optional wheel/tire matrix beyond the narrowed 2012 row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF closes the 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW 7 Series 750i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f01-760i-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F01",
+      "body_code": "F01",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "7 Series (F01, 2012)",
+      "variant_name": "760i",
+      "engine_code": "6.0L",
+      "engine_name": "6.0L V12 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n6",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.714,
+            3.143,
+            2.208,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
           ],
-          "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 760i state represented by this narrowed 2012-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0131447EN attachment 207815 confirms F01 SWB 760i (V12 N74, 400 kW, wheelbase 3070 mm — distinct from 760Li at 3210 mm in attachment 207817). ZF 8HP, ratios I 4.714 ... VIII 0.667, R 3.317, final drive 2.813; tires 245/50 R18 100Y RSC. SWB 760i is a real and separate variant from 760Li — NOT a phantom. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 760i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 2.813, and 245/50 R18 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes": "The official BMW 07/2012 technical-data PDF lists 245/50 R18 baseline tires for the exact F01 760i state represented by this narrowed 2012-only row.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
         ]
       },
-      {
-        "note": "Reverse gear ratio (research note): 3.317",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-760i-2012-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 07/2012 technical-data PDF closes the exact F01 760i state represented by this retimed 2012-only row: RWD, 8-speed automatic with Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 2.813, and 245/50 R18 baseline tires.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW F01 760i exact optional wheel/tire matrix beyond the narrowed 2012 row",
+          "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW F01 760i exact optional wheel/tire matrix beyond the narrowed 2012 row",
-        "reason": "The checked official BMW 07/2012 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full optional wheel/tire matrix from the same sheet for the exact 2012 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f01-740i-750i-2012-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G11.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G11.json
@@ -1,2884 +1,2318 @@
-[
-  {
-    "id": "bmw-g11-725ld-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "725Ld",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
+      "n3": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
+      "n4": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n5": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n11": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
+      "n12": "The official BMW DE launch-era 7 Series brochure technical-data table lists `245/50 R18 Y` as the baseline tire for the shared `740e/Le` column.",
+      "n13": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row.",
+      "n14": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row.",
+      "n15": "This run promoted the exact official 740e/740Le plug-in-hybrid ratio set and 3.077 final drive from the BMW 06/2016 technical-data PDF. Tire default remains manual-confirmation gated because the ACEA PDF lists 225/60 R17 while the later Germany catalog/source-backed row uses 245/50 R18.",
+      "n16": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row.",
+      "n17": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row.",
+      "n18": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 baseline tires for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
+      "n19": "The official BMW 11/2015 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 750i xDrive state represented by this narrowed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n20": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 as the baseline tire for the exact 750i xDrive state represented by this narrowed 2016-only row.",
+      "n21": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745Le rear-wheel-drive row.",
+      "n22": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745e rear-wheel-drive row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:g11-7-series-2015-spec-article",
         "bmw_pressclub_sources:g11-7-series-2019-press-kit"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This G11 research wave rechecks the official BMW 11/2015 launch specifications article and the official BMW DE launch-era 7 Series brochure/catalog technical table. Together they show that 2016 EU diesel rows are published as 730d/Ld RWD plus 730d/Ld xDrive and 740d/Ld xDrive AWD, but no exact 725Ld row appears in either the launch article or the Germany-market technical-data table, so this represented 2016 725Ld RWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 725Ld exact official 2016 technical-data row",
-        "reason": "The checked official BMW 11/2015 launch specifications article omits 725Ld from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 725Ld from both the rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU technical-data row for the variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 725Ld exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 725Ld technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-725d-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "725d",
-    "engine_code": "B47D20",
-    "engine_name": "B47D20 2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
+      "e2": [
+        "legacy_research_sources:2201c7bcf575",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:7699086a1abd",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 725d / 725Ld variants (B47D20 2.0L I4 diesel) are not present in the BMW PressClub G11 launch lineup (T0235242EN, 11/2015), the 2016 model year tech-data PDFs, or the 2019 LCI press kit (T0289615EN). No BMW PressClub spec PDF confirms this badge for the EU market. The family_default tire 245/40 R20 is implausible for a base diesel - the entry-level confirmed 730d carries 225/60 R17 baseline. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation pending an authoritative source.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 directly revalidated the official BMW 11/2015 G11 launch specifications article, and batch 10 then rechecked the official BMW DE launch-era 7 Series brochure/catalog technical table. Together they show that 2016 EU diesel rows are published as 730d/Ld RWD plus 730d/Ld xDrive and 740d/Ld xDrive AWD, but no exact 725d row appears in either the launch article or the Germany-market technical-data table, so this represented 2016 725d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 725d exact official 2016 technical-data row",
-        "reason": "The checked official BMW 11/2015 launch specifications article omits 725d from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 725d from both the rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU technical-data row for the variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 725d exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 725d technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-730ld-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "730Ld",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
-      },
-      "final_drive_rear": {
-        "value": 2.563,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 2.563 as the rear final-drive ratio for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 730Ld launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.563 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series Sedan 730Ld exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-730li-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "730Li",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW for EU. The 730Li (B48 2.0L I4 petrol in LWB) is a China and select-Asia market variant; it is not listed in any BMW EU PressClub spec article (T0235242EN, T0289615EN) or EU price list. The repo row is tagged 'eu' market which is incorrect for this badge. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This G11 research wave rechecks the official BMW 11/2015 launch specifications article and the official BMW DE launch-era 7 Series brochure/catalog technical table. Those checked official BMW sources publish exact rows for 730d, 730Ld, 730d xDrive, 730Ld xDrive, 740d/Ld xDrive, 740i, 740Li, 750i, 750Li, and xDrive petrol siblings, but they do not publish any exact 730Li row, so this represented 2016 730Li RWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 730Li exact official 2016 technical-data row",
-        "reason": "The checked official BMW 11/2015 launch specifications article omits 730Li from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 730Li from the checked 2016 rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU/Germany technical-data row for the variant.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 730Li exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 730Li technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-730d-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "730d",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
-      },
-      "final_drive_rear": {
-        "value": 2.563,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 2.563 as the rear final-drive ratio for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 730d launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.563 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series Sedan 730d exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-730i-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "730i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 730i variant did exist in the EU BMW G11 lineup but only from the 2019 LCI refresh onward (B48 2.0L I4 petrol). It was explicitly NOT in the 11/2015 launch lineup per BMW PressClub T0235242EN spec article. The current row's production_start_year/end_year of 2016/2016 is therefore wrong (correct era is 2019-2022). Tire family_default 245/40 R20 is also unconfirmed for a base petrol. Drivetrain, transmission, ratios and tires set to no_confidence pending year correction and a 2019-LCI tech-data PDF.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This G11 research wave keeps the row unsupported but improves the official evidence chain. The checked BMW 11/2015 launch specifications article and the official BMW DE launch-era technical-data table still omit any trim-specific 730i row, while reputable secondary exact-trim pages independently confirm that a 2016 BMW 7 Series 730i existed for the European market as a G11/G12 2.0-liter B48B20 I4 petrol state and capture checked 17-inch, 18-inch, and 19-inch fitments. An earlier attempt to use the official BMW Germany brochure column with 1998 cm3 / 190 kW / 400 Nm as exact 730i proof was rejected because that extracted column belongs to 740e/Le iPerformance context rather than a standalone 730i row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab",
-          "secondary_technical_sources:g11-730i-2016-tirewheelguide",
-          "secondary_technical_sources:g11-730i-2016-wheel-size"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 730i exact official 2016 technical-data row",
-        "reason": "The checked official BMW 11/2015 launch specifications article and the official BMW DE launch-era technical-data table both omit 730i from the published 2016 launch rows. Secondary exact-trim pages confirm the 2016 European-market 730i identity and engine family, but they do not replace a trim-specific official drivetrain sheet.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab",
-          "secondary_technical_sources:g11-730i-2016-tirewheelguide",
-          "secondary_technical_sources:g11-730i-2016-wheel-size"
-        ]
-      },
-      {
-        "item": "BMW G11 730i exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 730i technical-data row or a stronger independent secondary pair for drivetrain numerics, this pass cannot promote the inherited gearbox or final-drive placeholders. The checked exact-trim secondary pages support 17-inch, 18-inch, and 19-inch fitments for 730i, but they do not safely close one production-default tire package for the canonical row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab",
-          "secondary_technical_sources:g11-730i-2016-tirewheelguide",
-          "secondary_technical_sources:g11-730i-2016-wheel-size"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740ld-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740Ld",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
+      "e3": [
         "bmw_pressclub_sources:g11-7-series-2015-spec-article",
         "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
+      "e4": [
+        "bmw_pressclub_sources:g11-7-series-2015-spec-article"
+      ],
+      "e5": [
+        "bmw_pressclub_sources:g11-730d-2015-spec-pdf"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
+      ],
+      "e8": [
+        "legacy_research_sources:387f07d4c6ab"
+      ],
+      "e9": [
         "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 10 rechecks the official BMW 11/2015 launch specifications article, the exact 740d xDrive technical-data PDF, and the BMW DE launch-era 7 Series brochure. Together they show that `740Ld` is absent from the published rear-wheel-drive lineup and appears only through the shared `740d/Ld xDrive` all-wheel-drive technical-data column. This represented 2016 `740Ld` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "Official G11/G12 sources found in this run support 740Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 740Ld exact official 2016 RWD technical-data row",
-        "reason": "The checked official BMW launch-source chain shows `740Ld` only through the shared `740d/Ld xDrive` AWD technical-data column and does not publish any exact `740Ld` rear-wheel-drive row for the represented 2016 EU state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 740Ld exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 740Ld RWD technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "Unsupported rear-wheel-drive diesel placeholder",
-        "reason": "Official G11/G12 sources found in this run support 740Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740le-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740Le",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo + electric motor (PHEV)",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740e-2016-launch-article",
-        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
+        "legacy_research_sources:387f07d4c6ab"
       ],
-      "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms the exact 740Le plug-in-hybrid row is rear-wheel drive; 740Le xDrive is the distinct AWD sibling.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740e-2016-launch-article",
-        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-      ],
-      "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms eight-speed Steptronic wording for the exact 740Le plug-in-hybrid row; the repo keeps ZF8HP as the normalized automatic-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists 0.667 as eighth gear for the exact 740Le rear-wheel-drive PHEV row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists final drive 3.077 for the exact 740Le rear-wheel-drive PHEV row.",
-        "value": 3.077
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF directly publishes this full forward ratio set for the exact 740Le rear-wheel-drive PHEV row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ],
-        "notes": "The official BMW DE launch-era 7 Series brochure technical-data table lists `245/50 R18 Y` as the baseline tire for the shared `740e/Le` column.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:387f07d4c6ab"
-          ],
-          "notes": "The official BMW DE launch-era 7 Series brochure technical-data table lists `245/50 R18 Y` as the baseline tire for the shared `740e/Le` column.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 9 rechecks the launch-era BMW DE 7 Series brochure and uses the exact `740e/Le` technical-data column to correct this long-wheelbase plug-in-hybrid row. The official table closes `fuel_type=PHEV`, rear-wheel drive for `740e/Le`, `8-Gang Steptronic` wording, and a `245/50 R18 Y` baseline tire for the represented 2016 740Le row, while keeping the separate `740Le xDrive` sibling outside this exact RWD configuration. The checked official source does not publish a gear-ratio table or final-drive value for the 740Le, so the inherited ratio placeholders remain unresolved.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "This run promoted the exact official 740e/740Le plug-in-hybrid ratio set and 3.077 final drive from the BMW 06/2016 technical-data PDF. Tire default remains manual-confirmation gated because the ACEA PDF lists 225/60 R17 while the later Germany catalog/source-backed row uses 245/50 R18.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 740Le exact official 2016 gear-ratio and final-drive mapping",
-        "reason": "The checked official BMW DE launch-era brochure closes the exact 740Le rear-wheel-drive PHEV identity, `8-Gang Steptronic` wording, and baseline 18-inch tire, but it does not publish a gear-ratio table or final-drive value for the shared `740e/Le` column.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 740Le exact optional wheel/tire matrix",
-        "reason": "The checked official BMW DE launch-era brochure safely closes the baseline `245/50 R18` package for the shared `740e/Le` column, but this pass does not encode the broader optional wheel/tire matrix for the exact long-wheelbase 740Le row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11/G12 740e/740Le default tire market/date conflict",
-        "reason": "The official 06/2016 ACEA technical-data PDF lists 225/60 R17 as standard, while the later Germany catalog/source-backed row uses 245/50 R18. Keep wheel-order manual confirmation until the market/date-specific default is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740li-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740Li",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
-      },
-      "final_drive_rear": {
-        "value": 3.077,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 740Li launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.456, 3.077 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series Sedan 740Li exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740d-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740d",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-        "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 740d / 740Ld variants in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article and the dedicated g11-740d-xdrive-2015-spec-pdf (T0235242EN/336673), which lists 740d xDrive AWD only. The repo's existing notes on this row already document this conflict. Drivetrain set to no_confidence (the canonical RWD designation is incorrect); transmission, ratios and tires also set to no_confidence as no source supports a RWD ratio set for this badge in the EU market.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 16 directly revalidated the official BMW 11/2015 G11 launch specifications article and the exact 740d xDrive technical-data PDF, and batch 10 then rechecked the official BMW DE launch-era 7 Series brochure/catalog technical table. Those checked official BMW sources publish 740d xDrive and 740Ld xDrive in the AWD technical-data columns, but they do not publish an exact 740d RWD row, so this represented 2016 740d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "Official G11/G12 sources found in this run support 740d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 740d exact official 2016 RWD technical-data row",
-        "reason": "The checked official BMW 11/2015 launch sources publish only 740d xDrive and 740Ld xDrive rows for the represented launch window, and the official BMW DE launch-era technical-data table also places 740d/Ld only in the xDrive section rather than the rear-wheel-drive section, so this pass still has no exact official 2016 EU technical-data row for a 740d RWD state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 740d exact final-drive, top-gear, and default-tire mapping",
-        "reason": "Without an official exact 740d RWD technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "Unsupported rear-wheel-drive diesel placeholder",
-        "reason": "Official G11/G12 sources found in this run support 740d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740e-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740e",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Turbo + electric motor (PHEV)",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740e-2016-launch-article",
-        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-      ],
-      "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms the exact 740e plug-in-hybrid row is rear-wheel drive; 740Le xDrive is the distinct AWD sibling.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740e-2016-launch-article",
-        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-      ],
-      "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms eight-speed Steptronic wording for the exact 740e plug-in-hybrid row; the repo keeps ZF8HP as the normalized automatic-family code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists 0.667 as eighth gear for the exact 740e rear-wheel-drive PHEV row.",
-        "value": 0.667
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists final drive 3.077 for the exact 740e rear-wheel-drive PHEV row.",
-        "value": 3.077
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2016 740e/740Le technical-data PDF directly publishes this full forward ratio set for the exact 740e rear-wheel-drive PHEV row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ],
-        "notes": "The official BMW DE launch-era 7 Series brochure technical-data table lists `245/50 R18 Y` as the baseline tire for the shared `740e/Le` column.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:387f07d4c6ab"
-          ],
-          "notes": "The official BMW DE launch-era 7 Series brochure technical-data table lists `245/50 R18 Y` as the baseline tire for the shared `740e/Le` column.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 9 rechecks the launch-era BMW DE 7 Series brochure and uses the exact `740e/Le` technical-data column to correct this short-wheelbase plug-in-hybrid row. The official table closes `fuel_type=PHEV`, rear-wheel drive for `740e/Le`, `8-Gang Steptronic` wording, and a `245/50 R18 Y` baseline tire for the represented 2016 740e row, while keeping the separate `740Le xDrive` sibling outside this exact RWD configuration. The checked official source does not publish a gear-ratio table or final-drive value for the 740e, so the inherited ratio placeholders remain unresolved.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "This run promoted the exact official 740e/740Le plug-in-hybrid ratio set and 3.077 final drive from the BMW 06/2016 technical-data PDF. Tire default remains manual-confirmation gated because the ACEA PDF lists 225/60 R17 while the later Germany catalog/source-backed row uses 245/50 R18.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 740e exact official 2016 gear-ratio and final-drive mapping",
-        "reason": "The checked official BMW DE launch-era brochure closes the exact 740e rear-wheel-drive PHEV identity, `8-Gang Steptronic` wording, and baseline 18-inch tire, but it does not publish a gear-ratio table or final-drive value for the shared `740e/Le` column.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11 740e exact optional wheel/tire matrix",
-        "reason": "The checked official BMW DE launch-era brochure safely closes the baseline `245/50 R18` package for the shared `740e/Le` column, but this pass does not encode the broader optional wheel/tire matrix for the exact short-wheelbase 740e row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "BMW G11/G12 740e/740Le default tire market/date conflict",
-        "reason": "The official 06/2016 ACEA technical-data PDF lists 225/60 R17 as standard, while the later Germany catalog/source-backed row uses 245/50 R18. Keep wheel-order manual confirmation until the market/date-specific default is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740e-2016-spec-pdf",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-740i-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "740i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
-      },
-      "final_drive_rear": {
-        "value": 3.077,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 225/60 R17 baseline tires for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 740i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.456, 3.077 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series Sedan 740i exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-740i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-750ld-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "750Ld",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 9 rechecks the official BMW 11/2015 launch specifications article and the BMW DE launch-era 7 Series brochure. Together they show that `750d/Ld` is absent from the published rear-wheel-drive lineup and appears only as `750d/Ld xDrive` in the all-wheel-drive technical-data columns. This represented 2016 `750Ld` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "Official Germany catalog and later BMW technical-data evidence found in this run support 750Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 750Ld exact official 2016 rear-wheel-drive technical-data row",
-        "reason": "The checked official BMW launch-source chain shows `750d/Ld` only as `750d/Ld xDrive` in the AWD technical-data columns and does not publish any exact `750Ld` rear-wheel-drive row for the represented 2016 EU state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "Unsupported rear-wheel-drive diesel placeholder",
-        "reason": "Official Germany catalog and later BMW technical-data evidence found in this run support 750Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-750d-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "750d",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.667,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 750d / 750Ld variants (B57S quad-turbo 3.0L diesel, 294 kW) in the EU market are xDrive-only - no RWD configuration was offered. Confirmed by BMW PressClub T0235242EN launch spec article (which lists 750d/Ld in the xDrive columns only) and BMW DE brochure. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2201c7bcf575",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7699086a1abd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 9 rechecks the official BMW 11/2015 launch specifications article and the BMW DE launch-era 7 Series brochure. Together they show that `750d` is absent from the published rear-wheel-drive lineup and appears only as `750d/Ld xDrive` in the all-wheel-drive technical-data columns. This represented 2016 `750d` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "Official Germany catalog and later BMW technical-data evidence found in this run support 750d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G11 750d exact official 2016 rear-wheel-drive technical-data row",
-        "reason": "The checked official BMW launch-source chain shows `750d` only through the `750d/Ld xDrive` AWD technical-data columns and does not publish any exact `750d` rear-wheel-drive row for the represented 2016 EU state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      },
-      {
-        "item": "Unsupported rear-wheel-drive diesel placeholder",
-        "reason": "Official Germany catalog and later BMW technical-data evidence found in this run support 750d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:387f07d4c6ab"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-750i-eu-2016-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "750i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e10": [
         "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
       ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
+      "e11": [
+        "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
       ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 2.813 as the rear final-drive ratio for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 baseline tires for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 baseline tires for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 750i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.813 rear final drive, and 245/50 R18 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series Sedan 750i exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-750i-xdrive-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "7 Series (G11, 2016)",
-    "variant_name": "750i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e12": [
+        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
+        "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
+        "legacy_research_sources:387f07d4c6ab"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
+      ],
+      "e14": [
+        "bmw_pressclub_sources:g11-740d-xdrive-2015-spec-pdf",
+        "legacy_research_sources:387f07d4c6ab"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:g11-740e-2016-launch-article",
+        "bmw_pressclub_sources:g11-740e-2016-spec-pdf"
+      ],
+      "e16": [
+        "bmw_pressclub_sources:g11-740e-2016-spec-pdf",
+        "legacy_research_sources:387f07d4c6ab"
+      ],
+      "e17": [
+        "bmw_pressclub_sources:g11-7-series-2015-spec-article",
+        "legacy_research_sources:387f07d4c6ab",
+        "secondary_technical_sources:g11-730i-2016-tirewheelguide",
+        "secondary_technical_sources:g11-730i-2016-wheel-size"
+      ],
+      "e18": [
         "bmw_pressclub_sources:g11-7-series-2015-spec-article",
         "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
       ],
-      "notes": "The official BMW 11/2015 7 Series specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact 750i xDrive state represented by this narrowed 2016-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 750i xDrive state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 750i xDrive state represented by this narrowed 2016-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 750i xDrive state represented by this narrowed 2016-only row."
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 750i xDrive state represented by this narrowed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 750i xDrive state represented by this narrowed 2016-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 as the baseline tire for the exact 750i xDrive state represented by this narrowed 2016-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-          ],
-          "notes": "The official BMW 11/2015 technical-data PDF lists 245/50 R18 as the baseline tire for the exact 750i xDrive state represented by this narrowed 2016-only row.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
+      "e19": [
+        "bmw_pressclub_sources:g11-7-series-2019-press-kit",
+        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2015 7 Series specifications page and technical-data PDF establish the exact 750i xDrive launch-state mapping: AWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2015-spec-article",
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 7 Series 750i xDrive exact optional wheel/tire matrix beyond the narrowed 2016 row",
-        "reason": "The checked official BMW 11/2015 technical-data PDF closes the 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 7 Series 750i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-g11-745le-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2019,
-    "production_end_year": 2022,
-    "model_name": "7 Series (G11, 2019-2022)",
-    "variant_name": "745Le",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6 Turbo",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-      ],
-      "notes": "The official BMW 01/2019 facelift technical-data PDF publishes the exact 745Le rear-wheel-drive plug-in-hybrid row separately from the 745Le xDrive sibling, so this represented 2019-2022 row is closed as rear-wheel drive.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-      ],
-      "notes": "The official BMW 01/2019 facelift technical-data PDF lists 8-speed Steptronic wording for the exact 745Le rear-wheel-drive row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.667,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 0.667 as the top-gear ratio for the exact 745Le rear-wheel-drive row."
+  "configurations": [
+    {
+      "id": "bmw-g11-725ld-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "725Ld",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n2",
+        "value": "RWD"
       },
-      "final_drive_rear": {
-        "value": 3.077,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 745Le rear-wheel-drive row."
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
       },
-      "gear_ratios": {
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists the full forward gear-ratio set for the exact 745Le rear-wheel-drive row."
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This G11 research wave rechecks the official BMW 11/2015 launch specifications article and the official BMW DE launch-era 7 Series brochure/catalog technical table. Together they show that 2016 EU diesel rows are published as 730d/Ld RWD plus 730d/Ld xDrive and 740d/Ld xDrive AWD, but no exact 725Ld row appears in either the launch article or the Germany-market technical-data table, so this represented 2016 725Ld RWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 725Ld exact official 2016 technical-data row",
+          "reason": "The checked official BMW 11/2015 launch specifications article omits 725Ld from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 725Ld from both the rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU technical-data row for the variant.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "BMW G11 725Ld exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 725Ld technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745Le rear-wheel-drive row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g11-725d-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "725d",
+      "engine_code": "B47D20",
+      "engine_name": "B47D20 2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n2",
+        "value": "RWD"
       },
-      "options": [
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
+          "note": "Batch 16 directly revalidated the official BMW 11/2015 G11 launch specifications article, and batch 10 then rechecked the official BMW DE launch-era 7 Series brochure/catalog technical table. Together they show that 2016 EU diesel rows are published as 730d/Ld RWD plus 730d/Ld xDrive and 740d/Ld xDrive AWD, but no exact 725d row appears in either the launch article or the Germany-market technical-data table, so this represented 2016 725d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 725d exact official 2016 technical-data row",
+          "reason": "The checked official BMW 11/2015 launch specifications article omits 725d from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 725d from both the rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU technical-data row for the variant.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "BMW G11 725d exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 725d technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-730ld-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "730Ld",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
           ],
-          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745Le rear-wheel-drive row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
+        },
+        "final_drive_rear": {
+          "value": 2.563,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 2.563 as the rear final-drive ratio for the exact 7 Series Sedan 730Ld state represented by this narrowed 2016-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n13",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 730Ld launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.563 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series Sedan 730Ld exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-730li-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "730Li",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n10",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n10",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n10",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n10",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This G11 research wave rechecks the official BMW 11/2015 launch specifications article and the official BMW DE launch-era 7 Series brochure/catalog technical table. Those checked official BMW sources publish exact rows for 730d, 730Ld, 730d xDrive, 730Ld xDrive, 740d/Ld xDrive, 740i, 740Li, 750i, 750Li, and xDrive petrol siblings, but they do not publish any exact 730Li row, so this represented 2016 730Li RWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 730Li exact official 2016 technical-data row",
+          "reason": "The checked official BMW 11/2015 launch specifications article omits 730Li from the published EU launch lineup, and the official BMW DE launch-era technical-data table also omits 730Li from the checked 2016 rear-wheel-drive and xDrive sections, so this pass still has no exact official 2016 EU/Germany technical-data row for the variant.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "BMW G11 730Li exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 730Li technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-730d-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "730d",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
+        },
+        "final_drive_rear": {
+          "value": 2.563,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 2.563 as the rear final-drive ratio for the exact 7 Series Sedan 730d state represented by this narrowed 2016-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n14",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 730d launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.563 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series Sedan 730d exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-730i-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "730i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e1",
+        "notes_ref": "n11",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n11",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n11",
+          "value": 0.667,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n11",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This G11 research wave keeps the row unsupported but improves the official evidence chain. The checked BMW 11/2015 launch specifications article and the official BMW DE launch-era technical-data table still omit any trim-specific 730i row, while reputable secondary exact-trim pages independently confirm that a 2016 BMW 7 Series 730i existed for the European market as a G11/G12 2.0-liter B48B20 I4 petrol state and capture checked 17-inch, 18-inch, and 19-inch fitments. An earlier attempt to use the official BMW Germany brochure column with 1998 cm3 / 190 kW / 400 Nm as exact 730i proof was rejected because that extracted column belongs to 740e/Le iPerformance context rather than a standalone 730i row.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 730i exact official 2016 technical-data row",
+          "reason": "The checked official BMW 11/2015 launch specifications article and the official BMW DE launch-era technical-data table both omit 730i from the published 2016 launch rows. Secondary exact-trim pages confirm the 2016 European-market 730i identity and engine family, but they do not replace a trim-specific official drivetrain sheet.",
+          "evidence_refs_ref": "e17"
+        },
+        {
+          "item": "BMW G11 730i exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 730i technical-data row or a stronger independent secondary pair for drivetrain numerics, this pass cannot promote the inherited gearbox or final-drive placeholders. The checked exact-trim secondary pages support 17-inch, 18-inch, and 19-inch fitments for 730i, but they do not safely close one production-default tire package for the canonical row.",
+          "evidence_refs_ref": "e17"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-740ld-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740Ld",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.667,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 2.813,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 10 rechecks the official BMW 11/2015 launch specifications article, the exact 740d xDrive technical-data PDF, and the BMW DE launch-era 7 Series brochure. Together they show that `740Ld` is absent from the published rear-wheel-drive lineup and appears only through the shared `740d/Ld xDrive` all-wheel-drive technical-data column. This represented 2016 `740Ld` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note": "Official G11/G12 sources found in this run support 740Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 740Ld exact official 2016 RWD technical-data row",
+          "reason": "The checked official BMW launch-source chain shows `740Ld` only through the shared `740d/Ld xDrive` AWD technical-data column and does not publish any exact `740Ld` rear-wheel-drive row for the represented 2016 EU state.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "BMW G11 740Ld exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 740Ld RWD technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Unsupported rear-wheel-drive diesel placeholder",
+          "reason": "Official G11/G12 sources found in this run support 740Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-740le-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740Le",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo + electric motor (PHEV)",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e15",
+        "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms the exact 740Le plug-in-hybrid row is rear-wheel drive; 740Le xDrive is the distinct AWD sibling.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e15",
+        "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms eight-speed Steptronic wording for the exact 740Le plug-in-hybrid row; the repo keeps ZF8HP as the normalized automatic-family code.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists 0.667 as eighth gear for the exact 740Le rear-wheel-drive PHEV row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists final drive 3.077 for the exact 740Le rear-wheel-drive PHEV row.",
+          "value": 3.077
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF directly publishes this full forward ratio set for the exact 740Le rear-wheel-drive PHEV row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 01/2019 facelift press kit and paired technical-data PDF close the exact 745Le rear-wheel-drive plug-in-hybrid mapping: 2019-on facelift timing, RWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 3.077, and 245/50 R18 baseline tires. This row keeps only the baseline wheel package because the broader optional wheel matrix was not recovered from a direct official source in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit",
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 745Le exact optional wheel/tire matrix beyond the baseline 245/50 R18 package",
-        "reason": "The checked official BMW 01/2019 facelift technical-data PDF closes the exact baseline 18-inch tire package, but this pass did not recover a direct official wheel-options source precise enough to encode the broader optional wheel matrix for the exact 745Le rear-wheel-drive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g11-745e-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G11",
-    "body_code": "G11",
-    "production_start_year": 2019,
-    "production_end_year": 2022,
-    "model_name": "7 Series (G11, 2019-2022)",
-    "variant_name": "745e",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-      ],
-      "notes": "The official BMW 01/2019 facelift technical-data PDF publishes the exact 745e rear-wheel-drive plug-in-hybrid row separately from the 745Le and 745Le xDrive siblings, so this represented 2019-2022 row is closed as rear-wheel drive.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-      ],
-      "notes": "The official BMW 01/2019 facelift technical-data PDF lists 8-speed Steptronic wording for the exact 745e rear-wheel-drive row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.667,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 0.667 as the top-gear ratio for the exact 745e rear-wheel-drive row."
-      },
-      "final_drive_rear": {
-        "value": 3.077,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 745e rear-wheel-drive row."
-      },
-      "gear_ratios": {
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists the full forward gear-ratio set for the exact 745e rear-wheel-drive row."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745e rear-wheel-drive row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "Batch 9 rechecks the launch-era BMW DE 7 Series brochure and uses the exact `740e/Le` technical-data column to correct this long-wheelbase plug-in-hybrid row. The official table closes `fuel_type=PHEV`, rear-wheel drive for `740e/Le`, `8-Gang Steptronic` wording, and a `245/50 R18 Y` baseline tire for the represented 2016 740Le row, while keeping the separate `740Le xDrive` sibling outside this exact RWD configuration. The checked official source does not publish a gear-ratio table or final-drive value for the 740Le, so the inherited ratio placeholders remain unresolved.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 740Le exact official 2016 gear-ratio and final-drive mapping",
+          "reason": "The checked official BMW DE launch-era brochure closes the exact 740Le rear-wheel-drive PHEV identity, `8-Gang Steptronic` wording, and baseline 18-inch tire, but it does not publish a gear-ratio table or final-drive value for the shared `740e/Le` column.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW G11 740Le exact optional wheel/tire matrix",
+          "reason": "The checked official BMW DE launch-era brochure safely closes the baseline `245/50 R18` package for the shared `740e/Le` column, but this pass does not encode the broader optional wheel/tire matrix for the exact long-wheelbase 740Le row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW G11/G12 740e/740Le default tire market/date conflict",
+          "reason": "The official 06/2016 ACEA technical-data PDF lists 225/60 R17 as standard, while the later Germany catalog/source-backed row uses 245/50 R18. Keep wheel-order manual confirmation until the market/date-specific default is split.",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-740li-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740Li",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 245/50 R18 as the baseline tire for the exact 745e rear-wheel-drive row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
+        },
+        "final_drive_rear": {
+          "value": 3.077,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 7 Series Sedan 740Li state represented by this narrowed 2016-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 740Li launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.456, 3.077 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series Sedan 740Li exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-740d-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740d",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.667,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 2.813,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 16 directly revalidated the official BMW 11/2015 G11 launch specifications article and the exact 740d xDrive technical-data PDF, and batch 10 then rechecked the official BMW DE launch-era 7 Series brochure/catalog technical table. Those checked official BMW sources publish 740d xDrive and 740Ld xDrive in the AWD technical-data columns, but they do not publish an exact 740d RWD row, so this represented 2016 740d RWD configuration remains an unsupported advisory row rather than a validated exact state.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note": "Official G11/G12 sources found in this run support 740d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 740d exact official 2016 RWD technical-data row",
+          "reason": "The checked official BMW 11/2015 launch sources publish only 740d xDrive and 740Ld xDrive rows for the represented launch window, and the official BMW DE launch-era technical-data table also places 740d/Ld only in the xDrive section rather than the rear-wheel-drive section, so this pass still has no exact official 2016 EU technical-data row for a 740d RWD state.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "BMW G11 740d exact final-drive, top-gear, and default-tire mapping",
+          "reason": "Without an official exact 740d RWD technical-data row for the represented 2016 EU state, this pass cannot promote the inherited gearbox, final-drive, or tire placeholders.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Unsupported rear-wheel-drive diesel placeholder",
+          "reason": "Official G11/G12 sources found in this run support 740d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-740e-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740e",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Turbo + electric motor (PHEV)",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e15",
+        "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms the exact 740e plug-in-hybrid row is rear-wheel drive; 740Le xDrive is the distinct AWD sibling.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e15",
+        "notes": "Official BMW 06/2016 740e/740Le iPerformance material confirms eight-speed Steptronic wording for the exact 740e plug-in-hybrid row; the repo keeps ZF8HP as the normalized automatic-family code.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists 0.667 as eighth gear for the exact 740e rear-wheel-drive PHEV row.",
+          "value": 0.667
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF lists final drive 3.077 for the exact 740e rear-wheel-drive PHEV row.",
+          "value": 3.077
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Official BMW 06/2016 740e/740Le technical-data PDF directly publishes this full forward ratio set for the exact 740e rear-wheel-drive PHEV row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 01/2019 facelift press kit and paired technical-data PDF close the exact 745e rear-wheel-drive plug-in-hybrid mapping: 2019-on facelift timing, RWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 3.077, and 245/50 R18 baseline tires. This row keeps only the baseline wheel package because the broader optional wheel matrix was not recovered from a direct official source in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-7-series-2019-press-kit",
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n12",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "Batch 9 rechecks the launch-era BMW DE 7 Series brochure and uses the exact `740e/Le` technical-data column to correct this short-wheelbase plug-in-hybrid row. The official table closes `fuel_type=PHEV`, rear-wheel drive for `740e/Le`, `8-Gang Steptronic` wording, and a `245/50 R18 Y` baseline tire for the represented 2016 740e row, while keeping the separate `740Le xDrive` sibling outside this exact RWD configuration. The checked official source does not publish a gear-ratio table or final-drive value for the 740e, so the inherited ratio placeholders remain unresolved.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 740e exact official 2016 gear-ratio and final-drive mapping",
+          "reason": "The checked official BMW DE launch-era brochure closes the exact 740e rear-wheel-drive PHEV identity, `8-Gang Steptronic` wording, and baseline 18-inch tire, but it does not publish a gear-ratio table or final-drive value for the shared `740e/Le` column.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW G11 740e exact optional wheel/tire matrix",
+          "reason": "The checked official BMW DE launch-era brochure safely closes the baseline `245/50 R18` package for the shared `740e/Le` column, but this pass does not encode the broader optional wheel/tire matrix for the exact short-wheelbase 740e row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW G11/G12 740e/740Le default tire market/date conflict",
+          "reason": "The official 06/2016 ACEA technical-data PDF lists 225/60 R17 as standard, while the later Germany catalog/source-backed row uses 245/50 R18. Keep wheel-order manual confirmation until the market/date-specific default is split.",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 745e exact optional wheel/tire matrix beyond the baseline 245/50 R18 package",
-        "reason": "The checked official BMW 01/2019 facelift technical-data PDF closes the exact baseline 18-inch tire package, but this pass did not recover a direct official wheel-options source precise enough to encode the broader optional wheel matrix for the exact 745e rear-wheel-drive row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g11-745e-2019-spec-pdf"
+    },
+    {
+      "id": "bmw-g11-740i-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "740i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e6",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
+        },
+        "final_drive_rear": {
+          "value": 3.077,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 7 Series Sedan 740i state represented by this narrowed 2016-only row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n17",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          }
         ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 740i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.456, 3.077 rear final drive, and 225/60 R17 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series Sedan 740i exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 225/60 R17 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "bmw-g11-750ld-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "750Ld",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n4",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.667,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 9 rechecks the official BMW 11/2015 launch specifications article and the BMW DE launch-era 7 Series brochure. Together they show that `750d/Ld` is absent from the published rear-wheel-drive lineup and appears only as `750d/Ld xDrive` in the all-wheel-drive technical-data columns. This represented 2016 `750Ld` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note": "Official Germany catalog and later BMW technical-data evidence found in this run support 750Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 750Ld exact official 2016 rear-wheel-drive technical-data row",
+          "reason": "The checked official BMW launch-source chain shows `750d/Ld` only as `750d/Ld xDrive` in the AWD technical-data columns and does not publish any exact `750Ld` rear-wheel-drive row for the represented 2016 EU state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Unsupported rear-wheel-drive diesel placeholder",
+          "reason": "Official Germany catalog and later BMW technical-data evidence found in this run support 750Ld as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-750d-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "750d",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n4",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.667,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 2.813,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 9 rechecks the official BMW 11/2015 launch specifications article and the BMW DE launch-era 7 Series brochure. Together they show that `750d` is absent from the published rear-wheel-drive lineup and appears only as `750d/Ld xDrive` in the all-wheel-drive technical-data columns. This represented 2016 `750d` rear-wheel-drive row therefore remains a contradicted advisory placeholder rather than a validated exact production state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note": "Official Germany catalog and later BMW technical-data evidence found in this run support 750d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW G11 750d exact official 2016 rear-wheel-drive technical-data row",
+          "reason": "The checked official BMW launch-source chain shows `750d` only through the `750d/Ld xDrive` AWD technical-data columns and does not publish any exact `750d` rear-wheel-drive row for the represented 2016 EU state.",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "item": "Unsupported rear-wheel-drive diesel placeholder",
+          "reason": "Official Germany catalog and later BMW technical-data evidence found in this run support 750d as xDrive/AWD, not the current rear-wheel-drive placeholder. Keep the RWD row no-confidence and unavailable for driveshaft/wheel order analysis until it is converted or replaced with an exact xDrive row.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-750i-eu-2016-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "750i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms RWD for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 2.813 as the rear final-drive ratio for the exact 7 Series Sedan 750i state represented by this narrowed 2016-only row.",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n18",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e10",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 technical-data PDF closes the exact 7 Series Sedan 750i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, reverse 3.478, 2.813 rear final drive, and 245/50 R18 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series Sedan 750i exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 245/50 R18 baseline fitment, but this pass does not encode the full staggered optional wheel/tire matrix from the same sheet for the exact 2016 row.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-750i-xdrive-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "7 Series (G11, 2016)",
+      "variant_name": "750i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e18",
+        "notes": "The official BMW 11/2015 7 Series specifications page and technical-data PDF confirm xDrive all-wheel drive for the exact 750i xDrive state represented by this narrowed 2016-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e11",
+        "notes": "The official BMW 11/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact 750i xDrive state represented by this narrowed 2016-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "The official BMW 11/2015 technical-data PDF lists 0.640 as the top-gear ratio for the exact 750i xDrive state represented by this narrowed 2016-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "The official BMW 11/2015 technical-data PDF lists the full forward gear-ratio set for the exact 750i xDrive state represented by this narrowed 2016-only row."
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n19",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n19",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n20",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e11",
+            "notes_ref": "n20",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2015 7 Series specifications page and technical-data PDF establish the exact 750i xDrive launch-state mapping: AWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2016-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e18"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 7 Series 750i xDrive exact optional wheel/tire matrix beyond the narrowed 2016 row",
+          "reason": "The checked official BMW 11/2015 technical-data PDF closes the 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "BMW 7 Series 750i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e11"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-745le-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2019,
+      "production_end_year": 2022,
+      "model_name": "7 Series (G11, 2019-2022)",
+      "variant_name": "745Le",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6 Turbo",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 01/2019 facelift technical-data PDF publishes the exact 745Le rear-wheel-drive plug-in-hybrid row separately from the 745Le xDrive sibling, so this represented 2019-2022 row is closed as rear-wheel drive.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 8-speed Steptronic wording for the exact 745Le rear-wheel-drive row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.667,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 0.667 as the top-gear ratio for the exact 745Le rear-wheel-drive row."
+        },
+        "final_drive_rear": {
+          "value": 3.077,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 745Le rear-wheel-drive row."
+        },
+        "gear_ratios": {
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists the full forward gear-ratio set for the exact 745Le rear-wheel-drive row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n21",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n21",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 01/2019 facelift press kit and paired technical-data PDF close the exact 745Le rear-wheel-drive plug-in-hybrid mapping: 2019-on facelift timing, RWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 3.077, and 245/50 R18 baseline tires. This row keeps only the baseline wheel package because the broader optional wheel matrix was not recovered from a direct official source in this pass.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 745Le exact optional wheel/tire matrix beyond the baseline 245/50 R18 package",
+          "reason": "The checked official BMW 01/2019 facelift technical-data PDF closes the exact baseline 18-inch tire package, but this pass did not recover a direct official wheel-options source precise enough to encode the broader optional wheel matrix for the exact 745Le rear-wheel-drive row.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g11-745e-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G11",
+      "body_code": "G11",
+      "production_start_year": 2019,
+      "production_end_year": 2022,
+      "model_name": "7 Series (G11, 2019-2022)",
+      "variant_name": "745e",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 01/2019 facelift technical-data PDF publishes the exact 745e rear-wheel-drive plug-in-hybrid row separately from the 745Le and 745Le xDrive siblings, so this represented 2019-2022 row is closed as rear-wheel drive.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e7",
+        "notes": "The official BMW 01/2019 facelift technical-data PDF lists 8-speed Steptronic wording for the exact 745e rear-wheel-drive row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.667,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 0.667 as the top-gear ratio for the exact 745e rear-wheel-drive row."
+        },
+        "final_drive_rear": {
+          "value": 3.077,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists 3.077 as the rear final-drive ratio for the exact 745e rear-wheel-drive row."
+        },
+        "gear_ratios": {
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "The official BMW 01/2019 facelift technical-data PDF lists the full forward gear-ratio set for the exact 745e rear-wheel-drive row."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n22",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n22",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 01/2019 facelift press kit and paired technical-data PDF close the exact 745e rear-wheel-drive plug-in-hybrid mapping: 2019-on facelift timing, RWD, 8-speed Steptronic/ZF8HP mapping, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, rear final drive 3.077, and 245/50 R18 baseline tires. This row keeps only the baseline wheel package because the broader optional wheel matrix was not recovered from a direct official source in this pass.",
+          "evidence_refs_ref": "e19"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 745e exact optional wheel/tire matrix beyond the baseline 245/50 R18 package",
+          "reason": "The checked official BMW 01/2019 facelift technical-data PDF closes the exact baseline 18-inch tire package, but this pass did not recover a direct official wheel-options source precise enough to encode the broader optional wheel matrix for the exact 745e rear-wheel-drive row.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G70.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G70.json
@@ -1,652 +1,535 @@
-[
-  {
-    "id": "bmw-g70-i7-edrive50-eu-2022-ss1-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G70",
-    "body_code": "G70",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "7 Series (G70, 2022-2026)",
-    "variant_name": "i7 eDrive50",
-    "engine_code": "Electric",
-    "engine_name": "Electric Single Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
+      "n2": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
+      "n3": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
+      "n4": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): BMW PressClub Swiss/DE T0413529DE attachment 579757 (04/2023) — official BMW Group ACEA tech-data PDF — confirms G70 i7 M70 xDrive dual single-speed configuration with front Elektromotor Getriebeübersetzung 8.774 and rear Elektromotor Getriebeübersetzung 8.765. Repo values were already correct via legacy_research_sources reference; this run adds explicit corroboration from the Swiss attachment.",
+      "n6": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 i7 eDrive50 (335 kW single rear-motor) was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU). Reference values for context only: i7 xDrive60 rear motor ratio 12.3 and i7 M70 rear motor ratio 8.765 are official_exact, but eDrive50's distinct 335 kW rear motor cannot be assumed equal to either. Family_default 11.1 retained as best estimate, downgraded to no_confidence pending discovery of an official spec PDF. BMW DE 11/2023 Preisliste confirms transmission name '1-Gang, automatisch' (single-speed).",
+      "n7": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "BMW's Germany-market catalog attachments and current Germany price list all list the exact i7 eDrive50 with 245/50 R19 standard tires.",
+      "n9": "The official BMW Germany 7 Series price list lists the exact 740d xDrive with 19-inch Doppelspeiche 903 wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
+      "n10": "The official BMW Germany 7 Series price list lists the exact 750e xDrive with 19-inch Aerodynamikräder 904 Bicolor wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
+      "n11": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "The official BMW Germany 7 Series price list lists the exact M760e xDrive with 21-inch M Aerodynamikräder 909 M wheels in staggered 9J x 21 front with 255/40 R21 tires and 10.5J x 21 rear with 285/35 R21 tires as the standard package.",
+      "n14": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / BMW M press material with High confidence.",
+      "n15": "BMW's Germany-market technical-data PDF and current Germany price list both list the exact i7 M70 xDrive with a staggered standard package: 255/40 R21 front and 285/35 R21 rear.",
+      "n16": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g70-de-preisliste-2023-11",
+        "bmw_pressclub_sources:g70-additional-variants-article-2022",
+        "bmw_pressclub_sources:g70-launch-press-book-2022"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 i7 eDrive50 (335 kW single rear-motor) was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU). Reference values for context only: i7 xDrive60 rear motor ratio 12.3 and i7 M70 rear motor ratio 8.765 are official_exact, but eDrive50's distinct 335 kW rear motor cannot be assumed equal to either. Family_default 11.1 retained as best estimate, downgraded to no_confidence pending discovery of an official spec PDF. BMW DE 11/2023 Preisliste confirms transmission name '1-Gang, automatisch' (single-speed).",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
+      "e2": [
+        "legacy_research_sources:e4fef97ece37"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 i7 eDrive50 (335 kW single rear-motor) was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU). Reference values for context only: i7 xDrive60 rear motor ratio 12.3 and i7 M70 rear motor ratio 8.765 are official_exact, but eDrive50's distinct 335 kW rear motor cannot be assumed equal to either. Family_default 11.1 retained as best estimate, downgraded to no_confidence pending discovery of an official spec PDF. BMW DE 11/2023 Preisliste confirms transmission name '1-Gang, automatisch' (single-speed).",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:43771d65c9e5",
-          "legacy_research_sources:5a5c196c955b"
-        ],
-        "notes": "BMW publishes the exact i7 eDrive50 as a single-speed electric drivetrain. The canonical ratio model represents that fixed single forward ratio as 1.0.",
-        "value": 1.0
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 i7 eDrive50 (335 kW single rear-motor) was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU). Reference values for context only: i7 xDrive60 rear motor ratio 12.3 and i7 M70 rear motor ratio 8.765 are official_exact, but eDrive50's distinct 335 kW rear motor cannot be assumed equal to either. Family_default 11.1 retained as best estimate, downgraded to no_confidence pending discovery of an official spec PDF. BMW DE 11/2023 Preisliste confirms transmission name '1-Gang, automatisch' (single-speed).",
-        "value": 11.1,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-i7-xdrive60-acea-2022",
-          "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023",
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:43771d65c9e5",
-          "legacy_research_sources:5a5c196c955b",
-          "legacy_research_sources:e4fef97ece37"
-        ],
-        "notes": "BMW's Germany-market catalog attachments and current Germany price list all list the exact i7 eDrive50 with 245/50 R19 standard tires.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:e4fef97ece37"
-          ],
-          "notes": "BMW's Germany-market catalog attachments and current Germany price list all list the exact i7 eDrive50 with 245/50 R19 standard tires.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of BMW's 04/2022 G70 launch article, the current BMW Germany technical-data page, Germany-market catalog attachments, and the current BMW Germany price list now confirms the exact i7 eDrive50 as the Europe-launch rear-wheel-drive 1-Gang EV with 245/50 R19 standard tires, so this row is retimed from 2023 to a 2022 Europe start.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:43771d65c9e5",
-          "legacy_research_sources:5a5c196c955b",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-i7-xdrive60-acea-2022",
-          "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023",
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact i7 eDrive50 numeric reduction ratio and overall-drive value",
-        "reason": "The directly revalidated BMW launch material, current technical-data page, catalog attachments, and price list confirm the exact i7 eDrive50 as the rear-wheel-drive 1-Gang EV with 245/50 R19 standard tires, but they still do not publish a numeric reduction ratio or overall-drive value for this trim.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:43771d65c9e5",
-          "legacy_research_sources:5a5c196c955b",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g70-740d-xdrive-eu-2023-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G70",
-    "body_code": "G70",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "7 Series (G70, 2023-2026)",
-    "variant_name": "740d xDrive",
-    "engine_code": "B57",
-    "engine_name": "B57 3.0L I6 Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
+        "legacy_research_sources:0fcfffa568a6",
+        "legacy_research_sources:2b258af30ac4",
+        "legacy_research_sources:2ced3d6e2dff",
+        "legacy_research_sources:386e9ba97f8b",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:41656ee717a8",
+        "legacy_research_sources:43771d65c9e5",
+        "legacy_research_sources:5a5c196c955b",
+        "legacy_research_sources:8ca59a933c62",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:d795879ff7ec",
+        "legacy_research_sources:d9e8060997ac",
+        "legacy_research_sources:dcccf9a2f873",
+        "legacy_research_sources:e4fef97ece37",
+        "legacy_research_sources:f31f1ea854da"
+      ],
+      "e4": [
         "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
         "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-        "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
+      "e5": [
+        "legacy_research_sources:0fcfffa568a6",
+        "legacy_research_sources:386e9ba97f8b",
+        "legacy_research_sources:41656ee717a8",
+        "legacy_research_sources:e4fef97ece37"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e6": [
+        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:g70-i7-xdrive60-acea-2022",
+        "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023",
+        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
+      ],
+      "e8": [
+        "legacy_research_sources:43771d65c9e5",
+        "legacy_research_sources:5a5c196c955b",
+        "legacy_research_sources:e4fef97ece37"
+      ],
+      "e9": [
+        "legacy_research_sources:0fcfffa568a6",
+        "legacy_research_sources:386e9ba97f8b",
+        "legacy_research_sources:43771d65c9e5",
+        "legacy_research_sources:5a5c196c955b",
+        "legacy_research_sources:e4fef97ece37"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:g70-de-preisliste-2023-11",
+        "bmw_pressclub_sources:g70-de-preisliste-2026-03"
+      ],
+      "e11": [
+        "legacy_research_sources:8ca59a933c62",
+        "legacy_research_sources:d9e8060997ac",
+        "legacy_research_sources:f31f1ea854da",
+        "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
+      ],
+      "e12": [
+        "legacy_research_sources:8ca59a933c62",
+        "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
+      ],
+      "e13": [
+        "legacy_research_sources:8ca59a933c62",
+        "legacy_research_sources:e4fef97ece37"
+      ],
+      "e14": [
+        "legacy_research_sources:8ca59a933c62",
+        "legacy_research_sources:d9e8060997ac",
+        "legacy_research_sources:e4fef97ece37",
+        "legacy_research_sources:f31f1ea854da"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g70-i7-edrive50-eu-2022-ss1-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G70",
+      "body_code": "G70",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "7 Series (G70, 2022-2026)",
+      "variant_name": "i7 eDrive50",
+      "engine_code": "Electric",
+      "engine_name": "Electric Single Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
         "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
-        ]
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n6",
+        "value": "RWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
-        "value": 2.647,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
-        ]
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n6",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source.",
-        "value": 2.647,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.501,
-          3.52,
-          2.2,
-          1.72,
-          1.301,
-          1.0,
-          0.833,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source. Forward gear ratios I..VIII per ACEA tech-data PDF."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ],
-        "notes": "The official BMW Germany 7 Series price list lists the exact 740d xDrive with 19-inch Doppelspeiche 903 wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
           "evidence_refs": [
-            "legacy_research_sources:e4fef97ece37"
+            "legacy_research_sources:386e9ba97f8b",
+            "legacy_research_sources:43771d65c9e5",
+            "legacy_research_sources:5a5c196c955b"
           ],
-          "notes": "The official BMW Germany 7 Series price list lists the exact 740d xDrive with 19-inch Doppelspeiche 903 wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
+          "notes": "BMW publishes the exact i7 eDrive50 as a single-speed electric drivetrain. The canonical ratio model represents that fixed single forward ratio as 1.0.",
+          "value": 1.0
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n6",
+          "value": 11.1,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of BMW's 04/2022 G70 launch article, the current BMW Germany technical-data page, Germany-market catalog attachments, and the current BMW Germany price list now confirms the exact i7 eDrive50 as the Europe-launch rear-wheel-drive 1-Gang EV with 245/50 R19 standard tires, so this row is retimed from 2023 to a 2022 Europe start.",
+          "evidence_refs_ref": "e9"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "21\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "22\" package"
+          "note_ref": "n7",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact 740d xDrive as the Europe-market AWD diesel variant with eight-speed Steptronic transmission wording and 245/50 R19 standard tires.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.543",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-en-2022",
-          "bmw_pressclub_sources:g70-740d-xdrive-acea-de-2022"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact 740d xDrive top-gear and final-drive ratios",
-        "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact 740d xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "item": "Exact 740d xDrive optional wheel and tire matrix",
-        "reason": "This pass directly revalidated the standard 19-inch 245/50 R19 package, but it did not recover a full exact BMW wheel matrix for the row's retained 21-inch and 22-inch option entries.",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g70-750e-xdrive-eu-2023-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G70",
-    "body_code": "G70",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "7 Series (G70, 2023-2026)",
-    "variant_name": "750e xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-        "bmw_pressclub_sources:g70-de-preisliste-2026-03"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 750e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); the 11/2022 'additional drive variants' article (T0404080EN) only attached the 740d spec, and the BMW press book confirms PHEV launch 'from spring 2023' as a separate event whose spec PDF could not be located. BMW DE 2023+ Preisliste only publishes the marketing name '8-Gang Steptronic Sport' — same designation as the 740d, suggesting shared ZF 8HP gearbox family, but no numeric ratios. Final drive remained at family_default 2.813 (G11-inherited) and is downgraded to no_confidence: G11 precedent shows PHEV final drives (e.g. 740e 3.077) typically differ from diesel xDrive (740d 2.563), so the 740d's 2.647 cannot be assumed. Top gear 0.640 likewise no_confidence pending source.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ],
-        "notes": "The official BMW Germany 7 Series price list lists the exact 750e xDrive with 19-inch Aerodynamikräder 904 Bicolor wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Exact i7 eDrive50 numeric reduction ratio and overall-drive value",
+          "reason": "The directly revalidated BMW launch material, current technical-data page, catalog attachments, and price list confirm the exact i7 eDrive50 as the rear-wheel-drive 1-Gang EV with 245/50 R19 standard tires, but they still do not publish a numeric reduction ratio or overall-drive value for this trim.",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g70-740d-xdrive-eu-2023-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G70",
+      "body_code": "G70",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "7 Series (G70, 2023-2026)",
+      "variant_name": "740d xDrive",
+      "engine_code": "B57",
+      "engine_name": "B57 3.0L I6 Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:e4fef97ece37"
+          "notes_ref": "n1",
+          "value": 0.64,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 2.647,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 2.647,
+          "evidence_refs_ref": "e4"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.501,
+            3.52,
+            2.2,
+            1.72,
+            1.301,
+            1.0,
+            0.833,
+            0.64
           ],
-          "notes": "The official BMW Germany 7 Series price list lists the exact 750e xDrive with 19-inch Aerodynamikräder 904 Bicolor wheels in 8.5J x 19 and 245/50 R19 tires as the standard package.",
+          "evidence_refs_ref": "e4",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0404080EN attachment 609753 (English, 11/2022) and T0404080DE attachment 609750 (German, 11/2022) — both official BMW Group ACEA tech-data PDFs — publish G70 740d xDrive Eight-speed Steptronic ratios I 5.501 / II 3.520 / III 2.200 / IV 1.720 / V 1.301 / VI 1.000 / VII 0.833 / VIII 0.640, R 4.543, final drive 2.647 (single published value for both axes on AWD xDrive). Repo's prior family_default 2.813 was a stale G11 inheritance and has been corrected. Top gear value 0.640 happens to match family default but is now backed by primary official source. Forward gear ratios I..VIII per ACEA tech-data PDF."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "21\" package"
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "22\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact 740d xDrive as the Europe-market AWD diesel variant with eight-speed Steptronic transmission wording and 245/50 R19 standard tires.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "21\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "22\" package"
+          "note": "Reverse gear ratio (research note): 4.543",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact 750e xDrive as the Europe-market AWD plug-in hybrid variant with eight-speed Steptronic Sport transmission wording and 245/50 R19 standard tires.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact 750e xDrive top-gear and final-drive ratios",
-        "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact 750e xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "item": "Exact 750e xDrive optional wheel and tire matrix",
-        "reason": "This pass directly revalidated the standard 19-inch 245/50 R19 package, but it did not recover a full exact BMW wheel matrix for the row's retained 21-inch and 22-inch option entries.",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g70-m760e-xdrive-eu-2023-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G70",
-    "body_code": "G70",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "7 Series (G70, 2023-2026)",
-    "variant_name": "M760e xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-        "bmw_pressclub_sources:g70-de-preisliste-2026-03"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW ACEA spec PDF for the G70 M760e xDrive PHEV was found in any PressClub market (Global, Deutschland, Schweiz, NL, AT, BE, FR, IT, UK, JP, CA, AU); same situation as 750e xDrive. BMW DE Preisliste only publishes marketing name '8-Gang Steptronic Sport' (same as 740d), suggesting shared ZF 8HP gearbox family, but no numeric ratios. Repo's family_default top_gear 0.640 and final_drive 2.813 (G11 inheritance) downgraded to no_confidence pending discovery of an official spec PDF — G11 precedent shows PHEV final drives differ from diesel xDrive variants.",
-        "value": 2.813,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ],
-        "notes": "The official BMW Germany 7 Series price list lists the exact M760e xDrive with 21-inch M Aerodynamikräder 909 M wheels in staggered 9J x 21 front with 255/40 R21 tires and 10.5J x 21 rear with 285/35 R21 tires as the standard package.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 35.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Exact 740d xDrive top-gear and final-drive ratios",
+          "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact 740d xDrive row.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Exact 740d xDrive optional wheel and tire matrix",
+          "reason": "This pass directly revalidated the standard 19-inch 245/50 R19 package, but it did not recover a full exact BMW wheel matrix for the row's retained 21-inch and 22-inch option entries.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g70-750e-xdrive-eu-2023-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G70",
+      "body_code": "G70",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "7 Series (G70, 2023-2026)",
+      "variant_name": "750e xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.64,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:e4fef97ece37"
-          ],
-          "notes": "The official BMW Germany 7 Series price list lists the exact M760e xDrive with 21-inch M Aerodynamikräder 909 M wheels in staggered 9J x 21 front with 255/40 R21 tires and 10.5J x 21 rear with 285/35 R21 tires as the standard package.",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "21\" package"
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "22\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact 750e xDrive as the Europe-market AWD plug-in hybrid variant with eight-speed Steptronic Sport transmission wording and 245/50 R19 standard tires.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact 750e xDrive top-gear and final-drive ratios",
+          "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact 750e xDrive row.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Exact 750e xDrive optional wheel and tire matrix",
+          "reason": "This pass directly revalidated the standard 19-inch 245/50 R19 package, but it did not recover a full exact BMW wheel matrix for the row's retained 21-inch and 22-inch option entries.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g70-m760e-xdrive-eu-2023-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G70",
+      "body_code": "G70",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "7 Series (G70, 2023-2026)",
+      "variant_name": "M760e xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n3",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 2.813,
+          "evidence_refs_ref": "e1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n13",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
@@ -657,226 +540,146 @@
             "aspect_pct": 35.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "21\" package"
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "22\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact M760e xDrive as the Europe-market AWD BMW M plug-in hybrid with eight-speed Steptronic Sport transmission wording and staggered 255/40 R21 front plus 285/35 R21 rear standard tires.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / BMW M press material with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "21\" package"
+          "note_ref": "n11",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / BMW M press material with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "22\" package"
+          "note_ref": "n12",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of BMW's G70 launch and additional-variants articles, the current BMW Germany technical-data page, and the current BMW Germany 7 Series price list now confirms the exact M760e xDrive as the Europe-market AWD BMW M plug-in hybrid with eight-speed Steptronic Sport transmission wording and staggered 255/40 R21 front plus 285/35 R21 rear standard tires.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g70-de-preisliste-2023-11",
-          "bmw_pressclub_sources:g70-additional-variants-article-2022",
-          "bmw_pressclub_sources:g70-launch-press-book-2022"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact M760e xDrive top-gear and final-drive ratios",
-        "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact M760e xDrive row.",
-        "evidence_refs": [
-          "legacy_research_sources:0fcfffa568a6",
-          "legacy_research_sources:386e9ba97f8b",
-          "legacy_research_sources:41656ee717a8",
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      },
-      {
-        "item": "Exact M760e xDrive optional wheel and tire matrix beyond the standard 21-inch staggered package",
-        "reason": "This pass directly revalidated the standard staggered 21-inch tire package, but it did not recover a full exact BMW wheel matrix for the row's retained optional entries.",
-        "evidence_refs": [
-          "legacy_research_sources:e4fef97ece37"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g70-i7-m70-xdrive-eu-2023-ss1-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G70",
-    "body_code": "G70",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "7 Series (G70, 2023-2026)",
-    "variant_name": "i7 M70 xDrive",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:8ca59a933c62",
-        "legacy_research_sources:d9e8060997ac",
-        "legacy_research_sources:f31f1ea854da",
-        "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub Swiss/DE T0413529DE attachment 579757 (04/2023) — official BMW Group ACEA tech-data PDF — confirms G70 i7 M70 xDrive dual single-speed configuration with front Elektromotor Getriebeübersetzung 8.774 and rear Elektromotor Getriebeübersetzung 8.765. Repo values were already correct via legacy_research_sources reference; this run adds explicit corroboration from the Swiss attachment.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:8ca59a933c62",
-        "legacy_research_sources:d9e8060997ac",
-        "legacy_research_sources:f31f1ea854da",
-        "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub Swiss/DE T0413529DE attachment 579757 (04/2023) — official BMW Group ACEA tech-data PDF — confirms G70 i7 M70 xDrive dual single-speed configuration with front Elektromotor Getriebeübersetzung 8.774 and rear Elektromotor Getriebeübersetzung 8.765. Repo values were already correct via legacy_research_sources reference; this run adds explicit corroboration from the Swiss attachment.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "legacy_research_sources:d9e8060997ac",
-          "legacy_research_sources:f31f1ea854da"
-        ],
-        "notes": "BMW publishes the exact i7 M70 xDrive as a single-speed electric drivetrain. The canonical ratio model represents that fixed single forward ratio as 1.0.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub Swiss/DE T0413529DE attachment 579757 (04/2023) — official BMW Group ACEA tech-data PDF — confirms G70 i7 M70 xDrive dual single-speed configuration with front Elektromotor Getriebeübersetzung 8.774 and rear Elektromotor Getriebeübersetzung 8.765. Repo values were already correct via legacy_research_sources reference; this run adds explicit corroboration from the Swiss attachment.",
-        "value": 8.774
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "bmw_pressclub_sources:g70-i7-m70-xdrive-acea-ch-2023"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub Swiss/DE T0413529DE attachment 579757 (04/2023) — official BMW Group ACEA tech-data PDF — confirms G70 i7 M70 xDrive dual single-speed configuration with front Elektromotor Getriebeübersetzung 8.774 and rear Elektromotor Getriebeübersetzung 8.765. Repo values were already correct via legacy_research_sources reference; this run adds explicit corroboration from the Swiss attachment.",
-        "value": 8.765
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "legacy_research_sources:e4fef97ece37"
-        ],
-        "notes": "BMW's Germany-market technical-data PDF and current Germany price list both list the exact i7 M70 xDrive with a staggered standard package: 255/40 R21 front and 285/35 R21 rear.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 35.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_exact",
+          "item": "Exact M760e xDrive top-gear and final-drive ratios",
+          "reason": "The directly revalidated BMW launch/update articles, current technical-data page, and price list do not publish extractable numeric top-gear or final-drive values for the exact M760e xDrive row.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Exact M760e xDrive optional wheel and tire matrix beyond the standard 21-inch staggered package",
+          "reason": "This pass directly revalidated the standard staggered 21-inch tire package, but it did not recover a full exact BMW wheel matrix for the row's retained optional entries.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g70-i7-m70-xdrive-eu-2023-ss1-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G70",
+      "body_code": "G70",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "7 Series (G70, 2023-2026)",
+      "variant_name": "i7 M70 xDrive",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e11",
+        "notes_ref": "n5",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e11",
+        "notes_ref": "n5",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
           "evidence_refs": [
             "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:e4fef97ece37"
+            "legacy_research_sources:d9e8060997ac",
+            "legacy_research_sources:f31f1ea854da"
           ],
-          "notes": "BMW's Germany-market technical-data PDF and current Germany price list both list the exact i7 M70 xDrive with a staggered standard package: 255/40 R21 front and 285/35 R21 rear.",
+          "notes": "BMW publishes the exact i7 M70 xDrive as a single-speed electric drivetrain. The canonical ratio model represents that fixed single forward ratio as 1.0.",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n5",
+          "value": 8.774
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n5",
+          "value": 8.765
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes_ref": "n15",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 40.0,
@@ -887,98 +690,72 @@
             "aspect_pct": 35.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e13",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "21\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0fcfffa568a6",
-            "legacy_research_sources:2b258af30ac4",
-            "legacy_research_sources:2ced3d6e2dff",
-            "legacy_research_sources:386e9ba97f8b",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:41656ee717a8",
-            "legacy_research_sources:43771d65c9e5",
-            "legacy_research_sources:5a5c196c955b",
-            "legacy_research_sources:8ca59a933c62",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:d795879ff7ec",
-            "legacy_research_sources:d9e8060997ac",
-            "legacy_research_sources:dcccf9a2f873",
-            "legacy_research_sources:e4fef97ece37",
-            "legacy_research_sources:f31f1ea854da"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / BMW M model page with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "21\" package"
           },
-          "default_axle_for_speed": "rear",
-          "name": "22\" package"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "22\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of BMW's i7 M70 xDrive launch article, the exact Germany-market technical-data PDF, the current BMW Germany M 7 Series technical-data page, and the current BMW Germany price list now confirms the exact trim as the AWD dual-motor EV with a 1-Gang drivetrain, front overall ratio 8.774, rear overall ratio 8.765, and staggered 255/40 R21 front plus 285/35 R21 rear standard tires.",
+          "evidence_refs_ref": "e14"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of BMW's i7 M70 xDrive launch article, the exact Germany-market technical-data PDF, the current BMW Germany M 7 Series technical-data page, and the current BMW Germany price list now confirms the exact trim as the AWD dual-motor EV with a 1-Gang drivetrain, front overall ratio 8.774, rear overall ratio 8.765, and staggered 255/40 R21 front plus 285/35 R21 rear standard tires.",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "legacy_research_sources:d9e8060997ac",
-          "legacy_research_sources:e4fef97ece37",
-          "legacy_research_sources:f31f1ea854da"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Exact i7 M70 xDrive optional wheel and tire matrix beyond the standard 21-inch staggered package",
+          "reason": "This pass directly revalidated the standard staggered 21-inch tire package and confirmed the nearby 20-inch staggered package is not applicable to the i7 M70 xDrive, but it did not recover a full exact BMW matrix for the row's retained optional entries.",
+          "evidence_refs_ref": "e14"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact i7 M70 xDrive optional wheel and tire matrix beyond the standard 21-inch staggered package",
-        "reason": "This pass directly revalidated the standard staggered 21-inch tire package and confirmed the nearby 20-inch staggered package is not applicable to the i7 M70 xDrive, but it did not recover a full exact BMW matrix for the row's retained optional entries.",
-        "evidence_refs": [
-          "legacy_research_sources:8ca59a933c62",
-          "legacy_research_sources:d9e8060997ac",
-          "legacy_research_sources:e4fef97ece37",
-          "legacy_research_sources:f31f1ea854da"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_convertible/G14.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_convertible/G14.json
@@ -1,88 +1,84 @@
-[
-  {
-    "id": "bmw-g14-m850i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G14",
-    "body_code": "G14",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Convertible (G14, 2019)",
-    "variant_name": "M850i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n2": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
+      "n3": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n4": "The official BMW 02/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
+      ],
+      "e3": [
         "bmw_pressclub_sources:g14-8-series-convertible-2018-launch-article",
         "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
       ],
-      "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-      ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e4": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:8f2bf93bfab5",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:e1449089775f"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g14-m850i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G14",
+      "body_code": "G14",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Convertible (G14, 2019)",
+      "variant_name": "M850i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
-        "value": 0.64
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-          ],
-          "notes": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Convertible M850i xDrive state represented by this narrowed 2019-only row.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
@@ -93,173 +89,142 @@
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8f2bf93bfab5",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e1449089775f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8f2bf93bfab5",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e1449089775f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Convertible M850i xDrive launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.813 final-drive ratio, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Convertible M850i xDrive launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.813 final-drive ratio, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-launch-article",
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Convertible M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 8 Series Convertible M850i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g14-840i-eu-2020-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G14",
-    "body_code": "G14",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "8 Series Convertible (G14, 2020)",
-    "variant_name": "840i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g14-840i-convertible-2020-spec-article",
-        "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
       ],
-      "notes": "The official BMW 02/2020 technical-data article and PDF confirm rear-wheel drive for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-      ],
-      "notes": "The official BMW 02/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 02/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 02/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 02/2020 technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
-        "value": 2.929
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 02/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW 8 Series Convertible M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 8 Series Convertible M850i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g14-840i-eu-2020-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G14",
+      "body_code": "G14",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "8 Series Convertible (G14, 2020)",
+      "variant_name": "840i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-article",
+          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
+        ],
+        "notes": "The official BMW 02/2020 technical-data article and PDF confirm rear-wheel drive for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 02/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 02/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "The official BMW 02/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 02/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 02/2020 technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Convertible 840i state represented by this retimed 2020-only row.",
+          "value": 2.929
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
@@ -270,37 +235,53 @@
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 02/2020 technical-data article and PDF close the exact 840i Convertible state: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is retimed from the unsupported 2019 placeholder to the first directly evidenced 2020 state because the earlier G14 launch packet covers M850i xDrive Convertible and 840d xDrive Convertible rather than 840i Convertible.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:g14-8-series-convertible-2018-launch-article",
+            "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf",
+            "bmw_pressclub_sources:g14-840i-convertible-2020-spec-article",
+            "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 02/2020 technical-data article and PDF close the exact 840i Convertible state: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is retimed from the unsupported 2019 placeholder to the first directly evidenced 2020 state because the earlier G14 launch packet covers M850i xDrive Convertible and 840d xDrive Convertible rather than 840i Convertible.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-launch-article",
-          "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf",
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-article",
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Convertible 840i exact optional wheel/tire matrix beyond the narrowed 2020 row",
+          "reason": "The checked official BMW 02/2020 technical-data sheet closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Convertible 840i exact optional wheel/tire matrix beyond the narrowed 2020 row",
-        "reason": "The checked official BMW 02/2020 technical-data sheet closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g14-840i-convertible-2020-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_coupe/G15.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_coupe/G15.json
@@ -1,97 +1,156 @@
-[
-  {
-    "id": "bmw-g15-840i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G15",
-    "body_code": "G15",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Coupe (G15, 2019)",
-    "variant_name": "840i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Sonnet redo research (2026-04 v2): M8 (G15/F92) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
+      "n3": "Sonnet redo research (2026-04 v2): M8 Competition (G15/F93) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
+      "n4": "Reverse gear ratio (research note): 3.993",
+      "n5": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
+      "n6": "The official BMW launch technical-data PDF publishes a single 2.929 final-drive ratio for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n7": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
+      "n8": "Wave 18 added official BMW G15 and M8 technical-data evidence proving that M850i xDrive uses an 8HP76 Sport ratio set with top gear 0.640 and final drive 2.813, and that M8/M8 Competition Coupe are M xDrive all-wheel-drive configurations rather than rear-wheel-drive. Production now applies a variant-level gearbox override for M850i xDrive and corrects M8 drivetrain mapping to AWD.",
+      "n9": "Reverse gear ratio (research note): 3.456",
+      "n10": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
+      ],
+      "e2": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:53c036dd5c01",
+        "legacy_research_sources:72e9c147f482",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
+      ],
+      "e4": [
         "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
         "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
       ],
-      "notes": "The official BMW launch article and technical-data PDF confirm rear-wheel drive for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
+      "e5": [
+        "secondary_technical_sources:zf-8hp-m-steptronic-spec",
+        "secondary_technical_sources:ultimatespecs-g15-m8-lci",
+        "secondary_technical_sources:motortrend-2020-m8"
       ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e6": [
+        "secondary_technical_sources:motortrend-2020-m8",
+        "secondary_technical_sources:caranddriver-2020-m8",
+        "secondary_technical_sources:ultimatespecs-g15-m8-lci"
+      ],
+      "e7": [
+        "legacy_research_sources:3bf1daddf136",
+        "legacy_research_sources:52e2ccf0b07d",
+        "legacy_research_sources:b3655e5aa9ee",
+        "legacy_research_sources:f3fe62f03e97"
+      ],
+      "e8": [
+        "secondary_technical_sources:zf-8hp-m-steptronic-spec",
+        "secondary_technical_sources:ultimatespecs-g15-m850i-lci"
+      ],
+      "e9": [
+        "legacy_research_sources:52e2ccf0b07d",
+        "legacy_research_sources:f3fe62f03e97"
+      ],
+      "e10": [
+        "secondary_technical_sources:bmw-m8-pressclub-usa-t0296777",
+        "secondary_technical_sources:motortrend-2020-m8",
+        "secondary_technical_sources:caranddriver-2020-m8"
+      ],
+      "e11": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:3bf1daddf136",
+        "legacy_research_sources:52e2ccf0b07d",
+        "legacy_research_sources:53c036dd5c01",
+        "legacy_research_sources:72e9c147f482",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:b3655e5aa9ee",
+        "legacy_research_sources:f3fe62f03e97"
+      ],
+      "e12": [
+        "secondary_technical_sources:zf-8hp-m-steptronic-spec",
+        "secondary_technical_sources:ultimatespecs-g15-m8-lci"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
+        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
+      ],
+      "e14": [
+        "secondary_technical_sources:zf-8hp-m-steptronic-spec",
+        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
+      ],
+      "e15": [
+        "secondary_technical_sources:motortrend-2019-m850i",
+        "secondary_technical_sources:ultimatespecs-g15-m850i-lci",
+        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g15-840i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G15",
+      "body_code": "G15",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Coupe (G15, 2019)",
+      "variant_name": "840i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
-        "value": 0.64
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW launch article and technical-data PDF confirm rear-wheel drive for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
+        "value": "RWD"
       },
-      "gear_ratios": {
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row."
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
-        "value": 2.929
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Coupe 840i state represented by this narrowed 2019-only row.",
+          "value": 2.929
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
@@ -102,146 +161,123 @@
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Coupe 840i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row remains narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.993",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m850i-lci"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Coupe 840i exact optional wheel/tire matrix beyond the narrowed 2019 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g15-840i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G15",
-    "body_code": "G15",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Coupe (G15, 2019)",
-    "variant_name": "840i xDrive",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
-        "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-      ],
-      "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-      ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.929 final-drive ratio for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.929
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.929 final-drive ratio for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.929
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf",
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): ZF GA8HP76X (xDrive variant of 8HP75/76 family) used in 840i xDrive. Same forward gear set as the RWD 840i sibling row whose ratios are confirmed official_exact from the BMW press PDF. Confidence official_derived because the xDrive-specific spec sheet was not separately located."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
+          "default_axle_for_speed": "rear"
         },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Coupe 840i launch-state mapping: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row remains narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Coupe 840i exact optional wheel/tire matrix beyond the narrowed 2019 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g15-840i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G15",
+      "body_code": "G15",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Coupe (G15, 2019)",
+      "variant_name": "840i xDrive",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 2.929
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 2.929
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "The official BMW launch technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Coupé 840i xDrive state represented by this narrowed 2019-only row.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf",
+            "secondary_technical_sources:zf-8hp-m-steptronic-spec"
+          ],
+          "notes": "Sonnet redo research (2026-04 v2): ZF GA8HP76X (xDrive variant of 8HP75/76 family) used in 840i xDrive. Same forward gear set as the RWD 840i sibling row whose ratios are confirmed official_exact from the BMW press PDF. Confidence official_derived because the xDrive-specific spec sheet was not separately located."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
@@ -252,645 +288,473 @@
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Coupé 840i xDrive launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.929 final-drive ratio, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF establish the exact 8 Series Coupé 840i xDrive launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 2.929 final-drive ratio, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.993",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m850i-lci"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Coupé 840i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 8 Series Coupé 840i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g15-m8-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G15",
-    "body_code": "G15",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Coupe (G15, 2019)",
-    "variant_name": "M8",
-    "engine_code": "4.4L",
-    "engine_name": "4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "value": "AWD",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:52e2ccf0b07d",
-        "legacy_research_sources:f3fe62f03e97"
       ],
-      "notes": "Official BMW M8 technical data confirms M xDrive all-wheel drive for the M8 Coupe."
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 (G15/F92) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci",
-          "secondary_technical_sources:motortrend-2020-m8"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 (G15/F92) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      },
-      "final_drive_front": {
-        "value": 3.154,
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 (G15/F92) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "reputable_secondary_crosschecked",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci",
-          "secondary_technical_sources:motortrend-2020-m8"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): M8 (G15/F92) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded."
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Coupé 840i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 8 Series Coupé 840i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-m8-pressclub-usa-t0296777",
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA M8 press release T0296777EN_US explicitly publishes 275/35R20 front and 285/35R20 rear (non-runflat, wheels 9.5x20 front / 10.5x20 rear). MotorTrend 2020 M8 and Car and Driver 2020 M8 confirm same staggered fitment. Prior repo value 245/35R20 front (no rear) was a wrong family_default likely pulled from the M850i front-tire spec.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
+    {
+      "id": "bmw-g15-m8-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G15",
+      "body_code": "G15",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Coupe (G15, 2019)",
+      "variant_name": "M8",
+      "engine_code": "4.4L",
+      "engine_name": "4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "value": "AWD",
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes": "Official BMW M8 technical data confirms M xDrive all-wheel drive for the M8 Coupe."
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n2",
+          "value": 0.64,
+          "evidence_refs_ref": "e5"
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n2",
+          "value": 3.154,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "value": 3.154,
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n2",
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "reputable_secondary_crosschecked",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n2"
         }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e10",
+          "notes": "Sonnet redo research (2026-04 v2): BMW USA M8 press release T0296777EN_US explicitly publishes 275/35R20 front and 285/35R20 rear (non-runflat, wheels 9.5x20 front / 10.5x20 rear). MotorTrend 2020 M8 and Car and Driver 2020 M8 confirm same staggered fitment. Prior repo value 245/35R20 front (no rear) was a wrong family_default likely pulled from the M850i front-tire spec.",
           "front": {
-            "width_mm": 245.0,
+            "width_mm": 275.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
+          "rear": {
+            "width_mm": 285.0,
             "aspect_pct": 35.0,
-            "rim_in": 21.0
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
           },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e11"
         },
         {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note_ref": "n9",
+          "evidence_refs_ref": "e12"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW G15 and M8 technical-data evidence proving that M850i xDrive uses an 8HP76 Sport ratio set with top gear 0.640 and final drive 2.813, and that M8/M8 Competition Coupe are M xDrive all-wheel-drive configurations rather than rear-wheel-drive. Production now applies a variant-level gearbox override for M850i xDrive and corrects M8 drivetrain mapping to AWD.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:53c036dd5c01",
-          "legacy_research_sources:72e9c147f482",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.456",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G15 840i / 840i xDrive exact final drive and top-gear mapping across markets",
-        "reason": "Wave 18 official ratio sheet verifies 840d and M850i xDrive states plus M8 AWD context, but this pass did not recover one exact 840i/840i xDrive ratio table for the represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      },
-      {
-        "item": "BMW G15 M8 Coupe final-drive numeric mapping in row schema",
-        "reason": "Wave 18 confirms M8 AWD drivetrain from official BMW M technical data, but this pass did not promote a separate M8 ratio override because one consistent year-spanning numeric table was not closed.",
-        "evidence_refs": [
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g15-m8-competition-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G15",
-    "body_code": "G15",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Coupe (G15, 2019)",
-    "variant_name": "M8 Competition",
-    "engine_code": "4.4L",
-    "engine_name": "4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "value": "AWD",
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:52e2ccf0b07d",
-        "legacy_research_sources:f3fe62f03e97"
       ],
-      "notes": "Official BMW M8 technical data confirms M xDrive all-wheel drive for the M8 Competition Coupe."
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 Competition (G15/F93) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci",
-          "secondary_technical_sources:motortrend-2020-m8"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 Competition (G15/F93) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      },
-      "final_drive_front": {
-        "value": 3.154,
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): M8 Competition (G15/F93) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded.",
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "reputable_secondary_crosschecked",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci",
-          "secondary_technical_sources:motortrend-2020-m8"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): M8 Competition (G15/F93) uses ZF M Steptronic (BMW GS8D45BG, 8HP45-family programming) with the same forward gear set as G80 M3 Competition / G82 M4 Competition / F90 M5 Competition: [5.000, 3.200, 2.143, 1.720, 1.313, 1.000, 0.823, 0.640]. Top gear 0.640 supersedes prior family_default 0.667. Final drive 3.154 (rounded 3.15 in MotorTrend, Car and Driver, UltimateSpecs LCI) supersedes prior family_default 3.077. BMW USA press release T0296777EN_US explicitly publishes default tires 275/35R20 front and 285/35R20 rear (staggered, larger fronts than the rest of the 8 Series family). Reverse gear ratio 3.456 per ZF M Steptronic spec; UltimateSpecs G15 LCI M8 shows 3.48 rounded."
+      "unresolved": [
+        {
+          "item": "BMW G15 840i / 840i xDrive exact final drive and top-gear mapping across markets",
+          "reason": "Wave 18 official ratio sheet verifies 840d and M850i xDrive states plus M8 AWD context, but this pass did not recover one exact 840i/840i xDrive ratio table for the represented row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW G15 M8 Coupe final-drive numeric mapping in row schema",
+          "reason": "Wave 18 confirms M8 AWD drivetrain from official BMW M technical data, but this pass did not promote a separate M8 ratio override because one consistent year-spanning numeric table was not closed.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:bmw-m8-pressclub-usa-t0296777",
-          "secondary_technical_sources:motortrend-2020-m8",
-          "secondary_technical_sources:caranddriver-2020-m8"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): same 275/35R20 front / 285/35R20 rear staggered fitment as M8 standard, only forged wheel design differs.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
+    {
+      "id": "bmw-g15-m8-competition-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G15",
+      "body_code": "G15",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Coupe (G15, 2019)",
+      "variant_name": "M8 Competition",
+      "engine_code": "4.4L",
+      "engine_name": "4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "value": "AWD",
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes": "Official BMW M8 technical data confirms M xDrive all-wheel drive for the M8 Competition Coupe."
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e5"
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.154,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "value": 3.154,
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "reputable_secondary_crosschecked",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n3"
         }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e10",
+          "notes": "Sonnet redo research (2026-04 v2): same 275/35R20 front / 285/35R20 rear staggered fitment as M8 standard, only forged wheel design differs.",
           "front": {
-            "width_mm": 245.0,
+            "width_mm": 275.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
+          "rear": {
+            "width_mm": 285.0,
             "aspect_pct": 35.0,
-            "rim_in": 21.0
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
           },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e11"
         },
         {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:53c036dd5c01",
-            "legacy_research_sources:72e9c147f482",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note_ref": "n9",
+          "evidence_refs_ref": "e12"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW G15 and M8 technical-data evidence proving that M850i xDrive uses an 8HP76 Sport ratio set with top gear 0.640 and final drive 2.813, and that M8/M8 Competition Coupe are M xDrive all-wheel-drive configurations rather than rear-wheel-drive. Production now applies a variant-level gearbox override for M850i xDrive and corrects M8 drivetrain mapping to AWD.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:53c036dd5c01",
-          "legacy_research_sources:72e9c147f482",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.456",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m8-lci"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW G15 840i / 840i xDrive exact final drive and top-gear mapping across markets",
-        "reason": "Wave 18 official ratio sheet verifies 840d and M850i xDrive states plus M8 AWD context, but this pass did not recover one exact 840i/840i xDrive ratio table for the represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      },
-      {
-        "item": "BMW G15 M8 Coupe final-drive numeric mapping in row schema",
-        "reason": "Wave 18 confirms M8 AWD drivetrain from official BMW M technical data, but this pass did not promote a separate M8 ratio override because one consistent year-spanning numeric table was not closed.",
-        "evidence_refs": [
-          "legacy_research_sources:3bf1daddf136",
-          "legacy_research_sources:52e2ccf0b07d",
-          "legacy_research_sources:b3655e5aa9ee",
-          "legacy_research_sources:f3fe62f03e97"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g15-m850i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G15",
-    "body_code": "G15",
-    "production_start_year": 2019,
-    "production_end_year": 2019,
-    "model_name": "8 Series Coupe (G15, 2019)",
-    "variant_name": "M850i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
-        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
       ],
-      "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-      ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row."
-      },
-      "gear_ratios": {
-        "value": [
-          5.5,
-          3.52,
-          2.2,
-          1.72,
-          1.317,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): existing repo array [5.5, 3.52, 2.2, 1.72, 1.317, 1.0, 0.823, 0.64] does not match any documented ZF 8HP75/76 ratio set. The N63B44T3 engine in BMW X7 xDrive50i / 750i (same gearbox family GA8HP76X) publishes [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] in BMW press kits. The 5.5/3.52/2.2 first-three values appear to be a transcription artifact rather than a valid ratio set. Confidence downgraded to no_confidence pending direct verification against an original BMW G15 launch ACEA tech-data PDF (T0292069EN currently 404 globally and not captured by Wayback). Best-estimate replacement value if corroborated: [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640]."
-      },
-      "final_drive_front": {
-        "value": 2.813,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2019-m850i",
-          "secondary_technical_sources:ultimatespecs-g15-m850i-lci",
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation. Sonnet redo research (2026-04 v2): EU 2.813 retained per BMW xDrive single-FD convention; US-market spec 3.40 noted as separate market variant."
-      },
-      "final_drive_rear": {
-        "value": 2.813,
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "secondary_technical_sources:motortrend-2019-m850i",
-          "secondary_technical_sources:ultimatespecs-g15-m850i-lci",
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation. Sonnet redo research (2026-04 v2): EU press value 2.813 retained; US consumer sources (MotorTrend 2019, Car and Driver 2019) cite 3.40 axle ratio for the US-spec M850i, suggesting an EU/US market FD difference. UltimateSpecs G15 LCI M850i xDrive confirms 2.81 (rounded EU value)."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW G15 840i / 840i xDrive exact final drive and top-gear mapping across markets",
+          "reason": "Wave 18 official ratio sheet verifies 840d and M850i xDrive states plus M8 AWD context, but this pass did not recover one exact 840i/840i xDrive ratio table for the represented row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW G15 M8 Coupe final-drive numeric mapping in row schema",
+          "reason": "Wave 18 confirms M8 AWD drivetrain from official BMW M technical data, but this pass did not promote a separate M8 ratio override because one consistent year-spanning numeric table was not closed.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g15-m850i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G15",
+      "body_code": "G15",
+      "production_start_year": 2019,
+      "production_end_year": 2019,
+      "model_name": "8 Series Coupe (G15, 2019)",
+      "variant_name": "M850i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e13",
+        "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic."
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row."
+        },
+        "gear_ratios": {
+          "value": [
+            5.5,
+            3.52,
+            2.2,
+            1.72,
+            1.317,
+            1.0,
+            0.823,
+            0.64
           ],
-          "notes": "The official BMW launch technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row.",
+          "confidence": "unverified",
+          "evidence_refs_ref": "e14",
+          "notes": "Sonnet redo research (2026-04 v2): existing repo array [5.5, 3.52, 2.2, 1.72, 1.317, 1.0, 0.823, 0.64] does not match any documented ZF 8HP75/76 ratio set. The N63B44T3 engine in BMW X7 xDrive50i / 750i (same gearbox family GA8HP76X) publishes [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] in BMW press kits. The 5.5/3.52/2.2 first-three values appear to be a transcription artifact rather than a valid ratio set. Confidence downgraded to no_confidence pending direct verification against an original BMW G15 launch ACEA tech-data PDF (T0292069EN currently 404 globally and not captured by Wayback). Best-estimate replacement value if corroborated: [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640]."
+        },
+        "final_drive_front": {
+          "value": 2.813,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e15",
+          "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation. Sonnet redo research (2026-04 v2): EU 2.813 retained per BMW xDrive single-FD convention; US-market spec 3.40 noted as separate market variant."
+        },
+        "final_drive_rear": {
+          "value": 2.813,
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e15",
+          "notes": "The official BMW launch technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Coupe M850i xDrive state represented by this narrowed 2019-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation. Sonnet redo research (2026-04 v2): EU press value 2.813 retained; US consumer sources (MotorTrend 2019, Car and Driver 2019) cite 3.40 axle ratio for the US-spec M850i, suggesting an EU/US market FD difference. UltimateSpecs G15 LCI M850i xDrive confirms 2.81 (rounded EU value)."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n10",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
@@ -901,56 +765,61 @@
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch article and technical-data PDF close the exact 8 Series Coupe M850i xDrive launch-state mapping: AWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, the single published 2.813 final-drive ratio duplicated across the front and rear axle fields, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e14"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF close the exact 8 Series Coupe M850i xDrive launch-state mapping: AWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, the single published 2.813 final-drive ratio duplicated across the front and rear axle fields, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2019-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.993",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "secondary_technical_sources:ultimatespecs-g15-m850i-lci"
-        ]
-      },
-      {
-        "note": "ratios.gear_ratios: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:zf-8hp-m-steptronic-spec",
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Coupe M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW 8 Series Coupe M850i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Coupe M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2019 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW 8 Series Coupe M850i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g15-m850i-coupe-2018-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_gran_coupe/G16.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_gran_coupe/G16.json
@@ -1,97 +1,82 @@
-[
-  {
-    "id": "bmw-g16-840i-eu-2020-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G16",
-    "body_code": "G16",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "8 Series Gran Coupe (G16, 2020)",
-    "variant_name": "840i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "The official BMW 11/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
+      "n2": "The official BMW 11/2020 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n3": "The official BMW 11/2020 technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
+      ],
+      "e2": [
         "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-article",
         "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2020 technical-data article and PDF confirm rear-wheel drive for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g16-840i-eu-2020-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G16",
+      "body_code": "G16",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "8 Series Gran Coupe (G16, 2020)",
+      "variant_name": "840i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
-        "value": 0.64
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2020 technical-data article and PDF confirm rear-wheel drive for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
+        "value": "RWD"
       },
-      "gear_ratios": {
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row."
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
-        "value": 2.929
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "The official BMW 11/2020 technical-data PDF lists staggered 245/45 R18 front and 275/40 R18 rear baseline tires for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 11/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row."
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 11/2020 technical-data PDF lists 2.929 as the final-drive ratio for the exact 8 Series Gran Coupe 840i state represented by this narrowed 2020-only row.",
+          "value": 2.929
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
@@ -102,138 +87,116 @@
             "aspect_pct": 40.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2020 technical-data article and PDF close the exact 840i Gran Coupe launch state: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-article",
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Gran Coupe 840i exact optional wheel/tire matrix beyond the narrowed 2020 row",
-        "reason": "The checked official BMW 11/2020 technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g16-m850i-xdrive-eu-2020-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G16",
-    "body_code": "G16",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "8 Series Gran Coupe (G16, 2020)",
-    "variant_name": "M850i xDrive",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-article",
-        "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2020 technical-data article and PDF confirm xDrive all-wheel drive for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "value": [
-          5.5,
-          3.52,
-          2.2,
-          1.72,
-          1.317,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row."
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF publishes a single 2.813 final-drive ratio for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2020 technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
+          "default_axle_for_speed": "rear"
         },
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
+        ]
       },
-      "options": [
+      "verification_notes": [
         {
+          "note": "The official BMW 11/2020 technical-data article and PDF close the exact 840i Gran Coupe launch state: RWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, 2.929 final drive, and staggered 245/45 R18 front plus 275/40 R18 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Gran Coupe 840i exact optional wheel/tire matrix beyond the narrowed 2020 row",
+          "reason": "The checked official BMW 11/2020 technical-data PDF closes the staggered 18-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g16-m850i-xdrive-eu-2020-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G16",
+      "body_code": "G16",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "8 Series Gran Coupe (G16, 2020)",
+      "variant_name": "M850i xDrive",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 11/2020 technical-data article and PDF confirm xDrive all-wheel drive for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 11/2020 technical-data PDF confirms 8-speed Steptronic wording for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 11/2020 technical-data PDF lists 0.640 as the top-gear ratio for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "value": [
+            5.5,
+            3.52,
+            2.2,
+            1.72,
+            1.317,
+            1.0,
+            0.823,
+            0.64
           ],
-          "notes": "The official BMW 11/2020 technical-data PDF lists staggered 245/35 R20 front and 275/30 R20 rear baseline tires for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 11/2020 technical-data PDF lists the full forward gear-ratio set for the exact 8 Series Gran Coupe M850i xDrive state represented by this narrowed 2020-only row."
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 35.0,
@@ -244,42 +207,53 @@
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2020 technical-data article and PDF close the exact M850i xDrive Gran Coupe launch state: AWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, the single published 2.813 final-drive ratio duplicated across the front and rear axle fields, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-article",
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW 8 Series Gran Coupe M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2020 row",
-        "reason": "The checked official BMW 11/2020 technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          }
         ]
       },
-      {
-        "item": "BMW 8 Series Gran Coupe M850i xDrive separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g16-8-series-gran-coupe-2020-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2020 technical-data article and PDF close the exact M850i xDrive Gran Coupe launch state: AWD, 8-speed Steptronic/ZF8HP mapping, full forward ratios, the single published 2.813 final-drive ratio duplicated across the front and rear axle fields, and staggered 245/35 R20 front plus 275/30 R20 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW 8 Series Gran Coupe M850i xDrive exact optional wheel/tire matrix beyond the narrowed 2020 row",
+          "reason": "The checked official BMW 11/2020 technical-data PDF closes the staggered 20-inch baseline fitment, but it does not prove one full optional wheel/tire matrix for this exact row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW 8 Series Gran Coupe M850i xDrive separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/i4/G26.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/i4/G26.json
@@ -1,357 +1,246 @@
-[
-  {
-    "id": "bmw-g26-m50-eu-2022-ss1-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G26",
-    "body_code": "G26",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "i4 (G26, 2022-2026)",
-    "variant_name": "M50",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
+      "n2": "Official BMW launch and 2024 DE technical-data sheets now confirm that the exact i4 M50/M50 xDrive uses dual-motor AWD with axle-specific single-speed reduction ratios and staggered tire packages, but the published values differ between launch-era and later DE documents. The broad 2022-2026 row therefore stays unchanged because one exact M50 ratio/tire set would be unsafe to project across the full represented span, especially after BMW renamed the range-topper to M60 xDrive from July 2025.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:01210c7a71f1",
+        "legacy_research_sources:29a89fc89c3f",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:3cc96631762a",
+        "legacy_research_sources:3d6342c4594f",
         "legacy_research_sources:44aa64d36517",
+        "legacy_research_sources:51439c900c55",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
         "legacy_research_sources:af3332d3612c"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 8.698
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 8.698
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01210c7a71f1",
-            "legacy_research_sources:29a89fc89c3f",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3cc96631762a",
-            "legacy_research_sources:3d6342c4594f",
-            "legacy_research_sources:44aa64d36517",
-            "legacy_research_sources:51439c900c55",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:af3332d3612c"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01210c7a71f1",
-            "legacy_research_sources:29a89fc89c3f",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3cc96631762a",
-            "legacy_research_sources:3d6342c4594f",
-            "legacy_research_sources:44aa64d36517",
-            "legacy_research_sources:51439c900c55",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:af3332d3612c"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
-        }
+      "e2": [
+        "legacy_research_sources:44aa64d36517",
+        "legacy_research_sources:af3332d3612c"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch and 2024 DE technical-data sheets now confirm that the exact i4 M50/M50 xDrive uses dual-motor AWD with axle-specific single-speed reduction ratios and staggered tire packages, but the published values differ between launch-era and later DE documents. The broad 2022-2026 row therefore stays unchanged because one exact M50 ratio/tire set would be unsafe to project across the full represented span, especially after BMW renamed the range-topper to M60 xDrive from July 2025.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW i4 M50 exact axle-ratio applicability across the represented 2022-2026 span",
-        "reason": "Official BMW launch specs show axle ratios 9.053 / 9.053 for the exact i4 M50, while official DE July 2024 technical data shows front 9.744 and rear 8.776 for the exact i4 M50 xDrive, so this pass did not choose one exact ratio set for the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ]
-      },
-      {
-        "item": "BMW i4 M50 broad-row tire mapping and post-2025 naming continuity",
-        "reason": "Official BMW sources prove staggered M50 tire packages and also show that M60 xDrive replaces the predecessor from July 2025, so the current broad 2022-2026 M50 row should not absorb one exact tire or ratio set without a row split.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-g26-edrive40-eu-2022-ss1-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G26",
-    "body_code": "G26",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "i4 (G26, 2022-2026)",
-    "variant_name": "eDrive40",
-    "engine_code": "Electric",
-    "engine_name": "Electric Single Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:44aa64d36517",
-        "legacy_research_sources:af3332d3612c"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 1.0
+  "configurations": [
+    {
+      "id": "bmw-g26-m50-eu-2022-ss1-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G26",
+      "body_code": "G26",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "i4 (G26, 2022-2026)",
+      "variant_name": "M50",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 8.698
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01210c7a71f1",
-            "legacy_research_sources:29a89fc89c3f",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3cc96631762a",
-            "legacy_research_sources:3d6342c4594f",
-            "legacy_research_sources:44aa64d36517",
-            "legacy_research_sources:51439c900c55",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:af3332d3612c"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 8.698
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 8.698
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:01210c7a71f1",
-            "legacy_research_sources:29a89fc89c3f",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3cc96631762a",
-            "legacy_research_sources:3d6342c4594f",
-            "legacy_research_sources:44aa64d36517",
-            "legacy_research_sources:51439c900c55",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:af3332d3612c"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 20\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW i4 M50 exact axle-ratio applicability across the represented 2022-2026 span",
+          "reason": "Official BMW launch specs show axle ratios 9.053 / 9.053 for the exact i4 M50, while official DE July 2024 technical data shows front 9.744 and rear 8.776 for the exact i4 M50 xDrive, so this pass did not choose one exact ratio set for the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW i4 M50 broad-row tire mapping and post-2025 naming continuity",
+          "reason": "Official BMW sources prove staggered M50 tire packages and also show that M60 xDrive replaces the predecessor from July 2025, so the current broad 2022-2026 M50 row should not absorb one exact tire or ratio set without a row split.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch and 2024 DE technical-data sheets now confirm that the exact i4 M50/M50 xDrive uses dual-motor AWD with axle-specific single-speed reduction ratios and staggered tire packages, but the published values differ between launch-era and later DE documents. The broad 2022-2026 row therefore stays unchanged because one exact M50 ratio/tire set would be unsafe to project across the full represented span, especially after BMW renamed the range-topper to M60 xDrive from July 2025.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
+    {
+      "id": "bmw-g26-edrive40-eu-2022-ss1-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G26",
+      "body_code": "G26",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "i4 (G26, 2022-2026)",
+      "variant_name": "eDrive40",
+      "engine_code": "Electric",
+      "engine_name": "Electric Single Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 8.698
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW i4 M50 exact axle-ratio applicability across the represented 2022-2026 span",
+          "reason": "Official BMW launch specs show axle ratios 9.053 / 9.053 for the exact i4 M50, while official DE July 2024 technical data shows front 9.744 and rear 8.776 for the exact i4 M50 xDrive, so this pass did not choose one exact ratio set for the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW i4 M50 broad-row tire mapping and post-2025 naming continuity",
+          "reason": "Official BMW sources prove staggered M50 tire packages and also show that M60 xDrive replaces the predecessor from July 2025, so the current broad 2022-2026 M50 row should not absorb one exact tire or ratio set without a row split.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW i4 M50 exact axle-ratio applicability across the represented 2022-2026 span",
-        "reason": "Official BMW launch specs show axle ratios 9.053 / 9.053 for the exact i4 M50, while official DE July 2024 technical data shows front 9.744 and rear 8.776 for the exact i4 M50 xDrive, so this pass did not choose one exact ratio set for the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ]
-      },
-      {
-        "item": "BMW i4 M50 broad-row tire mapping and post-2025 naming continuity",
-        "reason": "Official BMW sources prove staggered M50 tire packages and also show that M60 xDrive replaces the predecessor from July 2025, so the current broad 2022-2026 M50 row should not absorb one exact tire or ratio set without a row split.",
-        "evidence_refs": [
-          "legacy_research_sources:01210c7a71f1",
-          "legacy_research_sources:29a89fc89c3f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3cc96631762a",
-          "legacy_research_sources:3d6342c4594f",
-          "legacy_research_sources:44aa64d36517",
-          "legacy_research_sources:51439c900c55",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:af3332d3612c"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/ix/I20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/ix/I20.json
@@ -1,524 +1,361 @@
-[
-  {
-    "id": "bmw-i20-m60-eu-2022-ss1-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "I20",
-    "body_code": "I20",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "iX (I20, 2022-2026)",
-    "variant_name": "M60",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor (Performance)",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
+      "n2": "Official BMW Germany launch-era documentation now confirms the exact iX M60 DE mapping for drivetrain context, single-speed wording, and tire fitment: AWD, 1-speed transmission wording, standard 255/50 R21 tires, and optional 275/40 R22 wheels. The broad iX row remains unchanged because the exact M60 front/rear ratio values and numeric top-gear data were not resolved from exact official sources in this pass.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:037a64fa5220",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:4e23ce55b301",
+        "legacy_research_sources:5a588b230474",
+        "legacy_research_sources:6c3f77a91318",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:99ade101fb93",
+        "legacy_research_sources:a011f712276d"
+      ],
+      "e2": [
         "legacy_research_sources:4e23ce55b301",
         "legacy_research_sources:6c3f77a91318"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW Germany launch-era documentation now confirms the exact iX M60 DE mapping for drivetrain context, single-speed wording, and tire fitment: AWD, 1-speed transmission wording, standard 255/50 R21 tires, and optional 275/40 R22 wheels. The broad iX row remains unchanged because the exact M60 front/rear ratio values and numeric top-gear data were not resolved from exact official sources in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
-        "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      },
-      {
-        "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
-        "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-i20-xdrive40-eu-2022-ss1-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "I20",
-    "body_code": "I20",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "iX (I20, 2022-2026)",
-    "variant_name": "xDrive40",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:4e23ce55b301",
-        "legacy_research_sources:6c3f77a91318"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 1.0
+  "configurations": [
+    {
+      "id": "bmw-i20-m60-eu-2022-ss1-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "I20",
+      "body_code": "I20",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "iX (I20, 2022-2026)",
+      "variant_name": "M60",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor (Performance)",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 45.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW Germany launch-era documentation now confirms the exact iX M60 DE mapping for drivetrain context, single-speed wording, and tire fitment: AWD, 1-speed transmission wording, standard 255/50 R21 tires, and optional 275/40 R22 wheels. The broad iX row remains unchanged because the exact M60 front/rear ratio values and numeric top-gear data were not resolved from exact official sources in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
-        "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      },
-      {
-        "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
-        "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-i20-xdrive50-eu-2022-ss1-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "I20",
-    "body_code": "I20",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "iX (I20, 2022-2026)",
-    "variant_name": "xDrive50",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:4e23ce55b301",
-        "legacy_research_sources:6c3f77a91318"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "value": 9.079
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
+          "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
+          "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-i20-xdrive40-eu-2022-ss1-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "I20",
+      "body_code": "I20",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "iX (I20, 2022-2026)",
+      "variant_name": "xDrive40",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 45.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:037a64fa5220",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4e23ce55b301",
-            "legacy_research_sources:5a588b230474",
-            "legacy_research_sources:6c3f77a91318",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99ade101fb93",
-            "legacy_research_sources:a011f712276d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport 21\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
+          "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
+          "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW Germany launch-era documentation now confirms the exact iX M60 DE mapping for drivetrain context, single-speed wording, and tire fitment: AWD, 1-speed transmission wording, standard 255/50 R21 tires, and optional 275/40 R22 wheels. The broad iX row remains unchanged because the exact M60 front/rear ratio values and numeric top-gear data were not resolved from exact official sources in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
+    {
+      "id": "bmw-i20-xdrive50-eu-2022-ss1-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "I20",
+      "body_code": "I20",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "iX (I20, 2022-2026)",
+      "variant_name": "xDrive50",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 9.079
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 45.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW technical data with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
+          "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
+          "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW iX M60 exact front/rear overall ratios or final-drive ratio values",
-        "reason": "Exact official M60 sources checked in this pass confirmed drivetrain context and tire sizes, but they did not yield machine-readable exact front/rear or overall reduction ratios for the M60.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      },
-      {
-        "item": "BMW iX M60 numeric top-gear ratio and broad-row applicability across 2022-2026",
-        "reason": "Exact official M60 sources use single-speed wording rather than a numeric top-gear ratio, and this pass did not prove one exact EV ratio package across the broad 2022-2026 row.",
-        "evidence_refs": [
-          "legacy_research_sources:037a64fa5220",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4e23ce55b301",
-          "legacy_research_sources:5a588b230474",
-          "legacy_research_sources:6c3f77a91318",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99ade101fb93",
-          "legacy_research_sources:a011f712276d"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/F80.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/F80.json
@@ -1,780 +1,684 @@
-[
-  {
-    "id": "bmw-f80-m3-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F80",
-    "body_code": "F80",
-    "production_start_year": 2014,
-    "production_end_year": 2018,
-    "model_name": "M3 (F80, 2014-2018)",
-    "variant_name": "M3",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "value": "RWD",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n4": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW 03/2014 tech-spec PDF: 255/40 ZR18 front, 275/40 ZR18 rear.",
+      "n5": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch alternative documented in F82 M4 sibling and M3 marketing materials.",
+      "n6": "Default tire name (research note): EU standard 18-inch (launch fitment)",
+      "n7": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW Competition 01/2016 tech-spec PDF: 265/30 ZR20 front, 285/30 ZR20 rear.",
+      "n8": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch forged option widely documented as Competition alternative wheel.",
+      "n9": "Default tire name (research note): Competition standard 20-inch"
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
+      ],
+      "e3": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:956542619eaf",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:bd5f589fe214"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
+        "bmw_pressclub_sources:f82-competition-2016-launch-article",
+        "legacy_research_sources:21e9bf67c7b7",
+        "legacy_research_sources:fbef3422499f"
+      ],
+      "e5": [
+        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
+        "legacy_research_sources:21e9bf67c7b7",
+        "legacy_research_sources:fbef3422499f"
+      ],
+      "e6": [
+        "legacy_research_sources:21e9bf67c7b7",
+        "legacy_research_sources:fbef3422499f"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
+        "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf",
+        "legacy_research_sources:21e9bf67c7b7",
+        "legacy_research_sources:fbef3422499f"
+      ],
+      "e8": [
+        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
+        "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf"
+      ],
+      "e9": [
+        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
+        "bmw_pressclub_sources:f82-competition-2016-launch-article"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:f82-competition-2016-launch-article",
+        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
+        "legacy_research_sources:21e9bf67c7b7",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:956542619eaf",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:bd5f589fe214",
+        "legacy_research_sources:fbef3422499f"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f82-competition-2016-launch-article",
+        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
       ]
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-45BZ)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.846,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-        "value": 3.462,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW 03/2014 tech-spec PDF: 255/40 ZR18 front, 275/40 ZR18 rear.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        },
-        {
-          "name": "Optional 19-inch",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch alternative documented in F82 M4 sibling and M3 marketing materials."
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW MY2018 technical-data evidence that the F80 M3 manual and M-DCT top-gear values in production were inaccurate. The official sheet lists 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671, so the row now promotes those exact top-gear values and full forward gear-ratio sets while keeping the drivetrain scope unchanged.",
-        "evidence_refs": [
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:956542619eaf",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:bd5f589fe214",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Default tire name (research note): EU standard 18-inch (launch fitment)"
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (F80) EU-vs-US transmission calibration continuity across all model years",
-        "reason": "Wave 18 evidence is from official BMW MY2018 US technical data; this pass did not recover a parallel ACEA sheet proving no year or market calibration drift for every F80 state.",
-        "evidence_refs": [
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition-specific ratio deltas across production years",
-        "reason": "The checked official source provides one MY2018 M3 and M3 DCT matrix but not a complete year-by-year competition-specific ratio timeline.",
-        "evidence_refs": [
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f80-m3-eu-2014-dct7-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F80",
-    "body_code": "F80",
-    "production_start_year": 2014,
-    "production_end_year": 2018,
-    "model_name": "M3 (F80, 2014-2018)",
-    "variant_name": "M3",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch M-DCT (Getrag GS7D36BG / 7DCI600)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.671,
+  "configurations": [
+    {
+      "id": "bmw-f80-m3-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F80",
+      "body_code": "F80",
+      "production_start_year": 2014,
+      "production_end_year": 2018,
+      "model_name": "M3 (F80, 2014-2018)",
+      "variant_name": "M3",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
+        "notes_ref": "n1",
+        "value": "RWD",
+        "evidence_refs_ref": "e1"
       },
-      "final_drive_rear": {
-        "value": 3.462,
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-45BZ)",
+        "evidence_refs_ref": "e1"
       },
-      "gear_ratios": {
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW 03/2014 tech-spec PDF: 255/40 ZR18 front, 275/40 ZR18 rear.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.846,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n1"
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 3.462,
+          "evidence_refs_ref": "e1"
+        },
+        "gear_ratios": {
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n1"
         }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "rear": {
+            "width_mm": 275.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          }
         },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          },
+          {
+            "name": "Optional 19-inch",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5"
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "family_default",
+          "note": "Wave 18 added official BMW MY2018 technical-data evidence that the F80 M3 manual and M-DCT top-gear values in production were inaccurate. The official sheet lists 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671, so the row now promotes those exact top-gear values and full forward gear-ratio sets while keeping the drivetrain scope unchanged.",
           "evidence_refs": [
+            "legacy_research_sources:21e9bf67c7b7",
             "legacy_research_sources:393d7682b19e",
             "legacy_research_sources:956542619eaf",
             "legacy_research_sources:95b9bf2bf0cf",
             "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
+            "legacy_research_sources:bd5f589fe214",
+            "legacy_research_sources:fbef3422499f"
+          ]
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (F80) EU-vs-US transmission calibration continuity across all model years",
+          "reason": "Wave 18 evidence is from official BMW MY2018 US technical data; this pass did not recover a parallel ACEA sheet proving no year or market calibration drift for every F80 state.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW M3 Competition-specific ratio deltas across production years",
+          "reason": "The checked official source provides one MY2018 M3 and M3 DCT matrix but not a complete year-by-year competition-specific ratio timeline.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f80-m3-eu-2014-dct7-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F80",
+      "body_code": "F80",
+      "production_start_year": 2014,
+      "production_end_year": 2018,
+      "model_name": "M3 (F80, 2014-2018)",
+      "variant_name": "M3",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "value": "RWD",
+        "evidence_refs_ref": "e1"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch M-DCT (Getrag GS7D36BG / 7DCI600)",
+        "evidence_refs_ref": "e1"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.671,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n1"
+        },
+        "final_drive_rear": {
+          "value": 3.462,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n1"
+        },
+        "gear_ratios": {
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 275.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          },
+          {
+            "name": "Optional 19-inch",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Wave 18 added official BMW MY2018 technical-data evidence that the F80 M3 manual and M-DCT top-gear values in production were inaccurate. This follow-up adds official BMW 03/2014 launch-period and 01/2018 Portugal evidence that the F80 M3 DCT final drive is 3.462, correcting the inherited 3.154 carryover while keeping the broader row scope unchanged.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
+            "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf",
+            "legacy_research_sources:21e9bf67c7b7",
+            "legacy_research_sources:393d7682b19e",
+            "legacy_research_sources:956542619eaf",
+            "legacy_research_sources:95b9bf2bf0cf",
+            "legacy_research_sources:97624cf593b1",
+            "legacy_research_sources:bd5f589fe214",
+            "legacy_research_sources:fbef3422499f"
+          ]
+        },
+        {
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (F80) exact continuity across the represented 2014-2018 row span",
+          "reason": "The checked official BMW 03/2014 launch-period and 01/2018 Portugal technical-data PDFs agree on the core M3 transmission and final-drive package, but this pass did not recover a complete official year-by-year chain for every intermediate model year in the row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW M3 exact standard-versus-optional tyre package semantics",
+          "reason": "The checked official BMW 03/2014 launch-period technical-data PDF shows the base M3 standard package as staggered 255/40 ZR18 front plus 275/40 ZR18 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f80-m3-competition-eu-2016-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F80",
+      "body_code": "F80",
+      "production_start_year": 2016,
+      "production_end_year": 2018,
+      "model_name": "M3 (F80, 2014-2018)",
+      "variant_name": "M3 Competition",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "value": "RWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-45BZ)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.846,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 3.462,
+          "evidence_refs_ref": "e9"
+        },
+        "gear_ratios": {
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        },
-        {
-          "name": "Optional 19-inch",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
           "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch alternative documented in F82 M4 sibling and M3 marketing materials."
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW MY2018 technical-data evidence that the F80 M3 manual and M-DCT top-gear values in production were inaccurate. This follow-up adds official BMW 03/2014 launch-period and 01/2018 Portugal evidence that the F80 M3 DCT final drive is 3.462, correcting the inherited 3.154 carryover while keeping the broader row scope unchanged.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:956542619eaf",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:bd5f589fe214",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Default tire name (research note): EU standard 18-inch (launch fitment)"
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (F80) exact continuity across the represented 2014-2018 row span",
-        "reason": "The checked official BMW 03/2014 launch-period and 01/2018 Portugal technical-data PDFs agree on the core M3 transmission and final-drive package, but this pass did not recover a complete official year-by-year chain for every intermediate model year in the row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf",
-          "bmw_pressclub_sources:f80-m3-2018-portugal-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW M3 exact standard-versus-optional tyre package semantics",
-        "reason": "The checked official BMW 03/2014 launch-period technical-data PDF shows the base M3 standard package as staggered 255/40 ZR18 front plus 275/40 ZR18 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f80-m3-competition-eu-2016-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F80",
-    "body_code": "F80",
-    "production_start_year": 2016,
-    "production_end_year": 2018,
-    "model_name": "M3 (F80, 2014-2018)",
-    "variant_name": "M3 Competition",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-45BZ)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.846,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-        "value": 3.462,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article"
-        ]
-      },
-      "gear_ratios": {
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW Competition 01/2016 tech-spec PDF: 265/30 ZR20 front, 285/30 ZR20 rear.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
+            "width_mm": 285.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          }
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          },
+          {
+            "name": "Competition forged 19-inch",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n8"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave narrows the F80 M3 Competition manual row to 2016-2018. Official BMW Competition Package launch material states that the Competition Package becomes available from spring 2016, and the paired Competition technical-data PDF confirms the manual top gear 0.846 and final drive 3.462 for the exact Competition state.",
+          "evidence_refs_ref": "e10"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 Competition exact continuity across the represented 2016-2018 row span",
+          "reason": "The checked official BMW 01/2016 Competition Package launch-period material closes the start year and core ratio/final-drive package, but this pass did not recover a complete official year-by-year chain for every later Competition model year in the row.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "BMW M3 Competition exact standard-versus-optional tyre package semantics",
+          "reason": "The checked official BMW 01/2016 Competition Package technical-data PDF shows the Competition standard package as staggered 265/30 ZR20 front plus 285/30 ZR20 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f80-m3-competition-eu-2016-dct7-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F80",
+      "body_code": "F80",
+      "production_start_year": 2016,
+      "production_end_year": 2018,
+      "model_name": "M3 (F80, 2014-2018)",
+      "variant_name": "M3 Competition",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "value": "RWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch M-DCT (Getrag GS7D36BG / 7DCI600)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.671,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1"
+        },
+        "final_drive_rear": {
+          "value": 3.462,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n1"
+        },
+        "gear_ratios": {
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        },
-        {
-          "name": "Competition forged 19-inch",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
           "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch forged option widely documented as Competition alternative wheel."
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave narrows the F80 M3 Competition manual row to 2016-2018. Official BMW Competition Package launch material states that the Competition Package becomes available from spring 2016, and the paired Competition technical-data PDF confirms the manual top gear 0.846 and final drive 3.462 for the exact Competition state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:956542619eaf",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:bd5f589fe214",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Default tire name (research note): Competition standard 20-inch"
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 Competition exact continuity across the represented 2016-2018 row span",
-        "reason": "The checked official BMW 01/2016 Competition Package launch-period material closes the start year and core ratio/final-drive package, but this pass did not recover a complete official year-by-year chain for every later Competition model year in the row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition exact standard-versus-optional tyre package semantics",
-        "reason": "The checked official BMW 01/2016 Competition Package technical-data PDF shows the Competition standard package as staggered 265/30 ZR20 front plus 285/30 ZR20 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f80-m3-competition-eu-2016-dct7-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F80",
-    "body_code": "F80",
-    "production_start_year": 2016,
-    "production_end_year": 2018,
-    "model_name": "M3 (F80, 2014-2018)",
-    "variant_name": "M3 Competition",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "value": "RWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch M-DCT (Getrag GS7D36BG / 7DCI600)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.671,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      },
-      "final_drive_rear": {
-        "value": 3.462,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      },
-      "gear_ratios": {
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:fbef3422499f"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. BMW Competition 01/2016 tech-spec PDF: 265/30 ZR20 front, 285/30 ZR20 rear.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:956542619eaf",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:bd5f589fe214"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
+            "width_mm": 285.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          },
+          {
+            "name": "Competition forged 19-inch",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n8"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave narrows the F80 M3 Competition M-DCT row to 2016-2018 and corrects its final drive to 3.462. Official BMW Competition Package launch material states that the Competition Package becomes available from spring 2016, and the paired Competition technical-data PDF confirms the DCT top gear 0.671 and final drive 3.462 for the exact Competition state.",
+          "evidence_refs_ref": "e10"
         },
         {
-          "name": "Competition forged 19-inch",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): F80 M3 sedan and F82 M4 coupe share identical S55 powertrain, transmission, gear ratios, reverse, and final drive (3.462). BMW PressClub T0179962EN/265695 (03/2014 launch tech-spec PDF) covers both bodies. Competition Pkg from 01/2016 (T0249809EN/412769) retained both MT6 (Getrag GS6-45BZ) and DCT7 (Getrag GS7D36BG / 7DCI600). Production end October 2018. 19-inch forged option widely documented as Competition alternative wheel."
+          "note_ref": "n3"
+        },
+        {
+          "note_ref": "n9"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave narrows the F80 M3 Competition M-DCT row to 2016-2018 and corrects its final drive to 3.462. Official BMW Competition Package launch material states that the Competition Package becomes available from spring 2016, and the paired Competition technical-data PDF confirms the DCT top gear 0.671 and final drive 3.462 for the exact Competition state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf",
-          "legacy_research_sources:21e9bf67c7b7",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:956542619eaf",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:bd5f589fe214",
-          "legacy_research_sources:fbef3422499f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Default tire name (research note): Competition standard 20-inch"
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 Competition exact continuity across the represented 2016-2018 row span",
+          "reason": "The checked official BMW 01/2016 Competition Package launch-period material closes the start year and core ratio/final-drive package, but this pass did not recover a complete official year-by-year chain for every later Competition model year in the row.",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "item": "BMW M3 Competition exact standard-versus-optional tyre package semantics",
+          "reason": "The checked official BMW 01/2016 Competition Package technical-data PDF shows the Competition standard package as staggered 265/30 ZR20 front plus 285/30 ZR20 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 Competition exact continuity across the represented 2016-2018 row span",
-        "reason": "The checked official BMW 01/2016 Competition Package launch-period material closes the start year and core ratio/final-drive package, but this pass did not recover a complete official year-by-year chain for every later Competition model year in the row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition exact standard-versus-optional tyre package semantics",
-        "reason": "The checked official BMW 01/2016 Competition Package technical-data PDF shows the Competition standard package as staggered 265/30 ZR20 front plus 285/30 ZR20 rear, but this pass did not retune the row's existing default-versus-option tyre ordering.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f80-m3-competition-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/G80.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/G80.json
@@ -1,779 +1,576 @@
-[
-  {
-    "id": "bmw-g80-m3-eu-2021-mt6-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G80",
-    "body_code": "G80",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M3 (G80, 2021-2026)",
-    "variant_name": "M3",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
+      "n3": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
+      "n4": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec).",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
+      "n6": "Official BMW exact technical-data sheets now confirm the G80 M3 Competition xDrive AWD mapping: Eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the exact public gearbox subtype code and the broader G80 variant matrix are still incomplete.",
+      "n7": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
+      "n8": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition xDrive saloon (42AY) AWD, ZF 8HP M-Steptronic with Drivelogic. Repo's existing official_exact ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 are confirmed. Default tire entry corrected: prior front dimension 285/30 ZR20 was actually the rear size; corrected to 275/35 ZR19 front + 285/30 ZR20 rear, matching the staggered EU OE setup."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:50c07cf41408",
+        "legacy_research_sources:6fd93dc07e14",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:b8cf19533840",
+        "legacy_research_sources:d78cb5eee4f7",
+        "legacy_research_sources:e0d00fcedc95",
+        "legacy_research_sources:e359a1117b6f"
+      ],
+      "e2": [
         "secondary_technical_sources:g80-m3-wikipedia",
+        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
         "secondary_technical_sources:g82-m4-motortrend-overview"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec).",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec).",
-      "code": "MT6",
-      "name": "6-speed manual (GS6-53BZ)",
-      "evidence_refs": [
+      "e3": [
+        "secondary_technical_sources:g80-m3-wikipedia"
+      ],
+      "e4": [
         "secondary_technical_sources:g80-m3-wikipedia",
-        "secondary_technical_sources:g80-m3-motortrend-2021-specs",
-        "secondary_technical_sources:g80-m3-motortrend-2022-specs",
-        "secondary_technical_sources:g80-m3-caranddriver-specs",
-        "secondary_technical_sources:zf-s6-53-wikipedia"
+        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec). Top gear value 0.812 sourced from C&D/MotorTrend secondary specs; ZF S6-53 article cites 0.872 - discrepancy noted.",
-        "value": 0.812,
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g80-m3-eu-2021-mt6-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G80",
+      "body_code": "G80",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M3 (G80, 2021-2026)",
+      "variant_name": "M3",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "secondary_technical_sources:g80-m3-caranddriver-specs",
+          "secondary_technical_sources:g80-m3-wikipedia",
+          "secondary_technical_sources:g82-m4-motortrend-overview"
+        ],
+        "notes_ref": "n4",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n4",
+        "code": "MT6",
+        "name": "6-speed manual (GS6-53BZ)",
+        "evidence_refs": [
+          "secondary_technical_sources:g80-m3-wikipedia",
           "secondary_technical_sources:g80-m3-motortrend-2021-specs",
           "secondary_technical_sources:g80-m3-motortrend-2022-specs",
+          "secondary_technical_sources:g80-m3-caranddriver-specs",
           "secondary_technical_sources:zf-s6-53-wikipedia"
         ]
       },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec).",
-        "value": 3.46,
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-caranddriver-specs",
-          "secondary_technical_sources:g80-m3-motortrend-2021-specs",
-          "secondary_technical_sources:g80-m3-motortrend-2022-specs"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec).",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 (citing BMW press kit), MotorTrend 2021/2022 specs, and C&D specs all confirm base G80 M3 = 6-speed manual GS6-53BZ (or BMW-branded variant) RWD-only. Final drive 3.46 (3 independent secondary sources, 2021-2022 MY consistent); repo's prior 3.846 was a stale family_default inheritance from older BMW M models, now corrected. 6th gear 0.812 inherited from G82 M4 prior research (C&D/MotorTrend); ZF S6-53 Wikipedia article suggests an alternate value 0.872 for GS6-53BZ - discrepancy unresolved without primary BMW ACEA PDF. EU OE tires staggered 275/35 ZR19 front + 285/30 ZR20 rear (same as G82 M4 base manual EU spec). Top gear value 0.812 sourced from C&D/MotorTrend secondary specs; ZF S6-53 article cites 0.872 - discrepancy noted.",
+          "value": 0.812,
+          "evidence_refs": [
+            "secondary_technical_sources:g80-m3-caranddriver-specs",
+            "secondary_technical_sources:g80-m3-motortrend-2021-specs",
+            "secondary_technical_sources:g80-m3-motortrend-2022-specs",
+            "secondary_technical_sources:zf-s6-53-wikipedia"
+          ]
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n4",
+          "value": 3.46,
+          "evidence_refs": [
+            "secondary_technical_sources:g80-m3-caranddriver-specs",
+            "secondary_technical_sources:g80-m3-motortrend-2021-specs",
+            "secondary_technical_sources:g80-m3-motortrend-2022-specs"
+          ]
         }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:50c07cf41408",
-            "legacy_research_sources:6fd93dc07e14",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:b8cf19533840",
-            "legacy_research_sources:d78cb5eee4f7",
-            "legacy_research_sources:e0d00fcedc95",
-            "legacy_research_sources:e359a1117b6f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:50c07cf41408",
-            "legacy_research_sources:6fd93dc07e14",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:b8cf19533840",
-            "legacy_research_sources:d78cb5eee4f7",
-            "legacy_research_sources:e0d00fcedc95",
-            "legacy_research_sources:e359a1117b6f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G80 M3 Competition xDrive AWD mapping: Eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the exact public gearbox subtype code and the broader G80 variant matrix are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
-        "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g80-m3-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G80",
-    "body_code": "G80",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M3 (G80, 2021-2026)",
-    "variant_name": "M3",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "secondary_technical_sources:g80-m3-wikipedia",
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:g80-m3-wikipedia",
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g80-m3-wikipedia",
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g80-m3-wikipedia",
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): Wikipedia BMW M3 G80 article (citing BMW press kit, footnote 167) explicitly states 'A manual gearbox is available only with rear wheel drive, and is the only transmission available on the standard M3 model.' Wikipedia spec table lists the base M3 saloon (52AY) only with the 6-speed manual; the ZF 8HP M-Steptronic is reserved for Competition variants. The base + 8AT RWD combination does not exist in any market - directly parallels the G82 M4 base 8AT phantom finding. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G80 M3 Competition xDrive AWD mapping: Eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the exact public gearbox subtype code and the broader G80 variant matrix are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
-        "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g80-m3-competition-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G80",
-    "body_code": "G80",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M3 (G80, 2021-2026)",
-    "variant_name": "M3 Competition",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:g80-m3-wikipedia"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
-      "code": "ZF8HP",
-      "name": "8-speed M-Steptronic Sport (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:g80-m3-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "reputable_secondary_crosschecked",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4). Forward gear ratios derived from the Competition xDrive row (same ZF 8HP M-Steptronic)."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4).",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:50c07cf41408",
-            "legacy_research_sources:6fd93dc07e14",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:b8cf19533840",
-            "legacy_research_sources:d78cb5eee4f7",
-            "legacy_research_sources:e0d00fcedc95",
-            "legacy_research_sources:e359a1117b6f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:50c07cf41408",
-            "legacy_research_sources:6fd93dc07e14",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:b8cf19533840",
-            "legacy_research_sources:d78cb5eee4f7",
-            "legacy_research_sources:e0d00fcedc95",
-            "legacy_research_sources:e359a1117b6f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G80 M3 Competition xDrive AWD mapping: Eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the exact public gearbox subtype code and the broader G80 variant matrix are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
-        "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g80-m3-competition-xdrive-eu-2021-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "G80",
-    "body_code": "G80",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M3 (G80, 2021-2026)",
-    "variant_name": "M3 Competition xDrive",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:50c07cf41408",
-        "legacy_research_sources:6fd93dc07e14"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition xDrive saloon (42AY) AWD, ZF 8HP M-Steptronic with Drivelogic. Repo's existing official_exact ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 are confirmed. Default tire entry corrected: prior front dimension 285/30 ZR20 was actually the rear size; corrected to 275/35 ZR19 front + 285/30 ZR20 rear, matching the staggered EU OE setup.",
-      "code": "ZF8HP",
-      "name": "8-speed M Steptronic transmission with Drivelogic"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:6fd93dc07e14",
-          "secondary_technical_sources:g80-m3-wikipedia",
-          "legacy_research_sources:e359a1117b6f",
-          "legacy_research_sources:b8cf19533840"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition xDrive saloon (42AY) AWD, ZF 8HP M-Steptronic with Drivelogic. Repo's existing official_exact ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 are confirmed. Default tire entry corrected: prior front dimension 285/30 ZR20 was actually the rear size; corrected to 275/35 ZR19 front + 285/30 ZR20 rear, matching the staggered EU OE setup.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:50c07cf41408",
-            "legacy_research_sources:6fd93dc07e14",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:b8cf19533840",
-            "legacy_research_sources:d78cb5eee4f7",
-            "legacy_research_sources:e0d00fcedc95",
-            "legacy_research_sources:e359a1117b6f"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
           "rear": {
             "width_mm": 285.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
+          "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g80-m3-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G80",
+      "body_code": "G80",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M3 (G80, 2021-2026)",
+      "variant_name": "M3",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.154,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7"
+        },
+        {
+          "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
+          "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g80-m3-competition-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G80",
+      "body_code": "G80",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M3 (G80, 2021-2026)",
+      "variant_name": "M3 Competition",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n3",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed M-Steptronic Sport (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.154,
+          "evidence_refs_ref": "e3"
+        },
+        "gear_ratios": {
+          "confidence": "reputable_secondary_crosschecked",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "evidence_refs_ref": "e3",
+          "notes": "Sonnet redo research (2026-04 v2): Wikipedia G80 M3 spec table (citing BMW press kit) confirms M3 Competition saloon (32AY) 375 kW with 8-speed M Steptronic Sport with Drivelogic, RWD. Same ZF 8HP M-Steptronic as the Competition xDrive (Row 3, official_exact in repo) - same hardware therefore same internal ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior top_gear 0.667 was inconsistent with the same physical gearbox/diff used on the xDrive row and was a stale family_default. Corrected to 0.640 to match the Competition xDrive row. EU OE tires 275/35 ZR19 front + 285/30 ZR20 rear (same architecture as base M3 and G82 M4). Forward gear ratios derived from the Competition xDrive row (same ZF 8HP M-Steptronic)."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard staggered setup"
+          "rear": {
+            "width_mm": 285.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n7"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
+          "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G80 M3 Competition xDrive AWD mapping: Eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the exact public gearbox subtype code and the broader G80 variant matrix are still incomplete.",
+    {
+      "id": "bmw-g80-m3-competition-xdrive-eu-2021-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "G80",
+      "body_code": "G80",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M3 (G80, 2021-2026)",
+      "variant_name": "M3 Competition xDrive",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
         "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
           "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
+          "legacy_research_sources:6fd93dc07e14"
+        ],
+        "notes_ref": "n2",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed M Steptronic transmission with Drivelogic"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "legacy_research_sources:e0d00fcedc95",
+            "legacy_research_sources:393d7682b19e",
+            "legacy_research_sources:d78cb5eee4f7",
+            "legacy_research_sources:50c07cf41408",
+            "legacy_research_sources:95b9bf2bf0cf",
+            "legacy_research_sources:97624cf593b1",
+            "legacy_research_sources:6fd93dc07e14",
+            "secondary_technical_sources:g80-m3-wikipedia",
+            "legacy_research_sources:e359a1117b6f",
+            "legacy_research_sources:b8cf19533840"
+          ],
+          "notes_ref": "n8",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 285.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard staggered setup"
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
+          "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M3 (G80, 2021-2026) full EU variant matrix beyond the exact M3 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M3 Competition xDrive ratios and staggered tire fitment, but it did not establish the full official matrix for every other G80 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      },
-      {
-        "item": "BMW M3 Competition xDrive public gearbox subtype code and reverse-ratio storage",
-        "reason": "Official BMW sources confirm the transmission name, full forward ratios, final drive, and staggered tires, but they do not publish a gearbox subtype code, and the current schema has no dedicated reverse-ratio field for the official 3.478 value.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:50c07cf41408",
-          "legacy_research_sources:6fd93dc07e14",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:b8cf19533840",
-          "legacy_research_sources:d78cb5eee4f7",
-          "legacy_research_sources:e0d00fcedc95",
-          "legacy_research_sources:e359a1117b6f"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/F82.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/F82.json
@@ -1,662 +1,533 @@
-[
-  {
-    "id": "bmw-f82-m4-eu-2014-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F82",
-    "body_code": "F82",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "M4 (F82, 2014-2020)",
-    "variant_name": "M4",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Official BMW 09/2018 technical data confirms the M4 manual top-gear value and full forward gear-ratio set.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n4": "Official BMW 09/2018 technical data confirms the M4 M-DCT top-gear value and full forward gear-ratio set."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.846,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 manual top-gear value and full forward gear-ratio set."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): Wikipedia F82 M4 confirms 6-speed manual + 7-speed M-DCT lineup. Repo's gear ratios I 4.110 / II 2.315 / III 1.542 / IV 1.179 / V 1.000 / VI 0.846 are already official_exact via BMW 09/2018 ACEA technical data (legacy_research_sources references). Final drive 3.462 also from BMW 09/2018 ACEA - promoted from family_default to official_exact (same source as the DCT7 row's official_exact FD). MotorTrend 2014 USA spec confirms 3.46 axle ratio (rounded). Production span 2014 - June 2020 per Wikipedia.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:f82-m4-motortrend-2014-specs",
-          "secondary_technical_sources:f82-m4-wikipedia"
-        ]
-      },
-      "gear_ratios": {
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 manual top-gear value and full forward gear-ratio set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:13ea013ef134",
+        "legacy_research_sources:accc520c8c58"
+      ],
+      "e2": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:7484e69ac570",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:eec306178221"
+      ],
+      "e3": [
+        "legacy_research_sources:13ea013ef134",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:7484e69ac570",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:accc520c8c58",
+        "legacy_research_sources:eec306178221"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:f82-competition-2016-launch-article",
+        "bmw_pressclub_sources:f82-my16-pricing-guide-pdf",
+        "legacy_research_sources:13ea013ef134",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:7484e69ac570",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:accc520c8c58",
+        "legacy_research_sources:eec306178221"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW 09/2018 technical-data evidence for the F82 M4 and M4 Competition showing 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671 with final drive 3.462. Production now promotes those exact top-gear values and full forward gear-ratio sets, replacing the prior mismatched top-gear defaults.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
-        "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      },
-      {
-        "item": "M4 special-edition ratio variance handling",
-        "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f82-m4-eu-2014-dct7-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F82",
-    "body_code": "F82",
-    "production_start_year": 2014,
-    "production_end_year": 2020,
-    "model_name": "M4 (F82, 2014-2020)",
-    "variant_name": "M4",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Sonnet redo research (2026-04 v2): Wikipedia F82 M4 confirms the 7-speed M-DCT (Getrag GS7D36BG) lineup option. Repo's official_exact gear ratios I 4.806 / II 2.593 / III 1.701 / IV 1.277 / V 1.000 / VI 0.844 / VII 0.671 with final drive 3.462 (BMW 09/2018 ACEA) confirmed correct. Production span 2014 - June 2020.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (M-DCT)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.671,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 M-DCT top-gear value and full forward gear-ratio set."
+  "configurations": [
+    {
+      "id": "bmw-f82-m4-eu-2014-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F82",
+      "body_code": "F82",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "M4 (F82, 2014-2020)",
+      "variant_name": "M4",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_rear": {
-        "value": 3.462,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Wave 18 and the follow-up F82 packet confirm the M4 M-DCT final drive as 3.462 across the recovered official BMW MY2016, MY2017, and MY2018 material. The prior 3.154 carryover was later G82 contamination, not an F82 value."
-      },
-      "gear_ratios": {
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 M-DCT top-gear value and full forward gear-ratio set."
-      }
-    },
-    "tires": {
-      "default": {
+      "transmission": {
         "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
       },
-      "options": [
-        {
-          "confidence": "family_default",
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.846,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "Sonnet redo research (2026-04 v2): Wikipedia F82 M4 confirms 6-speed manual + 7-speed M-DCT lineup. Repo's gear ratios I 4.110 / II 2.315 / III 1.542 / IV 1.179 / V 1.000 / VI 0.846 are already official_exact via BMW 09/2018 ACEA technical data (legacy_research_sources references). Final drive 3.462 also from BMW 09/2018 ACEA - promoted from family_default to official_exact (same source as the DCT7 row's official_exact FD). MotorTrend 2014 USA spec confirms 3.46 axle ratio (rounded). Production span 2014 - June 2020 per Wikipedia.",
+          "value": 3.462,
           "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
+            "secondary_technical_sources:f82-m4-motortrend-2014-specs",
+            "secondary_technical_sources:f82-m4-wikipedia"
+          ]
+        },
+        "gear_ratios": {
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW 09/2018 technical-data evidence for the F82 M4 and M4 Competition showing 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671 with final drive 3.462. This follow-up also corrects the DCT final drive from the inherited 3.154 carryover to the recovered official F82 value 3.462, replacing the last obvious G82 contamination in the row.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
-        "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      },
-      {
-        "item": "M4 special-edition ratio variance handling",
-        "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f82-m4-competition-eu-2016-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F82",
-    "body_code": "F82",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "M4 (F82, 2014-2020)",
-    "variant_name": "M4 Competition",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.846,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 manual top-gear value and full forward gear-ratio set."
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): F82 M4 Competition Package (2016 launch, S55 power increased to 331 kW / 444 hp) was offered with both the 6-speed manual and the 7-speed M-DCT - confirmed by Wikipedia and BMW PressClub Competition launch reference (already in repo via bmw_pressclub_sources). Manual gearbox ratios are identical to base M4: I 4.110 / II 2.315 / III 1.542 / IV 1.179 / V 1.000 / VI 0.846, final drive 3.462 - Competition Package only changes engine tune and chassis, not gearbox internals. Final drive promoted from family_default to official_exact using the same BMW 09/2018 ACEA evidence as the DCT row.",
-        "value": 3.462,
-        "evidence_refs": [
-          "secondary_technical_sources:f82-m4-wikipedia",
-          "secondary_technical_sources:f82-m4-motortrend-2016-specs"
-        ]
-      },
-      "gear_ratios": {
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 manual top-gear value and full forward gear-ratio set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
+          "note": "Wave 18 added official BMW 09/2018 technical-data evidence for the F82 M4 and M4 Competition showing 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671 with final drive 3.462. Production now promotes those exact top-gear values and full forward gear-ratio sets, replacing the prior mismatched top-gear defaults.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
+          "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "M4 special-edition ratio variance handling",
+          "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f82-m4-eu-2014-dct7-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F82",
+      "body_code": "F82",
+      "production_start_year": 2014,
+      "production_end_year": 2020,
+      "model_name": "M4 (F82, 2014-2020)",
+      "variant_name": "M4",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes": "Sonnet redo research (2026-04 v2): Wikipedia F82 M4 confirms the 7-speed M-DCT (Getrag GS7D36BG) lineup option. Repo's official_exact gear ratios I 4.806 / II 2.593 / III 1.701 / IV 1.277 / V 1.000 / VI 0.844 / VII 0.671 with final drive 3.462 (BMW 09/2018 ACEA) confirmed correct. Production span 2014 - June 2020.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (M-DCT)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.671,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4"
+        },
+        "final_drive_rear": {
+          "value": 3.462,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Wave 18 and the follow-up F82 packet confirm the M4 M-DCT final drive as 3.462 across the recovered official BMW MY2016, MY2017, and MY2018 material. The prior 3.154 carryover was later G82 contamination, not an F82 value."
+        },
+        "gear_ratios": {
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "This research wave narrows the F82 M4 Competition manual row to 2016-2020. Official BMW Competition Package launch material and the MY2016 pricing guide show the Competition package first becomes available from spring 2016 / effective March 11, 2016, so the prior 2014 start year was overbroad. Wave 18 official BMW technical-data evidence still confirms the manual top gear 0.846 and final drive 3.462 for the later Competition row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f82-my16-pricing-guide-pdf",
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
-        "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      },
-      {
-        "item": "M4 special-edition ratio variance handling",
-        "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f82-m4-competition-eu-2016-dct7-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "F82",
-    "body_code": "F82",
-    "production_start_year": 2016,
-    "production_end_year": 2020,
-    "model_name": "M4 (F82, 2014-2020)",
-    "variant_name": "M4 Competition",
-    "engine_code": "S55",
-    "engine_name": "S55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Sonnet redo research (2026-04 v2): F82 M4 Competition Package with 7-speed M-DCT confirmed by Wikipedia. Repo's official_exact gear ratios and final drive 3.462 (BMW 09/2018 ACEA) confirmed correct.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (M-DCT)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.671,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 M-DCT top-gear value and full forward gear-ratio set."
-      },
-      "final_drive_rear": {
-        "value": 3.462,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Wave 18 and the follow-up F82 packet confirm the Competition M-DCT final drive as 3.462 across the recovered official BMW MY2016, MY2017, and MY2018 material. The prior 3.154 carryover was later G82 contamination, not an F82 value."
-      },
-      "gear_ratios": {
-        "value": [
-          4.806,
-          2.593,
-          1.701,
-          1.277,
-          1.0,
-          0.844,
-          0.671
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ],
-        "notes": "Official BMW 09/2018 technical data confirms the M4 M-DCT top-gear value and full forward gear-ratio set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:eec306178221"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "family_default",
+          "note": "Wave 18 added official BMW 09/2018 technical-data evidence for the F82 M4 and M4 Competition showing 6-speed manual VI gear 0.846 and 7-speed M-DCT VII gear 0.671 with final drive 3.462. This follow-up also corrects the DCT final drive from the inherited 3.154 carryover to the recovered official F82 value 3.462, replacing the last obvious G82 contamination in the row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
+          "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "M4 special-edition ratio variance handling",
+          "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f82-m4-competition-eu-2016-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F82",
+      "body_code": "F82",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "M4 (F82, 2014-2020)",
+      "variant_name": "M4 Competition",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.846,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes": "Sonnet redo research (2026-04 v2): F82 M4 Competition Package (2016 launch, S55 power increased to 331 kW / 444 hp) was offered with both the 6-speed manual and the 7-speed M-DCT - confirmed by Wikipedia and BMW PressClub Competition launch reference (already in repo via bmw_pressclub_sources). Manual gearbox ratios are identical to base M4: I 4.110 / II 2.315 / III 1.542 / IV 1.179 / V 1.000 / VI 0.846, final drive 3.462 - Competition Package only changes engine tune and chassis, not gearbox internals. Final drive promoted from family_default to official_exact using the same BMW 09/2018 ACEA evidence as the DCT row.",
+          "value": 3.462,
           "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
+            "secondary_technical_sources:f82-m4-wikipedia",
+            "secondary_technical_sources:f82-m4-motortrend-2016-specs"
+          ]
+        },
+        "gear_ratios": {
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "This research wave narrows the F82 M4 Competition manual row to 2016-2020. Official BMW Competition Package launch material and the MY2016 pricing guide show the Competition package first becomes available from spring 2016 / effective March 11, 2016, so the prior 2014 start year was overbroad. Wave 18 official BMW technical-data evidence still confirms the manual top gear 0.846 and final drive 3.462 for the later Competition row.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7484e69ac570",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:eec306178221"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
+          "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "M4 special-edition ratio variance handling",
+          "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "This research wave narrows the F82 M4 Competition M-DCT row to 2016-2020 and corrects its final drive to 3.462. Official BMW Competition Package launch material and the MY2016 pricing guide show the Competition package first becomes available from spring 2016 / effective March 11, 2016, while the recovered official BMW MY2016, MY2017, and MY2018 technical-data material confirms the Competition M-DCT top gear 0.671 and final drive 3.462 rather than the inherited 3.154 carryover.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f82-competition-2016-launch-article",
-          "bmw_pressclub_sources:f82-my16-pricing-guide-pdf",
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:7484e69ac570",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:accc520c8c58",
-          "legacy_research_sources:eec306178221"
+    {
+      "id": "bmw-f82-m4-competition-eu-2016-dct7-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "F82",
+      "body_code": "F82",
+      "production_start_year": 2016,
+      "production_end_year": 2020,
+      "model_name": "M4 (F82, 2014-2020)",
+      "variant_name": "M4 Competition",
+      "engine_code": "S55",
+      "engine_name": "S55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes": "Sonnet redo research (2026-04 v2): F82 M4 Competition Package with 7-speed M-DCT confirmed by Wikipedia. Repo's official_exact gear ratios and final drive 3.462 (BMW 09/2018 ACEA) confirmed correct.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (M-DCT)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.671,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4"
+        },
+        "final_drive_rear": {
+          "value": 3.462,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Wave 18 and the follow-up F82 packet confirm the Competition M-DCT final drive as 3.462 across the recovered official BMW MY2016, MY2017, and MY2018 material. The prior 3.154 carryover was later G82 contamination, not an F82 value."
+        },
+        "gear_ratios": {
+          "value": [
+            4.806,
+            2.593,
+            1.701,
+            1.277,
+            1.0,
+            0.844,
+            0.671
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "This research wave narrows the F82 M4 Competition M-DCT row to 2016-2020 and corrects its final drive to 3.462. Official BMW Competition Package launch material and the MY2016 pricing guide show the Competition package first becomes available from spring 2016 / effective March 11, 2016, while the recovered official BMW MY2016, MY2017, and MY2018 technical-data material confirms the Competition M-DCT top gear 0.671 and final drive 3.462 rather than the inherited 3.154 carryover.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
+          "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "M4 special-edition ratio variance handling",
+          "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (F82) one exact ratio package across all lifecycle updates",
-        "reason": "Wave 18 confirms 09/2018 ACEA mapping, but this pass did not recover every pre-LCI and late-run sheet to prove no lifecycle ratio change.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      },
-      {
-        "item": "M4 special-edition ratio variance handling",
-        "reason": "Official sources include additional derivatives such as GTS states and this row intentionally keeps only base M4 and M4 Competition mapping.",
-        "evidence_refs": [
-          "legacy_research_sources:13ea013ef134",
-          "legacy_research_sources:accc520c8c58"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/G82.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/G82.json
@@ -1,1007 +1,714 @@
-[
-  {
-    "id": "bmw-g82-m4-eu-2021-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G82",
-    "body_code": "G82",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M4 (G82, 2021-2026)",
-    "variant_name": "M4",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
+      "n2": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
+      "n3": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
+      "n4": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
+      "n5": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
+      "n6": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
+      "n7": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition xDrive = 523hp, 8-speed M-Steptronic (ZF 8HP), AWD. Forward gear ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 already in repo and consistent with ZF 8HP M-Steptronic spec. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel).",
+      "n8": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
+      "n9": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
+      "n10": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n12": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n13": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n14": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n15": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n16": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n17": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:45650dc1f28e",
+        "legacy_research_sources:6454b4fe504c",
+        "legacy_research_sources:6925daca8aa1",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:9f8d6ee410eb",
+        "legacy_research_sources:bf1e088e1d64",
+        "legacy_research_sources:e26b69822173"
+      ],
+      "e2": [
+        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
+        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
+        "secondary_technical_sources:g82-m4-motortrend-overview"
+      ],
+      "e3": [
+        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
+        "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
+        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
+        "secondary_technical_sources:g82-m4-motortrend-overview"
+      ],
+      "e4": [
         "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
         "secondary_technical_sources:g82-m4-motortrend-overview"
       ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
-      "code": "MT6",
-      "name": "6-speed manual (GS6-45BZ)",
-      "evidence_refs": [
+      "e5": [
         "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-        "secondary_technical_sources:g82-m4-caranddriver-specs",
-        "secondary_technical_sources:g82-m4-motortrend-2022-specs"
+        "secondary_technical_sources:g82-m4-caranddriver-comp-drive"
+      ],
+      "e6": [
+        "secondary_technical_sources:g82-m4-caranddriver-mt6-test"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-caranddriver-specs"
-        ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g82-m4-eu-2021-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G82",
+      "body_code": "G82",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M4 (G82, 2021-2026)",
+      "variant_name": "M4",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n3",
+        "value": "RWD"
       },
-      "final_drive_rear": {
+      "transmission": {
         "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
-        "value": 3.46,
+        "notes_ref": "n3",
+        "code": "MT6",
+        "name": "6-speed manual (GS6-45BZ)",
         "evidence_refs": [
+          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
+          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
           "secondary_technical_sources:g82-m4-caranddriver-specs",
-          "secondary_technical_sources:g82-m4-motortrend-2022-specs",
-          "secondary_technical_sources:g82-m4-motortrend-2023-specs"
+          "secondary_technical_sources:g82-m4-motortrend-2022-specs"
         ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights, Car and Driver MT6 test (Michelin PS4S 275/35ZR-19 / 285/30ZR-20 BMW ★ OE), C&D specs page, MotorTrend 2022/2023 specs all confirm base G82 M4 = 6-speed manual (GS6-45BZ) RWD only. Final drive 3.46 (3 independent US sources, 2021-2023 MY consistent) — repo's prior 3.846 was a stale F82 family_default inheritance. 6th gear 0.812 matches GS6-45BZ family. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear per C&D test panel. BMW PressClub primary PDF was login-gated; no EU spec sheet listing individual MT6 ratios I-V was accessible.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 0.812,
           "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:45650dc1f28e",
-            "legacy_research_sources:6454b4fe504c",
-            "legacy_research_sources:6925daca8aa1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9f8d6ee410eb",
-            "legacy_research_sources:bf1e088e1d64",
-            "legacy_research_sources:e26b69822173"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:45650dc1f28e",
-            "legacy_research_sources:6454b4fe504c",
-            "legacy_research_sources:6925daca8aa1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9f8d6ee410eb",
-            "legacy_research_sources:bf1e088e1d64",
-            "legacy_research_sources:e26b69822173"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
-        "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g82-m4-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G82",
-    "body_code": "G82",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M4 (G82, 2021-2026)",
-    "variant_name": "M4",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "value": 0.667,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
             "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
+            "secondary_technical_sources:g82-m4-caranddriver-specs"
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n3",
+          "value": 3.46,
+          "evidence_refs": [
+            "secondary_technical_sources:g82-m4-caranddriver-specs",
+            "secondary_technical_sources:g82-m4-motortrend-2022-specs",
+            "secondary_technical_sources:g82-m4-motortrend-2023-specs"
+          ]
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-            "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The base (non-Competition) G82 M4 is offered ONLY with the 6-speed manual transmission and ONLY in RWD. BMW USA Technical Highlights lists 6-speed manual for base M4. Car and Driver: 'the base M4 is manual only and makes 473 horsepower; the Competition is available only with the automatic.' MotorTrend overview: 'the standard coupe is the only 2025 that comes with a six-speed manual transmission. It's offered in a single RWD specification.' This base + 8AT row does not exist in any market. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release / technical data with Medium confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
-        "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g82-m4-competition-eu-2021-mt6-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G82",
-    "body_code": "G82",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M4 (G82, 2021-2026)",
-    "variant_name": "M4 Competition",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-        "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "value": 0.812,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-            "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-            "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-            "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-            "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-            "secondary_technical_sources:g82-m4-motortrend-overview"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): The G82 M4 Competition (RWD or xDrive) is offered ONLY with the ZF 8HP M-Steptronic 8-speed automatic. BMW USA Technical Highlights lists 8-speed automatic for both M4 Competition variants. Car and Driver review of the Competition: 'Unlocking the Competition version's 503 horsepower ... requires ... life with an eight-speed automatic.' MotorTrend overview: 'M4 Competition variants receive an eight-speed automatic and are offered with RWD or xDrive AWD.' A Competition + MT6 combination does not exist in any market. Marked no_confidence as a phantom configuration.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test",
-          "secondary_technical_sources:g82-m4-motortrend-overview"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
-        "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g82-m4-competition-eu-2021-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G82",
-    "body_code": "G82",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M4 (G82, 2021-2026)",
-    "variant_name": "M4 Competition",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
-      "code": "ZF8HP",
-      "name": "8-speed M-Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
-        "value": 3.154,
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "reputable_secondary_crosschecked",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-comp-drive"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated. Forward gear ratios derived from Row 4 (M4 Competition xDrive) which uses the same ZF 8HP M-Steptronic."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:45650dc1f28e",
-            "legacy_research_sources:6454b4fe504c",
-            "legacy_research_sources:6925daca8aa1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9f8d6ee410eb",
-            "legacy_research_sources:bf1e088e1d64",
-            "legacy_research_sources:e26b69822173"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:45650dc1f28e",
-            "legacy_research_sources:6454b4fe504c",
-            "legacy_research_sources:6925daca8aa1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9f8d6ee410eb",
-            "legacy_research_sources:bf1e088e1d64",
-            "legacy_research_sources:e26b69822173"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
-        "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g82-m4-competition-xdrive-eu-2021-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Coupe",
-    "market": "EU",
-    "model_code": "G82",
-    "body_code": "G82",
-    "production_start_year": 2021,
-    "production_end_year": 2026,
-    "model_name": "M4 (G82, 2021-2026)",
-    "variant_name": "M4 Competition xDrive",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition xDrive = 523hp, 8-speed M-Steptronic (ZF 8HP), AWD. Forward gear ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 already in repo and consistent with ZF 8HP M-Steptronic spec. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel).",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition xDrive = 523hp, 8-speed M-Steptronic (ZF 8HP), AWD. Forward gear ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 already in repo and consistent with ZF 8HP M-Steptronic spec. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel).",
-      "code": "ZF8HP",
-      "name": "8-speed M-Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-        "secondary_technical_sources:g82-m4-motortrend-overview"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
-          "secondary_technical_sources:g82-m4-caranddriver-mt6-test"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition xDrive = 523hp, 8-speed M-Steptronic (ZF 8HP), AWD. Forward gear ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 with final drive 3.154 already in repo and consistent with ZF 8HP M-Steptronic spec. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel).",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 30.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:45650dc1f28e",
-            "legacy_research_sources:6454b4fe504c",
-            "legacy_research_sources:6925daca8aa1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9f8d6ee410eb",
-            "legacy_research_sources:bf1e088e1d64",
-            "legacy_research_sources:e26b69822173"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
           "rear": {
             "width_mm": 285.0,
             "aspect_pct": 30.0,
             "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
+          "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g82-m4-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G82",
+      "body_code": "G82",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M4 (G82, 2021-2026)",
+      "variant_name": "M4",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 0.667,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n1",
+          "value": 3.154,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n9"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
+          "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g82-m4-competition-eu-2021-mt6-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G82",
+      "body_code": "G82",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M4 (G82, 2021-2026)",
+      "variant_name": "M4 Competition",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.812,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.077,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n11",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n12",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n13",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n15",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n16",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
+          "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g82-m4-competition-eu-2021-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G82",
+      "body_code": "G82",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M4 (G82, 2021-2026)",
+      "variant_name": "M4 Competition",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n5",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n5",
+        "code": "ZF8HP",
+        "name": "8-speed M-Steptronic (ZF 8HP)",
+        "evidence_refs": [
+          "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
+          "secondary_technical_sources:g82-m4-caranddriver-comp-drive",
+          "secondary_technical_sources:g82-m4-motortrend-overview"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n5",
+          "value": 0.64,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n5",
+          "value": 3.154,
+          "evidence_refs_ref": "e5"
+        },
+        "gear_ratios": {
+          "confidence": "reputable_secondary_crosschecked",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "evidence_refs_ref": "e5",
+          "notes": "Sonnet redo research (2026-04 v2): BMW USA Technical Highlights confirms G82 M4 Competition RWD = ZF 8HP M-Steptronic 8-speed automatic, 503hp, RWD. The ZF 8HP M-Steptronic gearbox used here is the same hardware as the M4 Competition xDrive (Row 4) which the repo already documents with full ratios I 5.000 / II 3.200 / III 2.143 / IV 1.720 / V 1.313 / VI 1.000 / VII 0.823 / VIII 0.640 and final drive 3.154. Repo's prior values for this RWD row (top 0.667, FD 2.813) were inconsistent with the same physical gearbox/diff used on the xDrive row and were stale family_default values. Corrected to match the xDrive ratios. EU OE tires 275/35ZR-19 front / 285/30ZR-20 rear (same architecture as base M4 per C&D test panel). BMW PressClub primary PDF login-gated. Forward gear ratios derived from Row 4 (M4 Competition xDrive) which uses the same ZF 8HP M-Steptronic."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n5",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard staggered setup"
+          "rear": {
+            "width_mm": 285.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
+          "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data sheets now confirm the G82 M4 Competition xDrive mapping: eight-speed M Steptronic transmission with Drivelogic, full forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, final drive 3.154, and staggered 275/35 ZR19 front + 285/30 ZR20 rear tires. The row remains verification backlog because the full G82 matrix and optional same-size track-tire coverage are still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
+    {
+      "id": "bmw-g82-m4-competition-xdrive-eu-2021-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Coupe",
+      "market": "EU",
+      "model_code": "G82",
+      "body_code": "G82",
+      "production_start_year": 2021,
+      "production_end_year": 2026,
+      "model_name": "M4 (G82, 2021-2026)",
+      "variant_name": "M4 Competition xDrive",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n7",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n7",
+        "code": "ZF8HP",
+        "name": "8-speed M-Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n6",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "family_default",
+          "notes_ref": "n6",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n6",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n6",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
+          "evidence_refs": [
+            "secondary_technical_sources:g82-m4-bmwusa-tech-highlights",
+            "secondary_technical_sources:g82-m4-caranddriver-mt6-test"
+          ],
+          "notes_ref": "n7",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 285.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n6",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard staggered setup"
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
+          "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
+          "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M4 (G82, 2021-2026) full EU variant matrix beyond the exact M4 Competition xDrive mapping",
-        "reason": "This pass resolved the exact M4 Competition xDrive gearbox, full ratios, and standard staggered tires, but it did not establish the full official matrix for every other G82 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      },
-      {
-        "item": "BMW M4 Competition xDrive optional track-tire coverage and public gearbox subtype code",
-        "reason": "Official BMW sources confirm the exact standard staggered tires and full ratio set, but they do not provide a cleaner public subtype code, and the same-size optional track-tire packages were not promoted into production data in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:45650dc1f28e",
-          "legacy_research_sources:6454b4fe504c",
-          "legacy_research_sources:6925daca8aa1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9f8d6ee410eb",
-          "legacy_research_sources:bf1e088e1d64",
-          "legacy_research_sources:e26b69822173"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m5/F90.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m5/F90.json
@@ -1,346 +1,291 @@
-[
-  {
-    "id": "bmw-f90-m5-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F90",
-    "body_code": "F90",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "M5 (F90, 2018-2024)",
-    "variant_name": "M5",
-    "engine_code": "S63",
-    "engine_name": "S63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Official BMW 06/2020 technical data confirms the M5 8-speed ratio table and top-gear value 0.640.",
+      "n3": "Official BMW 06/2020 technical data confirms final drive 3.154 for the represented M5 8-speed drivetrain.",
+      "n4": "Wave 18 added official BMW 06/2020 M5 technical-data evidence confirming Eight-speed M Steptronic ratios 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640 and final drive 3.154 for M5 Competition with M xDrive context. Production now promotes the exact top-gear value 0.640 and full gear-ratio set for the row's 8-speed gearbox.",
+      "n5": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
     },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms the M5 8-speed ratio table and top-gear value 0.640."
-      },
-      "final_drive_front": {
-        "value": 3.154,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms final drive 3.154 for the represented M5 8-speed drivetrain."
-      },
-      "final_drive_rear": {
-        "value": 3.154,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms final drive 3.154 for the represented M5 8-speed drivetrain."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms the M5 8-speed ratio table and top-gear value 0.640."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:2fa52b3f8806",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:e4bd02b0cc12"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2fa52b3f8806",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e4bd02b0cc12"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2fa52b3f8806",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e4bd02b0cc12"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
-        }
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1a749424448c",
+        "legacy_research_sources:20f44bbf0284"
+      ],
+      "e2": [
+        "legacy_research_sources:2fa52b3f8806",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:e4bd02b0cc12"
+      ],
+      "e3": [
+        "legacy_research_sources:1a749424448c",
+        "legacy_research_sources:20f44bbf0284",
+        "legacy_research_sources:2fa52b3f8806",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:e4bd02b0cc12"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW 06/2020 M5 technical-data evidence confirming Eight-speed M Steptronic ratios 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640 and final drive 3.154 for M5 Competition with M xDrive context. Production now promotes the exact top-gear value 0.640 and full gear-ratio set for the row's 8-speed gearbox.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284",
-          "legacy_research_sources:2fa52b3f8806",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:e4bd02b0cc12"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M5 (F90) non-Competition year-span ratio continuity",
-        "reason": "Wave 18 source is an official 06/2020 technical sheet; this pass did not recover a complete pre- and post-facelift matrix for every F90 model-year state.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ]
-      },
-      {
-        "item": "BMW M5 tire baseline for non-EU markets",
-        "reason": "Official checked documents include EU and Germany homologation context; this pass did not map all regional wheel and tire defaults.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f90-m5-competition-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "Sedan",
-    "market": "EU",
-    "model_code": "F90",
-    "body_code": "F90",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "M5 (F90, 2018-2024)",
-    "variant_name": "M5 Competition",
-    "engine_code": "S63",
-    "engine_name": "S63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "value": 0.64,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms the M5 8-speed ratio table and top-gear value 0.640."
+  "configurations": [
+    {
+      "id": "bmw-f90-m5-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F90",
+      "body_code": "F90",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "M5 (F90, 2018-2024)",
+      "variant_name": "M5",
+      "engine_code": "S63",
+      "engine_name": "S63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
-        "value": 3.154,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms final drive 3.154 for the represented M5 8-speed drivetrain."
-      },
-      "final_drive_rear": {
-        "value": 3.154,
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms final drive 3.154 for the represented M5 8-speed drivetrain."
-      },
-      "gear_ratios": {
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ],
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ],
-        "notes": "Official BMW 06/2020 technical data confirms the M5 8-speed ratio table and top-gear value 0.640."
-      }
-    },
-    "tires": {
-      "default": {
+      "transmission": {
         "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:2fa52b3f8806",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:e4bd02b0cc12"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 35.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2fa52b3f8806",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e4bd02b0cc12"
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        },
+        "final_drive_front": {
+          "value": 3.154,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3"
+        },
+        "final_drive_rear": {
+          "value": 3.154,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3"
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 35.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:2fa52b3f8806",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:e4bd02b0cc12"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Performance 21\""
+          "note_ref": "n5"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M5 (F90) non-Competition year-span ratio continuity",
+          "reason": "Wave 18 source is an official 06/2020 technical sheet; this pass did not recover a complete pre- and post-facelift matrix for every F90 model-year state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M5 tire baseline for non-EU markets",
+          "reason": "Official checked documents include EU and Germany homologation context; this pass did not map all regional wheel and tire defaults.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Wave 18 added official BMW 06/2020 M5 technical-data evidence confirming Eight-speed M Steptronic ratios 5.000/3.200/2.143/1.720/1.313/1.000/0.823/0.640 and final drive 3.154 for M5 Competition with M xDrive context. Production now promotes the exact top-gear value 0.640 and full gear-ratio set for the row's 8-speed gearbox.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284",
-          "legacy_research_sources:2fa52b3f8806",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:e4bd02b0cc12"
+    {
+      "id": "bmw-f90-m5-competition-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "Sedan",
+      "market": "EU",
+      "model_code": "F90",
+      "body_code": "F90",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "M5 (F90, 2018-2024)",
+      "variant_name": "M5 Competition",
+      "engine_code": "S63",
+      "engine_name": "S63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "value": 0.64,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        },
+        "final_drive_front": {
+          "value": 3.154,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3"
+        },
+        "final_drive_rear": {
+          "value": 3.154,
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3"
+        },
+        "gear_ratios": {
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ],
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 35.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Performance 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW M5 (F90) non-Competition year-span ratio continuity",
+          "reason": "Wave 18 source is an official 06/2020 technical sheet; this pass did not recover a complete pre- and post-facelift matrix for every F90 model-year state.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW M5 tire baseline for non-EU markets",
+          "reason": "Official checked documents include EU and Germany homologation context; this pass did not map all regional wheel and tire defaults.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW M5 (F90) non-Competition year-span ratio continuity",
-        "reason": "Wave 18 source is an official 06/2020 technical sheet; this pass did not recover a complete pre- and post-facelift matrix for every F90 model-year state.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ]
-      },
-      {
-        "item": "BMW M5 tire baseline for non-EU markets",
-        "reason": "Official checked documents include EU and Germany homologation context; this pass did not map all regional wheel and tire defaults.",
-        "evidence_refs": [
-          "legacy_research_sources:1a749424448c",
-          "legacy_research_sources:20f44bbf0284"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/F48.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/F48.json
@@ -1,2997 +1,2466 @@
-[
-  {
-    "id": "bmw-f48-xdrive25d-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2016,
-    "model_name": "X1 (F48, 2016)",
-    "variant_name": "xDrive25d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
+      "n2": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
+      "n3": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
+      "n4": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n5": "Reverse gear ratio (research note): 3.538",
+      "n6": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - launch state (2015-2017). Confirmed by BMW PressClub T0223370/316345 (07/2015 launch tech-data PDF): engine B47C20O1 (170 kW), Aisin AWF8F45 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era; later changed to 2.851 - covered by Row 14). Default tyre 225/55 R17 97W. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F45 (transverse 8AT). Code retained as stored; transmission.name corrected.",
+      "n9": "Reverse gear ratio (research note): 4.221",
+      "n10": "BMW X1 F48 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0223367/316338 (07/2015 launch) and T0291600/424226 (03/2019 LCI continuity): engine B48A20M1 (141 kW / 192 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer; transmission.name corrected to Aisin AWF8F45.",
+      "n11": "Aisin AWF8F45 8th gear.",
+      "n12": "UKL2 Haldex AWD: single FD mirrored to rear.",
+      "n13": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n14": "Reverse gear ratio (research note): 4.015",
+      "n15": "BMW X1 F48 xDrive25i 8-speed Steptronic (Aisin AWF8F45) AWD. EU/ACEA market confirmed by BMW PressClub T0223371/316347 (07/2015) ACEA footer and T0291601/424228 (03/2019 LCI continuity). Engine B48A20M1 high-output tune (170 kW / 231 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' label is a misnomer; transmission.name corrected.",
+      "n16": "BMW X1 F48 sDrive16d 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325735 (11/2015 sDrive16d tech-data PDF): engine B37C15 (85 kW), 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628, reverse 3.538, FD 3.588, default tyre 225/55 R17 97W. The production_end_year was set to 2022 in the shard but the 03/2021 final-LCI spec PDF (T0327516) does not list sDrive16d at all - actual end-of-production for this badge is approximately 2018-2019 (pre-LCI only). Year span retained as recorded; values held against the well-evidenced launch state.",
+      "n17": "GS6-17BG gear set.",
+      "n18": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n19": "BMW X1 F48 sDrive18d 6-speed manual FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch), T0286555/419620 (09/2018 multi-variant), and T0327516/473615 (03/2021 final). Engine B47C20O0 (110 kW). 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628 (launch 2015-2017) - 6th gear value changed to 0.605 from 2018 onwards per T0286555 and T0327516. Final drive 3.389 stable across all years. Default tyre 225/55 R17 97W. Top gear stored as launch-era 0.628; era split not represented in this row.",
+      "n20": "BMW X1 F48 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch) and T0286555/419620 (09/2018 LCI multi-variant) and T0327516/473615 (03/2021). Engine B47C20O0. Aisin AWF8F35 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era 2015-2017) - later changed to 2.851 from 2018 onwards. Default tyre 225/55 R17 97W. NOTE: 'ZF8HP' label is a misnomer - actual unit is Aisin AWF8F35.",
+      "n21": "BMW X1 F48 sDrive18i 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325736 (11/2015), T0286555/419620 (09/2018), and T0327516/473615 (03/2021). Engine B38A15M0 (100 kW), 6-speed manual GS6-17BG, gear set 3.615/1.952/1.241/0.969/0.806/0.683, reverse 3.538, FD 3.882, default tyre 225/55 R17 97W. Stable across all production years.",
+      "n22": "BMW X1 F48 sDrive18i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin 6-speed Steptronic (AT6) for launch-era 2015-2017 per BMW PressClub T0232406/325736 (11/2015): gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 4.103. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 4.176, with overall gear ratios published. Engine B38A15M0 across both eras. The 'ZF8HP' code in the row ID is a misnomer in BOTH eras (neither is a ZF 8HP). Drivetrain and configuration well-evidenced; per-gear values held at no_confidence because the row cannot represent both eras simultaneously and a row split is out of scope for this research pass. Default tyre 225/55 R17 97W (stable).",
+      "n23": "BMW X1 F48 sDrive20d 6-speed manual FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016 sDrive20d tech-data PDF): engine B47C20O1 (140 kW), 6-speed manual GS6-17BG, gear set 3.538/1.923/1.219/0.881/0.810/0.674, reverse 3.538, FD 3.778, default tyre 225/55 R17 97W. NOTE: T0327516 (03/2021 final spec) lists sDrive20d as 8AT-only - the manual was discontinued at the LCI in 07/2019. Year span stored as 2016-2022 is broader than actual manual availability; values held against the 2016-2019 manual era.",
+      "n24": "BMW X1 F48 sDrive20d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016) and T0327516/473615 (03/2021). Engine B47C20O1. Aisin AWF8F35 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 2.955 (launch-era 2016-2018) - changed to 2.851 from approximately 2019 per T0327516 (03/2021). Wait: Actually for sDrive20d the 8AT uses petrol-calibration gear set per BMW PressClub. Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
+      "n25": "BMW X1 F48 sDrive20i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin AWF8F35 8-speed Steptronic for launch-era 2015-2017 per BMW PressClub T0223367/316338 (07/2015): gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 3.789. Engine corrected from 1.5L to B48 2.0L (1998 cm3 4-cyl per BMW PressClub - the 1.5L is the B38 used in sDrive18i). 'ZF8HP' is a misnomer in BOTH eras. Per-gear values held at no_confidence because row spans two incompatible gearboxes; row split out of scope. Default tyre 225/55 R17 97W.",
+      "n26": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2020 launch state). Confirmed by BMW PressClub T0314292/457889 (01/2020 xDrive25e tech-data PDF). PHEV layout: B38 1.5L 3-cyl petrol (1499 cm3, 92 kW) drives front wheels via Aisin 6-speed Steptronic; 70 kW electric motor drives rear axle (through-the-road AWD). Aisin 6AT gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944. Default tyre 225/55 R17 97W.",
+      "n27": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - LCI/late state (2018-2022 with FD 2.851). Confirmed by BMW PressClub T0327516/473615 (03/2021): engine B47C20O2 (170 kW), Aisin AWF8F45, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851 (vs launch 2.955 in Row 0). Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer.",
+      "n28": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2021 LCI state). Confirmed by BMW PressClub T0327516/473615 (03/2021). engine_code corrected from B48 to B38 - BMW PressClub spec confirms 1499 cm3 effective capacity (B38 1.5L 3-cyl), NOT B48 (which is 1998 cm3 2.0L 4-cyl). Same Aisin AT6 6-speed Steptronic + electric rear axle as 2020. 2021 default tyre is 205/55 R17 (NOT 225/55 R17; baseline tyre changed at 2021 LCI per T0327516). Aisin AT6 gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944.",
+      "n29": "Aisin AWF8F45 (diesel calibration) gear set.",
+      "n30": "Aisin AWF8F45 (petrol calibration) gear set.",
+      "n31": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n32": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n33": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n34": "Row spans two different gearboxes (Aisin 6AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed to represent each era cleanly.",
+      "n35": "Row spans two different gearboxes (Aisin AWF8F35 8AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed.",
+      "n36": "Aisin AT6 gear set.",
+      "n37": "Reverse gear ratio (research note): 3.185"
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_market_pages:f48-x1-price-list-2021-de"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e4": [
+        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e5": [
+        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e8": [
         "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - launch state (2015-2017). Confirmed by BMW PressClub T0223370/316345 (07/2015 launch tech-data PDF): engine B47C20O1 (170 kW), Aisin AWF8F45 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era; later changed to 2.851 - covered by Row 14). Default tyre 225/55 R17 97W. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F45 (transverse 8AT). Code retained as stored; transmission.name corrected.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
+      "e9": [
+        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
+        "secondary_technical_sources:bmw-x1-f48-wikipedia"
       ],
-      "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - launch state (2015-2017). Confirmed by BMW PressClub T0223370/316345 (07/2015 launch tech-data PDF): engine B47C20O1 (170 kW), Aisin AWF8F45 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era; later changed to 2.851 - covered by Row 14). Default tyre 225/55 R17 97W. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F45 (transverse 8AT). Code retained as stored; transmission.name corrected.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e10": [
+        "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
+        "secondary_technical_sources:bmw-x1-f48-wikipedia"
+      ],
+      "e12": [
+        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
+      ],
+      "e14": [
+        "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
+      ],
+      "e16": [
+        "bmw_pressclub_sources:f48-sdrive16d-sdrive18i-xdrive18d-2015-tech-spec-article",
+        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
+      ],
+      "e17": [
+        "legacy_research_sources:3643687db38c",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:71b4da2d92a2",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ],
+      "e18": [
+        "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
+      ],
+      "e19": [
+        "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e20": [
+        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf"
+      ],
+      "e21": [
+        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e22": [
+        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-article",
+        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e23": [
+        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-article",
+        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e24": [
+        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
+      ],
+      "e25": [
+        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-article",
+        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ],
+      "e26": [
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f48-xdrive25d-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2016,
+      "model_name": "X1 (F48, 2016)",
+      "variant_name": "xDrive25d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear per BMW PressClub T0223370/316345 (07/2015).",
-        "value": 0.673
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n8",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 launch-era final drive (2015-2017) per BMW PressClub T0223370/316345.",
-        "value": 2.955
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
       },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ],
-        "notes": "UKL2 Haldex AWD has a single FD value; mirrored to rear.",
-        "value": 2.955
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 (diesel calibration) gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - launch state (2015-2017). Confirmed by BMW PressClub T0223370/316345 (07/2015 launch tech-data PDF): engine B47C20O1 (170 kW), Aisin AWF8F45 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era; later changed to 2.851 - covered by Row 14). Default tyre 225/55 R17 97W. NOTE: shard's transmission code 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F45 (transverse 8AT). Code retained as stored; transmission.name corrected.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
+          "evidence_refs_ref": "e8",
+          "notes": "Aisin AWF8F45 8th gear per BMW PressClub T0223370/316345 (07/2015).",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "Aisin AWF8F45 launch-era final drive (2015-2017) per BMW PressClub T0223370/316345.",
+          "value": 2.955
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "UKL2 Haldex AWD has a single FD value; mirrored to rear.",
+          "value": 2.955
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "The official BMW 07/2015 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25d automatic launch state represented by this narrowed 2016-only row.",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n29"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes": "The official BMW 07/2015 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25d automatic launch state represented by this narrowed 2016-only row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 07/2015 xDrive25d technical-data PDF establishes the exact launch-state mapping for the X1 xDrive25d automatic row: AWD, 8-speed Steptronic, 0.673 top gear, a single published 2.955 final-drive ratio, and 225/55 R17 baseline tires. The official 03/2021 BMW X1 technical-data PDF later shows the same top gear and baseline tire but a different 2.851 final-drive ratio, so the inherited broad row was split into exact 2016 and 2021 states instead of preserving one mixed-era mapping.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-article",
+            "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          ]
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n9",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2015 xDrive25d technical-data PDF establishes the exact launch-state mapping for the X1 xDrive25d automatic row: AWD, 8-speed Steptronic, 0.673 top gear, a single published 2.955 final-drive ratio, and 225/55 R17 baseline tires. The official 03/2021 BMW X1 technical-data PDF later shows the same top gear and baseline tire but a different 2.851 final-drive ratio, so the inherited broad row was split into exact 2016 and 2021 states instead of preserving one mixed-era mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive25d exact optional wheel/tire matrix for the narrowed 2016 row",
-        "reason": "The checked official BMW 07/2015 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive25d separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-xdrive20i-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2019,
-    "model_name": "X1 (F48, 2016-2019)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0223367/316338 (07/2015 launch) and T0291600/424226 (03/2019 LCI continuity): engine B48A20M1 (141 kW / 192 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer; transmission.name corrected to Aisin AWF8F45.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0223367/316338 (07/2015 launch) and T0291600/424226 (03/2019 LCI continuity): engine B48A20M1 (141 kW / 192 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer; transmission.name corrected to Aisin AWF8F45.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive for xDrive20i petrol AWD.",
-        "value": 3.2
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ],
-        "notes": "UKL2 Haldex AWD: single FD mirrored to rear.",
-        "value": 3.2
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 (petrol calibration) gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0223367/316338 (07/2015 launch) and T0291600/424226 (03/2019 LCI continuity): engine B48A20M1 (141 kW / 192 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer; transmission.name corrected to Aisin AWF8F45.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X1 xDrive25d exact optional wheel/tire matrix for the narrowed 2016 row",
+          "reason": "The checked official BMW 07/2015 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW X1 xDrive25d separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-xdrive20i-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2019,
+      "model_name": "X1 (F48, 2016-2019)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e13",
+        "notes_ref": "n10",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e13",
+        "notes_ref": "n10",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes_ref": "n11",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes": "Aisin AWF8F45 final drive for xDrive20i petrol AWD.",
+          "value": 3.2
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e13",
+          "notes_ref": "n12",
+          "value": 3.2
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ],
+          "evidence_refs_ref": "e13",
+          "notes_ref": "n30"
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "official_exact",
           "evidence_refs": [
+            "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf"
+          ],
+          "notes_ref": "n10",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e18",
+            "notes": "The official BMW 07/2015 and 03/2019 technical-data PDFs agree on 225/55 R17 as the baseline tire for the exact X1 xDrive20i automatic configuration represented by this narrowed 2016-2019 row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 07/2015 and 03/2019 xDrive20i specifications pages and technical-data PDFs agree on the exact X1 xDrive20i automatic state: AWD, 8-speed Steptronic automatic only, 0.673 top gear, a single published 3.200 final-drive ratio, and 225/55 R17 baseline tires. Because this pass did not recover a later exact 2020+ technical-data sheet, the row is narrowed to the supported 2016-2019 state, and the unsupported manual sibling row was removed.",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
+          ]
+        },
+        {
+          "note_ref": "n13"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X1 xDrive20i exact optional wheel/tire matrix for the narrowed 2016-2019 row",
+          "reason": "The checked official BMW 07/2015 and 03/2019 technical-data PDFs close the baseline 17-inch fitment, but they do not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e18"
+        },
+        {
+          "item": "BMW X1 xDrive20i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e18"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-xdrive25i-eu-2016-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2021,
+      "model_name": "X1 (F48, 2016-2021)",
+      "variant_name": "xDrive25i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e14",
+        "notes_ref": "n15",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e14",
+        "notes_ref": "n15",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n11",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e14",
+          "notes": "Aisin AWF8F45 final drive for xDrive25i AWD.",
+          "value": 3.2
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n12",
+          "value": 3.2
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
           ],
-          "notes": "The official BMW 07/2015 and 03/2019 technical-data PDFs agree on 225/55 R17 as the baseline tire for the exact X1 xDrive20i automatic configuration represented by this narrowed 2016-2019 row.",
+          "evidence_refs_ref": "e14",
+          "notes_ref": "n30"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf"
+          ],
+          "notes_ref": "n15",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e19",
+            "notes": "The official BMW 07/2015, 03/2019, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the exact X1 xDrive25i automatic configuration represented by this narrowed 2016-2021 row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2015 and 03/2019 xDrive20i specifications pages and technical-data PDFs agree on the exact X1 xDrive20i automatic state: AWD, 8-speed Steptronic automatic only, 0.673 top gear, a single published 3.200 final-drive ratio, and 225/55 R17 baseline tires. Because this pass did not recover a later exact 2020+ technical-data sheet, the row is narrowed to the supported 2016-2019 state, and the unsupported manual sibling row was removed.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.015",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive20i exact optional wheel/tire matrix for the narrowed 2016-2019 row",
-        "reason": "The checked official BMW 07/2015 and 03/2019 technical-data PDFs close the baseline 17-inch fitment, but they do not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive20i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-xdrive25i-eu-2016-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2021,
-    "model_name": "X1 (F48, 2016-2021)",
-    "variant_name": "xDrive25i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25i 8-speed Steptronic (Aisin AWF8F45) AWD. EU/ACEA market confirmed by BMW PressClub T0223371/316347 (07/2015) ACEA footer and T0291601/424228 (03/2019 LCI continuity). Engine B48A20M1 high-output tune (170 kW / 231 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' label is a misnomer; transmission.name corrected.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25i 8-speed Steptronic (Aisin AWF8F45) AWD. EU/ACEA market confirmed by BMW PressClub T0223371/316347 (07/2015) ACEA footer and T0291601/424228 (03/2019 LCI continuity). Engine B48A20M1 high-output tune (170 kW / 231 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' label is a misnomer; transmission.name corrected.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive for xDrive25i AWD.",
-        "value": 3.2
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-        ],
-        "notes": "UKL2 Haldex AWD: single FD mirrored to rear.",
-        "value": 3.2
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 (petrol calibration) gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive25i 8-speed Steptronic (Aisin AWF8F45) AWD. EU/ACEA market confirmed by BMW PressClub T0223371/316347 (07/2015) ACEA footer and T0291601/424228 (03/2019 LCI continuity). Engine B48A20M1 high-output tune (170 kW / 231 hp), Aisin AWF8F45 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200, default tyre 225/55 R17 97W. 'ZF8HP' label is a misnomer; transmission.name corrected.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_exact",
+          "note": "The official BMW 07/2015, 03/2019, and 03/2021 xDrive25i technical-data PDFs agree on the checked exact X1 xDrive25i automatic state: AWD, 8-speed Steptronic, 0.673 top gear, a single published 3.200 final-drive ratio, and 225/55 R17 baseline tires. Because this pass did not recover a later exact 2022 technical-data sheet, the row is narrowed to the supported 2016-2021 state, and the unsupported manual sibling row was removed.",
           "evidence_refs": [
+            "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 07/2015, 03/2019, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the exact X1 xDrive25i automatic configuration represented by this narrowed 2016-2021 row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          ]
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n14",
+          "evidence_refs_ref": "e14"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 07/2015, 03/2019, and 03/2021 xDrive25i technical-data PDFs agree on the checked exact X1 xDrive25i automatic state: AWD, 8-speed Steptronic, 0.673 top gear, a single published 3.200 final-drive ratio, and 225/55 R17 baseline tires. Because this pass did not recover a later exact 2022 technical-data sheet, the row is narrowed to the supported 2016-2021 state, and the unsupported manual sibling row was removed.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.015",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive25i exact optional wheel/tire matrix for the narrowed 2016-2021 row",
-        "reason": "The checked official BMW 07/2015, 03/2019, and 03/2021 technical-data PDFs close the baseline 17-inch fitment, but they do not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive25i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive16d-eu-2016-mt6-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive16d",
-    "engine_code": "B37",
-    "engine_name": "B37 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive16d 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325735 (11/2015 sDrive16d tech-data PDF): engine B37C15 (85 kW), 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628, reverse 3.538, FD 3.588, default tyre 225/55 R17 97W. The production_end_year was set to 2022 in the shard but the 03/2021 final-LCI spec PDF (T0327516) does not list sDrive16d at all - actual end-of-production for this badge is approximately 2018-2019 (pre-LCI only). Year span retained as recorded; values held against the well-evidenced launch state.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 sDrive16d 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325735 (11/2015 sDrive16d tech-data PDF): engine B37C15 (85 kW), 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628, reverse 3.538, FD 3.588, default tyre 225/55 R17 97W. The production_end_year was set to 2022 in the shard but the 03/2021 final-LCI spec PDF (T0327516) does not list sDrive16d at all - actual end-of-production for this badge is approximately 2018-2019 (pre-LCI only). Year span retained as recorded; values held against the well-evidenced launch state.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG 6th gear per BMW PressClub T0232406/325735 (11/2015).",
-        "value": 0.628
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG final drive for sDrive16d.",
-        "value": 3.588
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          3.923,
-          2.136,
-          1.276,
-          0.921,
-          0.756,
-          0.628
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive16d 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325735 (11/2015 sDrive16d tech-data PDF): engine B37C15 (85 kW), 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628, reverse 3.538, FD 3.588, default tyre 225/55 R17 97W. The production_end_year was set to 2022 in the shard but the 03/2021 final-LCI spec PDF (T0327516) does not list sDrive16d at all - actual end-of-production for this badge is approximately 2018-2019 (pre-LCI only). Year span retained as recorded; values held against the well-evidenced launch state.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X1 xDrive25i exact optional wheel/tire matrix for the narrowed 2016-2021 row",
+          "reason": "The checked official BMW 07/2015, 03/2019, and 03/2021 technical-data PDFs close the baseline 17-inch fitment, but they do not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e19"
+        },
+        {
+          "item": "BMW X1 xDrive25i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive16d-eu-2016-mt6-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive16d",
+      "engine_code": "B37",
+      "engine_name": "B37 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n16",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes_ref": "n16",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
+          "evidence_refs_ref": "e5",
+          "notes": "GS6-17BG 6th gear per BMW PressClub T0232406/325735 (11/2015).",
+          "value": 0.628
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "GS6-17BG final drive for sDrive16d.",
+          "value": 3.588
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            3.923,
+            2.136,
+            1.276,
+            0.921,
+            0.756,
+            0.628
           ],
-          "notes": "Official BMW 11/2015 F48 sDrive16d technical-data PDF lists 225/55 R17 as the baseline tire for the launch manual state.",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n17"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n16",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes": "Official BMW 11/2015 F48 sDrive16d technical-data PDF lists 225/55 R17 as the baseline tire for the launch manual state.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 11/2015 specifications material supports an early sDrive16d manual state with 225/55 R17 baseline tires, 0.628 top gear, and 3.588 final drive. The current inherited 2016-2022 values are contradicted by that exact checked source, and the row remains too broad for later-year continuity.",
+          "evidence_refs_ref": "e16"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "This run replaced inherited sDrive16d manual family-default top gear, final drive, and tire values with the official 11/2015 launch-state values; the row remains manual-confirmation gated because later-year availability through the broad 2016-2022 span is unresolved.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 11/2015 specifications material supports an early sDrive16d manual state with 225/55 R17 baseline tires, 0.628 top gear, and 3.588 final drive. The current inherited 2016-2022 values are contradicted by that exact checked source, and the row remains too broad for later-year continuity.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-sdrive18i-xdrive18d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited sDrive16d manual family-default top gear, final drive, and tire values with the official 11/2015 launch-state values; the row remains manual-confirmation gated because later-year availability through the broad 2016-2022 span is unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.538",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this broad sDrive16d manual row should be narrowed to the proven 11/2015 state or split by later-year applicability",
-        "reason": "The saved official BMW 11/2015 specifications page and technical-data sheet prove an early manual state, but the checked 2018 and 2021 master sheets did not surface a matching later sDrive16d row for the full 2016-2022 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-sdrive18i-xdrive18d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive16d manual later-year continuity",
-        "reason": "The official 11/2015 packet supports the launch manual state, but this run did not recover a full 2016-2022 chain for sDrive16d manual availability.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive16d-eu-2016-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive16d",
-    "engine_code": "B37",
-    "engine_name": "B37 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ],
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive16d (B37 1.5L diesel) was offered exclusively with the 6-speed manual transmission - no automatic was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0232406 (11/2015 sDrive16d tech-data PDF, manual-only column), T0286555 (09/2018 multi-variant spec, no sDrive16d automatic), and T0327516 (03/2021 final spec, sDrive16d not present). The 'ZF8HP' code in the row ID is also a misnomer (UKL2 transverse cannot mount ZF 8HP). Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3643687db38c",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:71b4da2d92a2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "item": "Whether this broad sDrive16d manual row should be narrowed to the proven 11/2015 state or split by later-year applicability",
+          "reason": "The saved official BMW 11/2015 specifications page and technical-data sheet prove an early manual state, but the checked 2018 and 2021 master sheets did not surface a matching later sDrive16d row for the full 2016-2022 span.",
+          "evidence_refs_ref": "e16"
+        },
+        {
+          "item": "BMW X1 sDrive16d manual later-year continuity",
+          "reason": "The official 11/2015 packet supports the launch manual state, but this run did not recover a full 2016-2022 chain for sDrive16d manual availability.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive16d-eu-2016-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive16d",
+      "engine_code": "B37",
+      "engine_name": "B37 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "FWD",
+        "evidence_refs_ref": "e11"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e11"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.674,
+          "evidence_refs_ref": "e11"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.294,
+          "evidence_refs_ref": "e11"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e17",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The checked official BMW 11/2015 sDrive16d specifications page and technical-data packet are manual-only. No exact automatic sDrive16d row was recovered in the checked official set, so this represented automatic row remains unsupported rather than validated.",
+          "evidence_refs_ref": "e16"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "Checked official F48 sDrive16d material supports a manual launch state and does not recover an exact EU/ACEA sDrive16d automatic row; keep the current ZF8HP placeholder out of driveshaft/wheel order analysis until an exact market source is found.",
+          "evidence_refs_ref": "e5"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n6",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n31",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n32",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n33",
+          "evidence_refs_ref": "e11"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The checked official BMW 11/2015 sDrive16d specifications page and technical-data packet are manual-only. No exact automatic sDrive16d row was recovered in the checked official set, so this represented automatic row remains unsupported rather than validated.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-sdrive18i-xdrive18d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Checked official F48 sDrive16d material supports a manual launch state and does not recover an exact EU/ACEA sDrive16d automatic row; keep the current ZF8HP placeholder out of driveshaft/wheel order analysis until an exact market source is found.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether an EU-market automatic sDrive16d row existed in-scope for this configuration family",
-        "reason": "The only exact checked official BMW 11/2015 sDrive16d specifications packet is manual-only and no later checked official master sheet surfaced an exact automatic sDrive16d row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-sdrive18i-xdrive18d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F48 configuration mapping",
-        "reason": "Checked official F48 sDrive16d material supports a manual launch state and does not recover an exact EU/ACEA sDrive16d automatic row; keep the current ZF8HP placeholder out of driveshaft/wheel order analysis until an exact market source is found.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive16d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive18d-eu-2016-mt6-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive18d",
-    "engine_code": "B47",
-    "engine_name": "B47 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive18d 6-speed manual FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch), T0286555/419620 (09/2018 multi-variant), and T0327516/473615 (03/2021 final). Engine B47C20O0 (110 kW). 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628 (launch 2015-2017) - 6th gear value changed to 0.605 from 2018 onwards per T0286555 and T0327516. Final drive 3.389 stable across all years. Default tyre 225/55 R17 97W. Top gear stored as launch-era 0.628; era split not represented in this row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 sDrive18d 6-speed manual FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch), T0286555/419620 (09/2018 multi-variant), and T0327516/473615 (03/2021 final). Engine B47C20O0 (110 kW). 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628 (launch 2015-2017) - 6th gear value changed to 0.605 from 2018 onwards per T0286555 and T0327516. Final drive 3.389 stable across all years. Default tyre 225/55 R17 97W. Top gear stored as launch-era 0.628; era split not represented in this row.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "GS6-17BG 6th gear (launch-era 2015-2017) per BMW PressClub T0223368/316341. Note: T0286555 (09/2018) and T0327516 (03/2021) show updated value 0.605 - era split not represented in this row.",
-        "value": 0.628,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG final drive 3.389, stable across launch through final BMW PressClub specs.",
-        "value": 3.389
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          3.923,
-          2.136,
-          1.276,
-          0.921,
-          0.756,
-          0.628
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG gear set (launch-era values)."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive18d 6-speed manual FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch), T0286555/419620 (09/2018 multi-variant), and T0327516/473615 (03/2021 final). Engine B47C20O0 (110 kW). 6-speed manual GS6-17BG, gear set 3.923/2.136/1.276/0.921/0.756/0.628 (launch 2015-2017) - 6th gear value changed to 0.605 from 2018 onwards per T0286555 and T0327516. Final drive 3.389 stable across all years. Default tyre 225/55 R17 97W. Top gear stored as launch-era 0.628; era split not represented in this row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          "item": "Whether an EU-market automatic sDrive16d row existed in-scope for this configuration family",
+          "reason": "The only exact checked official BMW 11/2015 sDrive16d specifications packet is manual-only and no later checked official master sheet surfaced an exact automatic sDrive16d row.",
+          "evidence_refs_ref": "e16"
+        },
+        {
+          "item": "Unsupported exact F48 configuration mapping",
+          "reason": "Checked official F48 sDrive16d material supports a manual launch state and does not recover an exact EU/ACEA sDrive16d automatic row; keep the current ZF8HP placeholder out of driveshaft/wheel order analysis until an exact market source is found.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive18d-eu-2016-mt6-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive18d",
+      "engine_code": "B47",
+      "engine_name": "B47 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n19",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n19",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes": "GS6-17BG 6th gear (launch-era 2015-2017) per BMW PressClub T0223368/316341. Note: T0286555 (09/2018) and T0327516 (03/2021) show updated value 0.605 - era split not represented in this row.",
+          "value": 0.628,
+          "evidence_refs_ref": "e15"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "GS6-17BG final drive 3.389, stable across launch through final BMW PressClub specs.",
+          "value": 3.389
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            3.923,
+            2.136,
+            1.276,
+            0.921,
+            0.756,
+            0.628
           ],
-          "notes": "The checked official BMW 07/2015, 09/2018, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18d row.",
+          "evidence_refs_ref": "e15",
+          "notes": "GS6-17BG gear set (launch-era values)."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e24",
+          "notes_ref": "n19",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "The checked official BMW 07/2015, 09/2018, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18d row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 07/2015, 09/2018, and 03/2021 technical-data packets show that this broad sDrive18d manual row is mixed-era on top gear but stable on final drive and baseline tires. The row now promotes the stable 3.389 final drive and 225/55 R17 baseline tire while leaving top gear unresolved because the checked official manual value changes from 0.628 to 0.605 across the represented span.",
+          "evidence_refs_ref": "e25"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "Official F48 sDrive18d manual sources support the row identity, but the published sixth gear changes from 0.628 in the launch packet to 0.605 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n5",
+          "evidence_refs_ref": "e15"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 07/2015, 09/2018, and 03/2021 technical-data packets show that this broad sDrive18d manual row is mixed-era on top gear but stable on final drive and baseline tires. The row now promotes the stable 3.389 final drive and 225/55 R17 baseline tire while leaving top gear unresolved because the checked official manual value changes from 0.628 to 0.605 across the represented span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F48 sDrive18d manual sources support the row identity, but the published sixth gear changes from 0.628 in the launch packet to 0.605 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.538",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 sDrive18d manual exact top-gear continuity across the represented 2016-2022 row span",
-        "reason": "The checked official BMW manual sheets agree on the broad row's final drive and baseline tire, but manual top gear changes from 0.628 in 07/2015 and 09/2018 to 0.605 by 03/2021.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive18d exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Broad F48 row needs an exact split before order analysis",
-        "reason": "Official F48 sDrive18d manual sources support the row identity, but the published sixth gear changes from 0.628 in the launch packet to 0.605 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive18d-eu-2016-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive18d",
-    "engine_code": "B47",
-    "engine_name": "B47 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch) and T0286555/419620 (09/2018 LCI multi-variant) and T0327516/473615 (03/2021). Engine B47C20O0. Aisin AWF8F35 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era 2015-2017) - later changed to 2.851 from 2018 onwards. Default tyre 225/55 R17 97W. NOTE: 'ZF8HP' label is a misnomer - actual unit is Aisin AWF8F35.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch) and T0286555/419620 (09/2018 LCI multi-variant) and T0327516/473615 (03/2021). Engine B47C20O0. Aisin AWF8F35 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era 2015-2017) - later changed to 2.851 from 2018 onwards. Default tyre 225/55 R17 97W. NOTE: 'ZF8HP' label is a misnomer - actual unit is Aisin AWF8F35.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 8th gear, stable across all years.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "notes": "Aisin AWF8F35 final drive (launch-era 2015-2017). Note: BMW PressClub T0286555 (09/2018) and T0327516 (03/2021) show updated value 2.851 from 2018 onwards - era split not represented in this row.",
-        "value": 2.955,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 (diesel calibration) gear set, stable across all production years."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0223368/316341 (07/2015 launch) and T0286555/419620 (09/2018 LCI multi-variant) and T0327516/473615 (03/2021). Engine B47C20O0. Aisin AWF8F35 transverse 8AT, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.955 (launch-era 2015-2017) - later changed to 2.851 from 2018 onwards. Default tyre 225/55 R17 97W. NOTE: 'ZF8HP' label is a misnomer - actual unit is Aisin AWF8F35.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          "item": "BMW X1 sDrive18d manual exact top-gear continuity across the represented 2016-2022 row span",
+          "reason": "The checked official BMW manual sheets agree on the broad row's final drive and baseline tire, but manual top gear changes from 0.628 in 07/2015 and 09/2018 to 0.605 by 03/2021.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW X1 sDrive18d exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Broad F48 row needs an exact split before order analysis",
+          "reason": "Official F48 sDrive18d manual sources support the row identity, but the published sixth gear changes from 0.628 in the launch packet to 0.605 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive18d-eu-2016-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive18d",
+      "engine_code": "B47",
+      "engine_name": "B47 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n20",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n20",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Aisin AWF8F35 8th gear, stable across all years.",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes": "Aisin AWF8F35 final drive (launch-era 2015-2017). Note: BMW PressClub T0286555 (09/2018) and T0327516 (03/2021) show updated value 2.851 from 2018 onwards - era split not represented in this row.",
+          "value": 2.955,
+          "evidence_refs_ref": "e15"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "The checked official BMW 07/2015, 09/2018, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18d automatic row.",
+          "evidence_refs_ref": "e3",
+          "notes": "Aisin AWF8F35 (diesel calibration) gear set, stable across all production years."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e24",
+          "notes_ref": "n20",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "The checked official BMW 07/2015, 09/2018, and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18d automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 07/2015, 09/2018, and 03/2021 technical-data packets show that this broad sDrive18d automatic row is mixed-era on final drive but stable on top gear and baseline tires. The row now promotes the stable 0.673 top gear and 225/55 R17 baseline tire while keeping final drive unresolved because the checked official value changes from 2.955 to 2.851 across the represented span.",
+          "evidence_refs_ref": "e25"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "Official F48 sDrive18d automatic sources support the row identity, but final drive changes from 2.955 in the launch packet to 2.851 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n9",
+          "evidence_refs_ref": "e15"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 07/2015, 09/2018, and 03/2021 technical-data packets show that this broad sDrive18d automatic row is mixed-era on final drive but stable on top gear and baseline tires. The row now promotes the stable 0.673 top gear and 225/55 R17 baseline tire while keeping final drive unresolved because the checked official value changes from 2.955 to 2.851 across the represented span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F48 sDrive18d automatic sources support the row identity, but final drive changes from 2.955 in the launch packet to 2.851 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 sDrive18d automatic exact final-drive continuity across the represented 2016-2022 row span",
-        "reason": "The checked official BMW automatic sheets agree on top gear and baseline tire, but final drive changes from 2.955 in 07/2015 to 2.851 in 09/2018 and 03/2021.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive18d exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Broad F48 row needs an exact split before order analysis",
-        "reason": "Official F48 sDrive18d automatic sources support the row identity, but final drive changes from 2.955 in the launch packet to 2.851 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18d-xdrive18d-xdrive20d-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive18i-eu-2016-mt6-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive18i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive18i 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325736 (11/2015), T0286555/419620 (09/2018), and T0327516/473615 (03/2021). Engine B38A15M0 (100 kW), 6-speed manual GS6-17BG, gear set 3.615/1.952/1.241/0.969/0.806/0.683, reverse 3.538, FD 3.882, default tyre 225/55 R17 97W. Stable across all production years.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+      "unresolved": [
+        {
+          "item": "BMW X1 sDrive18d automatic exact final-drive continuity across the represented 2016-2022 row span",
+          "reason": "The checked official BMW automatic sheets agree on top gear and baseline tire, but final drive changes from 2.955 in 07/2015 to 2.851 in 09/2018 and 03/2021.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW X1 sDrive18d exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Broad F48 row needs an exact split before order analysis",
+          "reason": "Official F48 sDrive18d automatic sources support the row identity, but final drive changes from 2.955 in the launch packet to 2.851 in later packets; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e3"
+        }
       ],
-      "notes": "BMW X1 F48 sDrive18i 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325736 (11/2015), T0286555/419620 (09/2018), and T0327516/473615 (03/2021). Engine B38A15M0 (100 kW), 6-speed manual GS6-17BG, gear set 3.615/1.952/1.241/0.969/0.806/0.683, reverse 3.538, FD 3.882, default tyre 225/55 R17 97W. Stable across all production years.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)"
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "ratios": {
-      "top_gear_ratio": {
+    {
+      "id": "bmw-f48-sdrive18i-eu-2016-mt6-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive18i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n21",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n21",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "GS6-17BG 6th gear, stable across all years.",
+          "value": 0.683
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "GS6-17BG final drive for sDrive18i, stable.",
+          "value": 3.882
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            3.615,
+            1.952,
+            1.241,
+            0.969,
+            0.806,
+            0.683
+          ],
+          "evidence_refs_ref": "e20",
+          "notes_ref": "n17"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e20",
+          "notes_ref": "n21",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e21",
+            "notes": "The checked official BMW 11/2015 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18i manual row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 11/2015 and 03/2021 technical-data sheets agree on the broad sDrive18i manual state: 225/55 R17 baseline tires, 0.683 top gear, and 3.882 final drive. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "note_ref": "n13"
+        },
+        {
+          "note": "This run promoted sDrive18i manual drivetrain/transmission evidence to official-derived status; the existing official top gear, final drive, and baseline tire evidence remains valid while option availability stays unresolved.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e20"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X1 sDrive18i manual year-by-year continuity across the represented 2016-2022 row span",
+          "reason": "The checked official BMW 11/2015 and 03/2021 manual sheets agree on the promoted top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e21"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive18i-eu-2016-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive18i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n22",
+        "value": "FWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n22",
+        "code": "ZF8HP",
+        "name": "Aisin 6AT (2015-2017) / Magna 7DCT300 (2018-2022)",
         "evidence_refs": [
           "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
           "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG 6th gear, stable across all years.",
-        "value": 0.683
+          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
+          "secondary_technical_sources:bmw-x1-f48-wikipedia"
+        ]
       },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG final drive for sDrive18i, stable.",
-        "value": 3.882
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          3.615,
-          1.952,
-          1.241,
-          0.969,
-          0.806,
-          0.683
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive18i 6-speed manual FWD. Confirmed by BMW PressClub T0232406/325736 (11/2015), T0286555/419620 (09/2018), and T0327516/473615 (03/2021). Engine B38A15M0 (100 kW), 6-speed manual GS6-17BG, gear set 3.615/1.952/1.241/0.969/0.806/0.683, reverse 3.538, FD 3.882, default tyre 225/55 R17 97W. Stable across all production years.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n34",
+          "value": 0.674,
+          "evidence_refs_ref": "e4"
         },
-        "default_axle_for_speed": "rear"
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n34",
+          "value": 3.294,
+          "evidence_refs_ref": "e4"
+        }
       },
-      "options": [
-        {
-          "confidence": "official_derived",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
           "evidence_refs": [
             "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+            "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
           ],
-          "notes": "The checked official BMW 11/2015 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive18i manual row.",
+          "notes_ref": "n22",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e17",
+            "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW automatic sDrive18i sources do exist, but they do not support a ZF8HP row. The checked 11/2015 technical-data sheet shows 6-speed Steptronic, while the checked 09/2018 and 03/2021 master sheets show 7-speed Steptronic with double clutch, so this single ZF8HP row remains contradicted and overbroad.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note_ref": "n13"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note": "Official F48 sDrive18i automatic evidence is a 2015 six-speed Steptronic state and later seven-speed DCT state, not one broad ZF8HP/8-speed row; keep this placeholder out of driveshaft/wheel order analysis until split rows are built.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 11/2015 and 03/2021 technical-data sheets agree on the broad sDrive18i manual state: 225/55 R17 baseline tires, 0.683 top gear, and 3.882 final drive. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "This run promoted sDrive18i manual drivetrain/transmission evidence to official-derived status; the existing official top gear, final drive, and baseline tire evidence remains valid while option availability stays unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.538",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 sDrive18i manual year-by-year continuity across the represented 2016-2022 row span",
-        "reason": "The checked official BMW 11/2015 and 03/2021 manual sheets agree on the promoted top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive18i-eu-2016-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive18i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW X1 F48 sDrive18i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin 6-speed Steptronic (AT6) for launch-era 2015-2017 per BMW PressClub T0232406/325736 (11/2015): gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 4.103. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 4.176, with overall gear ratios published. Engine B38A15M0 across both eras. The 'ZF8HP' code in the row ID is a misnomer in BOTH eras (neither is a ZF 8HP). Drivetrain and configuration well-evidenced; per-gear values held at no_confidence because the row cannot represent both eras simultaneously and a row split is out of scope for this research pass. Default tyre 225/55 R17 97W (stable).",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "BMW X1 F48 sDrive18i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin 6-speed Steptronic (AT6) for launch-era 2015-2017 per BMW PressClub T0232406/325736 (11/2015): gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 4.103. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 4.176, with overall gear ratios published. Engine B38A15M0 across both eras. The 'ZF8HP' code in the row ID is a misnomer in BOTH eras (neither is a ZF 8HP). Drivetrain and configuration well-evidenced; per-gear values held at no_confidence because the row cannot represent both eras simultaneously and a row split is out of scope for this research pass. Default tyre 225/55 R17 97W (stable).",
-      "code": "ZF8HP",
-      "name": "Aisin 6AT (2015-2017) / Magna 7DCT300 (2018-2022)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Row spans two different gearboxes (Aisin 6AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed to represent each era cleanly.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Row spans two different gearboxes (Aisin 6AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed to represent each era cleanly.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive18i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin 6-speed Steptronic (AT6) for launch-era 2015-2017 per BMW PressClub T0232406/325736 (11/2015): gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 4.103. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 4.176, with overall gear ratios published. Engine B38A15M0 across both eras. The 'ZF8HP' code in the row ID is a misnomer in BOTH eras (neither is a ZF 8HP). Drivetrain and configuration well-evidenced; per-gear values held at no_confidence because the row cannot represent both eras simultaneously and a row split is out of scope for this research pass. Default tyre 225/55 R17 97W (stable).",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3643687db38c",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:71b4da2d92a2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
+          "item": "Exact cutover timing for the sDrive18i automatic change from 6-speed Steptronic to 7-speed dual-clutch",
+          "reason": "The checked official BMW automatic sources prove an early 6AT state and a later 7DCT state, but this pass did not split the broad 2016-2022 row at the precise transition point.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Unsupported exact F48 configuration mapping",
+          "reason": "Official F48 sDrive18i automatic evidence is a 2015 six-speed Steptronic state and later seven-speed DCT state, not one broad ZF8HP/8-speed row; keep this placeholder out of driveshaft/wheel order analysis until split rows are built.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive20d-eu-2016-mt6-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive20d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n23",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n23",
+        "code": "MT6",
+        "name": "6-speed manual (Getrag GS6-17BG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "GS6-17BG 6th gear per BMW PressClub T0260622/360424.",
+          "value": 0.674
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "GS6-17BG final drive for sDrive20d.",
+          "value": 3.778
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            3.538,
+            1.923,
+            1.219,
+            0.881,
+            0.81,
+            0.674
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n17"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n23",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW 07/2016 F48 sDrive20d technical-data PDF lists 225/55 R17 as the baseline tire for the manual state.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 07/2016 specifications material now closes an exact early sDrive20d manual state with 225/55 R17 baseline tires, 0.674 top gear, and 3.778 final drive. The broad 2016-2022 manual row still remains too wide for direct numeric promotion because the checked late-run BMW 03/2021 master sheet supports only an automatic sDrive20d state.",
+          "evidence_refs_ref": "e22"
+        },
+        {
+          "note": "Official 07/2016 F48 sDrive20d data supports this manual state, but the checked 2021 packet lists sDrive20d as automatic-only; keep the broad row out of driveshaft/wheel order analysis until the manual end date is split.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this broad sDrive20d manual row should be narrowed to the proven 07/2016 state or split away from the later automatic-only lineup",
+          "reason": "The checked official BMW 07/2016 packet proves an early manual sDrive20d state, while the checked 03/2021 master sheet supports only an automatic sDrive20d row for the later lineup.",
+          "evidence_refs_ref": "e22"
+        },
+        {
+          "item": "Broad F48 row needs an exact split before order analysis",
+          "reason": "Official 07/2016 F48 sDrive20d data supports this manual state, but the checked 2021 packet lists sDrive20d as automatic-only; keep the broad row out of driveshaft/wheel order analysis until the manual end date is split.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive20d-eu-2016-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive20d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n24",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e12",
+        "notes_ref": "n24",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes": "Aisin AWF8F35 8th gear.",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes": "Aisin AWF8F35 launch-era final drive (2016-2018) per BMW PressClub T0260622/360424. T0327516 (03/2021) shows updated value 2.851 from 2019 - era split not represented in this row.",
+          "value": 2.955,
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.029,
+            1.95,
+            1.457,
+            1.221,
+            1.0,
+            0.809,
+            0.673
+          ],
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 gear set per BMW PressClub T0260622/360424 - note: per source, sDrive20d 8AT uses the petrol-calibration gear set."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n24",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e12",
+            "notes": "The checked official BMW 07/2016 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive20d automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 07/2016 and 03/2021 technical-data packets show that this broad sDrive20d automatic row is mixed-era on final drive but stable on top gear and baseline tires. The row now promotes the stable 0.673 top gear and 225/55 R17 baseline tire while keeping final drive unresolved because the checked official value changes from 2.955 to 2.851 across the represented span.",
+          "evidence_refs_ref": "e22"
+        },
+        {
+          "note": "Official F48 sDrive20d automatic sources support the row identity, but final drive changes from 2.955 in the 2016 packet to 2.851 in the 2021 packet; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n14",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X1 sDrive20d automatic exact final-drive continuity across the represented 2016-2022 row span",
+          "reason": "The checked official BMW automatic sheets agree on top gear and baseline tire, but final drive changes from 2.955 in 07/2016 to 2.851 by 03/2021.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "BMW X1 sDrive20d exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "item": "Broad F48 row needs an exact split before order analysis",
+          "reason": "Official F48 sDrive20d automatic sources support the row identity, but final drive changes from 2.955 in the 2016 packet to 2.851 in the 2021 packet; keep the broad row out of driveshaft/wheel order analysis until it is split.",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive20i-eu-2016-mt6-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive20i",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "value": "FWD",
+        "evidence_refs_ref": "e9"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n4",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e9"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 0.812,
+          "evidence_refs_ref": "e9"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n4",
+          "value": 3.385,
+          "evidence_refs_ref": "e9"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 50.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e17",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The checked official BMW 07/2015, 09/2018, and 03/2021 source chain surfaces only automatic sDrive20i states: 8-speed Steptronic at launch, then 7-speed Steptronic with double clutch later. No exact manual sDrive20i technical-data row was recovered, so this MT6 row remains unsupported rather than validated.",
+          "evidence_refs_ref": "e23"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "Checked official F48 sDrive20i technical-data packets show automatic states only: 2015 8-speed Steptronic and later 7-speed DCT. No exact manual sDrive20i row was recovered, so this manual placeholder is not safe for driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n6",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n31",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n32",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n33",
+          "evidence_refs_ref": "e9"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW automatic sDrive18i sources do exist, but they do not support a ZF8HP row. The checked 11/2015 technical-data sheet shows 6-speed Steptronic, while the checked 09/2018 and 03/2021 master sheets show 7-speed Steptronic with double clutch, so this single ZF8HP row remains contradicted and overbroad.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Official F48 sDrive18i automatic evidence is a 2015 six-speed Steptronic state and later seven-speed DCT state, not one broad ZF8HP/8-speed row; keep this placeholder out of driveshaft/wheel order analysis until split rows are built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact cutover timing for the sDrive18i automatic change from 6-speed Steptronic to 7-speed dual-clutch",
-        "reason": "The checked official BMW automatic sources prove an early 6AT state and a later 7DCT state, but this pass did not split the broad 2016-2022 row at the precise transition point.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F48 configuration mapping",
-        "reason": "Official F48 sDrive18i automatic evidence is a 2015 six-speed Steptronic state and later seven-speed DCT state, not one broad ZF8HP/8-speed row; keep this placeholder out of driveshaft/wheel order analysis until split rows are built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive18i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive20d-eu-2016-mt6-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive20d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive20d 6-speed manual FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016 sDrive20d tech-data PDF): engine B47C20O1 (140 kW), 6-speed manual GS6-17BG, gear set 3.538/1.923/1.219/0.881/0.810/0.674, reverse 3.538, FD 3.778, default tyre 225/55 R17 97W. NOTE: T0327516 (03/2021 final spec) lists sDrive20d as 8AT-only - the manual was discontinued at the LCI in 07/2019. Year span stored as 2016-2022 is broader than actual manual availability; values held against the 2016-2019 manual era.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 sDrive20d 6-speed manual FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016 sDrive20d tech-data PDF): engine B47C20O1 (140 kW), 6-speed manual GS6-17BG, gear set 3.538/1.923/1.219/0.881/0.810/0.674, reverse 3.538, FD 3.778, default tyre 225/55 R17 97W. NOTE: T0327516 (03/2021 final spec) lists sDrive20d as 8AT-only - the manual was discontinued at the LCI in 07/2019. Year span stored as 2016-2022 is broader than actual manual availability; values held against the 2016-2019 manual era.",
-      "code": "MT6",
-      "name": "6-speed manual (Getrag GS6-17BG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG 6th gear per BMW PressClub T0260622/360424.",
-        "value": 0.674
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG final drive for sDrive20d.",
-        "value": 3.778
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          3.538,
-          1.923,
-          1.219,
-          0.881,
-          0.81,
-          0.674
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "GS6-17BG gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive20d 6-speed manual FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016 sDrive20d tech-data PDF): engine B47C20O1 (140 kW), 6-speed manual GS6-17BG, gear set 3.538/1.923/1.219/0.881/0.810/0.674, reverse 3.538, FD 3.778, default tyre 225/55 R17 97W. NOTE: T0327516 (03/2021 final spec) lists sDrive20d as 8AT-only - the manual was discontinued at the LCI in 07/2019. Year span stored as 2016-2022 is broader than actual manual availability; values held against the 2016-2019 manual era.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "Whether any EU-market manual sDrive20i state existed in-scope for this configuration family",
+          "reason": "The checked official BMW 07/2015, 09/2018, and 03/2021 packets only surfaced automatic sDrive20i states and did not recover an exact manual technical-data row.",
+          "evidence_refs_ref": "e23"
+        },
+        {
+          "item": "BMW X1 sDrive20i automatic-family cutover timing inside the represented 2016-2022 block",
+          "reason": "The checked official BMW packet proves automatic-only sDrive20i states, but it changes from 8-speed Steptronic at launch to 7-speed dual-clutch by 09/2018 and 03/2021.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Unsupported exact F48 configuration mapping",
+          "reason": "Checked official F48 sDrive20i technical-data packets show automatic states only: 2015 8-speed Steptronic and later 7-speed DCT. No exact manual sDrive20i row was recovered, so this manual placeholder is not safe for driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-sdrive20i-eu-2016-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2016,
+      "production_end_year": 2022,
+      "model_name": "X1 (F48, 2016-2022)",
+      "variant_name": "sDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "notes_ref": "n25",
+        "value": "FWD",
+        "evidence_refs_ref": "e7"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n25",
+        "code": "ZF8HP",
+        "name": "Aisin AWF8F35 8AT (2015-2017) / Magna 7DCT300 (2018-2022)",
+        "evidence_refs_ref": "e9"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n35",
+          "value": 0.674,
+          "evidence_refs_ref": "e7"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n35",
+          "value": 3.294,
+          "evidence_refs_ref": "e7"
+        }
+      },
+      "tires": {
+        "default": {
           "confidence": "official_exact",
           "evidence_refs": [
-            "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
+            "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
           ],
-          "notes": "Official BMW 07/2016 F48 sDrive20d technical-data PDF lists 225/55 R17 as the baseline tire for the manual state.",
+          "notes_ref": "n25",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e17",
+            "notes_ref": "n18",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The checked official BMW sDrive20i automatic source chain proves that this row is mixed-era and overbroad: the 07/2015 launch packet is 8-speed Steptronic with 0.673 top gear, 3.200 final drive, and 225/55 R17 baseline tires, while the 09/2018 and 03/2021 packets move sDrive20i to 7-speed Steptronic with double clutch and a 3.789 final drive. This broad ZF8HP row therefore remains a contradicted placeholder rather than one production-safe exact automatic mapping.",
+          "evidence_refs_ref": "e23"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "note": "Official F48 sDrive20i automatic sources support an early 8-speed Steptronic state but later 2018/2021 sources switch to 7-speed DCT; keep this broad ZF8HP row out of driveshaft/wheel order analysis until the automatic cutover is split.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n6",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 07/2016 specifications material now closes an exact early sDrive20d manual state with 225/55 R17 baseline tires, 0.674 top gear, and 3.778 final drive. The broad 2016-2022 manual row still remains too wide for direct numeric promotion because the checked late-run BMW 03/2021 master sheet supports only an automatic sDrive20d state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official 07/2016 F48 sDrive20d data supports this manual state, but the checked 2021 packet lists sDrive20d as automatic-only; keep the broad row out of driveshaft/wheel order analysis until the manual end date is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.538",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this broad sDrive20d manual row should be narrowed to the proven 07/2016 state or split away from the later automatic-only lineup",
-        "reason": "The checked official BMW 07/2016 packet proves an early manual sDrive20d state, while the checked 03/2021 master sheet supports only an automatic sDrive20d row for the later lineup.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Broad F48 row needs an exact split before order analysis",
-        "reason": "Official 07/2016 F48 sDrive20d data supports this manual state, but the checked 2021 packet lists sDrive20d as automatic-only; keep the broad row out of driveshaft/wheel order analysis until the manual end date is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive20d-eu-2016-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive20d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 sDrive20d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016) and T0327516/473615 (03/2021). Engine B47C20O1. Aisin AWF8F35 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 2.955 (launch-era 2016-2018) - changed to 2.851 from approximately 2019 per T0327516 (03/2021). Wait: Actually for sDrive20d the 8AT uses petrol-calibration gear set per BMW PressClub. Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 sDrive20d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016) and T0327516/473615 (03/2021). Engine B47C20O1. Aisin AWF8F35 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 2.955 (launch-era 2016-2018) - changed to 2.851 from approximately 2019 per T0327516 (03/2021). Wait: Actually for sDrive20d the 8AT uses petrol-calibration gear set per BMW PressClub. Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "notes": "Aisin AWF8F35 launch-era final drive (2016-2018) per BMW PressClub T0260622/360424. T0327516 (03/2021) shows updated value 2.851 from 2019 - era split not represented in this row.",
-        "value": 2.955,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.029,
-          1.95,
-          1.457,
-          1.221,
-          1.0,
-          0.809,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 gear set per BMW PressClub T0260622/360424 - note: per source, sDrive20d 8AT uses the petrol-calibration gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive20d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub T0260622/360424 (07/2016) and T0327516/473615 (03/2021). Engine B47C20O1. Aisin AWF8F35 transverse 8AT, gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 2.955 (launch-era 2016-2018) - changed to 2.851 from approximately 2019 per T0327516 (03/2021). Wait: Actually for sDrive20d the 8AT uses petrol-calibration gear set per BMW PressClub. Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer - actual unit is Aisin AWF8F35.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-          ],
-          "notes": "The checked official BMW 07/2016 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad sDrive20d automatic row.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "item": "Exact cutover timing for the sDrive20i automatic change from 8-speed Steptronic to 7-speed dual-clutch",
+          "reason": "The checked official BMW automatic packets prove an early 8AT state and later 7DCT states, but this pass did not split the broad 2016-2022 row at the precise transition point.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
+          "item": "BMW X1 sDrive20i exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment for the recovered automatic states, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "item": "Broad F48 row needs an exact split before order analysis",
+          "reason": "Official F48 sDrive20i automatic sources support an early 8-speed Steptronic state but later 2018/2021 sources switch to 7-speed DCT; keep this broad ZF8HP row out of driveshaft/wheel order analysis until the automatic cutover is split.",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 07/2016 and 03/2021 technical-data packets show that this broad sDrive20d automatic row is mixed-era on final drive but stable on top gear and baseline tires. The row now promotes the stable 0.673 top gear and 225/55 R17 baseline tire while keeping final drive unresolved because the checked official value changes from 2.955 to 2.851 across the represented span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F48 sDrive20d automatic sources support the row identity, but final drive changes from 2.955 in the 2016 packet to 2.851 in the 2021 packet; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.015",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 sDrive20d automatic exact final-drive continuity across the represented 2016-2022 row span",
-        "reason": "The checked official BMW automatic sheets agree on top gear and baseline tire, but final drive changes from 2.955 in 07/2016 to 2.851 by 03/2021.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive20d exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Broad F48 row needs an exact split before order analysis",
-        "reason": "Official F48 sDrive20d automatic sources support the row identity, but final drive changes from 2.955 in the 2016 packet to 2.851 in the 2021 packet; keep the broad row out of driveshaft/wheel order analysis until it is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20d-2016-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive20i-eu-2016-mt6-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive20i",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.385,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ],
-        "notes": "Sonnet redo (2026-04 v2): PHANTOM ROW. The BMW X1 F48 sDrive20i (B48 2.0L petrol) was offered with automatic transmission only - no manual was ever fitted to this variant in the EU. Confirmed by BMW PressClub T0223367 (07/2015, sDrive20i = 8-speed Steptronic only), T0286555 (09/2018, sDrive20i = 7-speed Steptronic with double clutch only), and T0327516 (03/2021, sDrive20i = 7DCT only). Three official BMW EU/ACEA tech sheets across launch through post-LCI all show automatic-only. Additionally engine_code '1.5L' in this row is wrong: official BMW spec confirms sDrive20i uses the B48 2.0L (1998 cm3, 4-cyl) - the 1.5L (B38) is the sDrive18i engine. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3643687db38c",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:71b4da2d92a2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The checked official BMW 07/2015, 09/2018, and 03/2021 source chain surfaces only automatic sDrive20i states: 8-speed Steptronic at launch, then 7-speed Steptronic with double clutch later. No exact manual sDrive20i technical-data row was recovered, so this MT6 row remains unsupported rather than validated.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Checked official F48 sDrive20i technical-data packets show automatic states only: 2015 8-speed Steptronic and later 7-speed DCT. No exact manual sDrive20i row was recovered, so this manual placeholder is not safe for driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x1-f48-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether any EU-market manual sDrive20i state existed in-scope for this configuration family",
-        "reason": "The checked official BMW 07/2015, 09/2018, and 03/2021 packets only surfaced automatic sDrive20i states and did not recover an exact manual technical-data row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive20i automatic-family cutover timing inside the represented 2016-2022 block",
-        "reason": "The checked official BMW packet proves automatic-only sDrive20i states, but it changes from 8-speed Steptronic at launch to 7-speed dual-clutch by 09/2018 and 03/2021.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F48 configuration mapping",
-        "reason": "Checked official F48 sDrive20i technical-data packets show automatic states only: 2015 8-speed Steptronic and later 7-speed DCT. No exact manual sDrive20i row was recovered, so this manual placeholder is not safe for driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-sdrive20i-eu-2016-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2016,
-    "production_end_year": 2022,
-    "model_name": "X1 (F48, 2016-2022)",
-    "variant_name": "sDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "notes": "BMW X1 F48 sDrive20i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin AWF8F35 8-speed Steptronic for launch-era 2015-2017 per BMW PressClub T0223367/316338 (07/2015): gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 3.789. Engine corrected from 1.5L to B48 2.0L (1998 cm3 4-cyl per BMW PressClub - the 1.5L is the B38 used in sDrive18i). 'ZF8HP' is a misnomer in BOTH eras. Per-gear values held at no_confidence because row spans two incompatible gearboxes; row split out of scope. Default tyre 225/55 R17 97W.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "BMW X1 F48 sDrive20i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin AWF8F35 8-speed Steptronic for launch-era 2015-2017 per BMW PressClub T0223367/316338 (07/2015): gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 3.789. Engine corrected from 1.5L to B48 2.0L (1998 cm3 4-cyl per BMW PressClub - the 1.5L is the B38 used in sDrive18i). 'ZF8HP' is a misnomer in BOTH eras. Per-gear values held at no_confidence because row spans two incompatible gearboxes; row split out of scope. Default tyre 225/55 R17 97W.",
-      "code": "ZF8HP",
-      "name": "Aisin AWF8F35 8AT (2015-2017) / Magna 7DCT300 (2018-2022)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x1-f48-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Row spans two different gearboxes (Aisin AWF8F35 8AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Row spans two different gearboxes (Aisin AWF8F35 8AT 2015-2017 vs Magna 7DCT300 2018-2022) with different gear sets and final drives. Values held at no_confidence; row split (out of scope) needed.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 sDrive20i automatic FWD - this row spans TWO different gearboxes in production: (a) Aisin AWF8F35 8-speed Steptronic for launch-era 2015-2017 per BMW PressClub T0223367/316338 (07/2015): gear set 5.250/3.029/1.950/1.457/1.221/1.000/0.809/0.673, reverse 4.015, FD 3.200. (b) Magna/Getrag 7DCT300 7-speed dual-clutch for LCI era 2018-2022 per T0286555/419620 (09/2018) and T0327516/473615 (03/2021): FD 3.789. Engine corrected from 1.5L to B48 2.0L (1998 cm3 4-cyl per BMW PressClub - the 1.5L is the B38 used in sDrive18i). 'ZF8HP' is a misnomer in BOTH eras. Per-gear values held at no_confidence because row spans two incompatible gearboxes; row split out of scope. Default tyre 225/55 R17 97W.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:3643687db38c",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:71b4da2d92a2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The checked official BMW sDrive20i automatic source chain proves that this row is mixed-era and overbroad: the 07/2015 launch packet is 8-speed Steptronic with 0.673 top gear, 3.200 final drive, and 225/55 R17 baseline tires, while the 09/2018 and 03/2021 packets move sDrive20i to 7-speed Steptronic with double clutch and a 3.789 final drive. This broad ZF8HP row therefore remains a contradicted placeholder rather than one production-safe exact automatic mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-article",
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F48 sDrive20i automatic sources support an early 8-speed Steptronic state but later 2018/2021 sources switch to 7-speed DCT; keep this broad ZF8HP row out of driveshaft/wheel order analysis until the automatic cutover is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact cutover timing for the sDrive20i automatic change from 8-speed Steptronic to 7-speed dual-clutch",
-        "reason": "The checked official BMW automatic packets prove an early 8AT state and later 7DCT states, but this pass did not split the broad 2016-2022 row at the precise transition point.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 sDrive20i exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment for the recovered automatic states, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Broad F48 row needs an exact split before order analysis",
-        "reason": "Official F48 sDrive20i automatic sources support an early 8-speed Steptronic state but later 2018/2021 sources switch to 7-speed DCT; keep this broad ZF8HP row out of driveshaft/wheel order analysis until the automatic cutover is split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-sdrive20i-xdrive20i-2015-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2018-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-xdrive25e-eu-2020-6-speed-step-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "X1 (F48, 2020)",
-    "variant_name": "xDrive25e",
-    "engine_code": "B38",
-    "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2020 launch state). Confirmed by BMW PressClub T0314292/457889 (01/2020 xDrive25e tech-data PDF). PHEV layout: B38 1.5L 3-cyl petrol (1499 cm3, 92 kW) drives front wheels via Aisin 6-speed Steptronic; 70 kW electric motor drives rear axle (through-the-road AWD). Aisin 6AT gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944. Default tyre 225/55 R17 97W.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2020 launch state). Confirmed by BMW PressClub T0314292/457889 (01/2020 xDrive25e tech-data PDF). PHEV layout: B38 1.5L 3-cyl petrol (1499 cm3, 92 kW) drives front wheels via Aisin 6-speed Steptronic; 70 kW electric motor drives rear axle (through-the-road AWD). Aisin 6AT gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944. Default tyre 225/55 R17 97W.",
-      "code": "6-SPEED-STEP",
-      "name": "6-speed Steptronic (Aisin AT6) + electric rear axle"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 6th gear per BMW PressClub T0314292/457889.",
-        "value": 0.672
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 final drive (front, ICE-driven) per BMW PressClub T0314292/457889.",
-        "value": 3.944
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 01/2020 technical-data PDF publishes a single 3.944 final-drive ratio for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.944
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.459,
-          2.508,
-          1.556,
-          1.142,
-          0.851,
-          0.672
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 gear set."
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f48-xdrive25e-eu-2020-6-speed-step-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "X1 (F48, 2020)",
+      "variant_name": "xDrive25e",
+      "engine_code": "B38",
+      "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
+      "fuel_type": "PHEV",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2020 launch state). Confirmed by BMW PressClub T0314292/457889 (01/2020 xDrive25e tech-data PDF). PHEV layout: B38 1.5L 3-cyl petrol (1499 cm3, 92 kW) drives front wheels via Aisin 6-speed Steptronic; 70 kW electric motor drives rear axle (through-the-road AWD). Aisin 6AT gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944. Default tyre 225/55 R17 97W.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n26",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n26",
+        "code": "6-SPEED-STEP",
+        "name": "6-speed Steptronic (Aisin AT6) + electric rear axle"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
+          "evidence_refs_ref": "e10",
+          "notes": "Aisin AT6 6th gear per BMW PressClub T0314292/457889.",
+          "value": 0.672
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "Aisin AT6 final drive (front, ICE-driven) per BMW PressClub T0314292/457889.",
+          "value": 3.944
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 01/2020 technical-data PDF publishes a single 3.944 final-drive ratio for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+          "value": 3.944
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.459,
+            2.508,
+            1.556,
+            1.142,
+            0.851,
+            0.672
           ],
-          "notes": "The official BMW 01/2020 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2020-only row.",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n36"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n26",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e10",
+            "notes": "The official BMW 01/2020 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2020-only row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
           },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 01/2020 xDrive25e technical-data PDF establishes the first checked exact X1 xDrive25e plug-in-hybrid state: AWD, 6-speed Steptronic, 0.672 top gear, a single published 3.944 final-drive ratio, and 225/55 R17 baseline tires. This exact PHEV state contradicts the inherited 2016 manual/ZF8HP rows, so the broad row was retimed and split into exact 2020 and 2021 states.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
         ]
       },
-      {
-        "note": "Reverse gear ratio (research note): 3.185",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive25e exact optional wheel/tire matrix for the narrowed 2020 row",
-        "reason": "The checked official BMW 01/2020 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive25e separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD plug-in-hybrid state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-xdrive25d-eu-2021-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2021,
-    "production_end_year": 2021,
-    "model_name": "X1 (F48, 2021)",
-    "variant_name": "xDrive25d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L I4 Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - LCI/late state (2018-2022 with FD 2.851). Confirmed by BMW PressClub T0327516/473615 (03/2021): engine B47C20O2 (170 kW), Aisin AWF8F45, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851 (vs launch 2.955 in Row 0). Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - LCI/late state (2018-2022 with FD 2.851). Confirmed by BMW PressClub T0327516/473615 (03/2021): engine B47C20O2 (170 kW), Aisin AWF8F45, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851 (vs launch 2.955 in Row 0). Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive (LCI-era 2018-2022) per BMW PressClub T0327516/473615.",
-        "value": 2.851
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "UKL2 Haldex AWD: single FD mirrored to rear.",
-        "value": 2.851
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 (diesel calibration) gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD - LCI/late state (2018-2022 with FD 2.851). Confirmed by BMW PressClub T0327516/473615 (03/2021): engine B47C20O2 (170 kW), Aisin AWF8F45, gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851 (vs launch 2.955 in Row 0). Default tyre 225/55 R17 97W. 'ZF8HP' is a misnomer.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "verification_notes": [
         {
-          "confidence": "official_exact",
+          "note": "The official BMW 01/2020 xDrive25e technical-data PDF establishes the first checked exact X1 xDrive25e plug-in-hybrid state: AWD, 6-speed Steptronic, 0.672 top gear, a single published 3.944 final-drive ratio, and 225/55 R17 baseline tires. This exact PHEV state contradicts the inherited 2016 manual/ZF8HP rows, so the broad row was retimed and split into exact 2020 and 2021 states.",
           "evidence_refs": [
+            "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-article",
+            "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf",
+            "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
             "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          ]
+        },
+        {
+          "note_ref": "n37",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X1 xDrive25e exact optional wheel/tire matrix for the narrowed 2020 row",
+          "reason": "The checked official BMW 01/2020 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e10"
+        },
+        {
+          "item": "BMW X1 xDrive25e separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD plug-in-hybrid state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e10"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-xdrive25d-eu-2021-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2021,
+      "production_end_year": 2021,
+      "model_name": "X1 (F48, 2021)",
+      "variant_name": "xDrive25d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L I4 Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n27",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n27",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n11",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Aisin AWF8F45 final drive (LCI-era 2018-2022) per BMW PressClub T0327516/473615.",
+          "value": 2.851
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n12",
+          "value": 2.851
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "The official BMW 03/2021 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25d automatic state represented by this narrowed 2021-only row.",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n29"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n27",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "The official BMW 03/2021 technical-data PDF lists 225/55 R17 as the baseline tire for the exact X1 xDrive25d automatic state represented by this narrowed 2021-only row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2021 X1 technical-data PDF confirms the later exact X1 xDrive25d automatic state with AWD, 8-speed Steptronic, 0.673 top gear, a single published 2.851 final-drive ratio, and 225/55 R17 baseline tires. This row is split from the exact 2016 launch-state row because BMW's checked later sheet does not preserve the launch final-drive value.",
+          "evidence_refs_ref": "e26"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2021 X1 technical-data PDF confirms the later exact X1 xDrive25d automatic state with AWD, 8-speed Steptronic, 0.673 top gear, a single published 2.851 final-drive ratio, and 225/55 R17 baseline tires. This row is split from the exact 2016 launch-state row because BMW's checked later sheet does not preserve the launch final-drive value.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive25d exact optional wheel/tire matrix for the narrowed 2021 row",
-        "reason": "The checked official BMW 03/2021 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive25d separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f48-xdrive25e-eu-2021-6-speed-step-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F48",
-    "body_code": "F48",
-    "production_start_year": 2021,
-    "production_end_year": 2021,
-    "model_name": "X1 (F48, 2021)",
-    "variant_name": "xDrive25e",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo (PHEV)",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2021 LCI state). Confirmed by BMW PressClub T0327516/473615 (03/2021). engine_code corrected from B48 to B38 - BMW PressClub spec confirms 1499 cm3 effective capacity (B38 1.5L 3-cyl), NOT B48 (which is 1998 cm3 2.0L 4-cyl). Same Aisin AT6 6-speed Steptronic + electric rear axle as 2020. 2021 default tyre is 205/55 R17 (NOT 225/55 R17; baseline tyre changed at 2021 LCI per T0327516). Aisin AT6 gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2021 LCI state). Confirmed by BMW PressClub T0327516/473615 (03/2021). engine_code corrected from B48 to B38 - BMW PressClub spec confirms 1499 cm3 effective capacity (B38 1.5L 3-cyl), NOT B48 (which is 1998 cm3 2.0L 4-cyl). Same Aisin AT6 6-speed Steptronic + electric rear axle as 2020. 2021 default tyre is 205/55 R17 (NOT 225/55 R17; baseline tyre changed at 2021 LCI per T0327516). Aisin AT6 gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944.",
-      "code": "6-SPEED-STEP",
-      "name": "6-speed Steptronic (Aisin AT6) + electric rear axle"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 6th gear.",
-        "value": 0.672
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 final drive.",
-        "value": 3.944
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2021 technical-data PDF publishes a single 3.944 final-drive ratio for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2021-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.944
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.459,
-          2.508,
-          1.556,
-          1.142,
-          0.851,
-          0.672
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AT6 gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X1 F48 xDrive25e iPerformance plug-in hybrid (2021 LCI state). Confirmed by BMW PressClub T0327516/473615 (03/2021). engine_code corrected from B48 to B38 - BMW PressClub spec confirms 1499 cm3 effective capacity (B38 1.5L 3-cyl), NOT B48 (which is 1998 cm3 2.0L 4-cyl). Same Aisin AT6 6-speed Steptronic + electric rear axle as 2020. 2021 default tyre is 205/55 R17 (NOT 225/55 R17; baseline tyre changed at 2021 LCI per T0327516). Aisin AT6 gear set 4.459/2.508/1.556/1.142/0.851/0.672, reverse 3.185, FD 3.944.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X1 xDrive25d exact optional wheel/tire matrix for the narrowed 2021 row",
+          "reason": "The checked official BMW 03/2021 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW X1 xDrive25d separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f48-xdrive25e-eu-2021-6-speed-step-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F48",
+      "body_code": "F48",
+      "production_start_year": 2021,
+      "production_end_year": 2021,
+      "model_name": "X1 (F48, 2021)",
+      "variant_name": "xDrive25e",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo (PHEV)",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n28",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n28",
+        "code": "6-SPEED-STEP",
+        "name": "6-speed Steptronic (Aisin AT6) + electric rear axle"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
+          "evidence_refs_ref": "e2",
+          "notes": "Aisin AT6 6th gear.",
+          "value": 0.672
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Aisin AT6 final drive.",
+          "value": 3.944
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 03/2021 technical-data PDF publishes a single 3.944 final-drive ratio for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2021-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+          "value": 3.944
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.459,
+            2.508,
+            1.556,
+            1.142,
+            0.851,
+            0.672
           ],
-          "notes": "The official BMW 03/2021 technical-data PDF lists 205/55 R17 as the baseline tire for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2021-only row.",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n36"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n28",
           "front": {
             "width_mm": 205.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "The official BMW 03/2021 technical-data PDF lists 205/55 R17 as the baseline tire for the exact X1 xDrive25e plug-in-hybrid state represented by this narrowed 2021-only row.",
+            "front": {
+              "width_mm": 205.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 18\" option"
+          },
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Official F48 19\" option"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2021 X1 technical-data PDF confirms the later exact X1 xDrive25e plug-in-hybrid state with AWD, 6-speed Steptronic, 0.672 top gear, a single published 3.944 final-drive ratio, and a later 205/55 R17 baseline tire. This row is split from the exact 2020 launch-state row because BMW's checked later sheet changes the baseline tire.",
+          "evidence_refs_ref": "e26"
         },
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 7.5J x 18 wheels with 225/50 R18 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 18\" option"
-        },
-        {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_market_pages:f48-x1-price-list-2021-de"
-          ],
-          "notes": "Official BMW Germany 04/2021 F48 X1 price list lists 8J x 19 wheels with 225/45 R19 tires. Applied as F48 official-derived option evidence; exact availability remains market/year/trim-specific.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Official F48 19\" option"
+          "note_ref": "n37",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2021 X1 technical-data PDF confirms the later exact X1 xDrive25e plug-in-hybrid state with AWD, 6-speed Steptronic, 0.672 top gear, a single published 3.944 final-drive ratio, and a later 205/55 R17 baseline tire. This row is split from the exact 2020 launch-state row because BMW's checked later sheet changes the baseline tire.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.185",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X1 xDrive25e exact optional wheel/tire matrix for the narrowed 2021 row",
+          "reason": "The checked official BMW 03/2021 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW X1 xDrive25e separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD plug-in-hybrid state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X1 xDrive25e exact optional wheel/tire matrix for the narrowed 2021 row",
-        "reason": "The checked official BMW 03/2021 technical-data PDF closes the baseline 17-inch fitment, but it does not prove one exact optional wheel/tire matrix for the narrowed row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X1 xDrive25e separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD plug-in-hybrid state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/U11.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/U11.json
@@ -1,500 +1,392 @@
-[
-  {
-    "id": "bmw-u11-xdrive23i-eu-2022-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U11",
-    "body_code": "U11",
-    "production_start_year": 2022,
-    "production_end_year": 2026,
-    "model_name": "X1 (U11, 2022-2026)",
-    "variant_name": "xDrive23i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub / model overview with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:6d0d993f5901",
+        "legacy_research_sources:78b598b517e4",
+        "legacy_research_sources:8fea5faa09d1",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:a9c2e6189261",
+        "legacy_research_sources:b3921f131921"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
+      ],
+      "e3": [
+        "bmw_market_pages:u11-x1-technical-data-de"
+      ],
+      "e4": [
         "bmw_market_pages:u11-x1-overview-de",
         "bmw_market_pages:u11-x1-technical-data-de",
         "bmw_market_pages:u11-x1-technical-data-uk"
       ],
-      "notes": "Current official BMW Germany overview and technical-data pages plus the BMW UK technical-data page all surface the exact U11 xDrive23i product identity. BMW's xDrive naming and the current product blocks are sufficient to confirm the AWD layout for this row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:6d0d993f5901",
-          "legacy_research_sources:78b598b517e4",
-          "legacy_research_sources:8fea5faa09d1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:a9c2e6189261",
-          "legacy_research_sources:b3921f131921"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of current BMW Germany overview and technical-data pages plus the BMW UK technical-data page now confirms that the exact U11 xDrive23i is a live first-party product surface and that BMW's embedded product metadata marks this variant with productionYear 2022. That is strong enough to retime the row to a 2022 start and replace the copied iX1 EV advisory block, but not strong enough to promote the inherited transmission or tire data.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-overview-de",
-          "bmw_market_pages:u11-x1-technical-data-de",
-          "bmw_market_pages:u11-x1-technical-data-uk"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact U11 xDrive23i transmission wording and raw ratio / final-drive mapping",
-        "reason": "The current BMW Germany and UK product pages directly confirm trim identity and productionYear 2022, but their rendered technical tables were not statically recoverable in this pass, so the inherited DCT and ratio fields remain unresolved.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-overview-de",
-          "bmw_market_pages:u11-x1-technical-data-de",
-          "bmw_market_pages:u11-x1-technical-data-uk"
-        ]
-      },
-      {
-        "item": "Exact U11 xDrive23i baseline and optional wheel/tire matrix",
-        "reason": "This pass confirmed the live BMW xDrive23i product surfaces and productionYear metadata, but it did not recover one directly readable first-party wheel and tire table for the exact row.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-overview-de",
-          "bmw_market_pages:u11-x1-technical-data-de",
-          "bmw_market_pages:u11-x1-technical-data-uk"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-u11-ix1-xdrive30-eu-2023-ss1-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U11",
-    "body_code": "U11",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "X1 (U11, 2023-2026)",
-    "variant_name": "iX1 xDrive30",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e5": [
         "bmw_pressclub_sources:u11-ix1-tech-spec-article",
         "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-      ],
-      "notes": "The official BMW Deutschland technical-data article and PDF for the exact iX1 xDrive30 describe coordinated drive torque from one electric motor at the front axle and one at the rear axle, which is sufficient to confirm the AWD layout for this row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-      ],
-      "notes": "The official BMW Deutschland technical-data PDF for the exact iX1 xDrive30 states \"Automatikgetriebe, einstufig mit fester Übersetzung\". The repo normalizes that EV wording to the canonical SS1 single-speed fixed-gear transmission label.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ],
-        "notes": "The official BMW Deutschland technical-data PDF describes a single-speed fixed-ratio EV transmission. The repo's EV ratio model represents that gearbox with a normalized top-gear value of 1.0.",
-        "value": 1.0
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ],
-        "notes": "The official BMW Deutschland technical-data PDF publishes the front electric-motor reduction ratio for the exact iX1 xDrive30 as 11.190.",
-        "value": 11.19
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ],
-        "notes": "The official BMW Deutschland technical-data PDF publishes the rear electric-motor reduction ratio for the exact iX1 xDrive30 as 10.050.",
-        "value": 10.05
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ],
-        "notes": "The official BMW Deutschland technical-data PDF for the exact iX1 xDrive30 publishes 205/65 R17 100Y XL tires on 7.5J x 17 wheels as the baseline fitment.",
-        "front": {
-          "width_mm": 205.0,
-          "aspect_pct": 65.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub / model overview with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "18\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub / model overview with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "19\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub / model overview with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "20\" package"
-        }
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of the official BMW Deutschland technical-data article and PDF now lets this exact iX1 xDrive30 row carry the EV-specific AWD layout, single-speed fixed-ratio transmission normalization, front and rear reduction ratios 11.190 / 10.050, and the 205/65 R17 launch-standard tire that were previously left only in row notes.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-article",
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Current-market iX1 xDrive30 optional wheel and tire matrix across the retained 2023-2026 row span",
-        "reason": "This pass directly revalidated the official launch technical-data PDF for the exact iX1 xDrive30 but did not recover a fresh current BMW market document proving the later option matrix well enough to replace the inherited option tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u11-ix1-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-u11-sdrive18i-eu-2023-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U11",
-    "body_code": "U11",
-    "production_start_year": 2023,
-    "production_end_year": 2026,
-    "model_name": "X1 (U11, 2023-2026)",
-    "variant_name": "sDrive18i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_market_pages:u11-x1-technical-data-de"
-      ],
-      "notes": "The current official BMW Germany U11 X1 technical-data page exposes the exact BMW X1 sDrive18i in its embedded per-trim schema block with driveWheelConfiguration set to Vorderradantrieb, which is sufficient to confirm the front-wheel-drive layout for this row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_market_pages:u11-x1-technical-data-de"
-      ],
-      "notes": "The current official BMW Germany U11 X1 technical-data page exposes the exact BMW X1 sDrive18i with a Steptronic Sport Getriebe mit Doppelkupplung label in the model dropdown and seven forward gears in the embedded schema block. The repo normalizes that row-specific BMW wording to the canonical DCT7 label.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
+  "configurations": [
+    {
+      "id": "bmw-u11-xdrive23i-eu-2022-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U11",
+      "body_code": "U11",
+      "production_start_year": 2022,
+      "production_end_year": 2026,
+      "model_name": "X1 (U11, 2022-2026)",
+      "variant_name": "xDrive23i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Current official BMW Germany overview and technical-data pages plus the BMW UK technical-data page all surface the exact U11 xDrive23i product identity. BMW's xDrive naming and the current product blocks are sufficient to confirm the AWD layout for this row.",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:6d0d993f5901",
-          "legacy_research_sources:78b598b517e4",
-          "legacy_research_sources:8fea5faa09d1",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:a9c2e6189261",
-          "legacy_research_sources:b3921f131921"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)"
       },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d0d993f5901",
-            "legacy_research_sources:78b598b517e4",
-            "legacy_research_sources:8fea5faa09d1",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:a9c2e6189261",
-            "legacy_research_sources:b3921f131921"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of the current BMW Germany U11 X1 technical-data page now confirms the exact sDrive18i trim surface, front-wheel-drive layout, and Steptronic Sport dual-clutch transmission wording for this row. That is strong enough to replace the copied iX1 EV advisory block and promote drivetrain/transmission support, but not strong enough to promote the inherited ratio or tire fields.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-technical-data-de"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact U11 sDrive18i raw ratio and final-drive mapping",
-        "reason": "The current BMW Germany technical-data page directly confirms the exact sDrive18i trim, FWD layout, and seven-speed dual-clutch wording, but its rendered numeric gear-ratio and final-drive tables were not recoverable in this pass.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-technical-data-de"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
         ]
       },
-      {
-        "item": "Exact U11 sDrive18i baseline and optional wheel/tire matrix",
-        "reason": "This pass did not recover one directly readable first-party BMW wheel and tire table for the exact sDrive18i trim, so the inherited 18-inch, 19-inch, and 20-inch tire entries remain unresolved.",
-        "evidence_refs": [
-          "bmw_market_pages:u11-x1-technical-data-de"
-        ]
+      "verification_notes": [
+        {
+          "note": "Direct validation of current BMW Germany overview and technical-data pages plus the BMW UK technical-data page now confirms that the exact U11 xDrive23i is a live first-party product surface and that BMW's embedded product metadata marks this variant with productionYear 2022. That is strong enough to retime the row to a 2022 start and replace the copied iX1 EV advisory block, but not strong enough to promote the inherited transmission or tire data.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact U11 xDrive23i transmission wording and raw ratio / final-drive mapping",
+          "reason": "The current BMW Germany and UK product pages directly confirm trim identity and productionYear 2022, but their rendered technical tables were not statically recoverable in this pass, so the inherited DCT and ratio fields remain unresolved.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "item": "Exact U11 xDrive23i baseline and optional wheel/tire matrix",
+          "reason": "This pass confirmed the live BMW xDrive23i product surfaces and productionYear metadata, but it did not recover one directly readable first-party wheel and tire table for the exact row.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
+    },
+    {
+      "id": "bmw-u11-ix1-xdrive30-eu-2023-ss1-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U11",
+      "body_code": "U11",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "X1 (U11, 2023-2026)",
+      "variant_name": "iX1 xDrive30",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e5",
+        "notes": "The official BMW Deutschland technical-data article and PDF for the exact iX1 xDrive30 describe coordinated drive torque from one electric motor at the front axle and one at the rear axle, which is sufficient to confirm the AWD layout for this row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW Deutschland technical-data PDF for the exact iX1 xDrive30 states \"Automatikgetriebe, einstufig mit fester Übersetzung\". The repo normalizes that EV wording to the canonical SS1 single-speed fixed-gear transmission label.",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW Deutschland technical-data PDF describes a single-speed fixed-ratio EV transmission. The repo's EV ratio model represents that gearbox with a normalized top-gear value of 1.0.",
+          "value": 1.0
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW Deutschland technical-data PDF publishes the front electric-motor reduction ratio for the exact iX1 xDrive30 as 11.190.",
+          "value": 11.19
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW Deutschland technical-data PDF publishes the rear electric-motor reduction ratio for the exact iX1 xDrive30 as 10.050.",
+          "value": 10.05
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW Deutschland technical-data PDF for the exact iX1 xDrive30 publishes 205/65 R17 100Y XL tires on 7.5J x 17 wheels as the baseline fitment.",
+          "front": {
+            "width_mm": 205.0,
+            "aspect_pct": 65.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "18\" package"
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" package"
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of the official BMW Deutschland technical-data article and PDF now lets this exact iX1 xDrive30 row carry the EV-specific AWD layout, single-speed fixed-ratio transmission normalization, front and rear reduction ratios 11.190 / 10.050, and the 205/65 R17 launch-standard tire that were previously left only in row notes.",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Current-market iX1 xDrive30 optional wheel and tire matrix across the retained 2023-2026 row span",
+          "reason": "This pass directly revalidated the official launch technical-data PDF for the exact iX1 xDrive30 but did not recover a fresh current BMW market document proving the later option matrix well enough to replace the inherited option tires.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-u11-sdrive18i-eu-2023-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U11",
+      "body_code": "U11",
+      "production_start_year": 2023,
+      "production_end_year": 2026,
+      "model_name": "X1 (U11, 2023-2026)",
+      "variant_name": "sDrive18i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The current official BMW Germany U11 X1 technical-data page exposes the exact BMW X1 sDrive18i in its embedded per-trim schema block with driveWheelConfiguration set to Vorderradantrieb, which is sufficient to confirm the front-wheel-drive layout for this row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The current official BMW Germany U11 X1 technical-data page exposes the exact BMW X1 sDrive18i with a Steptronic Sport Getriebe mit Doppelkupplung label in the model dropdown and seven forward gears in the embedded schema block. The repo normalizes that row-specific BMW wording to the canonical DCT7 label.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of the current BMW Germany U11 X1 technical-data page now confirms the exact sDrive18i trim surface, front-wheel-drive layout, and Steptronic Sport dual-clutch transmission wording for this row. That is strong enough to replace the copied iX1 EV advisory block and promote drivetrain/transmission support, but not strong enough to promote the inherited ratio or tire fields.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Exact U11 sDrive18i raw ratio and final-drive mapping",
+          "reason": "The current BMW Germany technical-data page directly confirms the exact sDrive18i trim, FWD layout, and seven-speed dual-clutch wording, but its rendered numeric gear-ratio and final-drive tables were not recoverable in this pass.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Exact U11 sDrive18i baseline and optional wheel/tire matrix",
+          "reason": "This pass did not recover one directly readable first-party BMW wheel and tire table for the exact sDrive18i trim, so the inherited 18-inch, 19-inch, and 20-inch tire entries remain unresolved.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/F39.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/F39.json
@@ -1,4215 +1,3060 @@
-[
-  {
-    "id": "bmw-f39-sdrive16d-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive16d",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "n2": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n3": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n4": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n5": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n6": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n7": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n8": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n9": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n10": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n12": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n13": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
+      "n14": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
+      "n15": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
+      "n16": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
+      "n17": "Reverse gear ratio (research note): 4.221",
+      "n18": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+      "n19": "BMW X2 F39 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub spec PDF T0282289EN/403768 (03/2018) and T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B47C20O0 (110 kW / 150 hp), gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: repo's transmission code label 'ZF8HP' is a misnomer (ZF 8HP is longitudinal-only); the actual gearbox is the Aisin AWF8F35 transverse 8AT. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
+      "n20": "BMW X2 F39 sDrive18i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0282289EN/403769 (03/2018), T0286557EN/419617 (09/2018), and T0327517EN/473618 (03/2021). Engine B38A15M0 (100 kW / 136 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final-drive) values; FD published separately as 4.176. Individual gear set derived: [3.769, 2.161, 1.380, 0.978, 0.766, 0.614, 0.547]. Standard tyre 225/55 R17 97W.",
+      "n21": "BMW X2 F39 sDrive20i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B48A20M0 (141 kW / 192 hp). BMW publishes DCT7 OVERALL ratios; FD 3.789 published separately. Individual gear set derived: [4.155, 2.381, 1.522, 1.079, 0.844, 0.677, 0.547] - same 7th gear (0.547) as sDrive18i, expected for same gearbox. Standard tyre 225/55 R17 97W.",
+      "n22": "BMW X2 F39 xDrive20d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec, xDrive20d section, FD=2.851) and T0327517EN/473618 (03/2021). Engine B47C20O1 (140 kW / 190 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. AWD via Haldex coupling on rear axle.",
+      "n23": "Aisin AWF8F45 8th gear.",
+      "n24": "BMW X2 F39 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0282289EN/403771 (03/2018 xDrive20i spec) and T0327517EN/473618 (03/2021). Engine B48A20M1 (141 kW / 192 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 3.200 (higher than diesel 2.851). Standard tyre 225/55 R17 97W.",
+      "n25": "BMW X2 F39 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0327517EN/473618 (03/2021 multi-variant spec, xDrive25d section). Engine B47C20O2 (170 kW / 231 hp) AWD tune. Same Aisin AWF8F45 gear set as xDrive20d: 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: an existing repo source note for f39-xdrive20d-xdrive25d-2017-spec-pdf cites FD 2.955 from a 10/2017 launch spec - this value was either pre-production or a transcription error and is superseded by the 2.851 confirmed in two subsequent multi-variant spec PDFs (09/2018 and 03/2021).",
+      "n26": "Getrag 7DCI300 final drive per BMW spec.",
+      "n27": "Aisin AWF8F45 gear set."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:510dd2aed163",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:cdf00de14164"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
         "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) is offered exclusively with the 6-speed manual transmission per BMW Cyprus brochure (PSL44 EWL) Power Transmission table. The DCT7 was never paired with this engine. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW Cyprus brochure proves the EU-family F39 sDrive16d exists as a front-wheel-drive row with manual-standard wording, bracketed automatic performance figures, and a 225/55 R17 base tyre. It does not name an exact automatic gearbox family, so this DCT7 row remains an unsupported placeholder rather than a production-backed dual-clutch mapping.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "note": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact DCT7 automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Recover an exact official F39 sDrive16d automatic gearbox sheet",
-        "reason": "The saved official EU-family source proves sDrive16d existence and the 225/55 R17 baseline but does not identify the automatic gearbox family, so this DCT7 row cannot be confirmed or corrected numerically in place.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact DCT7 automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive16d-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive16d",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 sDrive16d (B37 1.5L diesel, EU only, from 2019) standard transmission is the 6-speed manual per BMW Cyprus brochure. No BMW PressClub spec PDF or market brochure confirms an 8-speed Steptronic option for this variant. Additionally production_start_year 2018 is wrong: sDrive16d entered production in 2019. Drivetrain, transmission, ratios and tires set to no_confidence pending direct confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW Cyprus brochure proves the EU-family F39 sDrive16d exists as a front-wheel-drive row with manual-standard wording, bracketed automatic performance figures, and a 225/55 R17 base tyre. It does not name an exact automatic gearbox family, so this ZF8HP row remains an unsupported placeholder rather than a production-backed 8-speed mapping.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "note": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact 8-speed automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Recover an exact official F39 sDrive16d automatic gearbox sheet",
-        "reason": "The saved official EU-family source proves sDrive16d existence and the 225/55 R17 baseline but does not identify the automatic gearbox family, so this ZF8HP row cannot be confirmed or corrected numerically in place.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact 8-speed automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-brochure-2021-cy"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive18d-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive18d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+      ],
+      "e3": [
+        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
         "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+      ],
+      "e4": [
+        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
         "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 diesel variants (B37/B47 engines) were never paired with the Getrag 7DCI300 7-speed DCT. The DCT7 in F39 is a FWD petrol-only gearbox (sDrive18i / sDrive20i). All diesel variants used either the 6-speed manual (GS6-17BG) or the Aisin AWF8F35/AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec) listing diesel 8AT/6MT only and T0327517EN/473618 (03/2021 multi-variant spec) confirming. Drivetrain, transmission, ratios and tires set to no_confidence; safety gates require manual confirmation.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "note": "Official 2018 and 2021 F39 sDrive18d technical-data sheets show six-speed manual with optional 8-speed Steptronic, not a DCT7 automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 2018 and 2021 F39 sDrive18d technical-data sheets show six-speed manual with optional 8-speed Steptronic, not a DCT7 automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive18d-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive18d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      ],
+      "e5": [
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
+        "secondary_technical_sources:bmw-x2-f39-wikipedia"
+      ],
+      "e6": [
         "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
         "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
         "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub spec PDF T0282289EN/403768 (03/2018) and T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B47C20O0 (110 kW / 150 hp), gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: repo's transmission code label 'ZF8HP' is a misnomer (ZF 8HP is longitudinal-only); the actual gearbox is the Aisin AWF8F35 transverse 8AT. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
+      "e7": [
+        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e8": [
+        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
         "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
         "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub spec PDF T0282289EN/403768 (03/2018) and T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B47C20O0 (110 kW / 150 hp), gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: repo's transmission code label 'ZF8HP' is a misnomer (ZF 8HP is longitudinal-only); the actual gearbox is the Aisin AWF8F35 transverse 8AT. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F35)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 8th gear from BMW PressClub T0282289EN/403768 (03/2018).",
-        "value": 0.673
+      "e9": [
+        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e10": [
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e12": [
+        "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e13": [
+        "bmw_market_pages:f39-x2-brochure-2021-cy"
+      ],
+      "e14": [
+        "bmw_market_pages:f39-x2-price-list-2022-de",
+        "bmw_market_pages:f39-x2-brochure-2022-gr",
+        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
+        "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
+      ],
+      "e15": [
+        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
+        "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
+      ],
+      "e16": [
+        "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e17": [
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e18": [
+        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e19": [
+        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e20": [
+        "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e21": [
+        "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
+        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
+        "bmw_market_pages:f39-x2-brochure-2022-gr"
+      ],
+      "e22": [
+        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      ],
+      "e23": [
+        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec"
+      ],
+      "e24": [
+        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
+        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
+        "bmw_market_pages:f39-x2-price-list-2022-de"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f39-sdrive16d-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive16d",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n14",
+        "value": "FWD",
+        "evidence_refs_ref": "e5"
       },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 final drive (FWD).",
-        "value": 2.851
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n14",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e5"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F35 gear set per BMW PressClub spec."
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n14",
+          "value": 0.71,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n14",
+          "value": 3.636,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n14",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW Cyprus brochure proves the EU-family F39 sDrive16d exists as a front-wheel-drive row with manual-standard wording, bracketed automatic performance figures, and a 225/55 R17 base tyre. It does not name an exact automatic gearbox family, so this DCT7 row remains an unsupported placeholder rather than a production-backed dual-clutch mapping.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact DCT7 automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Recover an exact official F39 sDrive16d automatic gearbox sheet",
+          "reason": "The saved official EU-family source proves sDrive16d existence and the 225/55 R17 baseline but does not identify the automatic gearbox family, so this DCT7 row cannot be confirmed or corrected numerically in place.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact DCT7 automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec"
-        ],
-        "notes": "BMW X2 F39 sDrive18d 8-speed Steptronic (Aisin AWF8F35) FWD. Confirmed by BMW PressClub spec PDF T0282289EN/403768 (03/2018) and T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B47C20O0 (110 kW / 150 hp), gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: repo's transmission code label 'ZF8HP' is a misnomer (ZF 8HP is longitudinal-only); the actual gearbox is the Aisin AWF8F35 transverse 8AT. Code retained as stored to avoid breaking shard-internal references; transmission.name corrected.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f39-sdrive16d-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive16d",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n15",
+        "value": "FWD",
+        "evidence_refs_ref": "e5"
       },
-      "options": [
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n15",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e5"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 0.674,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n15",
+          "value": 3.294,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n15",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_derived",
+          "note": "The official BMW Cyprus brochure proves the EU-family F39 sDrive16d exists as a front-wheel-drive row with manual-standard wording, bracketed automatic performance figures, and a 225/55 R17 base tyre. It does not name an exact automatic gearbox family, so this ZF8HP row remains an unsupported placeholder rather than a production-backed 8-speed mapping.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact 8-speed automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e5"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Recover an exact official F39 sDrive16d automatic gearbox sheet",
+          "reason": "The saved official EU-family source proves sDrive16d existence and the 225/55 R17 baseline but does not identify the automatic gearbox family, so this ZF8HP row cannot be confirmed or corrected numerically in place.",
+          "evidence_refs_ref": "e13"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 brochures prove EU-family sDrive16d front-wheel-drive existence and base tire context but do not confirm an exact 8-speed automatic row; keep this placeholder out of driveshaft/wheel order analysis until an exact official automatic or manual replacement row is built.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive18d-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive18d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n16",
+        "value": "FWD",
+        "evidence_refs_ref": "e6"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n16",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n16",
+          "value": 0.71,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n16",
+          "value": 3.636,
+          "evidence_refs_ref": "e6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n16",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Official 2018 and 2021 F39 sDrive18d technical-data sheets show six-speed manual with optional 8-speed Steptronic, not a DCT7 automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e16"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 2018 and 2021 F39 sDrive18d technical-data sheets show six-speed manual with optional 8-speed Steptronic, not a DCT7 automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive18d-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive18d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n19",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e6",
+        "notes_ref": "n19",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F35)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 8th gear from BMW PressClub T0282289EN/403768 (03/2018).",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 final drive (FWD).",
+          "value": 2.851
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
+          ],
+          "evidence_refs_ref": "e6",
+          "notes": "Aisin AWF8F35 gear set per BMW PressClub spec."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
           "evidence_refs": [
             "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-            "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+            "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec"
           ],
-          "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive18d automatic row.",
+          "notes_ref": "n19",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e16",
+            "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive18d automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 sDrive18d automatic row: front-wheel drive, 8-speed Steptronic, 0.673 top gear, 2.851 final drive, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
+          "evidence_refs_ref": "e16"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n17",
+          "evidence_refs_ref": "e6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 sDrive18d automatic row: front-wheel drive, 8-speed Steptronic, 0.673 top gear, 2.851 final drive, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 sDrive18d automatic year-by-year continuity across the represented 2018-2023 row span",
-        "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X2 sDrive18d exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18d-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive18i-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive18i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 sDrive18i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0282289EN/403769 (03/2018), T0286557EN/419617 (09/2018), and T0327517EN/473618 (03/2021). Engine B38A15M0 (100 kW / 136 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final-drive) values; FD published separately as 4.176. Individual gear set derived: [3.769, 2.161, 1.380, 0.978, 0.766, 0.614, 0.547]. Standard tyre 225/55 R17 97W.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X2 F39 sDrive18i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0282289EN/403769 (03/2018), T0286557EN/419617 (09/2018), and T0327517EN/473618 (03/2021). Engine B38A15M0 (100 kW / 136 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final-drive) values; FD published separately as 4.176. Individual gear set derived: [3.769, 2.161, 1.380, 0.978, 0.766, 0.614, 0.547]. Standard tyre 225/55 R17 97W.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (Getrag 7DCI300)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Getrag 7DCI300 7th gear individual ratio derived from BMW spec overall ratio 2.285 / FD 4.176.",
-        "value": 0.547
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Getrag 7DCI300 final drive per BMW spec.",
-        "value": 4.176
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "value": [
-          3.769,
-          2.161,
-          1.38,
-          0.978,
-          0.766,
-          0.614,
-          0.547
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec"
-        ],
-        "notes": "Individual gear ratios derived by dividing BMW spec OVERALL ratios (15.741/9.024/5.766/4.085/3.197/2.562/2.285) by FD 4.176. BMW publishes overall ratios for DCT7; individual derivation is arithmetic."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec"
-        ],
-        "notes": "BMW X2 F39 sDrive18i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0282289EN/403769 (03/2018), T0286557EN/419617 (09/2018), and T0327517EN/473618 (03/2021). Engine B38A15M0 (100 kW / 136 hp). BMW spec PDFs publish DCT7 ratios as OVERALL (gear x final-drive) values; FD published separately as 4.176. Individual gear set derived: [3.769, 2.161, 1.380, 0.978, 0.766, 0.614, 0.547]. Standard tyre 225/55 R17 97W.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X2 sDrive18d automatic year-by-year continuity across the represented 2018-2023 row span",
+          "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e16"
+        },
+        {
+          "item": "BMW X2 sDrive18d exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e16"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive18i-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive18i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n20",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes_ref": "n20",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (Getrag 7DCI300)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "Getrag 7DCI300 7th gear individual ratio derived from BMW spec overall ratio 2.285 / FD 4.176.",
+          "value": 0.547
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n26",
+          "value": 4.176
+        },
+        "gear_ratios": {
           "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-            "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+          "value": [
+            3.769,
+            2.161,
+            1.38,
+            0.978,
+            0.766,
+            0.614,
+            0.547
           ],
-          "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive18i automatic row.",
+          "evidence_refs_ref": "e23",
+          "notes": "Individual gear ratios derived by dividing BMW spec OVERALL ratios (15.741/9.024/5.766/4.085/3.197/2.562/2.285) by FD 4.176. BMW publishes overall ratios for DCT7; individual derivation is arithmetic."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e23",
+          "notes_ref": "n20",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e18",
+            "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive18i automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 sDrive18i automatic row: front-wheel drive, 7-speed Steptronic dual-clutch, effective top gear 0.547, final drive 4.176, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
+          "evidence_refs_ref": "e18"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 sDrive18i automatic row: front-wheel drive, 7-speed Steptronic dual-clutch, effective top gear 0.547, final drive 4.176, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 sDrive18i automatic year-by-year continuity across the represented 2018-2023 row span",
-        "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X2 sDrive18i exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive18i-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive18i",
-    "engine_code": "B38",
-    "engine_name": "B38 1.5L I3 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "item": "BMW X2 sDrive18i automatic year-by-year continuity across the represented 2018-2023 row span",
+          "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e18"
+        },
+        {
+          "item": "BMW X2 sDrive18i exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e18"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive18i-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive18i",
+      "engine_code": "B38",
+      "engine_name": "B38 1.5L I3 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "value": "FWD",
+        "evidence_refs_ref": "e8"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e8"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 0.674,
+          "evidence_refs_ref": "e8"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 3.294,
+          "evidence_refs_ref": "e8"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n9",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "Official 2018 and 2021 F39 sDrive18i technical-data sheets show six-speed manual with optional 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e19"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "Official 2018 and 2021 F39 sDrive18i technical-data sheets show six-speed manual with optional 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 2018 and 2021 F39 sDrive18i technical-data sheets show six-speed manual with optional 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive20i-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive20i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 sDrive20i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B48A20M0 (141 kW / 192 hp). BMW publishes DCT7 OVERALL ratios; FD 3.789 published separately. Individual gear set derived: [4.155, 2.381, 1.522, 1.079, 0.844, 0.677, 0.547] - same 7th gear (0.547) as sDrive18i, expected for same gearbox. Standard tyre 225/55 R17 97W.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X2 F39 sDrive20i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B48A20M0 (141 kW / 192 hp). BMW publishes DCT7 OVERALL ratios; FD 3.789 published separately. Individual gear set derived: [4.155, 2.381, 1.522, 1.079, 0.844, 0.677, 0.547] - same 7th gear (0.547) as sDrive18i, expected for same gearbox. Standard tyre 225/55 R17 97W.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (Getrag 7DCI300)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Getrag 7DCI300 7th gear individual ratio (BMW spec overall 2.073 / FD 3.789).",
-        "value": 0.547
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Getrag 7DCI300 final drive per BMW spec.",
-        "value": 3.789
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "value": [
-          4.155,
-          2.381,
-          1.522,
-          1.079,
-          0.844,
-          0.677,
-          0.547
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Individual gear ratios derived by dividing BMW OVERALL ratios by FD 3.789."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X2 F39 sDrive20i 7-speed dual-clutch (Getrag 7DCI300) FWD. Confirmed by BMW PressClub spec PDFs T0286557EN/419617 (09/2018) and T0327517EN/473618 (03/2021). Engine B48A20M0 (141 kW / 192 hp). BMW publishes DCT7 OVERALL ratios; FD 3.789 published separately. Individual gear set derived: [4.155, 2.381, 1.522, 1.079, 0.844, 0.677, 0.547] - same 7th gear (0.547) as sDrive18i, expected for same gearbox. Standard tyre 225/55 R17 97W.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 2018 and 2021 F39 sDrive18i technical-data sheets show six-speed manual with optional 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive20i-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive20i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n21",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e10",
+        "notes_ref": "n21",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (Getrag 7DCI300)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "Getrag 7DCI300 7th gear individual ratio (BMW spec overall 2.073 / FD 3.789).",
+          "value": 0.547
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n26",
+          "value": 3.789
+        },
+        "gear_ratios": {
           "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-            "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+          "value": [
+            4.155,
+            2.381,
+            1.522,
+            1.079,
+            0.844,
+            0.677,
+            0.547
           ],
-          "notes": "The checked official BMW 10/2017 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive20i automatic row.",
+          "evidence_refs_ref": "e10",
+          "notes": "Individual gear ratios derived by dividing BMW OVERALL ratios by FD 3.789."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n21",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e20",
+            "notes": "The checked official BMW 10/2017 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 sDrive20i automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs agree on the broad F39 sDrive20i automatic row: front-wheel drive, 7-speed Steptronic dual-clutch, 0.547 top gear, 3.789 final drive, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
+          "evidence_refs_ref": "e20"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs agree on the broad F39 sDrive20i automatic row: front-wheel drive, 7-speed Steptronic dual-clutch, 0.547 top gear, 3.789 final drive, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 sDrive20i automatic year-by-year continuity across the represented 2018-2023 row span",
-        "reason": "The checked official BMW 10/2017 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X2 sDrive20i exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive20i-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive20i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The BMW X2 F39 FWD petrol variants (sDrive18i / sDrive20i) were offered exclusively with the Getrag 7DCI300 7-speed DCT. No 8-speed Steptronic was offered for FWD petrol. AWD petrol (xDrive20i, M35i) used the Aisin 8AT, but FWD petrol did not. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618 across all production years. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive20d automatic state as 8-speed Steptronic, not 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F39 sDrive20i technical-data sheets show 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted xDrive20d DCT7 row should be replaced by an exact Steptronic row",
-        "reason": "Official BMW PDFs support the EU-market F39 xDrive20d automatic state only as 8-speed Steptronic and do not support a dual-clutch row, but this pass did not split or delete the legacy broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 sDrive20i technical-data sheets show 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-sdrive18i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-sdrive20i-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive28i-eu-2018-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive28i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 sDrive28i row, while official BMW USA launch and 2021 model articles explicitly place sDrive28i in a US-market 8-speed-automatic family. This EU DCT7 row is therefore a wrong-market placeholder, not a production-backed EU dual-clutch mapping.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move sDrive28i into the correct non-EU market slice",
-        "reason": "The saved official packet shows EU 28i absence and US-market automatic-only 28i applicability, so this EU DCT7 placeholder should be removed or remapped only after a dedicated non-EU row exists.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-sdrive28i-eu-2018-zf8hp-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "sDrive28i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "FWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 sDrive28i row, while official BMW USA material shows sDrive28i as a US-market 8-speed-automatic row with a 3.200 final drive and 19-inch or 20-inch tyre packages. This EU row is therefore a wrong-market placeholder rather than a production-backed EU configuration.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move sDrive28i into the correct non-EU market slice",
-        "reason": "The saved official packet shows EU 28i absence and a distinct US-market automatic package, so this EU placeholder should be removed or remapped only after a dedicated non-EU row exists.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive20d-eu-2018-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive20d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "note": "Official 2018 and 2021 F39 xDrive20d technical-data sheets show 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:510dd2aed163",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:cdf00de14164"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 2018 and 2021 F39 xDrive20d technical-data sheets show 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive20d-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive20d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 xDrive20d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec, xDrive20d section, FD=2.851) and T0327517EN/473618 (03/2021). Engine B47C20O1 (140 kW / 190 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. AWD via Haldex coupling on rear axle.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      "unresolved": [
+        {
+          "item": "BMW X2 sDrive20i automatic year-by-year continuity across the represented 2018-2023 row span",
+          "reason": "The checked official BMW 10/2017 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e20"
+        },
+        {
+          "item": "BMW X2 sDrive20i exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e20"
+        }
       ],
-      "notes": "BMW X2 F39 xDrive20d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec, xDrive20d section, FD=2.851) and T0327517EN/473618 (03/2021). Engine B47C20O1 (140 kW / 190 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. AWD via Haldex coupling on rear axle.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive for xDrive20d.",
-        "value": 2.851
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive; UKL2 Haldex AWD has a single FD value with rear coupling output ratio not separately published.",
-        "value": 2.851
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 gear set per BMW PressClub spec."
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X2 F39 xDrive20d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0286557EN/419617 (09/2018 multi-variant spec, xDrive20d section, FD=2.851) and T0327517EN/473618 (03/2021). Engine B47C20O1 (140 kW / 190 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. AWD via Haldex coupling on rear axle.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f39-sdrive20i-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive20i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "value": "FWD",
+        "evidence_refs_ref": "e12"
       },
-      "options": [
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n9",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e12"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 0.674,
+          "evidence_refs_ref": "e12"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n9",
+          "value": 3.294,
+          "evidence_refs_ref": "e12"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n9",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-            "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+          "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive20d automatic state as 8-speed Steptronic, not 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note": "Official F39 sDrive20i technical-data sheets show 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e19"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e12"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Whether this contradicted xDrive20d DCT7 row should be replaced by an exact Steptronic row",
+          "reason": "Official BMW PDFs support the EU-market F39 xDrive20d automatic state only as 8-speed Steptronic and do not support a dual-clutch row, but this pass did not split or delete the legacy broad row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 sDrive20i technical-data sheets show 7-speed Steptronic DCT, not an 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e19"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive28i-eu-2018-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive28i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.71,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.636,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 sDrive28i row, while official BMW USA launch and 2021 model articles explicitly place sDrive28i in a US-market 8-speed-automatic family. This EU DCT7 row is therefore a wrong-market placeholder, not a production-backed EU dual-clutch mapping.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "note": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Move sDrive28i into the correct non-EU market slice",
+          "reason": "The saved official packet shows EU 28i absence and US-market automatic-only 28i applicability, so this EU DCT7 placeholder should be removed or remapped only after a dedicated non-EU row exists.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-sdrive28i-eu-2018-zf8hp-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "sDrive28i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "FWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.674,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.294,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 sDrive28i row, while official BMW USA material shows sDrive28i as a US-market 8-speed-automatic row with a 3.200 final drive and 19-inch or 20-inch tyre packages. This EU row is therefore a wrong-market placeholder rather than a production-backed EU configuration.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "note": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Move sDrive28i into the correct non-EU market slice",
+          "reason": "The saved official packet shows EU 28i absence and a distinct US-market automatic package, so this EU placeholder should be removed or remapped only after a dedicated non-EU row exists.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 28i evidence recovered in this run is USA-market only; it supports sDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive20d-eu-2018-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive20d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "AWD",
+        "evidence_refs_ref": "e9"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e9"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.71,
+          "evidence_refs_ref": "e9"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e9"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e9"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 45.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n18",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Official 2018 and 2021 F39 xDrive20d technical-data sheets show 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n4",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e9"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e9"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X2 (F39, 2018-2023) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X2 (F39, 2018-2023) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 2018 and 2021 F39 xDrive20d technical-data sheets show 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive20d-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive20d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n22",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes_ref": "n22",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n23",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "Aisin AWF8F45 final drive for xDrive20d.",
+          "value": 2.851
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive; UKL2 Haldex AWD has a single FD value with rear coupling output ratio not separately published.",
+          "value": 2.851
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "The checked official BMW 10/2017 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 xDrive20d automatic row.",
+          "evidence_refs_ref": "e10",
+          "notes": "Aisin AWF8F45 gear set per BMW PressClub spec."
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n22",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e3",
+            "notes": "The checked official BMW 10/2017 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 xDrive20d automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs agree on the broad F39 xDrive20d automatic row: all-wheel drive, 8-speed Steptronic, 0.673 top gear, a single published AWD drive ratio of 2.851, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders, mirroring the one published AWD ratio into both axle fields.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n17",
+          "evidence_refs_ref": "e10"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs agree on the broad F39 xDrive20d automatic row: all-wheel drive, 8-speed Steptronic, 0.673 top gear, a single published AWD drive ratio of 2.851, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders, mirroring the one published AWD ratio into both axle fields.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 xDrive20d automatic year-by-year continuity across the represented 2018-2023 row span",
-        "reason": "The checked official BMW 10/2017 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X2 xDrive20d exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive20i-eu-2018-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "item": "BMW X2 xDrive20d automatic year-by-year continuity across the represented 2018-2023 row span",
+          "reason": "The checked official BMW 10/2017 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW X2 xDrive20d exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive20i-eu-2018-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "AWD",
+        "evidence_refs_ref": "e11"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e11"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.71,
+          "evidence_refs_ref": "e11"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e11"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e11"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n11",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive20i automatic state as 8-speed Steptronic, not 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official F39 xDrive20i technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e11"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e11"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive20i automatic state as 8-speed Steptronic, not 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F39 xDrive20i technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2018-multi-variant-spec",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Whether this contradicted xDrive20i DCT7 row should be replaced by an exact Steptronic row",
-        "reason": "Official BMW PDFs support the EU-market F39 xDrive20i automatic state only as 8-speed Steptronic and do not support a dual-clutch row, but this pass did not split or delete the legacy broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 xDrive20i technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive20i-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0282289EN/403771 (03/2018 xDrive20i spec) and T0327517EN/473618 (03/2021). Engine B48A20M1 (141 kW / 192 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 3.200 (higher than diesel 2.851). Standard tyre 225/55 R17 97W.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ],
-      "notes": "BMW X2 F39 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0282289EN/403771 (03/2018 xDrive20i spec) and T0327517EN/473618 (03/2021). Engine B48A20M1 (141 kW / 192 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 3.200 (higher than diesel 2.851). Standard tyre 225/55 R17 97W.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive for xDrive20i petrol.",
-        "value": 3.2
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive; UKL2 Haldex AWD has a single FD.",
-        "value": 3.2
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 gear set."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X2 F39 xDrive20i 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0282289EN/403771 (03/2018 xDrive20i spec) and T0327517EN/473618 (03/2021). Engine B48A20M1 (141 kW / 192 hp) AWD tune. Gear set 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 3.200 (higher than diesel 2.851). Standard tyre 225/55 R17 97W.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_derived",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-            "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+          "item": "Whether this contradicted xDrive20i DCT7 row should be replaced by an exact Steptronic row",
+          "reason": "Official BMW PDFs support the EU-market F39 xDrive20i automatic state only as 8-speed Steptronic and do not support a dual-clutch row, but this pass did not split or delete the legacy broad row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 xDrive20i technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive20i-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n24",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e7",
+        "notes_ref": "n24",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n23",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Aisin AWF8F45 final drive for xDrive20i petrol.",
+          "value": 3.2
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive; UKL2 Haldex AWD has a single FD.",
+          "value": 3.2
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 xDrive20i automatic row.",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n27"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n24",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_derived",
+            "evidence_refs_ref": "e7",
+            "notes": "The checked official BMW 03/2018 and 03/2021 technical-data PDFs agree on 225/55 R17 as the baseline tire for the broad F39 xDrive20i automatic row.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 xDrive20i automatic row: all-wheel drive, 8-speed Steptronic, 0.673 top gear, a single published AWD drive ratio of 3.200, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders, mirroring the one published AWD ratio into both axle fields.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n17",
+          "evidence_refs_ref": "e7"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 03/2018 and 03/2021 technical-data PDFs agree on the broad F39 xDrive20i automatic row: all-wheel drive, 8-speed Steptronic, 0.673 top gear, a single published AWD drive ratio of 3.200, and 225/55 R17 baseline tires. The row now promotes those stable official values instead of the contradicted inherited placeholders, mirroring the one published AWD ratio into both axle fields.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 xDrive20i automatic year-by-year continuity across the represented 2018-2023 row span",
-        "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X2 xDrive20i exact optional wheel and tire matrix across the represented row span",
-        "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20i-2018-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive25d-eu-2018-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive25d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The Getrag 7DCI300 7-speed DCT in F39 is a FWD-only gearbox; it is mechanically incompatible with the Haldex AWD coupling used on xDrive variants. All AWD variants of the X2 F39 use the Aisin AWF8F45 8-speed Steptronic. Confirmed by BMW PressClub T0286557EN/419617 and T0327517EN/473618. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 45.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive25d automatic state as 8-speed Steptronic, never 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Official F39 xDrive25d technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Replace the contradicted xDrive25d DCT7 row with an exact Steptronic row",
-        "reason": "The saved official BMW sources support xDrive25d only as an 8-speed automatic state, but this pass does not delete or replace the legacy placeholder row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 xDrive25d technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive25d-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive25d",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
       ],
-      "notes": "BMW X2 F39 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0327517EN/473618 (03/2021 multi-variant spec, xDrive25d section). Engine B47C20O2 (170 kW / 231 hp) AWD tune. Same Aisin AWF8F45 gear set as xDrive20d: 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: an existing repo source note for f39-xdrive20d-xdrive25d-2017-spec-pdf cites FD 2.955 from a 10/2017 launch spec - this value was either pre-production or a transcription error and is superseded by the 2.851 confirmed in two subsequent multi-variant spec PDFs (09/2018 and 03/2021).",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
+      "unresolved": [
+        {
+          "item": "BMW X2 xDrive20i automatic year-by-year continuity across the represented 2018-2023 row span",
+          "reason": "The checked official BMW 03/2018 and 03/2021 packets agree on the promoted drivetrain, transmission, top-gear, final-drive, and baseline-tire values, but this pass did not recover a complete official year-by-year chain for every intermediate model year.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW X2 xDrive20i exact optional wheel and tire matrix across the represented row span",
+          "reason": "The checked official BMW packets close the baseline 225/55 R17 fitment, but this pass did not recover one exact optional wheel and tire matrix for the full broad row.",
+          "evidence_refs_ref": "e7"
+        }
       ],
-      "notes": "BMW X2 F39 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0327517EN/473618 (03/2021 multi-variant spec, xDrive25d section). Engine B47C20O2 (170 kW / 231 hp) AWD tune. Same Aisin AWF8F45 gear set as xDrive20d: 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: an existing repo source note for f39-xdrive20d-xdrive25d-2017-spec-pdf cites FD 2.955 from a 10/2017 launch spec - this value was either pre-production or a transcription error and is superseded by the 2.851 confirmed in two subsequent multi-variant spec PDFs (09/2018 and 03/2021).",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (Aisin AWF8F45)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 8th gear.",
-        "value": 0.673
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 final drive for xDrive25d. Supersedes the 2.955 value cited in the 10/2017 launch spec note (treated as pre-production).",
-        "value": 2.851
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive.",
-        "value": 2.851
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.519,
-          3.184,
-          2.05,
-          1.492,
-          1.235,
-          1.0,
-          0.801,
-          0.673
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Aisin AWF8F45 gear set."
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "BMW X2 F39 xDrive25d 8-speed Steptronic (Aisin AWF8F45) AWD. Confirmed by BMW PressClub T0327517EN/473618 (03/2021 multi-variant spec, xDrive25d section). Engine B47C20O2 (170 kW / 231 hp) AWD tune. Same Aisin AWF8F45 gear set as xDrive20d: 5.519/3.184/2.050/1.492/1.235/1.000/0.801/0.673, reverse 4.221, FD 2.851. Standard tyre 225/55 R17 97W. NOTE: an existing repo source note for f39-xdrive20d-xdrive25d-2017-spec-pdf cites FD 2.955 from a 10/2017 launch spec - this value was either pre-production or a transcription error and is superseded by the 2.851 confirmed in two subsequent multi-variant spec PDFs (09/2018 and 03/2021).",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-f39-xdrive25d-eu-2018-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive25d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "value": "AWD",
+        "evidence_refs_ref": "e3"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n3",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 0.71,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n3",
+          "value": 3.636,
+          "evidence_refs_ref": "e3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW 10/2017 and 03/2021 technical-data PDFs both show the EU-market F39 xDrive25d automatic state as 8-speed Steptronic, never 7-speed dual-clutch. This DCT7 row remains only as a contradicted placeholder until the broader F39 shard is reshaped.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official F39 xDrive25d technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e3"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch-period and later EU technical-data sources agree that the F39 xDrive25d is an AWD 8-speed Steptronic row and keep the 225/55 R17 baseline tyre, but they drift on the published final-drive value from 2.955 early in the run to 2.851 later in the run. This broad row therefore remains a mixed-era placeholder instead of promoting one unsafe all-years final-drive mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-price-list-2022-de"
-        ]
-      },
-      {
-        "note": "Official F39 technical-data sheets promote the xDrive25d automatic core fields to 8-speed Steptronic, 0.673 top gear, 2.851 final drive, all-wheel drive, and 225/55 R17 baseline tires; optional tire/package and full-span continuity remain unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Reverse gear ratio (research note): 4.221",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Split xDrive25d by era before promoting one exact final-drive value",
-        "reason": "The saved official BMW sources close the gearbox family and baseline tyre but disagree on the final-drive value across the represented span, so this broad AWD automatic row still needs year-aware reshaping before any exact numeric rewrite.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-price-list-2022-de"
-        ]
-      },
-      {
-        "item": "BMW X2 xDrive25d automatic year-by-year continuity and tire options",
-        "reason": "The official 2017/2021 technical-data evidence supports the core automatic row fields, but this pass did not recover one exact optional wheel/tire matrix or a full year-by-year chain for every 2018-2023 state.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive20d-xdrive25d-2017-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive25e-eu-2018-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive25e",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses a 6-speed Aisin Steptronic (AT6), NOT the Getrag 7DCI300 DCT7. Confirmed by BMW PressClub T0314293EN/457892 (05/2020 xDrive25e launch tech-data PDF). Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
+          "item": "Replace the contradicted xDrive25d DCT7 row with an exact Steptronic row",
+          "reason": "The saved official BMW sources support xDrive25d only as an 8-speed automatic state, but this pass does not delete or replace the legacy placeholder row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 xDrive25d technical-data sheets show all-wheel drive with 8-speed Steptronic, not a DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive25d-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive25d",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n25",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n25",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (Aisin AWF8F45)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e17",
+          "notes_ref": "n23",
+          "value": 0.673
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e17",
+          "notes": "Aisin AWF8F45 final drive for xDrive25d. Supersedes the 2.955 value cited in the 10/2017 launch spec note (treated as pre-production).",
+          "value": 2.851
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e17",
+          "notes": "Sonnet redo (2026-04 v2): mirrored from front axle final drive.",
+          "value": 2.851
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.519,
+            3.184,
+            2.05,
+            1.492,
+            1.235,
+            1.0,
+            0.801,
+            0.673
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "evidence_refs_ref": "e17",
+          "notes_ref": "n27"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e17",
+          "notes_ref": "n25",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 55.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW launch-period and later EU technical-data sources agree that the F39 xDrive25d is an AWD 8-speed Steptronic row and keep the 225/55 R17 baseline tyre, but they drift on the published final-drive value from 2.955 early in the run to 2.851 later in the run. This broad row therefore remains a mixed-era placeholder instead of promoting one unsafe all-years final-drive mapping.",
+          "evidence_refs_ref": "e24"
+        },
+        {
+          "note": "Official F39 technical-data sheets promote the xDrive25d automatic core fields to 8-speed Steptronic, 0.673 top gear, 2.851 final drive, all-wheel drive, and 225/55 R17 baseline tires; optional tire/package and full-span continuity remain unresolved.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n17",
+          "evidence_refs_ref": "e17"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "Split xDrive25d by era before promoting one exact final-drive value",
+          "reason": "The saved official BMW sources close the gearbox family and baseline tyre but disagree on the final-drive value across the represented span, so this broad AWD automatic row still needs year-aware reshaping before any exact numeric rewrite.",
+          "evidence_refs_ref": "e24"
+        },
+        {
+          "item": "BMW X2 xDrive25d automatic year-by-year continuity and tire options",
+          "reason": "The official 2017/2021 technical-data evidence supports the core automatic row fields, but this pass did not recover one exact optional wheel/tire matrix or a full year-by-year chain for every 2018-2023 state.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive25e-eu-2018-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive25e",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n12",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n12",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n12",
+          "value": 0.71,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n12",
+          "value": 3.636,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n12",
+          "value": 3.636,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n12",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW launch and technical-data material shows the F39 xDrive25e only from 2020 onward as a hybrid-specific AWD row with 6-speed Steptronic transmission and published final drive 3.944, not as a 2018 dual-clutch row. The checked official sources also disagree on the standard tyre between 225/55 R17 and 205/55 R17, so this DCT7 row remains only as a contradicted placeholder until the shard is reshaped into a dedicated 2020-on hybrid row.",
+          "evidence_refs_ref": "e21"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
+          "evidence_refs_ref": "e22"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch and technical-data material shows the F39 xDrive25e only from 2020 onward as a hybrid-specific AWD row with 6-speed Steptronic transmission and published final drive 3.944, not as a 2018 dual-clutch row. The checked official sources also disagree on the standard tyre between 225/55 R17 and 205/55 R17, so this DCT7 row remains only as a contradicted placeholder until the shard is reshaped into a dedicated 2020-on hybrid row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-brochure-2022-gr"
-        ]
-      },
-      {
-        "note": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Replace the contradicted xDrive25e DCT7 row with a dedicated 2020-on hybrid row",
-        "reason": "The saved official BMW sources support xDrive25e only as a later 6-speed hybrid AWD state and still show a standard-tyre conflict across the run, so this 2018 DCT7 placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-brochure-2022-gr"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive25e-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive25e",
-    "engine_code": "1.5L",
-    "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-        "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The X2 xDrive25e PHEV uses the Aisin AT6 6-speed Steptronic, NOT the AWF8F45 8-speed Steptronic. The 6AT is a different gearbox model with different gear ratios. Confirmed by BMW PressClub T0314293EN/457892. Additionally production_start_year 2018 is wrong: xDrive25e launched July 2020.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "item": "Replace the contradicted xDrive25e DCT7 row with a dedicated 2020-on hybrid row",
+          "reason": "The saved official BMW sources support xDrive25e only as a later 6-speed hybrid AWD state and still show a standard-tyre conflict across the run, so this 2018 DCT7 placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 DCT7 row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
+          "evidence_refs_ref": "e22"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive25e-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive25e",
+      "engine_code": "1.5L",
+      "engine_name": "1.5L B38 turbo + electric motor (PHEV)",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n13",
+        "value": "AWD",
+        "evidence_refs_ref": "e4"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n13",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e4"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n13",
+          "value": 0.674,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n13",
+          "value": 3.294,
+          "evidence_refs_ref": "e4"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n13",
+          "value": 3.294,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n13",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW launch and technical-data material shows the F39 xDrive25e only from 2020 onward as a hybrid-specific AWD row with 6-speed Steptronic transmission and published final drive 3.944, not as an 8-speed automatic row. The checked official sources also disagree on the standard tyre between 225/55 R17 and 205/55 R17, so this ZF8HP row remains only as a contradicted placeholder until the shard is reshaped into a dedicated 2020-on hybrid row.",
+          "evidence_refs_ref": "e21"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
+          "evidence_refs_ref": "e22"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW launch and technical-data material shows the F39 xDrive25e only from 2020 onward as a hybrid-specific AWD row with 6-speed Steptronic transmission and published final drive 3.944, not as an 8-speed automatic row. The checked official sources also disagree on the standard tyre between 225/55 R17 and 205/55 R17, so this ZF8HP row remains only as a contradicted placeholder until the shard is reshaped into a dedicated 2020-on hybrid row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-brochure-2022-gr"
-        ]
-      },
-      {
-        "note": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Replace the contradicted xDrive25e ZF8HP row with a dedicated 2020-on hybrid row",
-        "reason": "The saved official BMW sources support xDrive25e only as a later 6-speed hybrid AWD state and still show a standard-tyre conflict across the run, so this 8-speed placeholder cannot be corrected safely in place.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf",
-          "bmw_market_pages:f39-x2-brochure-2022-gr"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-xdrive25e-2020-tech-spec-pdf",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:f39-x2-2021-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive28i-eu-2018-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive28i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.71,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "item": "Replace the contradicted xDrive25e ZF8HP row with a dedicated 2020-on hybrid row",
+          "reason": "The saved official BMW sources support xDrive25e only as a later 6-speed hybrid AWD state and still show a standard-tyre conflict across the run, so this 8-speed placeholder cannot be corrected safely in place.",
+          "evidence_refs_ref": "e21"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official F39 xDrive25e evidence starts in 05/2020 and shows hybrid-specific xDrive with a 6-speed Steptronic transmission, not a 2018 8-speed automatic row; keep this contradicted placeholder out of driveshaft/wheel order analysis until a 2020-on PHEV row is built.",
+          "evidence_refs_ref": "e22"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive28i-eu-2018-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive28i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.71,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.636,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.636,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 xDrive28i row, while official BMW USA launch and 2021 model articles explicitly place xDrive28i in a US-market 8-speed-automatic family with a single published 3.200 drive ratio. This EU DCT7 row is therefore a wrong-market placeholder, not a production-backed EU dual-clutch mapping.",
+          "evidence_refs_ref": "e14"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 xDrive28i row, while official BMW USA launch and 2021 model articles explicitly place xDrive28i in a US-market 8-speed-automatic family with a single published 3.200 drive ratio. This EU DCT7 row is therefore a wrong-market placeholder, not a production-backed EU dual-clutch mapping.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Move xDrive28i into the correct non-EU market slice",
-        "reason": "The saved official packet shows EU 28i absence and US-market automatic-only xDrive28i applicability, so this EU DCT7 placeholder should be removed or remapped only after a dedicated non-EU row exists.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f39-xdrive28i-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F39",
-    "body_code": "F39",
-    "production_start_year": 2018,
-    "production_end_year": 2023,
-    "model_name": "X2 (F39, 2018-2023)",
-    "variant_name": "xDrive28i",
-    "engine_code": "2.0L",
-    "engine_name": "2.0L",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "value": "AWD",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (Aisin)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-        "secondary_technical_sources:bmw-x2-f39-wikipedia"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 0.674,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "value": 3.294,
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): PHANTOM ROW. The 28i badge (sDrive28i / xDrive28i) is a North American market designation only - it was NEVER offered in the EU lineup. The repo row carries an 'eu' market tag which is incorrect for this badge. BMW Germany 2022 price list contains no 28i variant; Wikipedia BMW X2 confirms 28i is North America only. Drivetrain, transmission, ratios and tires set to no_confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
+          "item": "Move xDrive28i into the correct non-EU market slice",
+          "reason": "The saved official packet shows EU 28i absence and US-market automatic-only xDrive28i applicability, so this EU DCT7 placeholder should be removed or remapped only after a dedicated non-EU row exists.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not an EU DCT7 row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f39-xdrive28i-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F39",
+      "body_code": "F39",
+      "production_start_year": 2018,
+      "production_end_year": 2023,
+      "model_name": "X2 (F39, 2018-2023)",
+      "variant_name": "xDrive28i",
+      "engine_code": "2.0L",
+      "engine_name": "2.0L",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "value": "AWD",
+        "evidence_refs_ref": "e2"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (Aisin)",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.674,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_front": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.294,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.294,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 xDrive28i row, while official BMW USA material shows xDrive28i as a US-market AWD 8-speed-automatic row with a 3.200 drive ratio and 19-inch or 20-inch tyre packages. This EU row is therefore a wrong-market placeholder rather than a production-backed EU configuration.",
+          "evidence_refs_ref": "e14"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
+          "note": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:510dd2aed163",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:cdf00de14164"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note_ref": "n4",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n5",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n7",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n8",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Checked official BMW Germany and Greece EU-family material does not surface any EU-market F39 xDrive28i row, while official BMW USA material shows xDrive28i as a US-market AWD 8-speed-automatic row with a 3.200 drive ratio and 19-inch or 20-inch tyre packages. This EU row is therefore a wrong-market placeholder rather than a production-backed EU configuration.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_front: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "secondary_technical_sources:bmw-x2-f39-wikipedia"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "Move xDrive28i into the correct non-EU market slice",
+          "reason": "The saved official packet shows EU 28i absence and a distinct US-market automatic package, so this EU placeholder should be removed or remapped only after a dedicated non-EU row exists.",
+          "evidence_refs_ref": "e14"
+        },
+        {
+          "item": "Unsupported exact F39 transmission/market mapping",
+          "reason": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
+          "evidence_refs_ref": "e15"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "Move xDrive28i into the correct non-EU market slice",
-        "reason": "The saved official packet shows EU 28i absence and a distinct US-market automatic package, so this EU placeholder should be removed or remapped only after a dedicated non-EU row exists.",
-        "evidence_refs": [
-          "bmw_market_pages:f39-x2-price-list-2022-de",
-          "bmw_market_pages:f39-x2-brochure-2022-gr",
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      },
-      {
-        "item": "Unsupported exact F39 transmission/market mapping",
-        "reason": "Official 28i evidence recovered in this run is USA-market only; it supports xDrive28i as a USA 8-speed automatic row, not a broad EU row. Keep this EU placeholder out of driveshaft/wheel order analysis until market-specific rows are split.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f39-x2-usa-2018-launch-article",
-          "bmw_pressclub_sources:f39-x2-usa-2021-edition-m-mesh-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/U10.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/U10.json
@@ -1,477 +1,410 @@
-[
-  {
-    "id": "bmw-u10-ix2-xdrive30-eu-2024-ss1-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U10",
-    "body_code": "U10",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "X2 (U10, 2024-2026)",
-    "variant_name": "iX2 xDrive30",
-    "engine_code": "Electric",
-    "engine_name": "Electric Dual Motor",
-    "fuel_type": "EV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
+      "n3": "The official BMW technical-data PDF for the exact X2 sDrive20i publishes 225/55 R18 102Y XL on 7.5J x 18 wheels as the launch-standard tire package."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:82cbe3b6f231",
+        "legacy_research_sources:83a17284711a",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ],
+      "e2": [
         "bmw_pressclub_sources:u10-ix2-launch-article"
       ],
-      "notes": "The official BMW launch article for the first-ever iX2 xDrive30 states that the exact EV uses two integrated drive units, one at the front axle and one at the rear, which is sufficient to confirm the AWD layout for this row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
+      "e3": [
         "bmw_market_pages:u10-ix2-technical-data-uk"
       ],
-      "notes": "The official BMW UK iX2 technical-data page for the exact IX25 iX2 xDrive30 page identity lists a 1-speed automatic transmission. The repo normalizes that market-facing EV wording to the canonical SS1 single-speed fixed-gear transmission label.",
-      "code": "SS1",
-      "name": "Single-speed fixed gear (EV)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e4": [
+        "bmw_pressclub_sources:u10-ix2-launch-article",
+        "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
+      ],
+      "e5": [
+        "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
+      ],
+      "e6": [
+        "bmw_market_pages:u10-x2-overview-at",
+        "bmw_market_pages:u10-x2-technical-data-at",
+        "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
+        "bmw_pressclub_sources:u10-ix2-launch-article"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-u10-ix2-xdrive30-eu-2024-ss1-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U10",
+      "body_code": "U10",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "X2 (U10, 2024-2026)",
+      "variant_name": "iX2 xDrive30",
+      "engine_code": "Electric",
+      "engine_name": "Electric Dual Motor",
+      "fuel_type": "EV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW launch article for the first-ever iX2 xDrive30 states that the exact EV uses two integrated drive units, one at the front axle and one at the rear, which is sufficient to confirm the AWD layout for this row.",
+        "value": "AWD"
+      },
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_market_pages:u10-ix2-technical-data-uk"
-        ],
-        "notes": "The official BMW UK iX2 technical-data page lists a 1-speed automatic transmission. The repo's EV ratio model represents that single-speed gearbox with a normalized top-gear value of 1.0 while reducer and final-drive details remain unresolved.",
-        "value": 1.0
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW UK iX2 technical-data page for the exact IX25 iX2 xDrive30 page identity lists a 1-speed automatic transmission. The repo normalizes that market-facing EV wording to the canonical SS1 single-speed fixed-gear transmission label.",
+        "code": "SS1",
+        "name": "Single-speed fixed gear (EV)"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:82cbe3b6f231",
-          "legacy_research_sources:83a17284711a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW UK iX2 technical-data page lists a 1-speed automatic transmission. The repo's EV ratio model represents that single-speed gearbox with a normalized top-gear value of 1.0 while reducer and final-drive details remain unresolved.",
+          "value": 1.0
         },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+        "final_drive_front": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
+          "notes_ref": "n2",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW's 10/2023 launch article confirms the exact iX2 xDrive30 enters the market in March 2024, uses one electric drive unit at the front axle and one at the rear, and rides on 17-inch light-alloy wheels as standard. The same article restricts the seven-speed dual-clutch wording to the combustion-engine X2 variants, so this EV row could not safely remain on a DCT7 identity.",
+          "evidence_refs_ref": "e2"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW technical data / model overview with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+          "note": "The official BMW UK technical-data page for the exact IX25 iX2 xDrive30 page identity lists a 1-speed automatic transmission. This pass therefore normalizes the row to the repo's SS1 single-speed EV transmission while leaving reducer ratios, final drives, and exact tire dimensions unresolved until a fuller technical sheet is recovered.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW's 10/2023 launch article confirms the exact iX2 xDrive30 enters the market in March 2024, uses one electric drive unit at the front axle and one at the rear, and rides on 17-inch light-alloy wheels as standard. The same article restricts the seven-speed dual-clutch wording to the combustion-engine X2 variants, so this EV row could not safely remain on a DCT7 identity.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-ix2-launch-article"
-        ]
-      },
-      {
-        "note": "The official BMW UK technical-data page for the exact IX25 iX2 xDrive30 page identity lists a 1-speed automatic transmission. This pass therefore normalizes the row to the repo's SS1 single-speed EV transmission while leaving reducer ratios, final drives, and exact tire dimensions unresolved until a fuller technical sheet is recovered.",
-        "evidence_refs": [
-          "bmw_market_pages:u10-ix2-technical-data-uk"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW iX2 xDrive30 exact reducer and final-drive mapping",
-        "reason": "The checked official BMW sources prove the AWD EV identity and 1-speed transmission shape, but this pass did not recover a technical-data sheet with the exact reducer or final-drive values for the U10 iX2 xDrive30 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-ix2-launch-article",
-          "bmw_market_pages:u10-ix2-technical-data-uk"
-        ]
-      },
-      {
-        "item": "BMW iX2 xDrive30 exact 17-inch baseline tire size and full wheel matrix",
-        "reason": "The official BMW launch article proves the exact iX2 xDrive30 rides on 17-inch wheels as standard, which contradicts the inherited 18-inch default stored on the row today, but this pass did not recover an official sheet with the precise baseline tire dimensions or the full optional wheel/tire matrix.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-ix2-launch-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-u10-sdrive20i-eu-2024-dct7-fwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U10",
-    "body_code": "U10",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "X2 (U10, 2024-2026)",
-    "variant_name": "sDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:u10-ix2-launch-article"
       ],
-      "notes": "The official BMW X2 launch article distinguishes the combustion-engine sDrive20i from the xDrive-only iX2 xDrive30 and X2 M35i xDrive launch entries, which is sufficient to confirm the front-wheel-drive layout for this exact row.",
-      "value": "FWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:u10-ix2-launch-article",
-        "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-      ],
-      "notes": "BMW's official launch article and technical-data PDF describe the exact X2 sDrive20i as using a seven-speed Steptronic transmission with double clutch. The repo normalizes that wording to the canonical DCT7 label.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-        ],
-        "notes": "The official BMW technical-data PDF for the exact X2 sDrive20i publishes 225/55 R18 102Y XL on 7.5J x 18 wheels as the launch-standard tire package.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_exact",
+          "item": "BMW iX2 xDrive30 exact reducer and final-drive mapping",
+          "reason": "The checked official BMW sources prove the AWD EV identity and 1-speed transmission shape, but this pass did not recover a technical-data sheet with the exact reducer or final-drive values for the U10 iX2 xDrive30 row.",
           "evidence_refs": [
-            "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-          ],
-          "notes": "The official BMW technical-data PDF for the exact X2 sDrive20i publishes 225/55 R18 102Y XL on 7.5J x 18 wheels as the launch-standard tire package.",
+            "bmw_pressclub_sources:u10-ix2-launch-article",
+            "bmw_market_pages:u10-ix2-technical-data-uk"
+          ]
+        },
+        {
+          "item": "BMW iX2 xDrive30 exact 17-inch baseline tire size and full wheel matrix",
+          "reason": "The official BMW launch article proves the exact iX2 xDrive30 rides on 17-inch wheels as standard, which contradicts the inherited 18-inch default stored on the row today, but this pass did not recover an official sheet with the precise baseline tire dimensions or the full optional wheel/tire matrix.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-u10-sdrive20i-eu-2024-dct7-fwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U10",
+      "body_code": "U10",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "X2 (U10, 2024-2026)",
+      "variant_name": "sDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW X2 launch article distinguishes the combustion-engine sDrive20i from the xDrive-only iX2 xDrive30 and X2 M35i xDrive launch entries, which is sufficient to confirm the front-wheel-drive layout for this exact row.",
+        "value": "FWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "BMW's official launch article and technical-data PDF describe the exact X2 sDrive20i as using a seven-speed Steptronic transmission with double clutch. The repo normalizes that wording to the canonical DCT7 label.",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "19\" package"
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "19\" package"
           },
-          "default_axle_for_speed": "rear",
-          "name": "20\" package"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "20\" package"
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Direct validation of the official BMW X2 launch article and technical-data PDF now confirms the exact U10 sDrive20i launch state for FWD layout, seven-speed dual-clutch transmission wording, and the 225/55 R18 baseline tire package.",
+          "evidence_refs_ref": "e4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Direct validation of the official BMW X2 launch article and technical-data PDF now confirms the exact U10 sDrive20i launch state for FWD layout, seven-speed dual-clutch transmission wording, and the 225/55 R18 baseline tire package.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-ix2-launch-article",
-          "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "Exact raw gearbox and final-drive split for the U10 X2 sDrive20i DCT row",
-        "reason": "The official BMW technical-data PDF publishes the seven-speed ratio table only as multiplied overall ratios, so this pass does not decompose those numbers into the repo's separate raw top-gear and final-drive fields.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-        ]
-      },
-      {
-        "item": "Current-market U10 X2 sDrive20i optional wheel and tire matrix across the retained 2024-2026 row span",
-        "reason": "This pass directly revalidated the launch-state standard 18-inch tire package, but it did not recover one current BMW market document strong enough to replace the inherited 19-inch and 20-inch option tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:u10-ix2-launch-article",
-          "bmw_pressclub_sources:u10-x2-2023-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-u10-xdrive25e-eu-2024-dct7-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "U10",
-    "body_code": "U10",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "X2 (U10, 2024-2026)",
-    "variant_name": "xDrive25e",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "DCT7",
-      "name": "7-speed dual-clutch (DKG)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.71
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:82cbe3b6f231",
-          "legacy_research_sources:83a17284711a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 45.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
+          "item": "Exact raw gearbox and final-drive split for the U10 X2 sDrive20i DCT row",
+          "reason": "The official BMW technical-data PDF publishes the seven-speed ratio table only as multiplied overall ratios, so this pass does not decompose those numbers into the repo's separate raw top-gear and final-drive fields.",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "item": "Current-market U10 X2 sDrive20i optional wheel and tire matrix across the retained 2024-2026 row span",
+          "reason": "This pass directly revalidated the launch-state standard 18-inch tire package, but it did not recover one current BMW market document strong enough to replace the inherited 19-inch and 20-inch option tires.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-u10-xdrive25e-eu-2024-dct7-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "U10",
+      "body_code": "U10",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "X2 (U10, 2024-2026)",
+      "variant_name": "xDrive25e",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "DCT7",
+        "name": "7-speed dual-clutch (DKG)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.71
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 45.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 45.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 235.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 20\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 5 strengthens this row from merely unsupported to likely generation conflation. Official BMW Austria U10 overview and technical-data pages identify the current U10 X2 lineup as petrol, diesel, and battery-electric variants and do not surface any X2 xDrive25e row, while the official 10/2023 U10 launch article likewise lists EV, petrol, and diesel variants only. The only checked official xDrive25e evidence belongs to the earlier F39 generation. The current U10 xDrive25e row is therefore retained only as an unsupported advisory reference pending exact official U10-market proof or a row split/removal decision.",
+          "evidence_refs_ref": "e6"
         },
         {
-          "confidence": "family_default",
+          "note": "The official F39 xDrive25e launch article describes a three-cylinder front-axle combustion engine plus rear-axle electric motor hybrid AWD system with 17-inch standard wheels, which further underlines that the current U10 row should not inherit generic DCT7-era U10 assumptions without an exact U10 source. The Austria U10 technical-data page does publish seven-speed dual-clutch wording for several combustion U10 models, but not for any xDrive25e row.",
           "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 235.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:82cbe3b6f231",
-            "legacy_research_sources:83a17284711a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 20\""
+            "bmw_market_pages:u10-x2-technical-data-at",
+            "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 5 strengthens this row from merely unsupported to likely generation conflation. Official BMW Austria U10 overview and technical-data pages identify the current U10 X2 lineup as petrol, diesel, and battery-electric variants and do not surface any X2 xDrive25e row, while the official 10/2023 U10 launch article likewise lists EV, petrol, and diesel variants only. The only checked official xDrive25e evidence belongs to the earlier F39 generation. The current U10 xDrive25e row is therefore retained only as an unsupported advisory reference pending exact official U10-market proof or a row split/removal decision.",
-        "evidence_refs": [
-          "bmw_market_pages:u10-x2-overview-at",
-          "bmw_market_pages:u10-x2-technical-data-at",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:u10-ix2-launch-article"
-        ]
-      },
-      {
-        "note": "The official F39 xDrive25e launch article describes a three-cylinder front-axle combustion engine plus rear-axle electric motor hybrid AWD system with 17-inch standard wheels, which further underlines that the current U10 row should not inherit generic DCT7-era U10 assumptions without an exact U10 source. The Austria U10 technical-data page does publish seven-speed dual-clutch wording for several combustion U10 models, but not for any xDrive25e row.",
-        "evidence_refs": [
-          "bmw_market_pages:u10-x2-technical-data-at",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X2 xDrive25e exact U10-market existence and production span",
+          "reason": "The checked official BMW Austria U10 overview/technical-data pages and the official U10 launch material did not recover any xDrive25e plug-in-hybrid variant, while the official xDrive25e source recovered in this pass belongs to the earlier F39 generation.",
+          "evidence_refs_ref": "e6"
+        },
+        {
+          "item": "BMW X2 xDrive25e row cleanup versus likely F39 carryover or mis-targeted U10 mapping",
+          "reason": "Because the checked official BMW sources tie xDrive25e to F39 and the surfaced U10 Austria lineup contains only EV, petrol, and diesel rows, this row should not receive guessed drivetrain, transmission, ratio, or wheel updates without an exact official U10 source.",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X2 xDrive25e exact U10-market existence and production span",
-        "reason": "The checked official BMW Austria U10 overview/technical-data pages and the official U10 launch material did not recover any xDrive25e plug-in-hybrid variant, while the official xDrive25e source recovered in this pass belongs to the earlier F39 generation.",
-        "evidence_refs": [
-          "bmw_market_pages:u10-x2-overview-at",
-          "bmw_market_pages:u10-x2-technical-data-at",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:u10-ix2-launch-article"
-        ]
-      },
-      {
-        "item": "BMW X2 xDrive25e row cleanup versus likely F39 carryover or mis-targeted U10 mapping",
-        "reason": "Because the checked official BMW sources tie xDrive25e to F39 and the surfaced U10 Austria lineup contains only EV, petrol, and diesel rows, this row should not receive guessed drivetrain, transmission, ratio, or wheel updates without an exact official U10 source.",
-        "evidence_refs": [
-          "bmw_market_pages:u10-x2-overview-at",
-          "bmw_market_pages:u10-x2-technical-data-at",
-          "bmw_pressclub_sources:f39-x2-xdrive25e-launch-article",
-          "bmw_pressclub_sources:u10-ix2-launch-article"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
@@ -1,2382 +1,2110 @@
-[
-  {
-    "id": "bmw-f25-xdrive20d-eu-2011-mt6-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "X3 (F25, 2011)",
-    "variant_name": "xDrive20d",
-    "engine_code": "2.0D",
-    "engine_name": "2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
+      "n2": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20d.",
+      "n3": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20i.",
+      "n4": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive28i.",
+      "n5": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive18d.",
+      "n6": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n7": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20d family.",
+      "n8": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20d family.",
+      "n9": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20d family.",
+      "n10": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20d family.",
+      "n11": "The official BMW 03/2011 technical-data PDF publishes a single 3.077 final-drive ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n12": "The official BMW 09/2011 technical-data PDF publishes a single 3.636 final-drive ratio for the exact X3 xDrive20i 6-speed manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n13": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20i family.",
+      "n14": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20i family.",
+      "n15": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20i family.",
+      "n16": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20i family.",
+      "n17": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 xDrive20i family.",
+      "n18": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n19": "The official BMW 09/2011 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive20i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n20": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n21": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive28i family.",
+      "n22": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive28i family.",
+      "n23": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive28i family.",
+      "n24": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive28i family.",
+      "n25": "The official BMW 03/2012 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n26": "The official BMW 03/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n27": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive30d.",
+      "n28": "The official BMW 09/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n29": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35d.",
+      "n30": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact X3 xDrive35i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n31": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35i.",
+      "n32": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 sDrive18d family.",
+      "n33": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 sDrive18d family.",
+      "n34": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 sDrive18d family.",
+      "n35": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 sDrive18d family.",
+      "n36": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive20i."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 6-speed manual launch state represented by this narrowed 2011 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      "e2": [
+        "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
       ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms a 6-speed manual transmission for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
-        "value": 0.659
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
-        "value": [
-          4.11,
-          2.248,
-          1.403,
-          1.0,
-          0.802,
-          0.659
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.727
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.727
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20d.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20d.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d manual row: AWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive20d-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "X3 (F25, 2011)",
-    "variant_name": "xDrive20d",
-    "engine_code": "2.0D",
-    "engine_name": "2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 8-speed automatic launch state represented by this narrowed 2011 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.077 final-drive ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.077 final-drive ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20d.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20d.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.077 final-drive ratio, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive20i-eu-2011-mt6-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "X3 (F25, 2011-2017)",
-    "variant_name": "xDrive20i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
         "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20i 6-speed manual configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
+      "e4": [
+        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms a 6-speed manual transmission for the exact X3 xDrive20i manual configuration. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists 0.846 as the top-gear ratio for the exact X3 xDrive20i 6-speed manual configuration.",
-        "value": 0.846
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20i 6-speed manual configuration.",
-        "value": [
-          4.11,
-          2.315,
-          1.542,
-          1.179,
-          1.0,
-          0.846
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.636 final-drive ratio for the exact X3 xDrive20i 6-speed manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.636 final-drive ratio for the exact X3 xDrive20i 6-speed manual configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20i.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 09/2011 technical-data PDF now confirms the exact X3 xDrive20i 6-speed manual configuration: xDrive AWD, 6-speed manual transmission, forward ratios 4.110 / 2.315 / 1.542 / 1.179 / 1.000 / 0.846, a single published final-drive ratio of 3.636, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 F25 xDrive20i 2011-2017 continuity",
-        "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive20i-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "X3 (F25, 2011-2017)",
-    "variant_name": "xDrive20i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
+      "e5": [
+        "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20i 8-speed automatic configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
+      "e6": [
+        "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
+        "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive20i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive20i 8-speed automatic configuration.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20i 8-speed automatic configuration.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive20i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive20i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive20i.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 xDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 09/2011 technical-data PDF now confirms the exact X3 xDrive20i 8-speed automatic configuration: xDrive AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.385, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 F25 xDrive20i 2011-2017 continuity",
-        "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive28i-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "X3 (F25, 2011)",
-    "variant_name": "xDrive28i",
-    "engine_code": "3.0L",
-    "engine_name": "3.0L I6",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
+      "e7": [
+        "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
       ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive28i automatic configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive28i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.727
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.727
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive28i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive28i.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2011 technical-data PDF shows that the exact early X3 xDrive28i row is a 2996 cc inline-6 AWD automatic configuration with the 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 ratio set, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires. The official 03/2012 refresh sheet then changes xDrive28i to a 1997 cc four-cylinder state with a 3.385 final drive, so the old 2011-2017 broad row was split instead of preserving one mixed-era mapping.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive28i-eu-2012-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "X3 (F25, 2012)",
-    "variant_name": "xDrive28i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e8": [
         "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2012 technical-data PDF confirms xDrive all-wheel drive for the refreshed X3 xDrive28i automatic state represented by this narrowed 2012 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+      "e9": [
+        "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the refreshed X3 xDrive28i state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e10": [
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
+        "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
+      ],
+      "e11": [
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
+      ],
+      "e12": [
+        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+      ],
+      "e13": [
+        "bmw_pressclub_sources:f25-euro-zula-04-14-pdf",
+        "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
+        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf",
+        "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f25-xdrive20d-eu-2011-mt6-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "X3 (F25, 2011)",
+      "variant_name": "xDrive20d",
+      "engine_code": "2.0D",
+      "engine_name": "2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 6-speed manual launch state represented by this narrowed 2011 row.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms a 6-speed manual transmission for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+          "value": 0.659
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+          "value": [
+            4.11,
+            2.248,
+            1.403,
+            1.0,
+            0.802,
+            0.659
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 3.727
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 3.727
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          }
         ]
       },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2012 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2012 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d manual row: AWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-xdrive20d-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "X3 (F25, 2011)",
+      "variant_name": "xDrive20d",
+      "engine_code": "2.0D",
+      "engine_name": "2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive28i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 8-speed automatic launch state represented by this narrowed 2011 row.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n11",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n11",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n8",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n10",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.077 final-drive ratio, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f25-xdrive20i-eu-2011-mt6-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "X3 (F25, 2011-2017)",
+      "variant_name": "xDrive20i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20i 6-speed manual configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms a 6-speed manual transmission for the exact X3 xDrive20i manual configuration. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 09/2011 technical-data PDF lists 0.846 as the top-gear ratio for the exact X3 xDrive20i 6-speed manual configuration.",
+          "value": 0.846
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20i 6-speed manual configuration.",
+          "value": [
+            4.11,
+            2.315,
+            1.542,
+            1.179,
+            1.0,
+            0.846
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n12",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n12",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 09/2011 technical-data PDF now confirms the exact X3 xDrive20i 6-speed manual configuration: xDrive AWD, 6-speed manual transmission, forward ratios 4.110 / 2.315 / 1.542 / 1.179 / 1.000 / 0.846, a single published final-drive ratio of 3.636, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n18"
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 F25 xDrive20i 2011-2017 continuity",
+          "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f25-xdrive20i-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "X3 (F25, 2011-2017)",
+      "variant_name": "xDrive20i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20i 8-speed automatic configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive20i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive20i 8-speed automatic configuration.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20i 8-speed automatic configuration.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n19",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n19",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n13",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n14",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n15",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes_ref": "n16",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes_ref": "n17",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 09/2011 technical-data PDF now confirms the exact X3 xDrive20i 8-speed automatic configuration: xDrive AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.385, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "note_ref": "n18"
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e6"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 F25 xDrive20i 2011-2017 continuity",
+          "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
+          "evidence_refs_ref": "e13"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f25-xdrive28i-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "X3 (F25, 2011)",
+      "variant_name": "xDrive28i",
+      "engine_code": "3.0L",
+      "engine_name": "3.0L I6",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e11",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive28i automatic configuration.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e11",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive28i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n20",
+          "value": 3.727
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n20",
+          "value": 3.727
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e11",
+          "notes_ref": "n4",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e11",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n21",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n22",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n23",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n24",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2011 technical-data PDF shows that the exact early X3 xDrive28i row is a 2996 cc inline-6 AWD automatic configuration with the 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 ratio set, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires. The official 03/2012 refresh sheet then changes xDrive28i to a 1997 cc four-cylinder state with a 3.385 final drive, so the old 2011-2017 broad row was split instead of preserving one mixed-era mapping.",
           "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf",
             "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive28i.",
+          ]
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f25-xdrive28i-eu-2012-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "X3 (F25, 2012)",
+      "variant_name": "xDrive28i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e8",
+        "notes": "The official BMW 03/2012 technical-data PDF confirms xDrive all-wheel drive for the refreshed X3 xDrive28i automatic state represented by this narrowed 2012 row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e8",
+        "notes": "The official BMW 03/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the refreshed X3 xDrive28i state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "The official BMW 03/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes": "The official BMW 03/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n25",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n25",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n4",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e8",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n21",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n22",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n23",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n24",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
           }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2012 technical-data PDF establishes the corrected X3 xDrive28i automatic row for the four-cylinder era: AWD, 8-speed automatic with Steptronic, 1997 cc inline-4 turbo engine identity, the same forward ratio set, a lower 3.385 final-drive ratio, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e8"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive28i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
+          "note_ref": "n1",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2012 technical-data PDF establishes the corrected X3 xDrive28i automatic row for the four-cylinder era: AWD, 8-speed automatic with Steptronic, 1997 cc inline-4 turbo engine identity, the same forward ratio set, a lower 3.385 final-drive ratio, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive30d-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "X3 (F25, 2011)",
-    "variant_name": "xDrive30d",
-    "engine_code": "3.0D",
-    "engine_name": "3.0L I6 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive30d 8-speed automatic launch state represented by this narrowed 2011 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive30d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-xdrive30d-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "X3 (F25, 2011)",
+      "variant_name": "xDrive30d",
+      "engine_code": "3.0D",
+      "engine_name": "3.0L I6 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive30d.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive30d 8-speed automatic launch state represented by this narrowed 2011 row.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive30d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive30d.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n26",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n26",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n27",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive30d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n27",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 xDrive30d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive30d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive30d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive30d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive30d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e1"
         },
         {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
+      }
+    },
+    {
+      "id": "bmw-f25-xdrive35d-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2011,
+      "model_name": "X3 (F25, 2011)",
+      "variant_name": "xDrive35d",
+      "engine_code": "3.0D",
+      "engine_name": "3.0L I6 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e9",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive35d 8-speed automatic state represented by this narrowed 2011 row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e9",
+        "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive35d state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 xDrive30d family.",
+          "evidence_refs_ref": "e9",
+          "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n28",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n28",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e9",
+          "notes_ref": "n29",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e9",
+            "notes_ref": "n29",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive35d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive35d family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 09/2011 technical-data PDF establishes the exact X3 xDrive35d row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires.",
+          "evidence_refs_ref": "e9"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive30d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive30d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
+          "note_ref": "n1",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive30d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive35d-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2011,
-    "model_name": "X3 (F25, 2011)",
-    "variant_name": "xDrive35d",
-    "engine_code": "3.0D",
-    "engine_name": "3.0L I6 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive35d 8-speed automatic state represented by this narrowed 2011 row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive35d state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 2.813
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-xdrive35i-eu-2011-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2011,
+      "production_end_year": 2017,
+      "model_name": "X3 (F25, 2011-2017)",
+      "variant_name": "xDrive35i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35d.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on xDrive all-wheel drive for the exact X3 xDrive35i automatic configuration.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e10",
+        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on 8-speed automatic with Steptronic wording for the exact X3 xDrive35i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35d.",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on 0.667 as the top-gear ratio for the exact X3 xDrive35i automatic configuration.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on the full forward gear-ratio set for the exact X3 xDrive35i automatic configuration.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n30",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n30",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e10",
+          "notes_ref": "n31",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e10",
+            "notes_ref": "n31",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive35i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive35i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 xDrive35i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            }
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on the exact X3 xDrive35i automatic state: AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.385, and 245/50 R18 baseline tires.",
+          "evidence_refs_ref": "e10"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive35d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive35d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
+          "note_ref": "n1",
+          "evidence_refs_ref": "e6"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 09/2011 technical-data PDF establishes the exact X3 xDrive35d row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-xdrive35i-eu-2011-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "X3 (F25, 2011-2017)",
-    "variant_name": "xDrive35i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-        "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on xDrive all-wheel drive for the exact X3 xDrive35i automatic configuration.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-        "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on 8-speed automatic with Steptronic wording for the exact X3 xDrive35i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on 0.667 as the top-gear ratio for the exact X3 xDrive35i automatic configuration.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on the full forward gear-ratio set for the exact X3 xDrive35i automatic configuration.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact X3 xDrive35i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on a single 3.385 final-drive ratio for the exact X3 xDrive35i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35i.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
-          "confidence": "official_exact",
+          "item": "BMW X3 F25 xDrive35i 2011-2017 continuity",
+          "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
           "evidence_refs": [
+            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf",
+            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
             "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
             "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 xDrive35i.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 xDrive35i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 xDrive35i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 xDrive35i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          }
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 09/2011 and 04/2014 technical-data PDFs agree on the exact X3 xDrive35i automatic state: AWD, 8-speed automatic with Steptronic wording, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.385, and 245/50 R18 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 F25 xDrive35i 2011-2017 continuity",
-        "reason": "Official 2011 and 2014 BMW technical-data and EU wheel/tire approval sheets agree for launch and facelift-era values, but this broad row still does not independently prove exact public continuity through the final 2017 model year.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf",
-          "bmw_pressclub_sources:f25-euro-zula-09-10-pdf",
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
-          "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f25-sdrive18d-eu-2012-mt6-rwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "X3 (F25, 2012)",
-    "variant_name": "sDrive18d",
-    "engine_code": "2.0D",
-    "engine_name": "2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
       ],
-      "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 6-speed manual state represented by this narrowed 2012 row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2012 technical-data PDF confirms a 6-speed manual transmission for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
-      "code": "MT6",
-      "name": "6-speed manual"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
-        "value": 0.659
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
-        "value": [
-          4.11,
-          2.248,
-          1.403,
-          1.0,
-          0.802,
-          0.659
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists 3.462 as the final-drive ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
-        "value": 3.462
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-sdrive18d-eu-2012-mt6-rwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "X3 (F25, 2012)",
+      "variant_name": "sDrive18d",
+      "engine_code": "2.0D",
+      "engine_name": "2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive18d.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 6-speed manual state represented by this narrowed 2012 row.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 11/2012 technical-data PDF confirms a 6-speed manual transmission for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+        "code": "MT6",
+        "name": "6-speed manual"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive18d.",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+          "value": 0.659
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+          "value": [
+            4.11,
+            2.248,
+            1.403,
+            1.0,
+            0.802,
+            0.659
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists 3.462 as the final-drive ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+          "value": 3.462
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n32",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n33",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n34",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n35",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
           }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d manual row: RWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, rear final drive 3.462, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
+          "note_ref": "n1",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d manual row: RWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, rear final drive 3.462, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-sdrive18d-eu-2012-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2012,
-    "production_end_year": 2012,
-    "model_name": "X3 (F25, 2012)",
-    "variant_name": "sDrive18d",
-    "engine_code": "2.0D",
-    "engine_name": "2.0L I4 Turbo Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
       ],
-      "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 8-speed automatic state represented by this narrowed 2012 row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 11/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 11/2012 technical-data PDF lists 3.077 as the final-drive ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
-        "value": 3.077
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-sdrive18d-eu-2012-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2012,
+      "production_end_year": 2012,
+      "model_name": "X3 (F25, 2012)",
+      "variant_name": "sDrive18d",
+      "engine_code": "2.0D",
+      "engine_name": "2.0L I4 Turbo Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive18d.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 8-speed automatic state represented by this narrowed 2012 row.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "The official BMW 11/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive18d.",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The official BMW 11/2012 technical-data PDF lists 3.077 as the final-drive ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n32",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n33",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n34",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e5",
+            "notes_ref": "n35",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
           }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.077, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e4"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 sDrive18d family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
+          "note_ref": "n1",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.077, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
-        ]
-      },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-12-pdf"
-        ]
-      }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
-    }
-  },
-  {
-    "id": "bmw-f25-sdrive20i-eu-2014-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F25",
-    "body_code": "F25",
-    "production_start_year": 2014,
-    "production_end_year": 2014,
-    "model_name": "X3 (F25, 2014)",
-    "variant_name": "sDrive20i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
       ],
-      "notes": "The official BMW 04/2014 facelift technical-data PDF confirms rear-wheel drive for the exact X3 sDrive20i automatic state represented by this narrowed 2014 row.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 04/2014 facelift technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive20i state represented by this narrowed 2014 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 04/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 04/2014 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 04/2014 technical-data PDF lists 3.385 as the final-drive ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
-        "value": 3.385
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-f25-sdrive20i-eu-2014-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F25",
+      "body_code": "F25",
+      "production_start_year": 2014,
+      "production_end_year": 2014,
+      "model_name": "X3 (F25, 2014)",
+      "variant_name": "sDrive20i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-        ],
-        "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive20i.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e12",
+        "notes": "The official BMW 04/2014 facelift technical-data PDF confirms rear-wheel drive for the exact X3 sDrive20i automatic state represented by this narrowed 2014 row.",
+        "value": "RWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e12",
+        "notes": "The official BMW 04/2014 facelift technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive20i state represented by this narrowed 2014 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
-          ],
-          "notes": "Official BMW PressClub technical-data PDF lists this as the baseline tire for the F25 X3 sDrive20i.",
+          "evidence_refs_ref": "e12",
+          "notes": "The official BMW 04/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes": "The official BMW 04/2014 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes": "The official BMW 04/2014 technical-data PDF lists 3.385 as the final-drive ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e12",
+          "notes_ref": "n36",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 sDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 55.0,
-            "rim_in": 17.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e12",
+            "notes_ref": "n36",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 17\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 sDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 18.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 17-inch optional package for the X3 sDrive20i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 55.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 18\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 sDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this 18-inch optional package for the X3 sDrive20i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 19\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 19.0
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 19-inch package for the X3 sDrive20i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 19\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 sDrive20i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            }
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e7",
+            "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 sDrive20i family.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\"",
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            }
           }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW F25 EU wheel/tire approval sheet lists this staggered 20-inch package for the X3 sDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          }
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-          ],
-          "notes": "Official BMW 04/2014 F25/F26 EU wheel/tire approval sheet lists this staggered 21-inch accessory package for the X3 sDrive20i family.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\"",
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          }
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 04/2014 facelift technical-data PDF establishes the exact X3 sDrive20i automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.385, and 225/60 R17 baseline tires.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
         ]
       },
-      {
-        "note": "This run replaced inherited F25 family-default tire options with BMW EU wheel/tire approval-sheet packages, including corrected staggered 19- and 20-inch rear tire dimensions.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f25-euro-zula-04-14-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 04/2014 facelift technical-data PDF establishes the exact X3 sDrive20i automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.385, and 225/60 R17 baseline tires.",
+          "evidence_refs_ref": "e12"
+        },
+        {
+          "note_ref": "n1",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "unresolved": [],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": false
       }
-    ],
-    "unresolved": [],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": false
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G01.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G01.json
@@ -1,996 +1,709 @@
-[
-  {
-    "id": "bmw-g01-m40i-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G01",
-    "body_code": "G01",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "X3 (G01, 2018-2024)",
-    "variant_name": "M40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
+      "n2": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
+      "n3": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded.",
+      "n4": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
+      "n5": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence.",
+      "n6": "Wave 21 re-check shows the checked 09/2018 and 06/2021 BMW Germany technical-data PDFs are exact X3 xDrive20i states. Across both states they prove Allrad, 8-Gang Steptronic Getriebe, final drive 3.385, top gear 0.640, and a 225/60 R18 basic tire, which is sufficient to land those stable fields as an xDrive20i variant-scoped production override. The full xDrive20i gear-ratio array changed between the checked 2018 and 2021 official sheets (5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 vs 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640), so one shared exact gear-ratio array would still be unsafe. Official Germany price-list material continues to confirm the broader G01 wheel/tire matrix and xDrive30i market context, and wave 10 validation also adds exact M40i source-ledger evidence from the 04/2020 ACEA technical-data sheet: AWD, 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires. The broad row remains verification backlog because the xDrive20i full gear-ratio array changed between the checked official sheets, xDrive30i still lacks a directly checked exact ratio PDF in this row, and this pass did not recover year-spanning official evidence proving one unchanged M40i package across the full 2018-2024 row.",
+      "n7": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n8": "Sonnet redo research (2026-04 v2): G01 sDrive20i was introduced globally July 2018 (Wikipedia G01) and the F25 predecessor's sDrive20i was sold in Germany, supporting EU availability. However no BMW PressClub DE technical-data PDF specifically for sDrive20i G01 was located in this run, so EU-specific official confirmation of final drive and tires is missing. Drivetrain confidence held at official_exact per the row's existing 'BMW press release' legacy classification (RWD layout is unambiguous). Top gear ratio corrected from placeholder 0.667 to 0.640 by analogy with xDrive20i (same B48 + 8HP50 pre-LCI / 8HP51 post-LCI; 8th gear ratio is 0.640 in both variants). Final drive and tires marked no_confidence pending BMW DE sDrive20i tech sheet recovery.",
+      "n9": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (2018, 2021 exact states) with High confidence.",
+      "n10": "Reverse gear ratio (research note): 3.456"
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:38a04165d331",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:8e51d741ecbd",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:9942185c701e",
+        "legacy_research_sources:9cb10e268364",
+        "legacy_research_sources:de6c75804abf"
+      ],
+      "e2": [
         "legacy_research_sources:9942185c701e"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP51Z)",
-      "evidence_refs": [
+      "e3": [
+        "legacy_research_sources:8e51d741ecbd"
+      ],
+      "e4": [
+        "secondary_technical_sources:g01-x3-wikipedia"
+      ],
+      "e5": [
         "legacy_research_sources:8e51d741ecbd",
         "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded.",
-        "value": 0.64,
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded. M40i standard staggered fitment 245/45 R20 F / 275/40 R20 R per BMW DE ACEA 04/2020.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 21 re-check shows the checked 09/2018 and 06/2021 BMW Germany technical-data PDFs are exact X3 xDrive20i states. Across both states they prove Allrad, 8-Gang Steptronic Getriebe, final drive 3.385, top gear 0.640, and a 225/60 R18 basic tire, which is sufficient to land those stable fields as an xDrive20i variant-scoped production override. The full xDrive20i gear-ratio array changed between the checked 2018 and 2021 official sheets (5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 vs 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640), so one shared exact gear-ratio array would still be unsafe. Official Germany price-list material continues to confirm the broader G01 wheel/tire matrix and xDrive30i market context, and wave 10 validation also adds exact M40i source-ledger evidence from the 04/2020 ACEA technical-data sheet: AWD, 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires. The broad row remains verification backlog because the xDrive20i full gear-ratio array changed between the checked official sheets, xDrive30i still lacks a directly checked exact ratio PDF in this row, and this pass did not recover year-spanning official evidence proving one unchanged M40i package across the full 2018-2024 row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.712",
-        "evidence_refs": [
-          "legacy_research_sources:8e51d741ecbd"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
-        "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i exact official ratio mapping",
-        "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
-        "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
-        "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i and M40i transmission subtype code",
-        "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g01-sdrive20i-eu-2018-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G01",
-    "body_code": "G01",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "X3 (G01, 2018-2024)",
-    "variant_name": "sDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:9942185c701e"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): G01 sDrive20i was introduced globally July 2018 (Wikipedia G01) and the F25 predecessor's sDrive20i was sold in Germany, supporting EU availability. However no BMW PressClub DE technical-data PDF specifically for sDrive20i G01 was located in this run, so EU-specific official confirmation of final drive and tires is missing. Drivetrain confidence held at official_exact per the row's existing 'BMW press release' legacy classification (RWD layout is unambiguous). Top gear ratio corrected from placeholder 0.667 to 0.640 by analogy with xDrive20i (same B48 + 8HP50 pre-LCI / 8HP51 post-LCI; 8th gear ratio is 0.640 in both variants). Final drive and tires marked no_confidence pending BMW DE sDrive20i tech sheet recovery.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP50Z / GA8HP51Z post-LCI)",
-      "evidence_refs": [
-        "secondary_technical_sources:g01-x3-wikipedia",
-        "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "reputable_secondary_crosschecked",
-        "notes": "Sonnet redo research (2026-04 v2): G01 sDrive20i was introduced globally July 2018 (Wikipedia G01) and the F25 predecessor's sDrive20i was sold in Germany, supporting EU availability. However no BMW PressClub DE technical-data PDF specifically for sDrive20i G01 was located in this run, so EU-specific official confirmation of final drive and tires is missing. Drivetrain confidence held at official_exact per the row's existing 'BMW press release' legacy classification (RWD layout is unambiguous). Top gear ratio corrected from placeholder 0.667 to 0.640 by analogy with xDrive20i (same B48 + 8HP50 pre-LCI / 8HP51 post-LCI; 8th gear ratio is 0.640 in both variants). Final drive and tires marked no_confidence pending BMW DE sDrive20i tech sheet recovery.",
-        "value": 0.64,
-        "evidence_refs": [
-          "secondary_technical_sources:zf8hp-bmw-x3-table",
-          "secondary_technical_sources:g01-x3-wikipedia"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): G01 sDrive20i was introduced globally July 2018 (Wikipedia G01) and the F25 predecessor's sDrive20i was sold in Germany, supporting EU availability. However no BMW PressClub DE technical-data PDF specifically for sDrive20i G01 was located in this run, so EU-specific official confirmation of final drive and tires is missing. Drivetrain confidence held at official_exact per the row's existing 'BMW press release' legacy classification (RWD layout is unambiguous). Top gear ratio corrected from placeholder 0.667 to 0.640 by analogy with xDrive20i (same B48 + 8HP50 pre-LCI / 8HP51 post-LCI; 8th gear ratio is 0.640 in both variants). Final drive and tires marked no_confidence pending BMW DE sDrive20i tech sheet recovery.",
-        "value": 3.077,
-        "evidence_refs": [
-          "secondary_technical_sources:g01-x3-wikipedia"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "secondary_technical_sources:g01-x3-wikipedia"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): G01 sDrive20i was introduced globally July 2018 (Wikipedia G01) and the F25 predecessor's sDrive20i was sold in Germany, supporting EU availability. However no BMW PressClub DE technical-data PDF specifically for sDrive20i G01 was located in this run, so EU-specific official confirmation of final drive and tires is missing. Drivetrain confidence held at official_exact per the row's existing 'BMW press release' legacy classification (RWD layout is unambiguous). Top gear ratio corrected from placeholder 0.667 to 0.640 by analogy with xDrive20i (same B48 + 8HP50 pre-LCI / 8HP51 post-LCI; 8th gear ratio is 0.640 in both variants). Final drive and tires marked no_confidence pending BMW DE sDrive20i tech sheet recovery.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 21 re-check shows the checked 09/2018 and 06/2021 BMW Germany technical-data PDFs are exact X3 xDrive20i states. Across both states they prove Allrad, 8-Gang Steptronic Getriebe, final drive 3.385, top gear 0.640, and a 225/60 R18 basic tire, which is sufficient to land those stable fields as an xDrive20i variant-scoped production override. The full xDrive20i gear-ratio array changed between the checked 2018 and 2021 official sheets (5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 vs 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640), so one shared exact gear-ratio array would still be unsafe. Official Germany price-list material continues to confirm the broader G01 wheel/tire matrix and xDrive30i market context, and wave 10 validation also adds exact M40i source-ledger evidence from the 04/2020 ACEA technical-data sheet: AWD, 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires. The broad row remains verification backlog because the xDrive20i full gear-ratio array changed between the checked official sheets, xDrive30i still lacks a directly checked exact ratio PDF in this row, and this pass did not recover year-spanning official evidence proving one unchanged M40i package across the full 2018-2024 row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g01-x3-wikipedia"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "secondary_technical_sources:g01-x3-wikipedia"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
-        "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i exact official ratio mapping",
-        "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
-        "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
-        "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i and M40i transmission subtype code",
-        "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g01-xdrive20i-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G01",
-    "body_code": "G01",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "X3 (G01, 2018-2024)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:9942185c701e"
+      "e6": [
+        "legacy_research_sources:38a04165d331",
+        "legacy_research_sources:9cb10e268364"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (2018, 2021 exact states) with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP50Z pre-LCI / GA8HP51Z post-LCI 06/2021)",
-      "evidence_refs": [
+      "e7": [
         "legacy_research_sources:38a04165d331",
         "legacy_research_sources:9cb10e268364",
         "secondary_technical_sources:zf8hp-bmw-x3-table"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
-        "value": 0.64,
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9cb10e268364"
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9cb10e268364"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9cb10e268364"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9cb10e268364",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE xDrive20i ACEA 09/2018 tech sheet (legacy_research_sources:38a04165d331) and 06/2021 LCI tech sheet (legacy_research_sources:9cb10e268364) both confirm final drive 3.385 (both axles via xDrive single-FD convention) and 8th gear 0.640. Pre-LCI 2018-2021 uses ZF GA8HP50Z (B48) with gear set [5.000, 3.200, 2.143, 1.720, 1.314, 1.000, 0.822, 0.640] and reverse 3.456. Post-LCI 2021-2024 uses ZF GA8HP51Z with gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640] and reverse 3.712. Encoded pre-LCI gear set as the row's primary value because the production_start_year is 2018; LCI ratio change is documented in the gear_ratios notes. Standard tire 225/60 R18 confirmed by 09/2018 ACEA sheet.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (2018, 2021 exact states) with High confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Wave 21 re-check shows the checked 09/2018 and 06/2021 BMW Germany technical-data PDFs are exact X3 xDrive20i states. Across both states they prove Allrad, 8-Gang Steptronic Getriebe, final drive 3.385, top gear 0.640, and a 225/60 R18 basic tire, which is sufficient to land those stable fields as an xDrive20i variant-scoped production override. The full xDrive20i gear-ratio array changed between the checked 2018 and 2021 official sheets (5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 vs 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640), so one shared exact gear-ratio array would still be unsafe. Official Germany price-list material continues to confirm the broader G01 wheel/tire matrix and xDrive30i market context, and wave 10 validation also adds exact M40i source-ledger evidence from the 04/2020 ACEA technical-data sheet: AWD, 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires. The broad row remains verification backlog because the xDrive20i full gear-ratio array changed between the checked official sheets, xDrive30i still lacks a directly checked exact ratio PDF in this row, and this pass did not recover year-spanning official evidence proving one unchanged M40i package across the full 2018-2024 row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (2018, 2021 exact states) with High confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.456",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
-        "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i exact official ratio mapping",
-        "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
-        "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
-        "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i and M40i transmission subtype code",
-        "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g01-xdrive30i-eu-2018-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G01",
-    "body_code": "G01",
-    "production_start_year": 2018,
-    "production_end_year": 2024,
-    "model_name": "X3 (G01, 2018-2024)",
-    "variant_name": "xDrive30i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:9942185c701e"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF GA8HP50Z pre-LCI / GA8HP51Z post-LCI 06/2021)",
-      "evidence_refs": [
+      "e8": [
+        "legacy_research_sources:38a04165d331"
+      ],
+      "e9": [
         "legacy_research_sources:9942185c701e",
         "secondary_technical_sources:zf8hp-bmw-x3-table"
+      ],
+      "e10": [
+        "legacy_research_sources:9942185c701e",
+        "legacy_research_sources:38a04165d331",
+        "legacy_research_sources:8e51d741ecbd"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
-        "value": 0.64,
-        "evidence_refs": [
-          "legacy_research_sources:9942185c701e",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g01-m40i-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G01",
+      "body_code": "G01",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "X3 (G01, 2018-2024)",
+      "variant_name": "M40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n5",
+        "value": "AWD"
       },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:8e51d741ecbd"
-        ]
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n3",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP51Z)",
+        "evidence_refs_ref": "e5"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
-        "value": 3.385,
-        "evidence_refs": [
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:8e51d741ecbd"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_derived",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.314,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9942185c701e",
-          "secondary_technical_sources:zf8hp-bmw-x3-table"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:38a04165d331"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE Germany price list 08/2022 (legacy_research_sources:9942185c701e) confirms G01 xDrive30i sale in Germany. xDrive30i shares the B48 + ZF 8HP50 (pre-LCI) / 8HP51 (post-LCI) drivetrain with xDrive20i, so gear ratios and final drive follow the same pattern. No xDrive30i-specific ACEA tech sheet was located, so gear_ratios and reverse are official_derived rather than official_exact; final drive 3.385 is strongly supported by both xDrive20i (S_XD20) and M40i (S_M40) confirmations. Top gear 0.640 confirmed across the family. Standard tire 225/60 R18 inherited from xDrive20i baseline.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
-          "front": {
-            "width_mm": 225.0,
-            "aspect_pct": 60.0,
-            "rim_in": 18.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 19\""
-        },
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
+          "notes_ref": "n3",
+          "value": 0.64,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes_ref": "n3",
+          "value": 3.385,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n3",
+          "value": 3.385,
+          "evidence_refs_ref": "e3"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n3"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub DE M40i ACEA 04/2020 tech sheet (legacy_research_sources:8e51d741ecbd) confirms ZF GA8HP51Z (B58) with full gear set [5.250, 3.360, 2.172, 1.720, 1.316, 1.000, 0.822, 0.640], reverse 3.712, final drive 3.385 (both axles via xDrive single-FD convention), and standard staggered tires 245/45 R20 front + 275/40 R20 rear. Prior repo placeholder values 0.667 / 3.077 / 245/45 R19 were legacy family_default inheritance from earlier 8HP70 generation and are superseded. M40i standard staggered fitment 245/45 R20 F / 275/40 R20 R per BMW DE ACEA 04/2020.",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
             "rim_in": 20.0
           },
+          "default_axle_for_speed": "rear",
           "rear": {
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "official_exact",
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub 04/2020 technical data with High confidence."
+        },
+        {
+          "note": "Reverse gear ratio (research note): 3.712",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
+          "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i exact official ratio mapping",
+          "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
+          "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
+          "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i and M40i transmission subtype code",
+          "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g01-sdrive20i-eu-2018-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G01",
+      "body_code": "G01",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "X3 (G01, 2018-2024)",
+      "variant_name": "sDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n7",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "reputable_secondary_crosschecked",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP50Z / GA8HP51Z post-LCI)",
+        "evidence_refs": [
+          "secondary_technical_sources:g01-x3-wikipedia",
+          "secondary_technical_sources:zf8hp-bmw-x3-table"
+        ]
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "reputable_secondary_crosschecked",
+          "notes_ref": "n8",
+          "value": 0.64,
           "evidence_refs": [
-            "legacy_research_sources:38a04165d331",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8e51d741ecbd",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:9942185c701e",
-            "legacy_research_sources:9cb10e268364",
-            "legacy_research_sources:de6c75804abf"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence.",
+            "secondary_technical_sources:zf8hp-bmw-x3-table",
+            "secondary_technical_sources:g01-x3-wikipedia"
+          ]
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n8",
+          "value": 3.077,
+          "evidence_refs_ref": "e4"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e4",
+          "notes_ref": "n8",
           "front": {
             "width_mm": 245.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+            "aspect_pct": 45.0,
+            "rim_in": 19.0
           },
-          "rear": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+        },
+        {
+          "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e4"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
+          "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i exact official ratio mapping",
+          "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
+          "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
+          "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i and M40i transmission subtype code",
+          "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Wave 21 re-check shows the checked 09/2018 and 06/2021 BMW Germany technical-data PDFs are exact X3 xDrive20i states. Across both states they prove Allrad, 8-Gang Steptronic Getriebe, final drive 3.385, top gear 0.640, and a 225/60 R18 basic tire, which is sufficient to land those stable fields as an xDrive20i variant-scoped production override. The full xDrive20i gear-ratio array changed between the checked 2018 and 2021 official sheets (5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640 vs 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640), so one shared exact gear-ratio array would still be unsafe. Official Germany price-list material continues to confirm the broader G01 wheel/tire matrix and xDrive30i market context, and wave 10 validation also adds exact M40i source-ledger evidence from the 04/2020 ACEA technical-data sheet: AWD, 8-Gang Steptronic Getriebe, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires. The broad row remains verification backlog because the xDrive20i full gear-ratio array changed between the checked official sheets, xDrive30i still lacks a directly checked exact ratio PDF in this row, and this pass did not recover year-spanning official evidence proving one unchanged M40i package across the full 2018-2024 row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
+    {
+      "id": "bmw-g01-xdrive20i-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G01",
+      "body_code": "G01",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "X3 (G01, 2018-2024)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n9",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP50Z pre-LCI / GA8HP51Z post-LCI 06/2021)",
+        "evidence_refs_ref": "e7"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 0.64,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_front": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 3.385,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n1",
+          "value": 3.385,
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e7",
+          "notes_ref": "n1"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e8",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n9",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence."
-      },
-      {
-        "note": "Reverse gear ratio (research note): 3.456",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:9942185c701e"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (2018, 2021 exact states) with High confidence."
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e8"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
+          "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i exact official ratio mapping",
+          "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
+          "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
+          "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i and M40i transmission subtype code",
+          "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
-        "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
+    },
+    {
+      "id": "bmw-g01-xdrive30i-eu-2018-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G01",
+      "body_code": "G01",
+      "production_start_year": 2018,
+      "production_end_year": 2024,
+      "model_name": "X3 (G01, 2018-2024)",
+      "variant_name": "xDrive30i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n4",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF GA8HP50Z pre-LCI / GA8HP51Z post-LCI 06/2021)",
+        "evidence_refs_ref": "e9"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_derived",
+          "notes_ref": "n2",
+          "value": 0.64,
+          "evidence_refs_ref": "e9"
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "notes_ref": "n2",
+          "value": 3.385,
+          "evidence_refs_ref": "e10"
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "notes_ref": "n2",
+          "value": 3.385,
+          "evidence_refs_ref": "e10"
+        },
+        "gear_ratios": {
+          "confidence": "official_derived",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.314,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs": [
+            "legacy_research_sources:38a04165d331",
+            "legacy_research_sources:9942185c701e",
+            "secondary_technical_sources:zf8hp-bmw-x3-table"
+          ],
+          "notes_ref": "n2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_derived",
+          "evidence_refs": [
+            "legacy_research_sources:9942185c701e",
+            "legacy_research_sources:38a04165d331"
+          ],
+          "notes_ref": "n2",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n4",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\""
+          }
         ]
       },
-      {
-        "item": "BMW X3 xDrive30i exact official ratio mapping",
-        "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
-        "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
-        "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30i and M40i transmission subtype code",
-        "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
-        "evidence_refs": [
-          "legacy_research_sources:38a04165d331",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8e51d741ecbd",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:9942185c701e",
-          "legacy_research_sources:9cb10e268364",
-          "legacy_research_sources:de6c75804abf"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n6",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW DE price-list / technical-data context with Medium confidence."
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs": [
+            "legacy_research_sources:38a04165d331",
+            "legacy_research_sources:9942185c701e"
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 xDrive20i exact gear-ratio and reverse-ratio applicability across the full 2018-2024 row span",
+          "reason": "Official BMW DE xDrive20i sheets now prove final drive 3.385, top gear 0.640, and the 225/60 R18 basic tire, but the full forward gear ratios and reverse ratio differ between the checked 09/2018 and 06/2021 technical-data PDFs, so one shared gear-ratio array would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i exact official ratio mapping",
+          "reason": "The checked 09/2018 and 06/2021 BMW Germany technical-data PDFs used in this row are exact xDrive20i sheets, while the currently retained xDrive30i notes are still supported mainly by Germany price-list context and not by one directly checked exact xDrive30i ratio PDF in this run.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 M40i production-data applicability across the full 2018-2024 row span",
+          "reason": "The checked official 04/2020 ACEA M40i sheet resolves final drive 3.385, top gear 0.640, the full forward ratio set, reverse ratio 3.712, and the standard staggered 245/45 R20 front + 275/40 R20 rear fitment, but this pass did not recover launch-year or later-year official sheets proving one unchanged M40i package across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 (G01, 2018-2024) full EU variant matrix beyond the exact xDrive30i and M40i mappings",
+          "reason": "This pass resolves the exact xDrive30i final drive, top gear, and Germany-market tire fitments and adds exact M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for the other G01 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X3 xDrive30i and M40i transmission subtype code",
+          "reason": "Official BMW sources prove 8-Gang Steptronic wording for the checked xDrive30i and M40i mappings but do not publish a gearbox subtype code such as a ZF 8HP variant number.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G45.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G45.json
@@ -1,106 +1,118 @@
-[
-  {
-    "id": "bmw-g45-m50-xdrive-eu-2024-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G45",
-    "body_code": "G45",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "X3 (G45, 2024-2026)",
-    "variant_name": "M50 xDrive",
-    "engine_code": "S58",
-    "engine_name": "S58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 M50 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
+      "n3": "Official BMW 06/2024 specification PDF lists the exact standard staggered 20-inch tire package for the G45 X3 M50 xDrive row: 255/45 R20 front and 285/40 R20 rear on 9J x 20 / 10.5J x 20 wheels.",
+      "n4": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 20 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
+      ],
+      "e2": [
+        "legacy_research_sources:314d8a95d8e2",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:3a6f114b8ee2",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ],
+      "e3": [
         "bmw_pressclub_sources:g45-x3-global-launch-article",
         "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
       ],
-      "notes": "Official BMW launch-article and specification-PDF material confirm that the exact X3 M50 xDrive row is an xDrive all-wheel-drive state in the Europe launch lineup.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g45-x3-global-launch-article",
-        "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
+      "e4": [
+        "bmw_pressclub_sources:g45-x3-long-version-pdf",
+        "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
+        "bmw_market_pages:g45-x3-price-list-de-2026"
       ],
-      "notes": "The official BMW launch article uses Eight-speed Steptronic Sport wording for the exact X3 M50 xDrive, while the official specification PDF prints Eight-speed Steptronic transmission for the same row. The repo normalizes those market-facing BMW labels to the canonical ZF8HP automatic family mapping because the checked official sources do not publish a subtype code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e5": [
+        "bmw_pressclub_sources:g45-x3-2024-spec-pdf"
+      ],
+      "e6": [
+        "bmw_market_pages:g45-x3-price-list-de-2026"
+      ],
+      "e7": [
+        "bmw_pressclub_sources:g45-x3-global-launch-article",
+        "bmw_market_pages:g45-x3-price-list-de-2026",
+        "bmw_market_pages:g45-x3-price-list-at-2026"
+      ],
+      "e8": [
+        "bmw_market_pages:g45-x3-model-page-de",
+        "bmw_pressclub_sources:g45-x3-long-version-pdf",
+        "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
+        "bmw_market_pages:g45-x3-price-list-de-2026"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g45-m50-xdrive-eu-2024-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G45",
+      "body_code": "G45",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "X3 (G45, 2024-2026)",
+      "variant_name": "M50 xDrive",
+      "engine_code": "S58",
+      "engine_name": "S58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF lists 0.640 as the 8th-gear ratio for the exact G45 X3 M50 xDrive row.",
-        "value": 0.64
+        "evidence_refs_ref": "e3",
+        "notes": "Official BMW launch-article and specification-PDF material confirm that the exact X3 M50 xDrive row is an xDrive all-wheel-drive state in the Europe launch lineup.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact G45 X3 M50 xDrive row.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 M50 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 3.385
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW launch article uses Eight-speed Steptronic Sport wording for the exact X3 M50 xDrive, while the official specification PDF prints Eight-speed Steptronic transmission for the same row. The repo normalizes those market-facing BMW labels to the canonical ZF8HP automatic family mapping because the checked official sources do not publish a subtype code.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 M50 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF lists the exact standard staggered 20-inch tire package for the G45 X3 M50 xDrive row: 255/45 R20 front and 285/40 R20 rear on 9J x 20 / 10.5J x 20 wheels.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 20.0
-        },
-        "rear": {
-          "width_mm": 285.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-          ],
-          "notes": "Official BMW 06/2024 specification PDF lists the exact standard staggered 20-inch tire package for the G45 X3 M50 xDrive row: 255/45 R20 front and 285/40 R20 rear on 9J x 20 / 10.5J x 20 wheels.",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 06/2024 specification PDF lists 0.640 as the 8th-gear ratio for the exact G45 X3 M50 xDrive row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "Official BMW 06/2024 specification PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact G45 X3 M50 xDrive row.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 45.0,
@@ -111,445 +123,366 @@
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard staggered 20\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:314d8a95d8e2",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3a6f114b8ee2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard staggered 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:314d8a95d8e2",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3a6f114b8ee2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 4 validation closes the exact launch-state numeric mapping for the G45 X3 M50 xDrive row. The official BMW 06/2024 launch article confirms Europe launch from Q4 2024 with xDrive AWD and Eight-speed Steptronic Sport wording, while the official specification PDF for the exact ACEA-market X3 M50 xDrive row proves forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, a single published final-drive value 3.385, top speed 250 km/h, and the standard staggered 255/45 R20 front plus 285/40 R20 rear tire package. The row now promotes that exact launch-state package while keeping explicit gearbox-subtype naming and hard 2026 end-of-production proof unresolved.",
+          "evidence_refs_ref": "e3"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 4 validation closes the exact launch-state numeric mapping for the G45 X3 M50 xDrive row. The official BMW 06/2024 launch article confirms Europe launch from Q4 2024 with xDrive AWD and Eight-speed Steptronic Sport wording, while the official specification PDF for the exact ACEA-market X3 M50 xDrive row proves forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, a single published final-drive value 3.385, top speed 250 km/h, and the standard staggered 255/45 R20 front plus 285/40 R20 rear tire package. The row now promotes that exact launch-state package while keeping explicit gearbox-subtype naming and hard 2026 end-of-production proof unresolved.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 M50 xDrive production-data applicability across the full 2024-2026 row span",
-        "reason": "The checked official BMW 06/2024 launch article and specification PDF prove the exact launch-state M50 xDrive package and Europe Q4 2024 introduction, but this pass did not recover a later official document proving that same package remained unchanged across the full represented 2024-2026 span.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X3 M50 xDrive exact public gearbox subtype and broader wheel-option matrix",
-        "reason": "The checked official BMW sources prove Eight-speed Steptronic / Steptronic Sport wording, the exact launch-state ratio package, and the standard staggered 20-inch setup, but they do not publish a gearbox subtype code such as ZF8HP or the full official optional wheel/tire matrix for the exact row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_pressclub_sources:g45-x3-m50-2024-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g45-xdrive20-eu-2024-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G45",
-    "body_code": "G45",
-    "production_start_year": 2024,
-    "production_end_year": 2026,
-    "model_name": "X3 (G45, 2024-2026)",
-    "variant_name": "xDrive20",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g45-x3-long-version-pdf",
-        "bmw_market_pages:g45-x3-price-list-de-2026"
       ],
-      "notes": "Official BMW launch-book and Germany price-list material confirm that the exact X3 20 xDrive row is an all-wheel-drive state with BMW xDrive / Allradantrieb wording.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g45-x3-long-version-pdf",
-        "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
-        "bmw_market_pages:g45-x3-price-list-de-2026"
+      "unresolved": [
+        {
+          "item": "BMW X3 M50 xDrive production-data applicability across the full 2024-2026 row span",
+          "reason": "The checked official BMW 06/2024 launch article and specification PDF prove the exact launch-state M50 xDrive package and Europe Q4 2024 introduction, but this pass did not recover a later official document proving that same package remained unchanged across the full represented 2024-2026 span.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW X3 M50 xDrive exact public gearbox subtype and broader wheel-option matrix",
+          "reason": "The checked official BMW sources prove Eight-speed Steptronic / Steptronic Sport wording, the exact launch-state ratio package, and the standard staggered 20-inch setup, but they do not publish a gearbox subtype code such as ZF8HP or the full official optional wheel/tire matrix for the exact row.",
+          "evidence_refs_ref": "e3"
+        }
       ],
-      "notes": "Official BMW launch-book, specification-PDF, and Germany price-list material use Eight-speed Steptronic / 8-Gang Steptronic wording for the exact X3 20 xDrive row. The repo normalizes those market-facing BMW labels to the canonical ZF8HP automatic family mapping because the checked official sources do not publish a subtype code.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF lists 0.640 as the 8th-gear ratio for the exact G45 X3 20 xDrive row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact G45 X3 20 xDrive row.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 20 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf"
-        ],
-        "notes": "Official BMW 06/2024 specification PDF publishes one final-drive value 3.385 for the exact G45 X3 20 xDrive row. The schema stores separate axle fields, so the single published value is duplicated conservatively across both axle slots.",
-        "value": 3.385
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g45-xdrive20-eu-2024-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G45",
+      "body_code": "G45",
+      "production_start_year": 2024,
+      "production_end_year": 2026,
+      "model_name": "X3 (G45, 2024-2026)",
+      "variant_name": "xDrive20",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
         "evidence_refs": [
           "bmw_pressclub_sources:g45-x3-long-version-pdf",
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
           "bmw_market_pages:g45-x3-price-list-de-2026"
         ],
-        "notes": "The strongest official BMW source chain for the exact X3 20 xDrive row converges on square 225/60 R18 tires on 8J x 18 wheels: the 06/2024 specification PDF prints 225/60 R18 directly, the 06/2024 launch-book says 18-inch wheels are standard on the X3 20 xDrive, and the April 2026 Germany price list repeats 225/60 R18 in the xDrive20 wheel matrix. A single selected-equipment text block in the same 2026 price list prints 225/60 R19, but that line conflicts with the other official BMW sources and is treated as an internal brochure inconsistency rather than the exact baseline fitment.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
+        "notes": "Official BMW launch-book and Germany price-list material confirm that the exact X3 20 xDrive row is an all-wheel-drive state with BMW xDrive / Allradantrieb wording.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e4",
+        "notes": "Official BMW launch-book, specification-PDF, and Germany price-list material use Eight-speed Steptronic / 8-Gang Steptronic wording for the exact X3 20 xDrive row. The repo normalizes those market-facing BMW labels to the canonical ZF8HP automatic family mapping because the checked official sources do not publish a subtype code.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g45-x3-long-version-pdf",
-            "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
-            "bmw_market_pages:g45-x3-price-list-de-2026"
-          ],
-          "notes": "The strongest official BMW source chain for the exact X3 20 xDrive row converges on square 225/60 R18 tires on 8J x 18 wheels as the standard package.",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 06/2024 specification PDF lists 0.640 as the 8th-gear ratio for the exact G45 X3 20 xDrive row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e5",
+          "notes": "Official BMW 06/2024 specification PDF lists the forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640 for the exact G45 X3 20 xDrive row.",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n4",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e5",
+          "notes_ref": "n4",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "The strongest official BMW source chain for the exact X3 20 xDrive row converges on square 225/60 R18 tires on 8J x 18 wheels: the 06/2024 specification PDF prints 225/60 R18 directly, the 06/2024 launch-book says 18-inch wheels are standard on the X3 20 xDrive, and the April 2026 Germany price list repeats 225/60 R18 in the xDrive20 wheel matrix. A single selected-equipment text block in the same 2026 price list prints 225/60 R19, but that line conflicts with the other official BMW sources and is treated as an internal brochure inconsistency rather than the exact baseline fitment.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard square 18\""
+          "default_axle_for_speed": "rear"
         },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "The strongest official BMW source chain for the exact X3 20 xDrive row converges on square 225/60 R18 tires on 8J x 18 wheels as the standard package.",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard square 18\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional square 245/50 R19 package on 8.5J x 19 wheels.",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional square 19\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional staggered 20-inch package with 255/45 R20 front and 285/40 R20 rear tires.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 20\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e6",
+            "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional staggered 21-inch package with 255/40 R21 front and 285/35 R21 rear tires.",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 285.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 21\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g45-x3-price-list-de-2026"
-          ],
-          "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional square 245/50 R19 package on 8.5J x 19 wheels.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional square 19\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g45-x3-price-list-de-2026"
-          ],
-          "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional staggered 20-inch package with 255/45 R20 front and 285/40 R20 rear tires.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "rear": {
-            "width_mm": 285.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 20\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_market_pages:g45-x3-price-list-de-2026"
-          ],
-          "notes": "Official BMW Germany April 2026 price list maps the exact X3 20 xDrive column to an optional staggered 21-inch package with 255/40 R21 front and 285/35 R21 rear tires.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 285.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 21\""
+          "note": "Batch 5 validation closes the exact launch-state numeric mapping for the G45 X3 20 xDrive row. Official BMW Germany model-page metadata surfaces the exact BMW X3 20 xDrive with model-range G45 and productionYear 2024, the 06/2024 launch-book places Europe launch in Q4 2024 and states that 18-inch wheels are standard on the X3 20 xDrive, the 06/2024 specification PDF proves Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, top speed 215 km/h, and standard 225/60 R18 tires, and the April 2026 BMW Germany price list confirms continued sale of the exact X3 20 xDrive plus the current square 19-inch and staggered 20-inch and 21-inch wheel packages. One selected-equipment text block in that same 2026 price list prints 225/60 R19, but the direct specification PDF, launch-book 18-inch statement, and wheel-matrix pages all support 225/60 R18 instead, so production data now follows that stronger three-source convergence.",
+          "evidence_refs_ref": "e8"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 5 validation closes the exact launch-state numeric mapping for the G45 X3 20 xDrive row. Official BMW Germany model-page metadata surfaces the exact BMW X3 20 xDrive with model-range G45 and productionYear 2024, the 06/2024 launch-book places Europe launch in Q4 2024 and states that 18-inch wheels are standard on the X3 20 xDrive, the 06/2024 specification PDF proves Eight-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.385, top speed 215 km/h, and standard 225/60 R18 tires, and the April 2026 BMW Germany price list confirms continued sale of the exact X3 20 xDrive plus the current square 19-inch and staggered 20-inch and 21-inch wheel packages. One selected-equipment text block in that same 2026 price list prints 225/60 R19, but the direct specification PDF, launch-book 18-inch statement, and wheel-matrix pages all support 225/60 R18 instead, so production data now follows that stronger three-source convergence.",
-        "evidence_refs": [
-          "bmw_market_pages:g45-x3-model-page-de",
-          "bmw_pressclub_sources:g45-x3-long-version-pdf",
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
-          "bmw_market_pages:g45-x3-price-list-de-2026"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 20 xDrive production-data applicability across the full 2024-2026 row span",
-        "reason": "The checked official BMW launch-book, specification-PDF, Germany model page, and April 2026 Germany price list prove the exact X3 20 xDrive launch-state package and 2026 continuity, but this pass did not recover a later official ratio table proving that the exact 2024 launch-state gearing and final-drive package remained unchanged across the full represented row span.",
-        "evidence_refs": [
-          "bmw_market_pages:g45-x3-model-page-de",
-          "bmw_pressclub_sources:g45-x3-long-version-pdf",
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
-          "bmw_market_pages:g45-x3-price-list-de-2026"
-        ]
-      },
-      {
-        "item": "BMW X3 20 xDrive exact public gearbox subtype naming",
-        "reason": "The checked official BMW sources prove Eight-speed Steptronic / 8-Gang Steptronic wording, the exact ratio package, and the wheel matrix, but they do not publish a gearbox subtype code such as ZF8HP.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-long-version-pdf",
-          "bmw_pressclub_sources:g45-x3-2024-spec-pdf",
-          "bmw_market_pages:g45-x3-price-list-de-2026"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g45-xdrive30-eu-2025-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G45",
-    "body_code": "G45",
-    "production_start_year": 2025,
-    "production_end_year": 2026,
-    "model_name": "X3 (G45, 2025-2026)",
-    "variant_name": "xDrive30",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 2.813
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 2.813
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:314d8a95d8e2",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3a6f114b8ee2",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 40.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      ],
+      "unresolved": [
         {
+          "item": "BMW X3 20 xDrive production-data applicability across the full 2024-2026 row span",
+          "reason": "The checked official BMW launch-book, specification-PDF, Germany model page, and April 2026 Germany price list prove the exact X3 20 xDrive launch-state package and 2026 continuity, but this pass did not recover a later official ratio table proving that the exact 2024 launch-state gearing and final-drive package remained unchanged across the full represented row span.",
+          "evidence_refs_ref": "e8"
+        },
+        {
+          "item": "BMW X3 20 xDrive exact public gearbox subtype naming",
+          "reason": "The checked official BMW sources prove Eight-speed Steptronic / 8-Gang Steptronic wording, the exact ratio package, and the wheel matrix, but they do not publish a gearbox subtype code such as ZF8HP.",
+          "evidence_refs_ref": "e4"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g45-xdrive30-eu-2025-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G45",
+      "body_code": "G45",
+      "production_start_year": 2025,
+      "production_end_year": 2026,
+      "model_name": "X3 (G45, 2025-2026)",
+      "variant_name": "xDrive30",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:314d8a95d8e2",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3a6f114b8ee2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 2.813
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 40.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 40.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Batch 5 strengthens this row from merely suspect to lifecycle-wide contradicted. Official BMW 06/2024 G45 launch material names the Europe-launch lineup as X3 20 xDrive, X3 20d xDrive, X3 30e xDrive, and X3 M50 xDrive, and current official BMW Germany and Austria price lists continue to name X3 30e xDrive, X3 20 xDrive, X3 20d xDrive, X3 40d xDrive, and X3 M50 xDrive without any non-PHEV X3 xDrive30 row. The current EU xDrive30 row is therefore retained only as an unsupported advisory reference pending exact market-proof or a row split/removal decision.",
+          "evidence_refs_ref": "e7"
         },
         {
-          "confidence": "family_default",
+          "note": "The official BMW UK G45 technical-data page confirms a live 2024 G45 UK technical-data surface, but the retrieved page identity defaulted to the supported X3 20 xDrive context rather than proving the existence of an EU-market xDrive30 trim.",
           "evidence_refs": [
-            "legacy_research_sources:314d8a95d8e2",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3a6f114b8ee2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:314d8a95d8e2",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3a6f114b8ee2",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+            "bmw_market_pages:g45-x3-technical-data-uk"
+          ]
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Batch 5 strengthens this row from merely suspect to lifecycle-wide contradicted. Official BMW 06/2024 G45 launch material names the Europe-launch lineup as X3 20 xDrive, X3 20d xDrive, X3 30e xDrive, and X3 M50 xDrive, and current official BMW Germany and Austria price lists continue to name X3 30e xDrive, X3 20 xDrive, X3 20d xDrive, X3 40d xDrive, and X3 M50 xDrive without any non-PHEV X3 xDrive30 row. The current EU xDrive30 row is therefore retained only as an unsupported advisory reference pending exact market-proof or a row split/removal decision.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_market_pages:g45-x3-price-list-de-2026",
-          "bmw_market_pages:g45-x3-price-list-at-2026"
-        ]
-      },
-      {
-        "note": "The official BMW UK G45 technical-data page confirms a live 2024 G45 UK technical-data surface, but the retrieved page identity defaulted to the supported X3 20 xDrive context rather than proving the existence of an EU-market xDrive30 trim.",
-        "evidence_refs": [
-          "bmw_market_pages:g45-x3-technical-data-uk"
-        ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X3 xDrive30 exact EU-market existence and production span",
+          "reason": "The checked official BMW G45 launch material for Europe supports X3 20 xDrive, X3 20d xDrive, X3 30e xDrive, and X3 M50 xDrive, and current official BMW Germany and Austria price lists continue that naming pattern without any exact X3 xDrive30 row.",
+          "evidence_refs_ref": "e7"
+        },
+        {
+          "item": "BMW X3 xDrive30 row cleanup versus likely non-EU or mis-targeted trim leakage",
+          "reason": "Because the checked official BMW Europe-facing G45 sources consistently surface 30e xDrive instead of xDrive30, this row may reflect a non-EU market mapping or a mislabeled exact row and should not receive guessed timing, drivetrain, ratio, or wheel updates without an exact official source.",
+          "evidence_refs_ref": "e7"
+        }
+      ],
+      "configuration_confidence": "no_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X3 xDrive30 exact EU-market existence and production span",
-        "reason": "The checked official BMW G45 launch material for Europe supports X3 20 xDrive, X3 20d xDrive, X3 30e xDrive, and X3 M50 xDrive, and current official BMW Germany and Austria price lists continue that naming pattern without any exact X3 xDrive30 row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_market_pages:g45-x3-price-list-de-2026",
-          "bmw_market_pages:g45-x3-price-list-at-2026"
-        ]
-      },
-      {
-        "item": "BMW X3 xDrive30 row cleanup versus likely non-EU or mis-targeted trim leakage",
-        "reason": "Because the checked official BMW Europe-facing G45 sources consistently surface 30e xDrive instead of xDrive30, this row may reflect a non-EU market mapping or a mislabeled exact row and should not receive guessed timing, drivetrain, ratio, or wheel updates without an exact official source.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g45-x3-global-launch-article",
-          "bmw_market_pages:g45-x3-price-list-de-2026",
-          "bmw_market_pages:g45-x3-price-list-at-2026"
-        ]
-      }
-    ],
-    "configuration_confidence": "no_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/F26.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/F26.json
@@ -1,521 +1,444 @@
-[
-  {
-    "id": "bmw-f26-xdrive20i-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F26",
-    "body_code": "F26",
-    "production_start_year": 2015,
-    "production_end_year": 2015,
-    "model_name": "X4 (F26, 2015)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive20i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n3": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
+      "n4": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive28i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n5": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
+      "n6": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive35i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n7": "The official BMW 03/2014 technical-data PDF lists 245/50 R18 as the baseline tire for the exact X4 xDrive35i state represented by this narrowed 2015-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive20i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e2": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:4f4a83d38242",
+        "legacy_research_sources:6b4f7c301842",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f26-xdrive20i-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F26",
+      "body_code": "F26",
+      "production_start_year": 2015,
+      "production_end_year": 2015,
+      "model_name": "X4 (F26, 2015)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
-        "value": 0.667
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive20i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive20i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive20i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive20i state represented by this narrowed 2015-only row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive20i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 225/60 R17 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive20i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 225/60 R17 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive20i exact optional wheel/tire matrix beyond the narrowed 2015 row",
-        "reason": "The checked official BMW 03/2014 technical-data PDF closes the 17-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive20i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f26-xdrive28i-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F26",
-    "body_code": "F26",
-    "production_start_year": 2015,
-    "production_end_year": 2015,
-    "model_name": "X4 (F26, 2015)",
-    "variant_name": "xDrive28i",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive28i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive28i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive28i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 60.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X4 xDrive20i exact optional wheel/tire matrix beyond the narrowed 2015 row",
+          "reason": "The checked official BMW 03/2014 technical-data PDF closes the 17-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive20i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f26-xdrive28i-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F26",
+      "body_code": "F26",
+      "production_start_year": 2015,
+      "production_end_year": 2015,
+      "model_name": "X4 (F26, 2015)",
+      "variant_name": "xDrive28i",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive28i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive28i state represented by this narrowed 2015-only row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
             "rim_in": 17.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 17\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 225.0,
+              "aspect_pct": 60.0,
+              "rim_in": 17.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 17\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive28i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 225/60 R17 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive28i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 225/60 R17 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive28i exact optional wheel/tire matrix beyond the narrowed 2015 row",
-        "reason": "The checked official BMW 03/2014 technical-data PDF closes the 17-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive28i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f26-xdrive35i-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F26",
-    "body_code": "F26",
-    "production_start_year": 2015,
-    "production_end_year": 2015,
-    "model_name": "X4 (F26, 2015)",
-    "variant_name": "xDrive35i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive35i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive35i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X4 xDrive35i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 03/2014 technical-data PDF lists 245/50 R18 as the baseline tire for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 50.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X4 xDrive28i exact optional wheel/tire matrix beyond the narrowed 2015 row",
+          "reason": "The checked official BMW 03/2014 technical-data PDF closes the 17-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive28i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f26-xdrive35i-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F26",
+      "body_code": "F26",
+      "production_start_year": 2015,
+      "production_end_year": 2015,
+      "model_name": "X4 (F26, 2015)",
+      "variant_name": "xDrive35i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 03/2014 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X4 xDrive35i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 03/2014 technical-data PDF lists 245/50 R18 as the baseline tire for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 03/2014 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X4 xDrive35i state represented by this narrowed 2015-only row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n6",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 50.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 50.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4f4a83d38242",
-            "legacy_research_sources:6b4f7c301842",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive35i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive35i exact optional wheel/tire matrix beyond the narrowed 2015 row",
-        "reason": "The checked official BMW 03/2014 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "item": "BMW X4 xDrive35i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 03/2014 technical-data PDF establishes the exact X4 xDrive35i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.385 final-drive ratio, and 245/50 R18 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X4 xDrive35i exact optional wheel/tire matrix beyond the narrowed 2015 row",
+          "reason": "The checked official BMW 03/2014 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive35i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/G02.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/G02.json
@@ -1,899 +1,485 @@
-[
-  {
-    "id": "bmw-g02-m40i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G02",
-    "body_code": "G02",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "X4 (G02, 2019-2025)",
-    "variant_name": "M40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Official BMW exact technical-data documents now confirm two checked G02 X4 M40i states for Germany/ACEA markets: 08/2018 with 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, reverse 3.456, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires; and 04/2020 with 8-Gang Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, the same final drive 3.385, and the same standard staggered 20-inch fitment. Wave 10 validation now also adds exact xDrive30i context: the checked 09/2018 and 03/2021 official sheets agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but disagree on the full forward and reverse ratios, while the current Germany price list confirms standard 225/60 R18 tires, optional 245/50 R19 tires, and optional staggered 245/45 R20 front + 275/40 R20 rear or 245/40 R21 front + 275/35 R21 rear fitments. Wave 11 adds the parallel xDrive20i result: the checked 04/2018 and 03/2021 official sheets likewise agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but publish conflicting full forward and reverse ratios, and the current Germany price list confirms the same 18/19/20/21-inch tire matrix. The broad row remains unchanged because BMW's own exact xDrive20i, xDrive30i, and M40i ratio sheets conflict across the represented span and this pass still does not close the full 2019-2025 row with one year-split-safe production package.",
+      "n3": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:1c565c59e754",
+        "legacy_research_sources:220ac7b59aa9",
+        "legacy_research_sources:286bb3c2fefa",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:4848a45fdcd1",
+        "legacy_research_sources:7de57732627a",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:9fd32b9ccf1f",
+        "legacy_research_sources:ca112b946e77",
+        "legacy_research_sources:f66a48c88326"
+      ],
+      "e2": [
         "legacy_research_sources:220ac7b59aa9",
         "legacy_research_sources:f66a48c88326"
       ],
-      "notes": "Exact official BMW X4 M40i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:220ac7b59aa9",
-        "legacy_research_sources:f66a48c88326"
-      ],
-      "notes": "Exact official BMW X4 M40i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two checked G02 X4 M40i states for Germany/ACEA markets: 08/2018 with 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, reverse 3.456, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires; and 04/2020 with 8-Gang Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, the same final drive 3.385, and the same standard staggered 20-inch fitment. Wave 10 validation now also adds exact xDrive30i context: the checked 09/2018 and 03/2021 official sheets agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but disagree on the full forward and reverse ratios, while the current Germany price list confirms standard 225/60 R18 tires, optional 245/50 R19 tires, and optional staggered 245/45 R20 front + 275/40 R20 rear or 245/40 R21 front + 275/35 R21 rear fitments. Wave 11 adds the parallel xDrive20i result: the checked 04/2018 and 03/2021 official sheets likewise agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but publish conflicting full forward and reverse ratios, and the current Germany price list confirms the same 18/19/20/21-inch tire matrix. The broad row remains unchanged because BMW's own exact xDrive20i, xDrive30i, and M40i ratio sheets conflict across the represented span and this pass still does not close the full 2019-2025 row with one year-split-safe production package.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i production-data applicability across the full G02 row span",
-        "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
-        "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g02-xdrive20i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G02",
-    "body_code": "G02",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "X4 (G02, 2019-2025)",
-    "variant_name": "xDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+      "e3": [
         "legacy_research_sources:286bb3c2fefa",
         "legacy_research_sources:ca112b946e77"
       ],
-      "notes": "Exact official BMW X4 xDrive20i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:286bb3c2fefa",
-        "legacy_research_sources:ca112b946e77"
-      ],
-      "notes": "Exact official BMW X4 xDrive20i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 245.0,
-            "aspect_pct": 45.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
+      "e4": [
+        "legacy_research_sources:1c565c59e754",
+        "legacy_research_sources:7de57732627a"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two checked G02 X4 M40i states for Germany/ACEA markets: 08/2018 with 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, reverse 3.456, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires; and 04/2020 with 8-Gang Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, the same final drive 3.385, and the same standard staggered 20-inch fitment. Wave 10 validation now also adds exact xDrive30i context: the checked 09/2018 and 03/2021 official sheets agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but disagree on the full forward and reverse ratios, while the current Germany price list confirms standard 225/60 R18 tires, optional 245/50 R19 tires, and optional staggered 245/45 R20 front + 275/40 R20 rear or 245/40 R21 front + 275/35 R21 rear fitments. Wave 11 adds the parallel xDrive20i result: the checked 04/2018 and 03/2021 official sheets likewise agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but publish conflicting full forward and reverse ratios, and the current Germany price list confirms the same 18/19/20/21-inch tire matrix. The broad row remains unchanged because BMW's own exact xDrive20i, xDrive30i, and M40i ratio sheets conflict across the represented span and this pass still does not close the full 2019-2025 row with one year-split-safe production package.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i production-data applicability across the full G02 row span",
-        "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
-        "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-g02-xdrive30i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G02",
-    "body_code": "G02",
-    "production_start_year": 2019,
-    "production_end_year": 2025,
-    "model_name": "X4 (G02, 2019-2025)",
-    "variant_name": "xDrive30i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1c565c59e754",
-        "legacy_research_sources:7de57732627a"
-      ],
-      "notes": "Exact official BMW X4 xDrive30i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1c565c59e754",
-        "legacy_research_sources:7de57732627a"
-      ],
-      "notes": "Exact official BMW X4 xDrive30i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
+  "configurations": [
+    {
+      "id": "bmw-g02-m40i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G02",
+      "body_code": "G02",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "X4 (G02, 2019-2025)",
+      "variant_name": "M40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official BMW X4 M40i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "value": "AWD"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Exact official BMW X4 M40i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 245.0,
-          "aspect_pct": 45.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 245.0,
             "aspect_pct": 45.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 40.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:1c565c59e754",
-            "legacy_research_sources:220ac7b59aa9",
-            "legacy_research_sources:286bb3c2fefa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:4848a45fdcd1",
-            "legacy_research_sources:7de57732627a",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:9fd32b9ccf1f",
-            "legacy_research_sources:ca112b946e77",
-            "legacy_research_sources:f66a48c88326"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          "note_ref": "n3"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i production-data applicability across the full G02 row span",
+          "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
+          "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two checked G02 X4 M40i states for Germany/ACEA markets: 08/2018 with 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.314 / 1.000 / 0.822 / 0.640, reverse 3.456, final drive 3.385, and standard staggered 245/45 R20 front + 275/40 R20 rear tires; and 04/2020 with 8-Gang Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, the same final drive 3.385, and the same standard staggered 20-inch fitment. Wave 10 validation now also adds exact xDrive30i context: the checked 09/2018 and 03/2021 official sheets agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but disagree on the full forward and reverse ratios, while the current Germany price list confirms standard 225/60 R18 tires, optional 245/50 R19 tires, and optional staggered 245/45 R20 front + 275/40 R20 rear or 245/40 R21 front + 275/35 R21 rear fitments. Wave 11 adds the parallel xDrive20i result: the checked 04/2018 and 03/2021 official sheets likewise agree on final drive 3.385, top gear 0.640, and standard 225/60 R18 tires but publish conflicting full forward and reverse ratios, and the current Germany price list confirms the same 18/19/20/21-inch tire matrix. The broad row remains unchanged because BMW's own exact xDrive20i, xDrive30i, and M40i ratio sheets conflict across the represented span and this pass still does not close the full 2019-2025 row with one year-split-safe production package.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
+    {
+      "id": "bmw-g02-xdrive20i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G02",
+      "body_code": "G02",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "X4 (G02, 2019-2025)",
+      "variant_name": "xDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Exact official BMW X4 xDrive20i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "Exact official BMW X4 xDrive20i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 45.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i production-data applicability across the full G02 row span",
+          "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
+          "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
+    },
+    {
+      "id": "bmw-g02-xdrive30i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G02",
+      "body_code": "G02",
+      "production_start_year": 2019,
+      "production_end_year": 2025,
+      "model_name": "X4 (G02, 2019-2025)",
+      "variant_name": "xDrive30i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Exact official BMW X4 xDrive30i technical-data PDFs confirm xDrive AWD for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes": "Exact official BMW X4 xDrive30i technical-data PDFs confirm the 8-speed Steptronic transmission for the checked G02 states, while BMW's own year-split ratio and tire changes keep the broader row unresolved.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 45.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 245.0,
+              "aspect_pct": 45.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
-        "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
-        "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i production-data applicability across the full G02 row span",
-        "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
-        "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
-      },
-      {
-        "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
-        "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
-        "evidence_refs": [
-          "legacy_research_sources:1c565c59e754",
-          "legacy_research_sources:220ac7b59aa9",
-          "legacy_research_sources:286bb3c2fefa",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:4848a45fdcd1",
-          "legacy_research_sources:7de57732627a",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:9fd32b9ccf1f",
-          "legacy_research_sources:ca112b946e77",
-          "legacy_research_sources:f66a48c88326"
-        ]
+      "verification_notes": [
+        {
+          "note_ref": "n2",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X4 xDrive20i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive20i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 04/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive20i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive20i tire matrix and 8-Gang Steptronic wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i exact gear-ratio and reverse-ratio applicability across the full G02 row span",
+          "reason": "Official BMW xDrive30i technical-data sheets now prove final drive 3.385, top gear 0.640, and the standard 225/60 R18 fitment, but the full forward and reverse ratios differ between the checked 09/2018 and 03/2021 documents, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 xDrive30i current optional wheel/tire matrix applicability and transmission subtype code",
+          "reason": "Official BMW sources now prove the current Germany-market xDrive30i tire matrix and Steptronic Sport wording, but they do not publish a gearbox subtype code or one exact official matrix proving unchanged 19/20/21-inch applicability across the full represented row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i production-data applicability across the full G02 row span",
+          "reason": "Official BMW M40i technical-data sheets now prove two exact ratio packages within the represented 2019-2025 span, but the launch 08/2018 and 04/2020 exact sheets disagree on the full forward and reverse ratios, so one shared production mapping would be inaccurate without a year split.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 (G02, 2019-2025) full EU variant matrix beyond the exact xDrive20i, xDrive30i, and M40i mappings",
+          "reason": "This pass resolves exact official xDrive20i, xDrive30i, and M40i source-ledger evidence, but it does not establish the full official ratio and tire matrix for every other G02 variant represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X4 M40i exact optional wheel/tire matrix and transmission subtype code",
+          "reason": "Official BMW sources now prove the exact standard staggered 20-inch M40i fitment and the checked ratio sets, but they do not publish a gearbox subtype code or one exact full optional wheel/tire matrix that closes the broad row safely.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/F15.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/F15.json
@@ -1,521 +1,450 @@
-[
-  {
-    "id": "bmw-f15-xdrive35i-eu-2014-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F15",
-    "body_code": "F15",
-    "production_start_year": 2014,
-    "production_end_year": 2014,
-    "model_name": "X5 (F15, 2014)",
-    "variant_name": "xDrive35i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "The official BMW 12/2013 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive35i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n3": "The official BMW 12/2013 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
+      "n4": "The official BMW 08/2014 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive50i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n5": "The official BMW 08/2014 technical-data PDF lists 255/50 R19 as the baseline tire for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
+      "n6": "The official BMW 05/2015 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive40e state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n7": "The official BMW 05/2015 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive40e state represented by this narrowed 2015-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
       ],
-      "notes": "The official BMW 12/2013 technical-data PDF confirms xDrive all-wheel drive for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
+      "e2": [
+        "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 12/2013 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X5 xDrive35i state represented by this narrowed 2014-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+      "e3": [
+        "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
+      ],
+      "e4": [
+        "legacy_research_sources:11ce22adfeaa",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:6d6ebea17ecb",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-f15-xdrive35i-eu-2014-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F15",
+      "body_code": "F15",
+      "production_start_year": 2014,
+      "production_end_year": 2014,
+      "model_name": "X5 (F15, 2014)",
+      "variant_name": "xDrive35i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 12/2013 technical-data PDF lists 0.667 as the top-gear ratio for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
-        "value": 0.667
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 12/2013 technical-data PDF confirms xDrive all-wheel drive for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
+        "value": "AWD"
       },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 12/2013 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 12/2013 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive35i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 12/2013 technical-data PDF confirms eight-speed automatic transmission with Steptronic wording for the exact X5 xDrive35i state represented by this narrowed 2014-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 12/2013 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive35i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 12/2013 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 12/2013 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 12/2013 technical-data PDF lists 0.667 as the top-gear ratio for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 12/2013 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X5 xDrive35i state represented by this narrowed 2014-only row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 12/2013 technical-data PDF establishes the exact X5 xDrive35i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.154 final-drive ratio, and 255/55 R18 baseline tires. This row is narrowed to the supported 2014-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e1"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 12/2013 technical-data PDF establishes the exact X5 xDrive35i launch-state mapping checked in this pass: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.154 final-drive ratio, and 255/55 R18 baseline tires. This row is narrowed to the supported 2014-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive35i exact optional wheel/tire matrix beyond the narrowed 2014 row",
-        "reason": "The checked official BMW 12/2013 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X5 xDrive35i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f15-xdrive50i-eu-2014-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F15",
-    "body_code": "F15",
-    "production_start_year": 2014,
-    "production_end_year": 2014,
-    "model_name": "X5 (F15, 2014)",
-    "variant_name": "xDrive50i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 08/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 08/2014 technical-data PDF confirms 8-speed Steptronic wording for the exact X5 xDrive50i state represented by this narrowed 2014-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 08/2014 technical-data PDF lists 0.640 as the top-gear ratio for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 08/2014 technical-data PDF lists the forward gear ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 08/2014 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive50i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 08/2014 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive50i state represented by this narrowed 2014-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 08/2014 technical-data PDF lists 255/50 R19 as the baseline tire for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X5 xDrive35i exact optional wheel/tire matrix beyond the narrowed 2014 row",
+          "reason": "The checked official BMW 12/2013 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 xDrive35i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f15-xdrive50i-eu-2014-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F15",
+      "body_code": "F15",
+      "production_start_year": 2014,
+      "production_end_year": 2014,
+      "model_name": "X5 (F15, 2014)",
+      "variant_name": "xDrive50i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 08/2014 technical-data PDF confirms xDrive all-wheel drive for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW 08/2014 technical-data PDF confirms 8-speed Steptronic wording for the exact X5 xDrive50i state represented by this narrowed 2014-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 08/2014 technical-data PDF lists 255/50 R19 as the baseline tire for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 08/2014 technical-data PDF lists 0.640 as the top-gear ratio for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "The official BMW 08/2014 technical-data PDF lists the forward gear ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact X5 xDrive50i state represented by this narrowed 2014-only row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n4",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 08/2014 technical-data PDF establishes the exact X5 xDrive50i state checked in this pass: AWD, 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published 3.154 final-drive ratio, and 255/50 R19 baseline tires. This row is narrowed to the supported 2014-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 08/2014 technical-data PDF establishes the exact X5 xDrive50i state checked in this pass: AWD, 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published 3.154 final-drive ratio, and 255/50 R19 baseline tires. This row is narrowed to the supported 2014-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive50i exact optional wheel/tire matrix beyond the narrowed 2014 row",
-        "reason": "The checked official BMW 08/2014 technical-data PDF closes the 19-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X5 xDrive50i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-f15-xdrive40e-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F15",
-    "body_code": "F15",
-    "production_start_year": 2015,
-    "production_end_year": 2015,
-    "model_name": "X5 (F15, 2015)",
-    "variant_name": "xDrive40e",
-    "engine_code": "N20",
-    "engine_name": "N20 2.0L I4 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
       ],
-      "notes": "The official BMW 05/2015 technical-data PDF confirms full hybrid drive with permanent torque vectoring to all four wheels for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 05/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact X5 xDrive40e state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 05/2015 technical-data PDF lists 0.667 as the top-gear ratio for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 05/2015 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 05/2015 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive40e state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 05/2015 technical-data PDF publishes a single 3.154 final-drive ratio for the exact X5 xDrive40e state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 05/2015 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 55.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X5 xDrive50i exact optional wheel/tire matrix beyond the narrowed 2014 row",
+          "reason": "The checked official BMW 08/2014 technical-data PDF closes the 19-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW X5 xDrive50i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-f15-xdrive40e-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F15",
+      "body_code": "F15",
+      "production_start_year": 2015,
+      "production_end_year": 2015,
+      "model_name": "X5 (F15, 2015)",
+      "variant_name": "xDrive40e",
+      "engine_code": "N20",
+      "engine_name": "N20 2.0L I4 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 05/2015 technical-data PDF confirms full hybrid drive with permanent torque vectoring to all four wheels for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e3",
+        "notes": "The official BMW 05/2015 technical-data PDF confirms 8-speed Steptronic wording for the exact X5 xDrive40e state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 05/2015 technical-data PDF lists 255/55 R18 as the baseline tire for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 05/2015 technical-data PDF lists 0.667 as the top-gear ratio for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "The official BMW 05/2015 technical-data PDF lists the forward gear ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 for the exact X5 xDrive40e state represented by this narrowed 2015-only row.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 55.0,
             "rim_in": 18.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 18\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n7",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 55.0,
+              "rim_in": 18.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 18\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:11ce22adfeaa",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:6d6ebea17ecb",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 05/2015 technical-data PDF establishes the exact X5 xDrive40e state checked in this pass: full hybrid AWD with permanent torque vectoring to all four wheels, 8-speed Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.154 final-drive ratio, and 255/55 R18 baseline tires. This row is narrowed and renamed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive40e exact optional wheel/tire matrix beyond the narrowed 2015 row",
-        "reason": "The checked official BMW 05/2015 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e4",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "item": "BMW X5 xDrive40e separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW 05/2015 technical-data PDF establishes the exact X5 xDrive40e state checked in this pass: full hybrid AWD with permanent torque vectoring to all four wheels, 8-speed Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.154 final-drive ratio, and 255/55 R18 baseline tires. This row is narrowed and renamed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X5 xDrive40e exact optional wheel/tire matrix beyond the narrowed 2015 row",
+          "reason": "The checked official BMW 05/2015 technical-data PDF closes the 18-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e3"
+        },
+        {
+          "item": "BMW X5 xDrive40e separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e3"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/G05.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/G05.json
@@ -1,653 +1,448 @@
-[
-  {
-    "id": "bmw-g05-m50i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G05",
-    "body_code": "G05",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X5 (G05, 2019-2026)",
-    "variant_name": "M50i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
+      "n3": "Official BMW DE and ACEA technical-data sources now confirm two exact G05 mappings: xDrive45e with 8-speed Steptronic, full forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.636, and standard 265/50 R19 tires; and launch-era xDrive40i with 8-speed Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.385, and standard 255/55 R18 tires. The broad G05 row remains verification backlog because later Germany-market xDrive40i material changes gearbox wording and the standard tire baseline, so one undifferentiated 2019-2026 production mapping would be unsafe and the full EU variant matrix is still incomplete."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:016fe2ba6b0f",
+        "legacy_research_sources:0b686d9345fd",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:3d68278cff53",
+        "legacy_research_sources:51dc23420162",
+        "legacy_research_sources:672d5c0fbe65",
+        "legacy_research_sources:6e8be3d590d9",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:f1e673d6713e"
+      ],
+      "e2": [
+        "legacy_research_sources:0b686d9345fd",
+        "legacy_research_sources:3d68278cff53"
+      ],
+      "e3": [
         "legacy_research_sources:672d5c0fbe65",
         "legacy_research_sources:6e8be3d590d9"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
+      "e4": [
+        "legacy_research_sources:0b686d9345fd",
+        "legacy_research_sources:3d68278cff53",
+        "legacy_research_sources:6e8be3d590d9"
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g05-m50i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G05",
+      "body_code": "G05",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X5 (G05, 2019-2026)",
+      "variant_name": "M50i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.077
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW DE and ACEA technical-data sources now confirm two exact G05 mappings: xDrive45e with 8-speed Steptronic, full forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.636, and standard 265/50 R19 tires; and launch-era xDrive40i with 8-speed Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.385, and standard 255/55 R18 tires. The broad G05 row remains verification backlog because later Germany-market xDrive40i material changes gearbox wording and the standard tire baseline, so one undifferentiated 2019-2026 production mapping would be unsafe and the full EU variant matrix is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
-        "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
-        "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
-        "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g05-xdrive40i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G05",
-    "body_code": "G05",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X5 (G05, 2019-2026)",
-    "variant_name": "xDrive40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:672d5c0fbe65",
-        "legacy_research_sources:6e8be3d590d9"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-        "value": 3.077
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-        "value": 3.077
+      "unresolved": [
+        {
+          "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
+          "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
+          "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
+          "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g05-xdrive40i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G05",
+      "body_code": "G05",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X5 (G05, 2019-2026)",
+      "variant_name": "xDrive40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e3",
+        "notes_ref": "n2",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
+          "notes_ref": "n2",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.077
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.077
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:016fe2ba6b0f",
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:51dc23420162",
-            "legacy_research_sources:672d5c0fbe65",
-            "legacy_research_sources:6e8be3d590d9",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:f1e673d6713e"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW DE and ACEA technical-data sources now confirm two exact G05 mappings: xDrive45e with 8-speed Steptronic, full forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, final drive 3.636, and standard 265/50 R19 tires; and launch-era xDrive40i with 8-speed Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.385, and standard 255/55 R18 tires. The broad G05 row remains verification backlog because later Germany-market xDrive40i material changes gearbox wording and the standard tire baseline, so one undifferentiated 2019-2026 production mapping would be unsafe and the full EU variant matrix is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data (launch / 03-2021 exact state; broad row still unresolved) with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
-        "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
-        "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
-        "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g05-xdrive45e-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G05",
-    "body_code": "G05",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X5 (G05, 2019-2026)",
-    "variant_name": "xDrive45e",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo PHEV",
-    "fuel_type": "PHEV",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:0b686d9345fd",
-        "legacy_research_sources:3d68278cff53"
       ],
-      "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs for the exact G05 X5 xDrive45e consistently describe full-hybrid drive with torque routed to all four wheels via BMW xDrive.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "legacy_research_sources:0b686d9345fd",
-        "legacy_research_sources:3d68278cff53"
-      ],
-      "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs for the exact G05 X5 xDrive45e print 8-speed/8-Gang Steptronic wording. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53"
-        ],
-        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list 0.667 as the top-gear ratio for the exact G05 X5 xDrive45e.",
-        "value": 0.667
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53"
-        ],
-        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list the full forward gear-ratio set for the exact G05 X5 xDrive45e.",
-        "value": [
-          4.714,
-          3.143,
-          2.106,
-          1.667,
-          1.285,
-          1.0,
-          0.839,
-          0.667
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53"
-        ],
-        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs publish one axle/final-drive value of 3.636 for the exact G05 X5 xDrive45e. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53"
-        ],
-        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs publish one axle/final-drive value of 3.636 for the exact G05 X5 xDrive45e. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
-        "value": 3.636
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:6e8be3d590d9"
-        ],
-        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list 265/50 R19 110W XL as the standard tire for the exact G05 X5 xDrive45e, and the official 08/2020 BMW Germany price list independently confirms the same standard 19-inch setup.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
+      "unresolved": [
         {
+          "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
+          "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
+          "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
+          "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g05-xdrive45e-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G05",
+      "body_code": "G05",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X5 (G05, 2019-2026)",
+      "variant_name": "xDrive45e",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo PHEV",
+      "fuel_type": "PHEV",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs for the exact G05 X5 xDrive45e consistently describe full-hybrid drive with torque routed to all four wheels via BMW xDrive.",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e2",
+        "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs for the exact G05 X5 xDrive45e print 8-speed/8-Gang Steptronic wording. The repo keeps ZF8HP as the canonical automatic-family code for that official Steptronic mapping.",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:0b686d9345fd",
-            "legacy_research_sources:3d68278cff53",
-            "legacy_research_sources:6e8be3d590d9"
-          ],
-          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs and the 08/2020 BMW Germany price list confirm this as the standard 19-inch setup for the exact G05 X5 xDrive45e.",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list 0.667 as the top-gear ratio for the exact G05 X5 xDrive45e.",
+          "value": 0.667
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list the full forward gear-ratio set for the exact G05 X5 xDrive45e.",
+          "value": [
+            4.714,
+            3.143,
+            2.106,
+            1.667,
+            1.285,
+            1.0,
+            0.839,
+            0.667
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs publish one axle/final-drive value of 3.636 for the exact G05 X5 xDrive45e. The repo duplicates that single official value into the front field until a source publishes a split front/rear ratio.",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e2",
+          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs publish one axle/final-drive value of 3.636 for the exact G05 X5 xDrive45e. The repo duplicates that single official value into the rear field until a source publishes a split front/rear ratio.",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e4",
+          "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs consistently list 265/50 R19 110W XL as the standard tire for the exact G05 X5 xDrive45e, and the official 08/2020 BMW Germany price list independently confirms the same standard 19-inch setup.",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e4",
+            "notes": "Official BMW 08/2019 and 03/2021 technical-data PDFs and the 08/2020 BMW Germany price list confirm this as the standard 19-inch setup for the exact G05 X5 xDrive45e.",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "Official BMW DE and ACEA technical-data sources now confirm two exact G05 mappings: xDrive45e with 8-speed Steptronic, full forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, one published axle/final-drive value 3.636, and standard 265/50 R19 tires; and launch-era xDrive40i with 8-speed Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.385, and standard 255/55 R18 tires. The official 08/2020 BMW Germany price list independently confirms the exact xDrive45e standard 19-inch setup, but the full optional wheel matrix still needs visual per-column checking before every 20/21/22-inch package can be promoted as xDrive45e-specific production data. The broad G05 row remains verification backlog because later Germany-market xDrive40i material changes gearbox wording and the standard tire baseline, so one undifferentiated 2019-2026 production mapping would be unsafe and the full EU variant matrix is still incomplete.",
+          "evidence_refs": [
+            "legacy_research_sources:0b686d9345fd",
+            "legacy_research_sources:3d68278cff53",
+            "legacy_research_sources:6e8be3d590d9",
+            "legacy_research_sources:016fe2ba6b0f",
+            "legacy_research_sources:393d7682b19e",
+            "legacy_research_sources:51dc23420162",
+            "legacy_research_sources:672d5c0fbe65",
+            "legacy_research_sources:95b9bf2bf0cf",
+            "legacy_research_sources:97624cf593b1",
+            "legacy_research_sources:f1e673d6713e"
+          ]
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW DE technical data (exact 2019 + 2021 states) with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW DE and ACEA technical-data sources now confirm two exact G05 mappings: xDrive45e with 8-speed Steptronic, full forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, one published axle/final-drive value 3.636, and standard 265/50 R19 tires; and launch-era xDrive40i with 8-speed Steptronic, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.385, and standard 255/55 R18 tires. The official 08/2020 BMW Germany price list independently confirms the exact xDrive45e standard 19-inch setup, but the full optional wheel matrix still needs visual per-column checking before every 20/21/22-inch package can be promoted as xDrive45e-specific production data. The broad G05 row remains verification backlog because later Germany-market xDrive40i material changes gearbox wording and the standard tire baseline, so one undifferentiated 2019-2026 production mapping would be unsafe and the full EU variant matrix is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW DE technical data (exact 2019 + 2021 states) with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
+          "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
+          "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
+          "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X5 xDrive40i production-data applicability across the full G05 row span",
-        "reason": "Official launch-era xDrive40i specs prove final drive 3.385, top gear 0.640, and a 255/55 R18 standard tire, while later Germany-market material changes the gearbox wording and the standard tire to 265/50 R19, so one undifferentiated 2019-2026 xDrive40i production mapping would be unsafe.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 (G05, 2019-2026) full EU variant matrix beyond the exact xDrive45e and xDrive40i mappings",
-        "reason": "This pass now resolves exact official xDrive45e and launch-era xDrive40i mappings, but it does not establish the complete official matrix for the other G05 variants represented by the broad row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      },
-      {
-        "item": "BMW X5 transmission subtype code and full optional wheel/tire matrix",
-        "reason": "Official BMW sources prove transmission names, ratios, and standard or selected option tires for the checked exact variants, but they do not publish a gearbox subtype code or one complete optional wheel/tire matrix across the represented row.",
-        "evidence_refs": [
-          "legacy_research_sources:016fe2ba6b0f",
-          "legacy_research_sources:0b686d9345fd",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:3d68278cff53",
-          "legacy_research_sources:51dc23420162",
-          "legacy_research_sources:672d5c0fbe65",
-          "legacy_research_sources:6e8be3d590d9",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:f1e673d6713e"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/F16.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/F16.json
@@ -1,339 +1,284 @@
-[
-  {
-    "id": "bmw-f16-xdrive50i-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F16",
-    "body_code": "F16",
-    "production_start_year": 2015,
-    "production_end_year": 2015,
-    "model_name": "X6 (F16, 2015)",
-    "variant_name": "xDrive50i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "The official BMW 06/2014 launch technical-data pages publish a single 3.154 final-drive ratio for the exact X6 xDrive50i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n3": "The official BMW 06/2014 launch technical-data pages list 255/50 R19 as the baseline tire for the exact X6 xDrive50i state represented by this narrowed 2015-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
         "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
       ],
-      "notes": "The official BMW 06/2014 launch technical-data pages confirm xDrive all-wheel drive for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-      ],
-      "notes": "The official BMW 06/2014 launch technical-data pages confirm 8-speed Steptronic sport transmission wording for the exact X6 xDrive50i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 06/2014 launch technical-data pages list 0.640 as the top-gear ratio for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 06/2014 launch technical-data pages list the forward gear ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
-        "value": [
-          5.0,
-          3.2,
-          2.143,
-          1.72,
-          1.313,
-          1.0,
-          0.823,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 06/2014 launch technical-data pages publish a single 3.154 final-drive ratio for the exact X6 xDrive50i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 06/2014 launch technical-data pages publish a single 3.154 final-drive ratio for the exact X6 xDrive50i state represented by this narrowed 2015-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ],
-        "notes": "The official BMW 06/2014 launch technical-data pages list 255/50 R19 as the baseline tire for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-          ],
-          "notes": "The official BMW 06/2014 launch technical-data pages list 255/50 R19 as the baseline tire for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 50.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0260d6f23394",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:ded47975365d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0260d6f23394",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:ded47975365d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
+      "e2": [
+        "legacy_research_sources:0260d6f23394",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:ded47975365d"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW 06/2014 launch technical-data pages establish the exact X6 xDrive50i state checked in this pass: AWD, 8-speed Steptronic sport transmission, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published 3.154 final-drive ratio, and 255/50 R19 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X6 xDrive50i exact optional wheel/tire matrix beyond the narrowed 2015 row",
-        "reason": "The checked official BMW 06/2014 launch technical-data pages close the 19-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X6 xDrive50i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-f16-xdrive35i-eu-2015-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "F16",
-    "body_code": "F16",
-    "production_start_year": 2015,
-    "production_end_year": 2019,
-    "model_name": "X6 (F16, 2015-2019)",
-    "variant_name": "xDrive35i",
-    "engine_code": "N55",
-    "engine_name": "N55 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
+  "configurations": [
+    {
+      "id": "bmw-f16-xdrive50i-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F16",
+      "body_code": "F16",
+      "production_start_year": 2015,
+      "production_end_year": 2015,
+      "model_name": "X6 (F16, 2015)",
+      "variant_name": "xDrive50i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 06/2014 launch technical-data pages confirm xDrive all-wheel drive for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
+        "value": "AWD"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.154
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW 06/2014 launch technical-data pages confirm 8-speed Steptronic sport transmission wording for the exact X6 xDrive50i state represented by this narrowed 2015-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:0260d6f23394",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:ded47975365d"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 06/2014 launch technical-data pages list 0.640 as the top-gear ratio for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
+          "value": 0.64
         },
-        "default_axle_for_speed": "rear"
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW 06/2014 launch technical-data pages list the forward gear ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640 for the exact X6 xDrive50i state represented by this narrowed 2015-only row.",
+          "value": [
+            5.0,
+            3.2,
+            2.143,
+            1.72,
+            1.313,
+            1.0,
+            0.823,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        }
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0260d6f23394",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:ded47975365d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0260d6f23394",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:ded47975365d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 45.0,
-            "rim_in": 20.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:0260d6f23394",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:ded47975365d"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW 06/2014 launch technical-data pages establish the exact X6 xDrive50i state checked in this pass: AWD, 8-speed Steptronic sport transmission, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, a single published 3.154 final-drive ratio, and 255/50 R19 baseline tires. This row is narrowed to the supported 2015-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e1"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X6 xDrive50i exact optional wheel/tire matrix beyond the narrowed 2015 row",
+          "reason": "The checked official BMW 06/2014 launch technical-data pages close the 19-inch baseline fitment, but this pass did not normalize one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X6 xDrive50i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:0260d6f23394",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:ded47975365d"
+    {
+      "id": "bmw-f16-xdrive35i-eu-2015-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "F16",
+      "body_code": "F16",
+      "production_start_year": 2015,
+      "production_end_year": 2019,
+      "model_name": "X6 (F16, 2015-2019)",
+      "variant_name": "xDrive35i",
+      "engine_code": "N55",
+      "engine_name": "N55 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "notes_ref": "n1",
+        "value": "AWD"
+      },
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n1",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 50.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 45.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note": "Verification backlog remains pending authoritative verification: official review did not yield a safe EU-only ratio update, so the existing entry is retained only as an unsupported reference.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X6 (F16, 2015-2019) EU ratio-relevant variant mapping",
+          "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "item": "BMW X6 (F16, 2015-2019) variant-level final_drive_ratio and top_gear_ratio confirmation",
+          "reason": "Official source links logged, but values not programmatically verified in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "configuration_confidence": "low_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X6 (F16, 2015-2019) EU ratio-relevant variant mapping",
-        "reason": "Authoritative per-model ratio extraction is still missing, so the no-guess policy keeps the existing values only as an unsupported reference.",
-        "evidence_refs": [
-          "legacy_research_sources:0260d6f23394",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:ded47975365d"
-        ]
-      },
-      {
-        "item": "BMW X6 (F16, 2015-2019) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "Official source links logged, but values not programmatically verified in this pass.",
-        "evidence_refs": [
-          "legacy_research_sources:0260d6f23394",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:ded47975365d"
-        ]
-      }
-    ],
-    "configuration_confidence": "low_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/G06.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/G06.json
@@ -1,348 +1,307 @@
-[
-  {
-    "id": "bmw-g06-m50i-eu-2020-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G06",
-    "body_code": "G06",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "X6 (G06, 2020)",
-    "variant_name": "M50i",
-    "engine_code": "N63",
-    "engine_name": "N63 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "The official BMW launch technical-data PDF publishes a single 3.154 final-drive ratio for the exact X6 M50i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n3": "The official BMW launch technical-data PDF lists staggered 275/40 R21 front and 315/35 R21 rear baseline tires for the exact X6 M50i state represented by this narrowed 2020-only row.",
+      "n4": "The official BMW launch technical-data PDF publishes a single 3.385 final-drive ratio for the exact X6 xDrive40i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+      "n5": "The official BMW launch technical-data PDF lists 265/50 R19 as the baseline tire for the exact X6 xDrive40i state represented by this narrowed 2020-only row."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
+      ],
+      "e2": [
         "bmw_pressclub_sources:g06-x6-2019-launch-article",
         "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
       ],
-      "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact X6 M50i state represented by this narrowed 2020-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-      ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact X6 M50i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact X6 M50i state represented by this narrowed 2020-only row.",
-        "value": 0.64
-      },
-      "final_drive_front": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 3.154 final-drive ratio for the exact X6 M50i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 3.154 final-drive ratio for the exact X6 M50i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.154
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists staggered 275/40 R21 front and 315/35 R21 rear baseline tires for the exact X6 M50i state represented by this narrowed 2020-only row.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "rear": {
-          "width_mm": 315.0,
-          "aspect_pct": 35.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-          ],
-          "notes": "The official BMW launch technical-data PDF lists staggered 275/40 R21 front and 315/35 R21 rear baseline tires for the exact X6 M50i state represented by this narrowed 2020-only row.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:2c16041881ea",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7c0362f09174",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:2c16041881ea",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7c0362f09174",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
+      "e3": [
+        "legacy_research_sources:2c16041881ea",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:7c0362f09174",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1"
       ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF establish the exact X6 M50i launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 3.154 final-drive ratio, and staggered 275/40 R21 front plus 315/35 R21 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-launch-article",
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X6 M50i exact optional wheel/tire matrix beyond the narrowed 2020 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the staggered 21-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ]
-      },
-      {
-        "item": "BMW X6 M50i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ]
-      }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
   },
-  {
-    "id": "bmw-g06-xdrive40i-eu-2020-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G06",
-    "body_code": "G06",
-    "production_start_year": 2020,
-    "production_end_year": 2020,
-    "model_name": "X6 (G06, 2020)",
-    "variant_name": "xDrive40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g06-x6-2019-launch-article",
-        "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-      ],
-      "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "official_derived",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-      ],
-      "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact X6 xDrive40i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
+  "configurations": [
+    {
+      "id": "bmw-g06-m50i-eu-2020-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G06",
+      "body_code": "G06",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "X6 (G06, 2020)",
+      "variant_name": "M50i",
+      "engine_code": "N63",
+      "engine_name": "N63 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
-        "value": 0.64
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact X6 M50i state represented by this narrowed 2020-only row.",
+        "value": "AWD"
       },
-      "final_drive_front": {
+      "transmission": {
         "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 3.385 final-drive ratio for the exact X6 xDrive40i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact X6 M50i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
       },
-      "final_drive_rear": {
-        "confidence": "official_derived",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF publishes a single 3.385 final-drive ratio for the exact X6 xDrive40i state represented by this narrowed 2020-only row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
-        "value": 3.385
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact X6 M50i state represented by this narrowed 2020-only row.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n3",
+          "front": {
+            "width_mm": 275.0,
+            "aspect_pct": 40.0,
+            "rim_in": 21.0
+          },
+          "rear": {
+            "width_mm": 315.0,
+            "aspect_pct": 35.0,
+            "rim_in": 21.0
+          },
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n3",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
+          },
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note": "The official BMW launch article and technical-data PDF establish the exact X6 M50i launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 3.154 final-drive ratio, and staggered 275/40 R21 front plus 315/35 R21 rear baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X6 M50i exact optional wheel/tire matrix beyond the narrowed 2020 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the staggered 21-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X6 M50i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g06-xdrive40i-eu-2020-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G06",
+      "body_code": "G06",
+      "production_start_year": 2020,
+      "production_end_year": 2020,
+      "model_name": "X6 (G06, 2020)",
+      "variant_name": "xDrive40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ],
-        "notes": "The official BMW launch technical-data PDF lists 265/50 R19 as the baseline tire for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
-        "front": {
-          "width_mm": 265.0,
-          "aspect_pct": 50.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
+        "evidence_refs_ref": "e2",
+        "notes": "The official BMW launch article and technical-data PDF confirm xDrive all-wheel drive for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "official_derived",
+        "evidence_refs_ref": "e1",
+        "notes": "The official BMW launch technical-data PDF confirms 8-speed Steptronic wording for the exact X6 xDrive40i state represented by this narrowed 2020-only row. The repo keeps ZF8HP as the canonical transmission-family mapping for that official automatic.",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "official_exact",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-          ],
-          "notes": "The official BMW launch technical-data PDF lists 265/50 R19 as the baseline tire for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
+          "evidence_refs_ref": "e1",
+          "notes": "The official BMW launch technical-data PDF lists 0.640 as the top-gear ratio for the exact X6 xDrive40i state represented by this narrowed 2020-only row.",
+          "value": 0.64
+        },
+        "final_drive_front": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "official_derived",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n4",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n5",
           "front": {
             "width_mm": 265.0,
             "aspect_pct": 50.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
         },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:2c16041881ea",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7c0362f09174",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 21.0
+        "options": [
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n5",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 50.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 21.0
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 21\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 21\""
-        },
-        {
-          "confidence": "reputable_secondary_crosschecked",
-          "evidence_refs": [
-            "legacy_research_sources:2c16041881ea",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:7c0362f09174",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "The official BMW launch article and technical-data PDF establish the exact X6 xDrive40i launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 3.385 final-drive ratio, and 265/50 R19 baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-launch-article",
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X6 xDrive40i exact optional wheel/tire matrix beyond the narrowed 2020 row",
-        "reason": "The checked official BMW launch technical-data PDF closes the 19-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
+          {
+            "confidence": "reputable_secondary_crosschecked",
+            "evidence_refs_ref": "e3",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
         ]
       },
-      {
-        "item": "BMW X6 xDrive40i separate front/rear final-drive publication",
-        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g06-x6-2019-spec-pdf"
-        ]
+      "verification_notes": [
+        {
+          "note": "The official BMW launch article and technical-data PDF establish the exact X6 xDrive40i launch-state mapping: AWD, 8-speed Steptronic, 0.640 top gear, a single published 3.385 final-drive ratio, and 265/50 R19 baseline tires. This row is narrowed to the supported 2020-only state because later exact numeric continuity was not recovered in this pass.",
+          "evidence_refs_ref": "e2"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X6 xDrive40i exact optional wheel/tire matrix beyond the narrowed 2020 row",
+          "reason": "The checked official BMW launch technical-data PDF closes the 19-inch baseline fitment, but it does not prove one exact optional wheel/tire matrix beyond the narrowed launch-state row.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X6 xDrive40i separate front/rear final-drive publication",
+          "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "high_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
-    ],
-    "configuration_confidence": "high_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x7/G07.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x7/G07.json
@@ -1,729 +1,462 @@
-[
-  {
-    "id": "bmw-g07-m60i-xdrive-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G07",
-    "body_code": "G07",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X7 (G07, 2019-2026)",
-    "variant_name": "M60i xDrive",
-    "engine_code": "S68",
-    "engine_name": "S68 4.4L V8 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
+      "n3": "Official BMW exact technical-data documents now confirm two G07 X7 mappings for ACEA/DE markets: xDrive40i with 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.636, standard 275/50 R20 tires, and optional 285/45 R21 or staggered 275/40 R22 + 315/35 R22 / 275/35 R23 + 315/30 R23 fitments; and M60i xDrive with 8-speed Steptronic transmission, full forward ratios 5.501 / 3.520 / 2.200 / 1.720 / 1.301 / 1.000 / 0.833 / 0.640, final drive 3.385, standard 285/45 R21 tires, and optional staggered 22/23-inch fitments. The broad row remains verification backlog because the full G07 matrix outside the exact xDrive40i and M60i xDrive mappings is still incomplete.",
+      "n4": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:8efb72f0dc5c",
+        "legacy_research_sources:936c0c69490c",
+        "legacy_research_sources:943733f37975",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:96cc5a533adb",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:99caa4fa4b54",
+        "legacy_research_sources:a82aa709528b",
+        "legacy_research_sources:bcbf4df558fb",
+        "legacy_research_sources:d0e736bd2502",
+        "legacy_research_sources:de50008b9df2"
+      ],
+      "e2": [
         "legacy_research_sources:8efb72f0dc5c",
         "legacy_research_sources:bcbf4df558fb",
         "legacy_research_sources:de50008b9df2"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 0.64
+      ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g07-m60i-xdrive-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G07",
+      "body_code": "G07",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X7 (G07, 2019-2026)",
+      "variant_name": "M60i xDrive",
+      "engine_code": "S68",
+      "engine_name": "S68 4.4L V8 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n2",
+        "value": "AWD"
       },
-      "gear_ratios": {
+      "transmission": {
         "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": [
-          5.501,
-          3.52,
-          2.2,
-          1.72,
-          1.301,
-          1.0,
-          0.833,
-          0.64
-        ]
+        "notes_ref": "n2",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
       },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.385
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "value": 3.385
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-        "front": {
-          "width_mm": 285.0,
-          "aspect_pct": 45.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
+          "notes_ref": "n2",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": [
+            5.501,
+            3.52,
+            2.2,
+            1.72,
+            1.301,
+            1.0,
+            0.833,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.385
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n2",
+          "value": 3.385
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 285.0,
             "aspect_pct": 45.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 22\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 23.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 23.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 23\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 22\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 23.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 23.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 23\""
+          "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two G07 X7 mappings for ACEA/DE markets: xDrive40i with 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.636, standard 275/50 R20 tires, and optional 285/45 R21 or staggered 275/40 R22 + 315/35 R22 / 275/35 R23 + 315/30 R23 fitments; and M60i xDrive with 8-speed Steptronic transmission, full forward ratios 5.501 / 3.520 / 2.200 / 1.720 / 1.301 / 1.000 / 0.833 / 0.640, final drive 3.385, standard 285/45 R21 tires, and optional staggered 22/23-inch fitments. The broad row remains verification backlog because the full G07 matrix outside the exact xDrive40i and M60i xDrive mappings is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW PressClub technical data with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
-        "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
-        "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g07-xdrive40d-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G07",
-    "body_code": "G07",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X7 (G07, 2019-2026)",
-    "variant_name": "xDrive40d",
-    "engine_code": "B57",
-    "engine_name": "B57 3.0L I6 Diesel",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:8efb72f0dc5c",
-        "legacy_research_sources:bcbf4df558fb",
-        "legacy_research_sources:de50008b9df2"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed automatic (ZF 8HP)"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.667
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.154
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.154
+      "unresolved": [
+        {
+          "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
+          "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
+          "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 21.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g07-xdrive40d-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G07",
+      "body_code": "G07",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X7 (G07, 2019-2026)",
+      "variant_name": "xDrive40d",
+      "engine_code": "B57",
+      "engine_name": "B57 3.0L I6 Diesel",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed automatic (ZF 8HP)"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.667
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.154
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.154
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 40.0,
             "rim_in": 21.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 21\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 21\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 22\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 295.0,
+              "aspect_pct": 30.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 22\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 22\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 295.0,
-            "aspect_pct": 30.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 22\""
+          "note_ref": "n4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two G07 X7 mappings for ACEA/DE markets: xDrive40i with 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.636, standard 275/50 R20 tires, and optional 285/45 R21 or staggered 275/40 R22 + 315/35 R22 / 275/35 R23 + 315/30 R23 fitments; and M60i xDrive with 8-speed Steptronic transmission, full forward ratios 5.501 / 3.520 / 2.200 / 1.720 / 1.301 / 1.000 / 0.833 / 0.640, final drive 3.385, standard 285/45 R21 tires, and optional staggered 22/23-inch fitments. The broad row remains verification backlog because the full G07 matrix outside the exact xDrive40i and M60i xDrive mappings is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
-        "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
-        "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g07-xdrive40i-eu-2019-zf8hp-awd",
-    "brand": "BMW",
-    "type": "SUV",
-    "market": "EU",
-    "model_code": "G07",
-    "body_code": "G07",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "X7 (G07, 2019-2026)",
-    "variant_name": "xDrive40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:8efb72f0dc5c",
-        "legacy_research_sources:bcbf4df558fb",
-        "legacy_research_sources:de50008b9df2"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "AWD"
-    },
-    "transmission": {
-      "confidence": "family_default",
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic transmission"
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 0.64
-      },
-      "gear_ratios": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ]
-      },
-      "final_drive_front": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
-      },
-      "final_drive_rear": {
-        "confidence": "family_default",
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "value": 3.636
+      "unresolved": [
+        {
+          "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
+          "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
+          "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
-        "confidence": "family_default",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ],
-        "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-        "front": {
-          "width_mm": 275.0,
-          "aspect_pct": 50.0,
-          "rim_in": 20.0
-        },
-        "default_axle_for_speed": "rear"
+    {
+      "id": "bmw-g07-xdrive40i-eu-2019-zf8hp-awd",
+      "brand": "BMW",
+      "type": "SUV",
+      "market": "EU",
+      "model_code": "G07",
+      "body_code": "G07",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "X7 (G07, 2019-2026)",
+      "variant_name": "xDrive40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n1",
+        "value": "AWD"
       },
-      "options": [
-        {
+      "transmission": {
+        "confidence": "family_default",
+        "notes_ref": "n1",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic transmission"
+      },
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "notes_ref": "n1",
+          "value": 0.64
+        },
+        "gear_ratios": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ]
+        },
+        "final_drive_front": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        },
+        "final_drive_rear": {
+          "confidence": "family_default",
+          "notes_ref": "n1",
+          "value": 3.636
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "family_default",
+          "evidence_refs_ref": "e1",
+          "notes_ref": "n1",
           "front": {
             "width_mm": 275.0,
             "aspect_pct": 50.0,
             "rim_in": 20.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 20\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 50.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 285.0,
+              "aspect_pct": 45.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional 21\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 40.0,
+              "rim_in": 22.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 35.0,
+              "rim_in": 22.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 22\""
+          },
+          {
+            "confidence": "official_exact",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 35.0,
+              "rim_in": 23.0
+            },
+            "rear": {
+              "width_mm": 315.0,
+              "aspect_pct": 30.0,
+              "rim_in": 23.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Optional staggered 23\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 285.0,
-            "aspect_pct": 45.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional 21\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 40.0,
-            "rim_in": 22.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 35.0,
-            "rim_in": 22.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 22\""
-        },
-        {
-          "confidence": "official_exact",
-          "evidence_refs": [
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:8efb72f0dc5c",
-            "legacy_research_sources:936c0c69490c",
-            "legacy_research_sources:943733f37975",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:96cc5a533adb",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:99caa4fa4b54",
-            "legacy_research_sources:a82aa709528b",
-            "legacy_research_sources:bcbf4df558fb",
-            "legacy_research_sources:d0e736bd2502",
-            "legacy_research_sources:de50008b9df2"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 35.0,
-            "rim_in": 23.0
-          },
-          "rear": {
-            "width_mm": 315.0,
-            "aspect_pct": 30.0,
-            "rim_in": 23.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Optional staggered 23\""
+          "note_ref": "n4"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW exact technical-data documents now confirm two G07 X7 mappings for ACEA/DE markets: xDrive40i with 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, final drive 3.636, standard 275/50 R20 tires, and optional 285/45 R21 or staggered 275/40 R22 + 315/35 R22 / 275/35 R23 + 315/30 R23 fitments; and M60i xDrive with 8-speed Steptronic transmission, full forward ratios 5.501 / 3.520 / 2.200 / 1.720 / 1.301 / 1.000 / 0.833 / 0.640, final drive 3.385, standard 285/45 R21 tires, and optional staggered 22/23-inch fitments. The broad row remains verification backlog because the full G07 matrix outside the exact xDrive40i and M60i xDrive mappings is still incomplete.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      ],
+      "unresolved": [
+        {
+          "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
+          "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
+          "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW X7 (G07, 2019-2026) full EU variant matrix beyond the exact xDrive40i and M60i xDrive mappings",
-        "reason": "This pass resolved exact official xDrive40i and M60i xDrive transmissions, final drives, and tire fitments, but it did not establish the full official matrix for every other G07 variant represented by the broad row, especially xDrive40d.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      },
-      {
-        "item": "BMW X7 xDrive40i and M60i xDrive public gearbox naming/subtype consistency",
-        "reason": "Official BMW sources align on the numeric ratio sets, but public wording varies between '8-speed Steptronic transmission', '8-Gang Steptronic Getriebe', and later sport-oriented wording, and no checked official source publishes a subtype code.",
-        "evidence_refs": [
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:8efb72f0dc5c",
-          "legacy_research_sources:936c0c69490c",
-          "legacy_research_sources:943733f37975",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:96cc5a533adb",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:99caa4fa4b54",
-          "legacy_research_sources:a82aa709528b",
-          "legacy_research_sources:bcbf4df558fb",
-          "legacy_research_sources:d0e736bd2502",
-          "legacy_research_sources:de50008b9df2"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/z4/G29.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/z4/G29.json
@@ -1,1424 +1,935 @@
-[
-  {
-    "id": "bmw-g29-m40i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "M40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
+{
+  "definitions": {
+    "notes": {
+      "n1": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n2": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
+      "n3": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
+      "n4": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+      "n5": "Sonnet redo research (2026-04 v2): BMW PressClub T0329593EN (03/2021) ACEA tech-data PDF publishes sDrive20i 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.636. The MT6 was not offered at 2018 launch and appeared by 03/2021. Top gear and final drive previously inherited family defaults are wrong.",
+      "n6": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive20i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154.",
+      "n7": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive30i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154. sDrive30i is Steptronic-only in all market years.",
+      "n8": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission.",
+      "n9": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n10": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+      "n11": "BMW PressClub T0289704EN (09/2018: 225/50 R17 98Y XL / 255/45 R17 98Y) and T0329593EN (03/2021: 225/50 R17 94W / 255/45 R17 98W). Size identical; speed rating revised Y to W between 2018 and 2021."
+    },
+    "evidence_ref_sets": {
+      "e1": [
+        "legacy_research_sources:04b8c186810a",
+        "legacy_research_sources:1911b8fd62eb",
+        "legacy_research_sources:393d7682b19e",
+        "legacy_research_sources:95b9bf2bf0cf",
+        "legacy_research_sources:97624cf593b1",
+        "legacy_research_sources:aeed8033e9c3",
+        "legacy_research_sources:cb241bb66e51",
+        "legacy_research_sources:f0f319a0cc78",
+        "legacy_research_sources:f215d565d740"
+      ],
+      "e2": [
+        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
+        "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
+        "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
+      ],
+      "e3": [
+        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
+        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
+      ],
+      "e4": [
         "legacy_research_sources:1911b8fd62eb",
         "legacy_research_sources:f215d565d740"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "reputable_secondary_crosschecked",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
+      "e5": [
         "bmw_pressclub_sources:g29-z4-pure-impulse-2024",
         "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
+      ],
+      "e6": [
+        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
       ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024. Top gear ratio not officially published; family-default value retained pending dedicated 01/2024 ACEA PDF.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-pure-impulse-2024",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
+    }
+  },
+  "configurations": [
+    {
+      "id": "bmw-g29-m40i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "M40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
       },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024. Final drive ratio not officially published.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-pure-impulse-2024",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
+      "transmission": {
         "confidence": "reputable_secondary_crosschecked",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-pure-impulse-2024"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): No M40i MT6-specific tire spec found. BMW PressClub T0289704EN/T0329593EN consistently list M40i (ZF8HP) at 255/40 ZR18 95Y / 275/40 ZR18 99Y on 9Jx18/10Jx18; M40i MT6 (Pure Impulse, MY2024) likely uses same chassis/fitment but unconfirmed.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        }
+        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024.",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e5"
       },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-pure-impulse-2024",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-pure-impulse-2024",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g29-m40i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "M40i",
-    "engine_code": "B58",
-    "engine_name": "B58 3.0L I6 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1911b8fd62eb",
-        "legacy_research_sources:f215d565d740"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission. Forward gear ratios from VIII to I."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) M40i sections: 255/40 ZR18 95Y front (9Jx18) / 275/40 ZR18 99Y rear (10Jx18).",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 275.0,
-          "aspect_pct": 40.0,
-          "rim_in": 18.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g29-sdrive20i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "sDrive20i",
-    "engine_code": "B38",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1911b8fd62eb",
-        "legacy_research_sources:f215d565d740"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0329593EN (03/2021) ACEA tech-data PDF publishes sDrive20i 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.636. The MT6 was not offered at 2018 launch and appeared by 03/2021. Top gear and final drive previously inherited family defaults are wrong.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0329593EN (03/2021) ACEA tech-data PDF publishes sDrive20i 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.636. The MT6 was not offered at 2018 launch and appeared by 03/2021. Top gear and final drive previously inherited family defaults are wrong.",
-        "value": 0.601,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0329593EN (03/2021) ACEA tech-data PDF publishes sDrive20i 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.636. The MT6 was not offered at 2018 launch and appeared by 03/2021. Top gear and final drive previously inherited family defaults are wrong.",
-        "value": 3.636,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          4.11,
-          2.248,
-          1.403,
-          1.0,
-          0.786,
-          0.601
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0329593EN (03/2021) ACEA tech-data PDF publishes sDrive20i 6-speed manual ratios I 4.110 / II 2.248 / III 1.403 / IV 1.000 / V 0.786 / VI 0.601, R 3.727, final drive 3.636. The MT6 was not offered at 2018 launch and appeared by 03/2021. Top gear and final drive previously inherited family defaults are wrong."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "BMW PressClub T0329593EN (03/2021) sDrive20i: 225/50 R17 94W front / 255/45 R17 98W rear (same fitment as ZF8HP variant).",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g29-sdrive20i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "sDrive20i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1911b8fd62eb",
-        "legacy_research_sources:f215d565d740"
-      ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive20i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive20i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive20i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive20i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154."
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "BMW PressClub T0289704EN (09/2018: 225/50 R17 98Y XL / 255/45 R17 98Y) and T0329593EN (03/2021: 225/50 R17 94W / 255/45 R17 98W). Size identical; speed rating revised Y to W between 2018 and 2021.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
-        },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
-        }
-      },
-      "options": [
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
-        }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g29-sdrive30i-eu-2019-mt6-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "sDrive30i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "unverified",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-        "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-      ],
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "unverified",
-      "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-      "code": "MT6",
-      "name": "6-speed manual",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-        "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 0.812,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "unverified",
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "value": 3.231,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      }
-    },
-    "tires": {
-      "default": {
-        "confidence": "unverified",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-        "front": {
-          "width_mm": 255.0,
-          "aspect_pct": 35.0,
-          "rim_in": 19.0
-        },
-        "default_axle_for_speed": "rear"
-      },
-      "options": [
-        {
+      "ratios": {
+        "top_gear_ratio": {
           "confidence": "unverified",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024. Top gear ratio not officially published; family-default value retained pending dedicated 01/2024 ACEA PDF.",
+          "value": 0.812,
+          "evidence_refs_ref": "e5"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0439268EN (Pure Impulse edition, January 2024) and BMW Germany Z4 technical-data page confirm a 6-speed manual gearbox is offered for the M40i from the 2024 model year ('a six-speed manual gearbox will also be available for the range-topping version for the first time'). Pure Impulse PDFs are image-based; individual gear ratios for the M40i MT6 are NOT text-extractable from any accessible BMW PressClub source. Top gear and final drive remain unverified; previous family_default values 0.812 / 3.231 are unsupported. Likely Getrag GS6-45BZ (same 6MT as G20 M340i / G22 M240i) but unconfirmed in this run. Production_start_year of 2019 is too early — manual added MY2024. Final drive ratio not officially published.",
+          "value": 3.231,
+          "evidence_refs_ref": "e5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "reputable_secondary_crosschecked",
           "evidence_refs": [
             "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
             "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-            "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
+            "bmw_pressclub_sources:g29-z4-pure-impulse-2024"
           ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
+          "notes": "Sonnet redo research (2026-04 v2): No M40i MT6-specific tire spec found. BMW PressClub T0289704EN/T0329593EN consistently list M40i (ZF8HP) at 255/40 ZR18 95Y / 275/40 ZR18 99Y on 9Jx18/10Jx18; M40i MT6 (Pure Impulse, MY2024) likely uses same chassis/fitment but unconfirmed.",
           "front": {
             "width_mm": 255.0,
-            "aspect_pct": 35.0,
-            "rim_in": 19.0
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
           },
           "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-            "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-            "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
-        },
-        {
-          "confidence": "unverified",
-          "evidence_refs": [
-            "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-            "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-            "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-          ],
-          "notes": "Sonnet redo research (2026-04 v2): No official BMW source confirms a Z4 G29 sDrive30i with 6-speed manual transmission in any market year. BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) both list sDrive30i with ZF 8HP only; the BMW Germany consumer technical-data page (HF31) lists only Steptronic Sport Getriebe for sDrive30i. The MT6 was added only on sDrive20i (MY2021) and on M40i (MY2024 Pure Impulse). Marked no_confidence as a phantom configuration; row should be considered for removal.",
-          "front": {
+          "rear": {
             "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
           },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        },
+        {
+          "note_ref": "n9",
+          "evidence_refs_ref": "e5"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e5"
         }
-      ]
-    },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
-      },
-      {
-        "note": "ratios.top_gear_ratio: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "ratios.final_drive_rear: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      },
-      {
-        "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf",
-          "bmw_pressclub_sources:g29-z4-bmw-de-tech-data"
-        ]
-      }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": false,
-      "usable_for_wheel_order": false,
-      "requires_manual_confirmation": true
-    }
-  },
-  {
-    "id": "bmw-g29-sdrive30i-eu-2019-zf8hp-rwd",
-    "brand": "BMW",
-    "type": "Convertible",
-    "market": "EU",
-    "model_code": "G29",
-    "body_code": "G29",
-    "production_start_year": 2019,
-    "production_end_year": 2026,
-    "model_name": "Z4 (G29, 2019-2026)",
-    "variant_name": "sDrive30i",
-    "engine_code": "B48",
-    "engine_name": "B48 2.0L I4 Turbo",
-    "fuel_type": "ICE",
-    "drivetrain": {
-      "confidence": "official_exact",
-      "evidence_refs": [
-        "legacy_research_sources:1911b8fd62eb",
-        "legacy_research_sources:f215d565d740"
       ],
-      "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-      "value": "RWD"
-    },
-    "transmission": {
-      "confidence": "official_exact",
-      "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive30i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154. sDrive30i is Steptronic-only in all market years.",
-      "code": "ZF8HP",
-      "name": "8-speed Steptronic (ZF 8HP)",
-      "evidence_refs": [
-        "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-        "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-      ]
-    },
-    "ratios": {
-      "top_gear_ratio": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive30i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154. sDrive30i is Steptronic-only in all market years.",
-        "value": 0.64,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "final_drive_rear": {
-        "confidence": "official_exact",
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive30i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154. sDrive30i is Steptronic-only in all market years.",
-        "value": 3.154,
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ]
-      },
-      "gear_ratios": {
-        "confidence": "official_exact",
-        "value": [
-          5.25,
-          3.36,
-          2.172,
-          1.72,
-          1.316,
-          1.0,
-          0.822,
-          0.64
-        ],
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) confirm sDrive30i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, FD 3.154. sDrive30i is Steptronic-only in all market years."
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
       }
     },
-    "tires": {
-      "default": {
+    {
+      "id": "bmw-g29-m40i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "M40i",
+      "engine_code": "B58",
+      "engine_name": "B58 3.0L I6 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
         "confidence": "official_exact",
-        "evidence_refs": [
-          "bmw_pressclub_sources:g29-z4-specs-2018-pdf",
-          "bmw_pressclub_sources:g29-z4-specs-2021-pdf"
-        ],
-        "notes": "BMW PressClub T0289704EN (09/2018: 225/50 R17 98Y XL / 255/45 R17 98Y) and T0329593EN (03/2021: 225/50 R17 94W / 255/45 R17 98W). Size identical; speed rating revised Y to W between 2018 and 2021.",
-        "front": {
-          "width_mm": 225.0,
-          "aspect_pct": 50.0,
-          "rim_in": 17.0
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n8",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n8",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
         },
-        "default_axle_for_speed": "rear",
-        "rear": {
-          "width_mm": 255.0,
-          "aspect_pct": 45.0,
-          "rim_in": 17.0
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n8",
+          "value": 3.154,
+          "evidence_refs_ref": "e3"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e3",
+          "notes": "Sonnet redo research (2026-04 v2): BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) ACEA tech-data PDFs both publish identical M40i ZF 8HP ratios I 5.250 / II 3.360 / III 2.172 / IV 1.720 / V 1.316 / VI 1.000 / VII 0.822 / VIII 0.640, R 3.712, final drive 3.154; Eight-speed Steptronic transmission. Forward gear ratios from VIII to I."
         }
       },
-      "options": [
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes": "BMW PressClub T0289704EN (09/2018) and T0329593EN (03/2021) M40i sections: 255/40 ZR18 95Y front (9Jx18) / 275/40 ZR18 99Y rear (10Jx18).",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 275.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g29-sdrive20i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "sDrive20i",
+      "engine_code": "B38",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n5",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e6"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n5",
+          "value": 0.601,
+          "evidence_refs_ref": "e6"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n5",
+          "value": 3.636,
+          "evidence_refs_ref": "e6"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            4.11,
+            2.248,
+            1.403,
+            1.0,
+            0.786,
+            0.601
           ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
+          "evidence_refs_ref": "e6",
+          "notes_ref": "n5"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e6",
+          "notes": "BMW PressClub T0329593EN (03/2021) sDrive20i: 225/50 R17 94W front / 255/45 R17 98W rear (same fitment as ZF8HP variant).",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 255.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g29-sdrive20i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "sDrive20i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n6",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n6",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n6",
+          "value": 3.154,
+          "evidence_refs_ref": "e3"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n6"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 255.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
+      }
+    },
+    {
+      "id": "bmw-g29-sdrive30i-eu-2019-mt6-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "sDrive30i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "unverified",
+        "evidence_refs_ref": "e2",
+        "notes_ref": "n2",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "unverified",
+        "notes_ref": "n2",
+        "code": "MT6",
+        "name": "6-speed manual",
+        "evidence_refs_ref": "e2"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 0.812,
+          "evidence_refs_ref": "e2"
+        },
+        "final_drive_rear": {
+          "confidence": "unverified",
+          "notes_ref": "n2",
+          "value": 3.231,
+          "evidence_refs_ref": "e2"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "unverified",
+          "evidence_refs_ref": "e2",
+          "notes_ref": "n2",
           "front": {
             "width_mm": 255.0,
             "aspect_pct": 35.0,
             "rim_in": 19.0
           },
-          "default_axle_for_speed": "rear",
-          "name": "Standard 19\""
+          "default_axle_for_speed": "rear"
+        },
+        "options": [
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "unverified",
+            "evidence_refs_ref": "e2",
+            "notes_ref": "n2",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
+        ]
+      },
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 265.0,
-            "aspect_pct": 30.0,
-            "rim_in": 20.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "Sport Line 20\""
+          "note_ref": "n4"
         },
         {
-          "confidence": "family_default",
-          "evidence_refs": [
-            "legacy_research_sources:04b8c186810a",
-            "legacy_research_sources:1911b8fd62eb",
-            "legacy_research_sources:393d7682b19e",
-            "legacy_research_sources:95b9bf2bf0cf",
-            "legacy_research_sources:97624cf593b1",
-            "legacy_research_sources:aeed8033e9c3",
-            "legacy_research_sources:cb241bb66e51",
-            "legacy_research_sources:f0f319a0cc78",
-            "legacy_research_sources:f215d565d740"
-          ],
-          "notes": "Migrated from legacy grouped car-library data into canonical exact-configuration form. Treat this value as inherited family data until variant-specific evidence is linked. Legacy variant-source research previously recorded this variant as BMW press release with High confidence.",
-          "front": {
-            "width_mm": 275.0,
-            "aspect_pct": 25.0,
-            "rim_in": 21.0
-          },
-          "default_axle_for_speed": "rear",
-          "name": "M Sport 21\""
+          "note_ref": "n9",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note_ref": "n10",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.default: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[0]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[1]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "tires.options[2]: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "drivetrain: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
+        },
+        {
+          "note": "transmission: confidence was 'no_confidence' (manual confirmation required); remapped to 'unverified' for schema compliance.",
+          "evidence_refs_ref": "e2"
         }
-      ]
+      ],
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": false,
+        "usable_for_wheel_order": false,
+        "requires_manual_confirmation": true
+      }
     },
-    "verification_notes": [
-      {
-        "note": "Official BMW ACEA technical-data PDFs now confirm exact G29 Z4 automatic mappings for both the sDrive30i and early M40i: 8-speed Steptronic transmission, forward ratios 5.250 / 3.360 / 2.172 / 1.720 / 1.316 / 1.000 / 0.822 / 0.640, reverse 3.712, final drive 3.154, with the sDrive30i carrying a standard staggered 225/50 R17 front + 255/45 R17 rear setup and the M40i carrying a standard staggered 255/40 ZR18 front + 275/40 ZR18 rear setup. Official current BMW DE material also confirms the sDrive30i remains an automatic RWD model, and official 2024 BMW material confirms the Pure Impulse edition reintroduced a 6-speed manual for the M40i. The broad Z4 row remains unchanged because it mixes sDrive20i, sDrive30i, and M40i variants and spans both automatic-only and later manual-capable eras without a safely unified exact row shape.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
+    {
+      "id": "bmw-g29-sdrive30i-eu-2019-zf8hp-rwd",
+      "brand": "BMW",
+      "type": "Convertible",
+      "market": "EU",
+      "model_code": "G29",
+      "body_code": "G29",
+      "production_start_year": 2019,
+      "production_end_year": 2026,
+      "model_name": "Z4 (G29, 2019-2026)",
+      "variant_name": "sDrive30i",
+      "engine_code": "B48",
+      "engine_name": "B48 2.0L I4 Turbo",
+      "fuel_type": "ICE",
+      "drivetrain": {
+        "confidence": "official_exact",
+        "evidence_refs_ref": "e4",
+        "notes_ref": "n1",
+        "value": "RWD"
+      },
+      "transmission": {
+        "confidence": "official_exact",
+        "notes_ref": "n7",
+        "code": "ZF8HP",
+        "name": "8-speed Steptronic (ZF 8HP)",
+        "evidence_refs_ref": "e3"
+      },
+      "ratios": {
+        "top_gear_ratio": {
+          "confidence": "official_exact",
+          "notes_ref": "n7",
+          "value": 0.64,
+          "evidence_refs_ref": "e3"
+        },
+        "final_drive_rear": {
+          "confidence": "official_exact",
+          "notes_ref": "n7",
+          "value": 3.154,
+          "evidence_refs_ref": "e3"
+        },
+        "gear_ratios": {
+          "confidence": "official_exact",
+          "value": [
+            5.25,
+            3.36,
+            2.172,
+            1.72,
+            1.316,
+            1.0,
+            0.822,
+            0.64
+          ],
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n7"
+        }
+      },
+      "tires": {
+        "default": {
+          "confidence": "official_exact",
+          "evidence_refs_ref": "e3",
+          "notes_ref": "n11",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "rear": {
+            "width_mm": 255.0,
+            "aspect_pct": 45.0,
+            "rim_in": 17.0
+          }
+        },
+        "options": [
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 255.0,
+              "aspect_pct": 35.0,
+              "rim_in": 19.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Standard 19\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 265.0,
+              "aspect_pct": 30.0,
+              "rim_in": 20.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "Sport Line 20\""
+          },
+          {
+            "confidence": "family_default",
+            "evidence_refs_ref": "e1",
+            "notes_ref": "n1",
+            "front": {
+              "width_mm": 275.0,
+              "aspect_pct": 25.0,
+              "rim_in": 21.0
+            },
+            "default_axle_for_speed": "rear",
+            "name": "M Sport 21\""
+          }
         ]
       },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
+      "verification_notes": [
+        {
+          "note_ref": "n3",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "note_ref": "n4"
+        }
+      ],
+      "unresolved": [
+        {
+          "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
+          "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
+          "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
+          "evidence_refs_ref": "e1"
+        },
+        {
+          "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
+          "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
+          "evidence_refs_ref": "e1"
+        }
+      ],
+      "configuration_confidence": "medium_confidence",
+      "order_analysis_policy": {
+        "usable_for_engine_order": true,
+        "usable_for_driveshaft_order": true,
+        "usable_for_wheel_order": true,
+        "requires_manual_confirmation": true
       }
-    ],
-    "unresolved": [
-      {
-        "item": "BMW Z4 M40i exact DE/EU manual final-drive and ratio confirmation",
-        "reason": "Checked official BMW sources now prove that the Pure Impulse edition reintroduced a 6-speed manual for the Z4 M40i, but this pass did not recover an exact Germany or ACEA technical-data source with numeric manual ratios, top gear, or final drive.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "Broad-row promotion of exact Z4 sDrive30i and M40i automatic ratios",
-        "reason": "The current production row still mixes sDrive20i, sDrive30i, and M40i variants and also spans both automatic-only and later manual-capable M40i years, so the exact sDrive30i and M40i automatic mappings should remain source-ledger-only until the row shape is split or variant-scoped continuity is proved.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      },
-      {
-        "item": "BMW Z4 sDrive30i later-year tire continuity and M40i optional tire-matrix coverage",
-        "reason": "Official ACEA automatic specs prove the exact sDrive30i 17-inch staggered base setup and the M40i 18-inch staggered base setup, while checked later BMW material confirms ongoing sDrive30i automatic continuity and Pure Impulse-era M40i wheel context, but this pass did not recover one official Germany-market matrix that safely unifies the full 2019-2026 tire coverage.",
-        "evidence_refs": [
-          "legacy_research_sources:04b8c186810a",
-          "legacy_research_sources:1911b8fd62eb",
-          "legacy_research_sources:393d7682b19e",
-          "legacy_research_sources:95b9bf2bf0cf",
-          "legacy_research_sources:97624cf593b1",
-          "legacy_research_sources:aeed8033e9c3",
-          "legacy_research_sources:cb241bb66e51",
-          "legacy_research_sources:f0f319a0cc78",
-          "legacy_research_sources:f215d565d740"
-        ]
-      }
-    ],
-    "configuration_confidence": "medium_confidence",
-    "order_analysis_policy": {
-      "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
-      "usable_for_wheel_order": true,
-      "requires_manual_confirmation": true
     }
-  }
-]
+  ]
+}

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -3,11 +3,45 @@
 `apps/server/vibesensor/data/vehicle_configurations/**/*.json` is the canonical
 runtime source for car ratio and tire data.
 
-Each shard file is a canonical JSON array of exact vehicle-configuration rows,
-grouped by brand, model family, and generation/body code:
+Each shard file is a canonical JSON object with optional shard-local
+`definitions` and a required `configurations` array of exact
+vehicle-configuration rows, grouped by brand, model family, and
+generation/body code:
 
 - `vehicle_configurations/<brand>/<model_family>/<generation_or_body_code>.json`
 - example: `vehicle_configurations/bmw/5_series/G30.json`
+
+Shard shape:
+
+```json
+{
+  "definitions": {
+    "notes": {"n1": "<repeated note text>"},
+    "evidence_ref_sets": {"e1": ["source_pack:source-id", "..."]}
+  },
+  "configurations": [
+    {
+      "id": "...",
+      "drivetrain": {
+        "confidence": "...",
+        "value": "RWD",
+        "notes_ref": "n1",
+        "evidence_refs_ref": "e1"
+      }
+    }
+  ]
+}
+```
+
+`definitions` is optional; if omitted, all field metadata is inline.
+Field metadata (`drivetrain`, `transmission`, `ratios.*`, `tires.*`, etc.)
+may use `notes_ref` instead of inline `notes`, and `evidence_refs_ref`
+instead of inline `evidence_refs`. Verification-note rows may also use
+`note_ref`. The loader expands every ref into its inline form before
+strict shape validation. Unknown refs fail closed.
+
+Definitions are kept shard-local on purpose: a single generation file
+remains understandable without jumping to a global metadata file.
 
 Each row represents one exact vehicle configuration and keeps the qualified
 order-analysis fields inline with their own metadata:
@@ -67,5 +101,5 @@ Canonical validation lives in:
 - `vibesensor.adapters.persistence.car_library_source_evidence` for
   `evidence_refs` resolution against `car_sources/*.json`
 
-The bundled grouped picker is a projection only. Canonical exact-row shard arrays
+The bundled grouped picker is a projection only. Canonical exact-row shards
 remain the single source of truth.

--- a/tools/dev/migrate_vehicle_shards_provenance.py
+++ b/tools/dev/migrate_vehicle_shards_provenance.py
@@ -1,0 +1,200 @@
+"""Migrate canonical vehicle configuration shards to use shard-local provenance refs.
+
+Each shard becomes::
+
+    {
+      "definitions": {
+        "notes": {"n1": "..."},
+        "evidence_ref_sets": {"e1": ["source:a", "source:b"]}
+      },
+      "configurations": [ ... ]
+    }
+
+Repeated `notes` strings and `evidence_refs` arrays within a shard are lifted
+into the shard-local definitions, replaced inline with `notes_ref` /
+`note_ref` / `evidence_refs_ref` keys. Unique values stay inline.
+
+Re-runnable: existing shard-object payloads are normalized rather than nested.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARD_DIR = (
+    REPO_ROOT / "apps" / "server" / "vibesensor" / "data" / "vehicle_configurations"
+)
+
+_NOTES_KEYS = ("notes", "note")
+_EVIDENCE_KEY = "evidence_refs"
+
+_REF_KEYS = {"notes_ref", "note_ref", "evidence_refs_ref"}
+
+
+def _resolve_existing_refs(
+    payload: Any, notes: dict[str, str], evidence: dict[str, list[str]]
+) -> Any:
+    """Inline any pre-existing refs so we can re-compute fresh definitions."""
+
+    if isinstance(payload, dict):
+        out: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key == "notes_ref":
+                out["notes"] = notes[value]
+            elif key == "note_ref":
+                out["note"] = notes[value]
+            elif key == "evidence_refs_ref":
+                out["evidence_refs"] = list(evidence[value])
+            else:
+                out[key] = _resolve_existing_refs(value, notes, evidence)
+        return out
+    if isinstance(payload, list):
+        return [_resolve_existing_refs(item, notes, evidence) for item in payload]
+    return payload
+
+
+def _load_inline_rows(shard_path: Path) -> list[dict[str, Any]]:
+    data = json.loads(shard_path.read_text(encoding="utf-8"))
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and "configurations" in data:
+        defs = data.get("definitions", {}) or {}
+        notes = defs.get("notes", {}) or {}
+        evidence = defs.get("evidence_ref_sets", {}) or {}
+        return _resolve_existing_refs(data["configurations"], notes, evidence)
+    raise ValueError(f"Unrecognized shard shape: {shard_path}")
+
+
+def _walk_field_metadata(
+    node: Any, notes_counter: Counter[str], evidence_counter: Counter[str]
+) -> None:
+    """Count `notes`/`note` strings and `evidence_refs` arrays anywhere in node."""
+
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in _NOTES_KEYS and isinstance(value, str):
+                notes_counter[value] += 1
+            elif key == _EVIDENCE_KEY and isinstance(value, list):
+                evidence_counter[json.dumps(value, separators=(",", ":"))] += 1
+            else:
+                _walk_field_metadata(value, notes_counter, evidence_counter)
+    elif isinstance(node, list):
+        for item in node:
+            _walk_field_metadata(item, notes_counter, evidence_counter)
+
+
+def _build_definitions(
+    rows: list[dict[str, Any]], min_count: int = 2
+) -> tuple[dict[str, str], dict[str, list[str]], dict[str, str], dict[str, str]]:
+    """Return (notes_defs, evidence_defs, notes_value_to_key, evidence_json_to_key)."""
+
+    notes_counter: Counter[str] = Counter()
+    evidence_counter: Counter[str] = Counter()
+    _walk_field_metadata(rows, notes_counter, evidence_counter)
+
+    notes_defs: dict[str, str] = {}
+    notes_value_to_key: dict[str, str] = {}
+    for value, count in notes_counter.most_common():
+        if count < min_count:
+            continue
+        key = f"n{len(notes_defs) + 1}"
+        notes_defs[key] = value
+        notes_value_to_key[value] = key
+
+    evidence_defs: dict[str, list[str]] = {}
+    evidence_json_to_key: dict[str, str] = {}
+    for value_json, count in evidence_counter.most_common():
+        if count < min_count:
+            continue
+        key = f"e{len(evidence_defs) + 1}"
+        evidence_defs[key] = json.loads(value_json)
+        evidence_json_to_key[value_json] = key
+
+    return notes_defs, evidence_defs, notes_value_to_key, evidence_json_to_key
+
+
+def _rewrite_with_refs(
+    node: Any,
+    notes_value_to_key: dict[str, str],
+    evidence_json_to_key: dict[str, str],
+) -> Any:
+    if isinstance(node, dict):
+        out: dict[str, Any] = {}
+        for key, value in node.items():
+            if (
+                key == "notes"
+                and isinstance(value, str)
+                and value in notes_value_to_key
+            ):
+                out["notes_ref"] = notes_value_to_key[value]
+            elif (
+                key == "note" and isinstance(value, str) and value in notes_value_to_key
+            ):
+                out["note_ref"] = notes_value_to_key[value]
+            elif key == _EVIDENCE_KEY and isinstance(value, list):
+                blob = json.dumps(value, separators=(",", ":"))
+                if blob in evidence_json_to_key:
+                    out["evidence_refs_ref"] = evidence_json_to_key[blob]
+                else:
+                    out[key] = list(value)
+            else:
+                out[key] = _rewrite_with_refs(
+                    value, notes_value_to_key, evidence_json_to_key
+                )
+        return out
+    if isinstance(node, list):
+        return [
+            _rewrite_with_refs(item, notes_value_to_key, evidence_json_to_key)
+            for item in node
+        ]
+    return node
+
+
+def _migrate_shard(shard_path: Path) -> tuple[int, int]:
+    rows = _load_inline_rows(shard_path)
+    notes_defs, evidence_defs, n_lookup, e_lookup = _build_definitions(rows)
+    rewritten = _rewrite_with_refs(rows, n_lookup, e_lookup)
+
+    output: dict[str, Any] = {}
+    if notes_defs or evidence_defs:
+        defs: dict[str, Any] = {}
+        if notes_defs:
+            defs["notes"] = notes_defs
+        if evidence_defs:
+            defs["evidence_ref_sets"] = evidence_defs
+        output["definitions"] = defs
+    output["configurations"] = rewritten
+
+    before = shard_path.stat().st_size
+    shard_path.write_text(
+        json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    after = shard_path.stat().st_size
+    return before, after
+
+
+def main(argv: list[str] | None = None) -> int:
+    target_dir = SHARD_DIR
+    if argv:
+        target_dir = Path(argv[0])
+    shards = sorted(target_dir.rglob("*.json"))
+    total_before = 0
+    total_after = 0
+    for shard in shards:
+        before, after = _migrate_shard(shard)
+        total_before += before
+        total_after += after
+        print(f"{shard.relative_to(target_dir)}: {before} -> {after} bytes")
+    if total_before:
+        pct = 100.0 * (total_before - total_after) / total_before
+        print(f"TOTAL: {total_before} -> {total_after} bytes ({pct:.1f}% reduction)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #3271.

## What

Lift repeated `notes` strings and `evidence_refs` arrays in vehicle config shards into shard-local `definitions`. Field metadata references them via `notes_ref` / `evidence_refs_ref` (and `note_ref` for verification notes). Loader expands refs before strict TypedDict validation.

Shard shape (canonical, replaces bare arrays):

```json
{
  "definitions": {
    "notes": {"n1": "..."},
    "evidence_ref_sets": {"e1": ["src:a", "src:b"]}
  },
  "configurations": [ ... ]
}
```

## Why

Issue #3271 — repeated provenance metadata was the dominant bloat. Refs are shard-local on purpose so a generation file remains readable on its own.

## Numbers

- 76 shards, 466 VehicleConfiguration objects unchanged after migration.
- 4,464,790 → 2,695,537 bytes (**-39.6%**). Target was ≥30%.

## Validation

- `pytest -q apps/server/tests/adapters/persistence/test_vehicle_configurations.py apps/server/tests/adapters/persistence/test_car_library_validation.py` → 13 passed.
- `pytest -q apps/server/tests/adapters apps/server/tests/domain apps/server/tests/use_cases` → 4069 passed.
- `make lint` (with UI deps installed) → clean.
- `make typecheck-backend` → clean.
- `make docs-lint` → clean.

New tests cover ref expansion, unknown notes_ref / evidence_refs_ref → fail-closed, and rejection of legacy bare-array shards.

## Risks

- Bare-array shard format is no longer accepted — intentional per issue ("avoid adding long-term compatibility branches"). Any external consumer reading the raw JSON must adapt to the new shape.
- Migration script `tools/dev/migrate_vehicle_shards_provenance.py` is idempotent and re-runnable on already-migrated shards.

## Out of scope

- Shard-level defaults (#3273), tire setup refs (#3275), policy derivation (#3276), JSON Schema (#3277), duplicate detection (#3278).