### PR TITLE
Derive vehicle order_analysis_policy with sparse override (#3276)

### DIFF
--- a/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
+++ b/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
@@ -387,3 +387,63 @@ def test_load_vehicle_configurations_fails_closed_for_unknown_setup_ref(
         tmp_path,
     ):
         assert load_vehicle_configurations() == []
+
+
+def test_load_vehicle_configurations_derives_order_analysis_policy_when_no_override(
+    tmp_path: Path,
+) -> None:
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    rows[0].pop("order_analysis_policy_override", None)
+    _write_shard(tmp_path, relative_path, fixture)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        loaded = load_vehicle_configurations()
+    assert loaded
+    config = loaded[0]
+    assert config.order_analysis_policy.usable_for_wheel_order is True
+    assert config.order_analysis_policy.requires_manual_confirmation is True
+
+
+def test_load_vehicle_configurations_applies_order_analysis_policy_override(
+    tmp_path: Path,
+) -> None:
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    rows[0]["order_analysis_policy_override"] = {
+        "reason": "row-marked-not-ready-for-wheel-order",
+        "usable_for_wheel_order": False,
+    }
+    _write_shard(tmp_path, relative_path, fixture)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        loaded = load_vehicle_configurations()
+    assert loaded
+    assert loaded[0].order_analysis_policy.usable_for_wheel_order is False
+
+
+def test_load_vehicle_configurations_fails_closed_for_unknown_override_field(
+    tmp_path: Path,
+) -> None:
+    relative_path, shard = _load_sample_shards(1)[0]
+    fixture = copy.deepcopy(shard)
+    rows = cast(list[dict[str, object]], fixture["configurations"])
+    rows[0]["order_analysis_policy_override"] = {
+        "reason": "broken",
+        "bogus_field": True,
+    }
+    _write_shard(tmp_path, relative_path, fixture)
+
+    with patch(
+        "vibesensor.adapters.persistence.vehicle_configurations._VEHICLE_CONFIG_DATA_DIR",
+        tmp_path,
+    ):
+        assert load_vehicle_configurations() == []

--- a/apps/server/tests/domain/test_vehicle_order_analysis_policy.py
+++ b/apps/server/tests/domain/test_vehicle_order_analysis_policy.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import (
+    VehicleOrderAnalysisPolicy,
+    VehicleOrderAnalysisPolicyOverride,
+    apply_order_analysis_policy_override,
+    derive_order_analysis_policy,
+)
+
+
+def test_derive_full_inputs_marks_all_kinds_feasible() -> None:
+    policy = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=3.5,
+        final_drive_rear=3.5,
+        drivetrain="AWD",
+    )
+    assert policy == VehicleOrderAnalysisPolicy(
+        usable_for_engine_order=True,
+        usable_for_driveshaft_order=True,
+        usable_for_wheel_order=True,
+        requires_manual_confirmation=True,
+    )
+
+
+def test_derive_missing_top_gear_blocks_engine_order_only() -> None:
+    policy = derive_order_analysis_policy(
+        top_gear_ratio=None,
+        final_drive_front=3.5,
+        final_drive_rear=None,
+        drivetrain="FWD",
+    )
+    assert policy.usable_for_engine_order is False
+    assert policy.usable_for_driveshaft_order is True
+    assert policy.usable_for_wheel_order is True
+
+
+def test_derive_fwd_uses_front_final_drive() -> None:
+    policy = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=None,
+        final_drive_rear=3.5,
+        drivetrain="FWD",
+    )
+    assert policy.usable_for_engine_order is False
+    assert policy.usable_for_driveshaft_order is False
+
+
+def test_derive_rwd_uses_rear_final_drive() -> None:
+    policy = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=3.5,
+        final_drive_rear=None,
+        drivetrain="RWD",
+    )
+    assert policy.usable_for_engine_order is False
+    assert policy.usable_for_driveshaft_order is False
+
+
+def test_derive_unknown_drivetrain_accepts_either_axle() -> None:
+    policy = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=3.5,
+        final_drive_rear=None,
+        drivetrain=None,
+    )
+    assert policy.usable_for_engine_order is True
+    assert policy.usable_for_driveshaft_order is True
+
+
+def test_apply_override_replaces_only_named_fields() -> None:
+    derived = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=3.5,
+        final_drive_rear=3.5,
+        drivetrain="AWD",
+    )
+    override = VehicleOrderAnalysisPolicyOverride(
+        reason="row-known-not-tested-on-wheel-order",
+        usable_for_wheel_order=False,
+    )
+    final = apply_order_analysis_policy_override(derived, override)
+    assert final.usable_for_wheel_order is False
+    assert final.usable_for_engine_order is True
+    assert final.usable_for_driveshaft_order is True
+    assert final.requires_manual_confirmation is True
+
+
+def test_apply_override_none_returns_derived() -> None:
+    derived = derive_order_analysis_policy(
+        top_gear_ratio=0.7,
+        final_drive_front=3.5,
+        final_drive_rear=3.5,
+        drivetrain="AWD",
+    )
+    assert apply_order_analysis_policy_override(derived, None) is derived
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("usable_for_engine_order", False),
+        ("usable_for_driveshaft_order", False),
+        ("requires_manual_confirmation", False),
+    ],
+)
+def test_each_override_field_independently_replaces(field: str, value: bool) -> None:
+    derived = VehicleOrderAnalysisPolicy(
+        usable_for_engine_order=True,
+        usable_for_driveshaft_order=True,
+        usable_for_wheel_order=True,
+        requires_manual_confirmation=True,
+    )
+    override = VehicleOrderAnalysisPolicyOverride(reason="test", **{field: value})
+    final = apply_order_analysis_policy_override(derived, override)
+    assert getattr(final, field) is value
+    for other in (
+        "usable_for_engine_order",
+        "usable_for_driveshaft_order",
+        "usable_for_wheel_order",
+        "requires_manual_confirmation",
+    ):
+        if other != field:
+            assert getattr(final, other) is True

