### PR TITLE
feat(domain): split order-reference trust from research completeness

### DIFF
--- a/apps/server/tests/domain/test_vehicle_configuration_coverage_policy.py
+++ b/apps/server/tests/domain/test_vehicle_configuration_coverage_policy.py
@@ -52,7 +52,7 @@ def _make_exact_configuration(
     )
 
 
-def test_exact_row_with_source_backed_critical_fields_is_trusted() -> None:
+def test_exact_row_with_source_backed_critical_fields_is_research_complete() -> None:
     config = _make_exact_configuration(top_gear_confidence="reputable_secondary_crosschecked")
 
     assert config.coverage_policy_fields == (
@@ -62,16 +62,52 @@ def test_exact_row_with_source_backed_critical_fields_is_trusted() -> None:
         "top_gear_ratio",
         "final_drive_rear",
     )
-    assert config.coverage_policy_classification == "trusted"
+    assert config.research_completeness == "trusted"
+    assert config.order_reference_trust == "trusted"
+    assert config.order_reference_trust_for("wheel_order") == "trusted"
+    assert config.order_reference_trust_for("driveshaft_order") == "trusted"
+    assert config.order_reference_trust_for("engine_order") == "trusted"
 
 
 def test_family_default_critical_field_marks_exact_row_approximate() -> None:
     config = _make_exact_configuration(top_gear_confidence="family_default")
 
-    assert config.coverage_policy_classification == "approximate"
+    # research_completeness still includes top_gear_ratio
+    assert config.research_completeness == "approximate"
+    # engine_order trust depends on top_gear_ratio so it is approximate too
+    assert config.order_reference_trust_for("engine_order") == "approximate"
+    # wheel/driveshaft trust ignores top_gear_ratio
+    assert config.order_reference_trust_for("wheel_order") == "trusted"
+    assert config.order_reference_trust_for("driveshaft_order") == "trusted"
 
 
 def test_unverified_critical_field_marks_exact_row_backlog_unverified() -> None:
     config = _make_exact_configuration(final_drive_confidence="unverified")
 
-    assert config.coverage_policy_classification == "backlog_unverified"
+    assert config.research_completeness == "backlog_unverified"
+    assert config.order_reference_trust_for("driveshaft_order") == "backlog_unverified"
+    assert config.order_reference_trust_for("engine_order") == "backlog_unverified"
+    # wheel order does not depend on the final drive
+    assert config.order_reference_trust_for("wheel_order") == "trusted"
+
+
+def test_weak_transmission_metadata_does_not_drop_order_reference_trust() -> None:
+    """Issue #3272: non-math transmission_name must not block order-reference trust."""
+
+    config = _make_exact_configuration(transmission_confidence="unverified")
+
+    assert config.research_completeness == "backlog_unverified"
+    # Math inputs are still strong, so trust stays "trusted"
+    assert config.order_reference_trust == "trusted"
+    assert config.order_reference_trust_for("engine_order") == "trusted"
+    assert config.order_reference_trust_for("driveshaft_order") == "trusted"
+    assert config.order_reference_trust_for("wheel_order") == "trusted"
+
+
+def test_weak_drivetrain_label_does_not_drop_order_reference_trust() -> None:
+    """drivetrain field is non-math metadata for trust purposes."""
+
+    config = _make_exact_configuration(drivetrain_confidence="family_default")
+
+    assert config.research_completeness == "approximate"
+    assert config.order_reference_trust == "trusted"

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -98,6 +98,7 @@ from .vehicle_configuration import (
     VehicleFieldConfidence,
     VehicleFieldMetadata,
     VehicleFuelType,
+    VehicleOrderAnalysisKind,
     VehicleOrderAnalysisPolicy,
 )
 from .vibration_origin import VibrationOrigin