--- a/apps/server/vibesensor/adapters/persistence/vehicle_configurations.py
+++ b/apps/server/vibesensor/adapters/persistence/vehicle_configurations.py
@@ -21,7 +21,9 @@ from vibesensor.domain import (
     VehicleFieldConfidence,
     VehicleFieldMetadata,
     VehicleFuelType,
-    VehicleOrderAnalysisPolicy,
+    VehicleOrderAnalysisPolicyOverride,
+    apply_order_analysis_policy_override,
+    derive_order_analysis_policy,
 )
 from vibesensor.shared._data_files import resolve_static_data_file
 
@@ -115,11 +117,12 @@ class VehicleConfigurationIssueRow(TypedDict):
     evidence_refs: NotRequired[list[str]]
 
 
-class VehicleOrderAnalysisPolicyRow(TypedDict):
-    usable_for_engine_order: bool
-    usable_for_driveshaft_order: bool
-    usable_for_wheel_order: bool
-    requires_manual_confirmation: bool
+class VehicleOrderAnalysisPolicyOverrideRow(TypedDict):
+    reason: str
+    usable_for_engine_order: NotRequired[bool]
+    usable_for_driveshaft_order: NotRequired[bool]
+    usable_for_wheel_order: NotRequired[bool]
+    requires_manual_confirmation: NotRequired[bool]
 
 
 class VehicleConfigurationRow(TypedDict):
@@ -134,7 +137,6 @@ class VehicleConfigurationRow(TypedDict):
     ratios: VehicleRatiosRow
     tires: VehicleTiresRow
     configuration_confidence: VehicleConfigurationConfidence
-    order_analysis_policy: VehicleOrderAnalysisPolicyRow
     market: NotRequired[str]
     model_code: NotRequired[str]
     body_code: NotRequired[str]
@@ -144,6 +146,7 @@ class VehicleConfigurationRow(TypedDict):
     engine_name: NotRequired[str]
     verification_notes: NotRequired[list[VehicleConfigurationNoteRow]]
     unresolved: NotRequired[list[VehicleConfigurationIssueRow]]
+    order_analysis_policy_override: NotRequired[VehicleOrderAnalysisPolicyOverrideRow]
 
 
 for _typed_dict in (
@@ -154,7 +157,7 @@ for _typed_dict in (
     VehicleFieldMetadataRow,
     VehicleNumericFieldRow,
     VehicleNumericSequenceFieldRow,
-    VehicleOrderAnalysisPolicyRow,
+    VehicleOrderAnalysisPolicyOverrideRow,
     VehicleRatiosRow,
     VehicleTireDimensionsRow,
     VehicleTireOptionRow,
@@ -210,6 +213,30 @@ def _tire_option_from_row(row: VehicleTireOptionRow) -> VehicleConfigurationTire
 def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguration:
     ratios = row["ratios"]
     default_tire_setup = _tire_setup_from_row(row["tires"]["default"])
+    drivetrain_value = row["drivetrain"]["value"]
+    final_drive_front = (
+        ratios["final_drive_front"]["value"] if "final_drive_front" in ratios else None
+    )
+    final_drive_rear = ratios["final_drive_rear"]["value"] if "final_drive_rear" in ratios else None
+    derived_policy = derive_order_analysis_policy(
+        top_gear_ratio=ratios["top_gear_ratio"]["value"],
+        final_drive_front=final_drive_front,
+        final_drive_rear=final_drive_rear,
+        drivetrain=drivetrain_value,
+    )
+    override_row = row.get("order_analysis_policy_override")
+    override = (
+        VehicleOrderAnalysisPolicyOverride(
+            reason=override_row["reason"],
+            usable_for_engine_order=override_row.get("usable_for_engine_order"),
+            usable_for_driveshaft_order=override_row.get("usable_for_driveshaft_order"),
+            usable_for_wheel_order=override_row.get("usable_for_wheel_order"),
+            requires_manual_confirmation=override_row.get("requires_manual_confirmation"),
+        )
+        if override_row is not None
+        else None
+    )
+    final_policy = apply_order_analysis_policy_override(derived_policy, override)
     return VehicleConfiguration(
         id=row["id"],
         brand=row["brand"],
@@ -224,7 +251,7 @@ def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguratio
         engine_code=row.get("engine_code"),
         engine_name=row.get("engine_name"),
         fuel_type=row["fuel_type"],
-        drivetrain=row["drivetrain"]["value"],
+        drivetrain=drivetrain_value,
         drivetrain_metadata=_metadata_from_row(row["drivetrain"]),
         transmission_code=row["transmission"].get("code"),
         transmission_name=row["transmission"]["name"],
@@ -235,17 +262,13 @@ def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguratio
         gear_ratios_metadata=(
             _metadata_from_row(ratios["gear_ratios"]) if "gear_ratios" in ratios else None
         ),
-        final_drive_front=(
-            ratios["final_drive_front"]["value"] if "final_drive_front" in ratios else None
-        ),
+        final_drive_front=final_drive_front,
         final_drive_front_metadata=(
             _metadata_from_row(ratios["final_drive_front"])
             if "final_drive_front" in ratios
             else None
         ),
-        final_drive_rear=(
-            ratios["final_drive_rear"]["value"] if "final_drive_rear" in ratios else None
-        ),
+        final_drive_rear=final_drive_rear,
         final_drive_rear_metadata=(
             _metadata_from_row(ratios["final_drive_rear"]) if "final_drive_rear" in ratios else None
         ),
@@ -258,7 +281,7 @@ def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguratio
         ),
         tire_metadata=_metadata_from_row(row["tires"]["default"]),
         configuration_confidence=row["configuration_confidence"],
-        order_analysis_policy=VehicleOrderAnalysisPolicy(**row["order_analysis_policy"]),
+        order_analysis_policy=final_policy,
         verification_notes=tuple(
             VehicleConfigurationNote(
                 note=note["note"],

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a1/8X.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a1/8X.json
@@ -182,11 +182,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -258,11 +257,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -346,11 +344,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -444,13 +441,7 @@
           "evidence_refs_ref": "e11"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a1/GB.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a1/GB.json
@@ -199,11 +199,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -305,11 +304,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -397,11 +395,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -503,11 +500,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -577,11 +573,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -678,11 +673,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8V.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8V.json
@@ -253,11 +253,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -347,11 +346,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -439,11 +437,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -531,11 +528,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -629,11 +625,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -727,11 +722,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -819,11 +813,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -911,11 +904,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1003,11 +995,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1095,11 +1086,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1193,11 +1183,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1291,11 +1280,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a3/8Y.json
@@ -273,11 +273,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -341,11 +340,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -452,11 +450,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -520,11 +517,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -588,11 +584,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -699,11 +694,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -813,11 +807,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -928,11 +921,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1000,11 +992,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1111,11 +1102,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B8.json
@@ -326,13 +326,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b8-1-8-tfsi-eu-2008-dct7-fwd",
@@ -413,11 +407,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -499,11 +492,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -595,11 +587,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -681,11 +671,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -767,11 +756,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -859,13 +847,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b8-2-0-tdi-quattro-eu-2008-dct7-awd",
@@ -956,11 +938,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -1048,11 +1028,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1135,11 +1114,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -1221,11 +1198,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1307,11 +1283,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1412,11 +1387,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -1514,11 +1487,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -1606,11 +1577,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1718,13 +1688,7 @@
           "evidence_refs_ref": "e30"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b8-3-0-tdi-quattro-eu-2008-dct7-awd",
@@ -1833,13 +1797,7 @@
           "evidence_refs_ref": "e31"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b8-3-0-tdi-quattro-eu-2008-zf8hp-awd",
@@ -1926,11 +1884,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2019,11 +1976,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2120,13 +2076,7 @@
           "evidence_refs_ref": "e34"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b8-3-0-tfsi-quattro-eu-2008-zf8hp-awd",
@@ -2223,11 +2173,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a4/B9.json
@@ -133,11 +133,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -210,11 +210,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -287,11 +286,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -364,11 +363,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -441,11 +439,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -518,11 +515,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -595,11 +591,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -672,11 +668,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -757,11 +753,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B8.json
@@ -170,11 +170,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -262,11 +261,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -369,11 +367,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -480,11 +477,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -578,11 +574,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -685,11 +680,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a5/B9.json
@@ -150,13 +150,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-b9-45-tfsi-quattro-eu-2017-dct7-awd",
@@ -246,11 +240,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C7.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C7.json
@@ -169,11 +169,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -265,11 +264,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -367,11 +365,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -469,11 +466,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -571,11 +567,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -673,11 +668,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a6/C8.json
@@ -139,13 +139,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-c8-45-tfsi-quattro-eu-2019-dct7-awd",
@@ -215,13 +209,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-c8-55-tfsi-quattro-eu-2019-dct7-awd",
@@ -291,13 +279,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C7.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C7.json
@@ -159,13 +159,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "audi-c7-a7-3-0-tfsi-quattro-eu-2011-dct7-awd",
@@ -247,13 +241,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a7_sportback/C8.json
@@ -197,11 +197,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -295,13 +293,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D4.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D4.json
@@ -135,13 +135,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "audi-d4-4-0-tfsi-quattro-eu-2011-zf8hp-awd",
@@ -208,13 +202,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D5.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/a8/D5.json
@@ -210,11 +210,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -288,11 +287,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -399,11 +397,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -491,11 +488,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -588,11 +584,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -680,11 +675,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/e_tron_gt/J1.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/e_tron_gt/J1.json
@@ -115,13 +115,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "audi-j1-e-tron-gt-quattro-eu-2022-ss1-awd",
@@ -184,13 +178,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q2/GA.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q2/GA.json
@@ -151,13 +151,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-ga-30-tfsi-eu-2017-dct7-fwd",
@@ -226,13 +220,7 @@
           ]
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-ga-35-tfsi-eu-2017-mt6-fwd",
@@ -301,13 +289,7 @@
           ]
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-ga-35-tfsi-eu-2017-dct7-fwd",
@@ -376,13 +358,7 @@
           ]
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q3/8U.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q3/8U.json
@@ -227,11 +227,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -307,11 +306,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -387,11 +385,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -477,11 +474,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -584,11 +580,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -680,11 +675,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -768,11 +762,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -856,11 +849,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q3/F3.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q3/F3.json
@@ -181,11 +181,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -322,11 +321,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -436,11 +434,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -551,11 +548,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -730,11 +726,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q4_e_tron/FZ.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q4_e_tron/FZ.json
@@ -109,13 +109,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "audi-fz-50-e-tron-quattro-eu-2022-ss1-awd",
@@ -178,13 +172,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q5/8R.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q5/8R.json
@@ -164,11 +164,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -236,11 +235,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -325,11 +323,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -414,11 +411,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -503,11 +499,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -592,11 +587,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q5/FY.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q5/FY.json
@@ -232,11 +232,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -339,11 +338,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -464,11 +462,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -596,11 +593,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -709,11 +705,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q7/4M.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q7/4M.json
@@ -213,11 +213,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -376,11 +375,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -470,11 +468,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -564,11 +561,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -663,11 +659,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -777,11 +772,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/q8/4M8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/q8/4M8.json
@@ -188,11 +188,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -278,11 +277,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -381,11 +379,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -475,11 +472,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/r8/4S.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/r8/4S.json
@@ -106,11 +106,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -174,11 +172,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8V.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8V.json
@@ -116,11 +116,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sedan/8Y.json
@@ -151,13 +151,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sportback/8Y.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_3_sportback/8Y.json
@@ -117,13 +117,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_4_avant/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_4_avant/B9.json
@@ -102,13 +102,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_5/B9.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_5/B9.json
@@ -132,11 +132,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_6_avant/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_6_avant/C8.json
@@ -109,13 +109,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/rs_7_sportback/C8.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/rs_7_sportback/C8.json
@@ -109,13 +109,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8J.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8J.json
@@ -163,13 +163,7 @@
           "evidence_refs_ref": "e5"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-8j-2-0-tfsi-eu-2011-mt6-fwd",
@@ -239,13 +233,7 @@
           "evidence_refs_ref": "e5"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "audi-8j-2-0-tfsi-quattro-eu-2011-dct6-awd",
@@ -326,11 +314,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -411,11 +398,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
@@ -291,11 +291,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -363,11 +362,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -440,11 +438,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -521,11 +518,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -606,11 +602,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -699,11 +694,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -779,11 +773,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -859,11 +852,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -939,11 +931,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1019,11 +1010,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1099,11 +1089,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1179,11 +1168,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1259,11 +1247,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1346,11 +1333,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": false,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1433,11 +1418,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": false,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F20.json
@@ -590,11 +590,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -663,11 +662,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -743,10 +741,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -823,10 +819,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -903,10 +897,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -983,10 +975,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1063,10 +1053,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1143,10 +1131,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1223,10 +1209,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1303,10 +1287,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1379,10 +1361,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1455,10 +1435,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1528,11 +1506,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1601,11 +1578,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1661,10 +1637,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1721,10 +1695,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1781,10 +1753,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1841,10 +1811,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1901,10 +1869,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1961,10 +1927,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F21.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F21.json
@@ -191,10 +191,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -248,10 +246,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -305,10 +301,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -362,10 +356,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -419,10 +411,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -476,10 +466,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -533,10 +521,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -590,10 +576,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -647,10 +631,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -704,10 +686,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -761,10 +741,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -818,10 +796,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -875,10 +851,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -932,10 +906,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F40.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/1_series/F40.json
@@ -192,11 +192,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -273,11 +272,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -352,11 +350,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -433,11 +430,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -537,11 +533,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -624,11 +619,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_active_tourer/F45.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_active_tourer/F45.json
@@ -237,11 +237,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -345,11 +344,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -453,11 +451,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -566,11 +563,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -692,11 +688,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -794,11 +789,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -895,11 +889,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1015,11 +1008,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1127,11 +1119,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/F22.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/F22.json
@@ -197,11 +197,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -313,11 +312,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -405,11 +403,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -516,11 +513,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -608,11 +604,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -719,11 +714,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -816,11 +810,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -913,11 +907,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1010,11 +1004,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1107,11 +1101,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/G42.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/2_series_coupe/G42.json
@@ -252,13 +252,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g42-230i-eu-2022-zf8hp-rwd",
@@ -377,11 +371,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -459,13 +451,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g42-230i-xdrive-eu-2022-zf8hp-awd",
@@ -540,11 +526,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/F30.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/F30.json
@@ -171,11 +171,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -255,11 +254,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -339,11 +337,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -423,11 +421,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -513,11 +511,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -603,11 +601,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -687,11 +685,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -771,11 +769,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/G20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/3_series/G20.json
@@ -409,11 +409,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -527,11 +526,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -624,13 +622,7 @@
           "evidence_refs_ref": "e9"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g20-318d-eu-2019-zf8hp-rwd",
@@ -724,13 +716,7 @@
           "evidence_refs_ref": "e28"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g20-318i-eu-2019-mt6-rwd",
@@ -826,11 +812,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -938,13 +923,7 @@
           "evidence_refs_ref": "e21"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g20-320ld-eu-2019-mt6-rwd",
@@ -1010,11 +989,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1099,11 +1077,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1170,11 +1147,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1241,11 +1217,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1353,13 +1328,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g20-320d-eu-2019-zf8hp-rwd",
@@ -1468,13 +1437,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g20-320e-eu-2019-mt6-rwd",
@@ -1549,11 +1512,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1648,13 +1610,7 @@
           "evidence_refs_ref": "e19"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g20-320i-eu-2019-mt6-rwd",
@@ -1745,11 +1701,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1844,13 +1799,7 @@
           "evidence_refs_ref": "e20"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g20-325li-eu-2019-mt6-rwd",
@@ -1916,11 +1865,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1987,11 +1935,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2058,11 +2005,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2129,11 +2075,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2224,11 +2169,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2345,11 +2289,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2456,11 +2398,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2570,13 +2511,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g20-330i-xdrive-eu-2019-zf8hp-awd",
@@ -2689,13 +2624,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/F32.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/F32.json
@@ -389,13 +389,7 @@
           "evidence_refs_ref": "e7"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f32-418i-eu-2014-mt6-rwd",
@@ -462,11 +456,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -534,11 +526,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_driveshaft_order": false
       }
     },
     {
@@ -602,13 +592,7 @@
           "evidence_refs_ref": "e13"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-420i-eu-2014-zf8hp-rwd",
@@ -671,13 +655,7 @@
           "evidence_refs_ref": "e13"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-420i-xdrive-eu-2014-mt6-awd",
@@ -769,13 +747,7 @@
           "evidence_refs_ref": "e8"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f32-428i-eu-2014-mt6-rwd",
@@ -843,13 +815,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-428i-eu-2014-zf8hp-rwd",
@@ -917,13 +883,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-430d-eu-2014-zf8hp-rwd",
@@ -1010,13 +970,7 @@
           "evidence_refs_ref": "e9"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-430i-eu-2014-mt6-rwd",
@@ -1078,13 +1032,7 @@
           "evidence_refs_ref": "e14"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-430i-eu-2014-zf8hp-rwd",
@@ -1146,13 +1094,7 @@
           "evidence_refs_ref": "e14"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-435d-xdrive-eu-2014-zf8hp-awd",
@@ -1244,13 +1186,7 @@
           "evidence_refs_ref": "e11"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-435i-eu-2014-mt6-rwd",
@@ -1318,13 +1254,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-435i-eu-2014-zf8hp-rwd",
@@ -1392,13 +1322,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-440i-eu-2014-mt6-rwd",
@@ -1465,13 +1389,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-440i-eu-2014-zf8hp-rwd",
@@ -1538,13 +1456,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-m4-eu-2014-mt6-rwd",
@@ -1626,13 +1538,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-m4-eu-2014-dct7-rwd",
@@ -1715,13 +1621,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f32-440i-xdrive-eu-2016-mt6-awd",
@@ -1800,13 +1700,7 @@
           "evidence_refs_ref": "e6"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-440i-xdrive-eu-2016-zf8hp-awd",
@@ -1885,13 +1779,7 @@
           "evidence_refs_ref": "e6"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-420i-xdrive-eu-2016-zf8hp-awd",
@@ -1985,13 +1873,7 @@
           "evidence_refs_ref": "e4"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-f32-430i-xdrive-eu-2016-zf8hp-awd",
@@ -2085,13 +1967,7 @@
           "evidence_refs_ref": "e4"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/G22.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/4_series/G22.json
@@ -141,13 +141,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g22-430i-xdrive-eu-2021-zf8hp-awd",
@@ -229,13 +223,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g22-m440i-xdrive-eu-2021-zf8hp-awd",
@@ -317,13 +305,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/F10.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/F10.json
@@ -284,10 +284,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -420,10 +418,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -554,10 +550,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -690,10 +684,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -824,10 +816,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -960,10 +950,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1047,11 +1035,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1171,10 +1158,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1243,10 +1228,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G30.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G30.json
@@ -258,11 +258,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -339,11 +337,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -431,11 +427,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -512,11 +506,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -604,11 +596,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -676,11 +666,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -766,11 +755,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -872,11 +860,11 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_engine_order": false,
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1044,11 +1032,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1159,11 +1146,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G60.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/5_series/G60.json
@@ -155,11 +155,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -246,11 +244,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -325,11 +321,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_coupe/F06.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_coupe/F06.json
@@ -211,10 +211,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -357,10 +355,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -471,10 +467,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -617,10 +611,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -719,10 +711,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -853,10 +843,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_turismo/G32.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/6_series_gran_turismo/G32.json
@@ -198,11 +198,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -291,11 +290,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -390,11 +388,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -493,11 +490,10 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -588,11 +584,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -687,11 +682,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -777,11 +771,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -886,11 +879,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/F01.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/F01.json
@@ -154,11 +154,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -254,11 +252,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -341,11 +337,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -441,11 +436,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -552,11 +545,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -652,11 +643,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G11.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G11.json
@@ -339,11 +339,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -418,11 +417,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -499,11 +497,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -588,11 +584,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -669,11 +664,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -758,11 +751,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -846,11 +838,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -941,11 +932,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1022,11 +1011,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1110,11 +1097,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1205,11 +1191,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1286,11 +1270,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1369,11 +1351,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1452,11 +1433,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1533,11 +1513,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1625,11 +1603,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1706,11 +1682,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1787,11 +1761,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G70.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/7_series/G70.json
@@ -253,11 +253,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -356,11 +355,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -440,11 +437,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -524,11 +520,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -607,11 +602,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_convertible/G14.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_convertible/G14.json
@@ -159,11 +159,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -248,11 +246,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_coupe/G15.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_coupe/G15.json
@@ -264,11 +264,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -368,11 +366,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -481,13 +477,7 @@
           "evidence_refs_ref": "e7"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g15-m8-competition-eu-2019-zf8hp-awd",
@@ -595,13 +585,7 @@
           "evidence_refs_ref": "e7"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g15-m850i-xdrive-eu-2019-zf8hp-awd",
@@ -689,11 +673,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_gran_coupe/G16.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/8_series_gran_coupe/G16.json
@@ -131,11 +131,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -220,11 +218,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/i4/G26.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/i4/G26.json
@@ -116,13 +116,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g26-edrive40-eu-2022-ss1-rwd",
@@ -181,13 +175,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/ix/I20.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/ix/I20.json
@@ -115,13 +115,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-i20-xdrive40-eu-2022-ss1-awd",
@@ -184,13 +178,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-i20-xdrive50-eu-2022-ss1-awd",
@@ -253,13 +241,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/F80.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/F80.json
@@ -258,13 +258,7 @@
           "evidence_refs_ref": "e6"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f80-m3-eu-2014-dct7-rwd",
@@ -362,13 +356,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f80-m3-competition-eu-2016-mt6-rwd",
@@ -455,13 +443,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f80-m3-competition-eu-2016-dct7-rwd",
@@ -549,13 +531,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/G80.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m3/G80.json
@@ -175,11 +175,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -255,11 +254,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -357,11 +355,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -476,13 +473,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/F82.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/F82.json
@@ -147,13 +147,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f82-m4-eu-2014-dct7-rwd",
@@ -231,13 +225,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f82-m4-competition-eu-2016-mt6-rwd",
@@ -316,13 +304,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f82-m4-competition-eu-2016-dct7-rwd",
@@ -400,13 +382,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/G82.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m4/G82.json
@@ -191,11 +191,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -271,11 +270,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -351,11 +349,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -457,11 +454,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -568,11 +564,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/m5/F90.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/m5/F90.json
@@ -142,13 +142,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f90-m5-competition-eu-2018-zf8hp-awd",
@@ -231,13 +225,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/F48.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/F48.json
@@ -313,13 +313,7 @@
           "evidence_refs_ref": "e8"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f48-xdrive20i-eu-2016-zf8hp-awd",
@@ -442,13 +436,7 @@
           "evidence_refs_ref": "e18"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f48-xdrive25i-eu-2016-zf8hp-awd",
@@ -573,13 +561,7 @@
           "evidence_refs_ref": "e19"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f48-sdrive16d-eu-2016-mt6-fwd",
@@ -691,13 +673,7 @@
           "evidence_refs_ref": "e5"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f48-sdrive16d-eu-2016-zf8hp-fwd",
@@ -785,11 +761,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -908,11 +883,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1033,11 +1007,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1145,13 +1118,7 @@
           "evidence_refs_ref": "e21"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f48-sdrive18i-eu-2016-zf8hp-fwd",
@@ -1247,11 +1214,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1365,11 +1331,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1490,11 +1455,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1588,11 +1552,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1689,11 +1652,10 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1813,13 +1775,7 @@
           "evidence_refs_ref": "e10"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f48-xdrive25d-eu-2021-zf8hp-awd",
@@ -1935,13 +1891,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f48-xdrive25e-eu-2021-6-speed-step-awd",
@@ -2055,13 +2005,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/U11.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x1/U11.json
@@ -138,11 +138,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -227,11 +225,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -301,11 +297,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/F39.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/F39.json
@@ -271,11 +271,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -361,11 +360,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -456,11 +454,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -571,13 +568,7 @@
           "evidence_refs_ref": "e16"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-sdrive18i-eu-2018-dct7-fwd",
@@ -679,13 +670,7 @@
           "evidence_refs_ref": "e18"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-sdrive18i-eu-2018-zf8hp-fwd",
@@ -775,11 +760,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -882,13 +866,7 @@
           "evidence_refs_ref": "e20"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-sdrive20i-eu-2018-zf8hp-fwd",
@@ -973,11 +951,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1053,11 +1030,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1133,11 +1109,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1234,11 +1209,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1352,13 +1326,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-xdrive20i-eu-2018-dct7-awd",
@@ -1449,11 +1417,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1567,13 +1534,7 @@
           "evidence_refs_ref": "e7"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-xdrive25d-eu-2018-dct7-awd",
@@ -1664,11 +1625,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1778,13 +1738,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-f39-xdrive25e-eu-2018-dct7-awd",
@@ -1875,11 +1829,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -1971,11 +1924,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2057,11 +2009,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -2143,11 +2094,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/U10.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x2/U10.json
@@ -164,11 +164,9 @@
         }
       ],
       "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -236,11 +234,9 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -315,11 +311,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