@@ -133,6 +134,7 @@ __all__ = [
     "VehicleFieldConfidence",
     "VehicleFieldMetadata",
     "VehicleFuelType",
+    "VehicleOrderAnalysisKind",
     "VehicleOrderAnalysisPolicy",
     # Value objects — snapshots
     "AnalysisSettingsSnapshot",

--- a/apps/server/vibesensor/domain/vehicle_configuration.py
+++ b/apps/server/vibesensor/domain/vehicle_configuration.py
@@ -20,6 +20,7 @@ __all__ = [
     "VehicleFieldConfidence",
     "VehicleFieldMetadata",
     "VehicleFuelType",
+    "VehicleOrderAnalysisKind",
     "VehicleOrderAnalysisPolicy",
 ]
 
@@ -51,6 +52,19 @@ VehicleConfigurationField = Literal[
     "transmission_name",
 ]
 VehicleCoverageClassification = Literal["trusted", "approximate", "backlog_unverified"]
+VehicleOrderAnalysisKind = Literal["wheel_order", "driveshaft_order", "engine_order"]
+
+
+def _classify_confidences(
+    confidences: tuple[VehicleFieldConfidence, ...],
+) -> VehicleCoverageClassification:
+    """Map a tuple of field confidences onto a single coverage classification."""
+
+    if any(confidence == "unverified" for confidence in confidences):
+        return "backlog_unverified"
+    if any(confidence == "family_default" for confidence in confidences):
+        return "approximate"
+    return "trusted"
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,7 +221,14 @@ class VehicleConfiguration:
 
     @property
     def coverage_policy_fields(self) -> tuple[VehicleConfigurationField, ...]:
-        """Return the minimum field set required to trust this config for order analysis."""
+        """Return the broad row research-completeness field set.
+
+        These fields drive :py:attr:`research_completeness`. They include
+        non-math fields (``transmission_name``, ``drivetrain``) that document
+        the row but are *not* required for order-reference math. For the
+        narrower order-analysis trust signal, use
+        :py:meth:`order_reference_trust_for` / :py:attr:`order_reference_trust`.
+        """
 
         fields: list[VehicleConfigurationField] = [
             "drivetrain",
@@ -238,18 +259,96 @@ class VehicleConfiguration:
         return entry.confidence if entry is not None else "unverified"
 
     @property
-    def coverage_policy_classification(self) -> VehicleCoverageClassification:
-        """Classify whether this config is trusted, approximate, or backlog-grade."""
+    def research_completeness(self) -> VehicleCoverageClassification:
+        """Classify broad row research completeness across all documented fields.
+
+        This signal reflects whether the row is broadly research-complete,
+        including non-math labels (e.g. ``transmission_name``). Use
+        :py:attr:`order_reference_trust` when the question is whether the
+        order-analysis math inputs are trustworthy.
+        """
 
         confidences = tuple(
             self.coverage_policy_confidence(field_name)
             for field_name in self.coverage_policy_fields
         )
-        if any(confidence == "unverified" for confidence in confidences):
+        return _classify_confidences(confidences)
+
+    def _order_reference_trust_fields(
+        self, kind: VehicleOrderAnalysisKind
+    ) -> tuple[VehicleConfigurationField, ...]:
+        """Return the order-math input fields that drive trust for *kind*."""
+
+        fields: list[VehicleConfigurationField] = ["tire_dimensions"]
+        if kind in ("driveshaft_order", "engine_order"):
+            if self.drivetrain == "FWD":
+                if self.final_drive_front is not None:
+                    fields.append("final_drive_front")
+            elif self.drivetrain == "RWD":
+                if self.final_drive_rear is not None:
+                    fields.append("final_drive_rear")
+            else:
+                if self.final_drive_rear is not None:
+                    fields.append("final_drive_rear")
+                elif self.final_drive_front is not None:
+                    fields.append("final_drive_front")
+        if kind == "engine_order":
+            fields.append("top_gear_ratio")
+        return tuple(fields)
+
+    def _order_reference_kind_feasible(self, kind: VehicleOrderAnalysisKind) -> bool:
+        if kind == "wheel_order":
+            return True
+        if self.driven_final_drive_ratio is None:
+            return False
+        if kind == "engine_order":
+            return self.top_gear_ratio is not None
+        return True
+
+    def order_reference_trust_for(
+        self, kind: VehicleOrderAnalysisKind
+    ) -> VehicleCoverageClassification:
+        """Classify trust in the math inputs for one order-analysis kind.
+
+        Trust is computed strictly from the runtime math inputs:
+
+        - ``wheel_order``  → tire dimensions
+        - ``driveshaft_order``  → tire dimensions + selected final-drive ratio
+        - ``engine_order``  → tire dimensions + selected final-drive ratio +
+          top-gear ratio
+
+        Non-math metadata such as ``transmission_name`` does not influence the
+        trust signal. When the row is not feasible for *kind* (e.g. EV with no
+        gear ratio for engine order), the classifier returns
+        ``"backlog_unverified"`` because no reliable math output is possible.
+        """
+
+        if not self._order_reference_kind_feasible(kind):
             return "backlog_unverified"
-        if any(confidence == "family_default" for confidence in confidences):
-            return "approximate"
-        return "trusted"
+        confidences: list[VehicleFieldConfidence] = []
+        for field_name in self._order_reference_trust_fields(kind):
+            entry = self.metadata_for(field_name)
+            confidences.append(entry.confidence if entry is not None else "unverified")
+        return _classify_confidences(tuple(confidences))
+
+    @property
+    def order_reference_trust(self) -> VehicleCoverageClassification:
+        """Return the worst trust classification across feasible analysis kinds."""
+
+        all_kinds: tuple[VehicleOrderAnalysisKind, ...] = (
+            "wheel_order",
+            "driveshaft_order",
+            "engine_order",
+        )
+        feasible = [kind for kind in all_kinds if self._order_reference_kind_feasible(kind)]
+        if not feasible:
+            return "backlog_unverified"
+        ranks = {"trusted": 0, "approximate": 1, "backlog_unverified": 2}
+        worst = max(
+            (self.order_reference_trust_for(kind) for kind in feasible),
+            key=lambda c: ranks[c],
+        )
+        return worst
 
     @property
     def requires_manual_drivetrain_confirmation(self) -> bool:

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -92,6 +92,27 @@ Configuration-level confidence values:
 - `no_confidence`
 - `not_applicable`
 
+## Coverage classifications
+
+`VehicleConfiguration` exposes two distinct coverage signals so callers can
+ask the right question:
+
+- `research_completeness` reflects broad row research quality across all
+  documented fields, including non-math labels such as `transmission_name`
+  and `drivetrain`. It is what the row looks like to a maintainer reviewing
+  research progress.
+- `order_reference_trust` (and `order_reference_trust_for(kind)`) reflects
+  trust in the actual runtime math inputs only:
+
+  - `wheel_order`  → tire dimensions
+  - `driveshaft_order`  → tire dimensions + selected final-drive ratio
+  - `engine_order`  → tire dimensions + selected final-drive ratio + top-gear
+    ratio
+
+Order-analysis consumers should use `order_reference_trust` so weak
+documentation on non-math fields does not artificially demote a row whose
+math inputs are evidence-backed.
+
 ## Validation
 
 Canonical validation lives in:


### PR DESCRIPTION
Closes #3272.

## What

Replace `VehicleConfiguration.coverage_policy_classification` with two distinct signals:

- `research_completeness`: existing broad classification across all documented fields (incl. non-math labels).
- `order_reference_trust` / `order_reference_trust_for(kind)`: math-only classification per analysis kind.
  - wheel_order      = tire_dimensions
  - driveshaft_order = tire_dimensions + selected final drive
  - engine_order     = tire_dimensions + selected final drive + top_gear_ratio

New `VehicleOrderAnalysisKind` type exported.

## Why

The old single classifier let weak non-math metadata (e.g. `transmission_name`) demote rows whose actual order-math inputs were evidence-backed. Issue #3272 asks for math-only trust as a separate signal.

## Validation

- `pytest -q apps/server/tests/domain/test_vehicle_configuration_coverage_policy.py apps/server/tests/adapters/persistence apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_car_data_confidence.py` → 208 passed.
- Full backend suite: 6890 passed, 8 skipped.
- `make lint`, `make typecheck-backend`, `make docs-lint` all clean.

New tests assert weak transmission_name and weak drivetrain confidence no longer drop `order_reference_trust`.

## Risks

- Internal API change: `coverage_policy_classification` removed (no production consumer; only 3 tests referenced it). Per repo no-backward-compat policy, no shim added.
- `coverage_policy_fields` / `coverage_policy_confidence` retained — still drive evidence-ref validation; documented as the broad/research field set.

## Out of scope

- Per-row policy derivation (#3276) which can now build on `order_reference_trust`.