@@ -463,10 +463,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -564,10 +562,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -672,13 +668,7 @@
           "evidence_refs_ref": "e13"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f25-xdrive20i-eu-2011-zf8hp-awd",
@@ -783,13 +773,7 @@
           "evidence_refs_ref": "e13"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f25-xdrive28i-eu-2011-zf8hp-awd",
@@ -930,10 +914,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1073,10 +1055,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1216,10 +1196,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1335,10 +1313,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1481,13 +1457,7 @@
           ]
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f25-sdrive18d-eu-2012-mt6-rwd",
@@ -1575,10 +1545,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1670,10 +1638,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     },
@@ -1824,10 +1790,8 @@
       ],
       "unresolved": [],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "requires_manual_confirmation": false
       }
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G01.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G01.json
@@ -229,13 +229,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g01-sdrive20i-eu-2018-zf8hp-rwd",
@@ -336,11 +330,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -452,13 +445,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g01-xdrive30i-eu-2018-zf8hp-awd",
@@ -622,13 +609,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G45.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/G45.json
@@ -192,13 +192,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g45-xdrive20-eu-2024-zf8hp-awd",
@@ -350,13 +344,7 @@
           "evidence_refs_ref": "e4"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g45-xdrive30-eu-2025-zf8hp-awd",
@@ -431,11 +419,10 @@
         }
       ],
       "configuration_confidence": "no_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/F26.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/F26.json
@@ -176,13 +176,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f26-xdrive28i-eu-2015-zf8hp-awd",
@@ -273,13 +267,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f26-xdrive35i-eu-2015-zf8hp-awd",
@@ -370,13 +358,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/G02.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x4/G02.json
@@ -167,13 +167,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g02-xdrive20i-eu-2019-zf8hp-awd",
@@ -268,13 +262,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     },
     {
       "id": "bmw-g02-xdrive30i-eu-2019-zf8hp-awd",
@@ -369,13 +357,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/F15.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/F15.json
@@ -183,11 +183,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -282,13 +280,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f15-xdrive40e-eu-2015-zf8hp-awd",
@@ -382,13 +374,7 @@
           "evidence_refs_ref": "e3"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/G05.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x5/G05.json
@@ -154,13 +154,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g05-xdrive40i-eu-2019-zf8hp-awd",
@@ -232,13 +226,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g05-xdrive45e-eu-2019-zf8hp-awd",
@@ -355,13 +343,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/F16.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/F16.json
@@ -160,13 +160,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "high_confidence"
     },
     {
       "id": "bmw-f16-xdrive35i-eu-2015-zf8hp-awd",
@@ -234,13 +228,7 @@
           "evidence_refs_ref": "e2"
         }
       ],
-      "configuration_confidence": "low_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "low_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/G06.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x6/G06.json
@@ -168,11 +168,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -250,11 +248,9 @@
         }
       ],
       "configuration_confidence": "high_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
+        "usable_for_wheel_order": false
       }
     }
   ]

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x7/G07.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x7/G07.json
@@ -176,13 +176,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g07-xdrive40d-eu-2019-zf8hp-awd",
@@ -263,13 +257,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g07-xdrive40i-eu-2019-zf8hp-awd",
@@ -353,13 +341,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/z4/G29.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/z4/G29.json
@@ -205,11 +205,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -314,13 +313,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g29-sdrive20i-eu-2019-mt6-rwd",
@@ -422,13 +415,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g29-sdrive20i-eu-2019-zf8hp-rwd",
@@ -517,13 +504,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     },
     {
       "id": "bmw-g29-sdrive30i-eu-2019-mt6-rwd",
@@ -615,11 +596,10 @@
         }
       ],
       "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
+      "order_analysis_policy_override": {
+        "reason": "preserved-from-pre-derivation-curated-data",
         "usable_for_driveshaft_order": false,
-        "usable_for_wheel_order": false,
-        "requires_manual_confirmation": true
+        "usable_for_wheel_order": false
       }
     },
     {
@@ -709,13 +689,7 @@
           "evidence_refs_ref": "e1"
         }
       ],
-      "configuration_confidence": "medium_confidence",
-      "order_analysis_policy": {
-        "usable_for_engine_order": true,
-        "usable_for_driveshaft_order": true,
-        "usable_for_wheel_order": true,
-        "requires_manual_confirmation": true
-      }
+      "configuration_confidence": "medium_confidence"
     }
   ]
 }

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -100,6 +100,9 @@ from .vehicle_configuration import (
     VehicleFuelType,
     VehicleOrderAnalysisKind,
     VehicleOrderAnalysisPolicy,
+    VehicleOrderAnalysisPolicyOverride,
+    apply_order_analysis_policy_override,
+    derive_order_analysis_policy,
 )
 from .vibration_origin import VibrationOrigin
 
@@ -136,6 +139,9 @@ __all__ = [
     "VehicleFuelType",
     "VehicleOrderAnalysisKind",
     "VehicleOrderAnalysisPolicy",
+    "VehicleOrderAnalysisPolicyOverride",
+    "apply_order_analysis_policy_override",
+    "derive_order_analysis_policy",
     # Value objects — snapshots
     "AnalysisSettingsSnapshot",
     "DrivingPhaseSummary",

--- a/apps/server/vibesensor/domain/vehicle_configuration.py
+++ b/apps/server/vibesensor/domain/vehicle_configuration.py
@@ -22,6 +22,9 @@ __all__ = [
     "VehicleFuelType",
     "VehicleOrderAnalysisKind",
     "VehicleOrderAnalysisPolicy",
+    "VehicleOrderAnalysisPolicyOverride",
+    "apply_order_analysis_policy_override",
+    "derive_order_analysis_policy",
 ]
 
 VehicleFuelType = Literal["ICE", "PHEV", "EV"]
@@ -112,6 +115,90 @@ class VehicleOrderAnalysisPolicy:
     usable_for_driveshaft_order: bool
     usable_for_wheel_order: bool
     requires_manual_confirmation: bool
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleOrderAnalysisPolicyOverride:
+    """Sparse override applied on top of the derived order-analysis policy.
+
+    Each non-``None`` field replaces the corresponding derived flag. ``reason``
+    documents why the row deviates from the derivation.
+    """
+
+    reason: str
+    usable_for_engine_order: bool | None = None
+    usable_for_driveshaft_order: bool | None = None
+    usable_for_wheel_order: bool | None = None
+    requires_manual_confirmation: bool | None = None
+
+
+def derive_order_analysis_policy(
+    *,
+    top_gear_ratio: float | None,
+    final_drive_front: float | None,
+    final_drive_rear: float | None,
+    drivetrain: VehicleDrivetrain | None,
+) -> VehicleOrderAnalysisPolicy:
+    """Compute the default order-analysis policy from row math inputs.
+
+    A row is *feasible* for an analysis kind when its math inputs are present:
+
+    - ``wheel_order``: tire dimensions (always present on canonical rows).
+    - ``driveshaft_order``: driven final-drive ratio.
+    - ``engine_order``: driven final-drive ratio + top-gear ratio.
+
+    The derived policy uses feasibility for the ``usable_for_*`` flags and
+    sets ``requires_manual_confirmation`` to ``True`` by default. Specific
+    rows can override individual flags via
+    :class:`VehicleOrderAnalysisPolicyOverride`.
+    """
+
+    if drivetrain == "FWD":
+        driven_final_drive: float | None = final_drive_front
+    elif drivetrain == "RWD":
+        driven_final_drive = final_drive_rear
+    else:
+        driven_final_drive = final_drive_rear or final_drive_front
+    has_driven = driven_final_drive is not None
+    has_top_gear = top_gear_ratio is not None
+    return VehicleOrderAnalysisPolicy(
+        usable_for_engine_order=has_top_gear and has_driven,
+        usable_for_driveshaft_order=has_driven,
+        usable_for_wheel_order=True,
+        requires_manual_confirmation=True,
+    )
+
+
+def apply_order_analysis_policy_override(
+    derived: VehicleOrderAnalysisPolicy,
+    override: VehicleOrderAnalysisPolicyOverride | None,
+) -> VehicleOrderAnalysisPolicy:
+    """Return a policy with *override* fields replacing matching *derived* fields."""
+
+    if override is None:
+        return derived
+    return VehicleOrderAnalysisPolicy(
+        usable_for_engine_order=(
+            derived.usable_for_engine_order
+            if override.usable_for_engine_order is None
+            else override.usable_for_engine_order
+        ),
+        usable_for_driveshaft_order=(
+            derived.usable_for_driveshaft_order
+            if override.usable_for_driveshaft_order is None
+            else override.usable_for_driveshaft_order
+        ),
+        usable_for_wheel_order=(
+            derived.usable_for_wheel_order
+            if override.usable_for_wheel_order is None
+            else override.usable_for_wheel_order
+        ),
+        requires_manual_confirmation=(
+            derived.requires_manual_confirmation
+            if override.requires_manual_confirmation is None
+            else override.requires_manual_confirmation
+        ),
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -99,9 +99,12 @@ order-analysis fields inline with their own metadata:
   and tire setup values live next to their confidence, evidence refs,
   verification notes, and unresolved items
 - `configuration_confidence` summarizes whole-row confidence
-- `order_analysis_policy` states whether the row is usable for engine,
-  driveshaft, and wheel-order analysis and whether manual confirmation is still
-  required
+- the order-analysis policy is derived at load time from the row math inputs
+  (top-gear ratio, driven final-drive, drivetrain) by
+  `derive_order_analysis_policy`. Rows that need to deviate from the derivation
+  carry a sparse `order_analysis_policy_override` block with an explicit
+  `reason` and only the differing flags. Rows that match the derivation omit
+  the block entirely.
 
 `apps/server/vibesensor/data/car_sources/*.json` now contains only reusable
 source-document metadata. `evidence_refs` inside canonical rows resolve through

--- a/tools/dev/migrate_vehicle_shards_derived_policy.py
+++ b/tools/dev/migrate_vehicle_shards_derived_policy.py
@@ -1,0 +1,134 @@
+"""Migrate vehicle-configuration shards from stored ``order_analysis_policy``
+to derived policy + sparse ``order_analysis_policy_override``.
+
+For each row, the order-analysis policy is now computed from row math inputs
+(:func:`vibesensor.domain.derive_order_analysis_policy`). Rows whose stored
+flags match the derivation drop the block entirely; rows that differ keep
+only the differing fields under ``order_analysis_policy_override`` together
+with a ``reason`` string.
+
+The migration is idempotent: it accepts shards that already use overrides
+and recomputes them from the row math without mutating equivalent state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vibesensor.domain import (
+    VehicleOrderAnalysisPolicy,
+    derive_order_analysis_policy,
+)
+from vibesensor.shared._data_files import resolve_static_data_file
+
+DATA_DIR = resolve_static_data_file("vehicle_configurations")
+DEFAULT_REASON = "preserved-from-pre-derivation-curated-data"
+POLICY_FIELDS = (
+    "usable_for_engine_order",
+    "usable_for_driveshaft_order",
+    "usable_for_wheel_order",
+    "requires_manual_confirmation",
+)
+
+
+def _row_drivetrain(row: dict, defaults: dict) -> str | None:
+    drivetrain = row.get("drivetrain") or defaults.get("drivetrain")
+    if isinstance(drivetrain, dict):
+        return drivetrain.get("value")
+    return drivetrain
+
+
+def _row_ratio_value(row: dict, key: str) -> float | None:
+    ratios = row.get("ratios") or {}
+    block = ratios.get(key)
+    if isinstance(block, dict):
+        return block.get("value")
+    return None
+
+
+def _stored_policy(row: dict) -> VehicleOrderAnalysisPolicy:
+    stored = row.get("order_analysis_policy")
+    override = row.get("order_analysis_policy_override")
+    derived = derive_order_analysis_policy(
+        top_gear_ratio=_row_ratio_value(row, "top_gear_ratio"),
+        final_drive_front=_row_ratio_value(row, "final_drive_front"),
+        final_drive_rear=_row_ratio_value(row, "final_drive_rear"),
+        drivetrain=_row_drivetrain(row, {}),
+    )
+    if isinstance(stored, dict):
+        return VehicleOrderAnalysisPolicy(**{f: stored[f] for f in POLICY_FIELDS})
+    if isinstance(override, dict):
+        return VehicleOrderAnalysisPolicy(
+            **{
+                f: override[f] if f in override else getattr(derived, f)
+                for f in POLICY_FIELDS
+            }
+        )
+    return derived
+
+
+def _build_override_block(
+    stored: VehicleOrderAnalysisPolicy,
+    derived: VehicleOrderAnalysisPolicy,
+    existing_reason: str,
+) -> dict | None:
+    delta = {
+        f: getattr(stored, f)
+        for f in POLICY_FIELDS
+        if getattr(stored, f) != getattr(derived, f)
+    }
+    if not delta:
+        return None
+    return {"reason": existing_reason, **delta}
+
+
+def _migrate_row(row: dict) -> dict:
+    existing_override = row.get("order_analysis_policy_override")
+    existing_reason = (
+        existing_override.get("reason", DEFAULT_REASON)
+        if isinstance(existing_override, dict)
+        else DEFAULT_REASON
+    )
+    stored = _stored_policy(row)
+    derived = derive_order_analysis_policy(
+        top_gear_ratio=_row_ratio_value(row, "top_gear_ratio"),
+        final_drive_front=_row_ratio_value(row, "final_drive_front"),
+        final_drive_rear=_row_ratio_value(row, "final_drive_rear"),
+        drivetrain=_row_drivetrain(row, {}),
+    )
+    override_block = _build_override_block(stored, derived, existing_reason)
+    new_row = {
+        k: v
+        for k, v in row.items()
+        if k not in {"order_analysis_policy", "order_analysis_policy_override"}
+    }
+    if override_block is not None:
+        new_row["order_analysis_policy_override"] = override_block
+    return new_row
+
+
+def _migrate_shard(shard_path: Path) -> bool:
+    raw = json.loads(shard_path.read_text())
+    rows = raw.get("configurations", [])
+    new_rows = [_migrate_row(row) for row in rows]
+    if new_rows == rows:
+        return False
+    raw["configurations"] = new_rows
+    shard_path.write_text(json.dumps(raw, indent=2, ensure_ascii=False) + "\n")
+    return True
+
+
+def main() -> int:
+    changed = 0
+    total = 0
+    for shard in sorted(DATA_DIR.rglob("*.json")):
+        total += 1
+        if _migrate_shard(shard):
+            changed += 1
+    print(f"Migrated {changed}/{total} shards")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #3276.

## What
- New domain helpers `derive_order_analysis_policy` (feasibility from drivetrain + top-gear + driven final-drive) and `apply_order_analysis_policy_override`. Override is sparse with a required `reason`.
- Loader (`vehicle_configurations.py`) drops required `order_analysis_policy` block; reads optional `order_analysis_policy_override`. Final policy = derived + override.
- Migration `tools/dev/migrate_vehicle_shards_derived_policy.py` rewrites all 76 shards. Idempotent.
- Tests: domain helpers (8 cases) + adapter (3 cases incl. fail-closed for unknown override field).
- Doc updated in `docs/car_library_architecture.md`.

## Why
Single source of truth for feasibility (row math). Deviations from the derivation must now carry an explicit `reason`, not a silent flag combination. Schema simplifies for #3277 JSON Schema.

## Validation
- `pytest -q apps/server/tests` → 6911 passed, 8 skipped
- `make lint`, `make typecheck-backend`, `make docs-lint` clean
- Migration confirmed idempotent (second run = 0 changes)

## Risk
Per no-backward-compat policy: shards missing the new shape fail closed. Migration committed alongside loader.

Size: medium.