### PR TITLE
Duplicate / near-duplicate vehicle configuration detection (#3278)

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_library_validation.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_validation.py
@@ -186,3 +186,68 @@ def test_validate_vehicle_configurations_accepts_low_dct_top_gear() -> None:
     issues = validate_vehicle_configurations([low_top_gear], allowlist={})
 
     assert not issues
+
+
+def test_validate_vehicle_configurations_flags_exact_duplicate_rows() -> None:
+    base = _make_valid_vehicle_configuration()
+    a = replace(base, id="bmw|test|a")
+    b = replace(base, id="bmw|test|b")
+
+    issues = validate_vehicle_configurations([a, b], allowlist={})
+
+    rules = [i.rule for i in issues]
+    assert rules.count("duplicate_vehicle_configuration") == 2
+    entities = sorted(i.entity for i in issues if i.rule == "duplicate_vehicle_configuration")
+    assert entities == ["bmw|test|a", "bmw|test|b"]
+
+
+def test_validate_vehicle_configurations_flags_fuzzy_label_collision() -> None:
+    base = _make_valid_vehicle_configuration()
+    a = replace(base, id="bmw|test|a", variant_name="xDrive30i")
+    b = replace(
+        base,
+        id="bmw|test|b",
+        variant_name="x Drive 30 i",
+        top_gear_ratio=0.7,
+        top_gear_ratio_metadata=_metadata("official_exact"),
+    )
+
+    issues = validate_vehicle_configurations([a, b], allowlist={})
+
+    near = [i for i in issues if i.rule == "near_duplicate_vehicle_configuration"]
+    assert len(near) == 2
+    assert {i.entity for i in near} == {"bmw|test|a", "bmw|test|b"}
+
+
+def test_validate_vehicle_configurations_distinct_rows_have_no_duplicate_issues() -> None:
+    base = _make_valid_vehicle_configuration()
+    a = replace(base, id="bmw|test|a", variant_name="xDrive30i")
+    b = replace(
+        base,
+        id="bmw|test|b",
+        variant_name="xDrive40i",
+        top_gear_ratio=0.7,
+        top_gear_ratio_metadata=_metadata("official_exact"),
+    )
+
+    issues = validate_vehicle_configurations([a, b], allowlist={})
+
+    assert not any(
+        i.rule in {"duplicate_vehicle_configuration", "near_duplicate_vehicle_configuration"}
+        for i in issues
+    )
+
+
+def test_validate_vehicle_configurations_allowlist_silences_duplicate() -> None:
+    base = _make_valid_vehicle_configuration()
+    a = replace(base, id="bmw|test|a")
+    b = replace(base, id="bmw|test|b")
+
+    allowlist = {
+        ("duplicate_vehicle_configuration", "bmw|test|a"): "intentional twin row",
+        ("duplicate_vehicle_configuration", "bmw|test|b"): "intentional twin row",
+    }
+
+    issues = validate_vehicle_configurations([a, b], allowlist=allowlist)
+
+    assert not [i for i in issues if i.rule == "duplicate_vehicle_configuration"]

--- a/apps/server/vibesensor/adapters/persistence/car_library_validation.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library_validation.py
@@ -134,6 +134,7 @@ def validate_vehicle_configurations(
     issues: list[CarLibraryValidationIssue] = []
     for config in configs:
         _validate_vehicle_configuration(config, issues)
+    _validate_vehicle_configuration_duplicates(configs, issues)
     return _filter_allowlisted_issues(issues, allowlist)
 
 
@@ -674,6 +675,104 @@ def _tire_spec_from_values(*, width: object, aspect: object, rim: object) -> Tir
             "rim_in": rim_value,
         }
     )
+
+
+def _normalize_label(value: object) -> str:
+    text = str(value or "").casefold()
+    return re.sub(r"[^a-z0-9]+", "", text)
+
+
+def _round_ratio(value: float | None) -> float | None:
+    return None if value is None else round(value, 4)
+
+
+def _tire_signature(tire: TireSpec | None) -> tuple[float, float, float] | None:
+    if tire is None:
+        return None
+    return (round(tire.width_mm, 1), round(tire.aspect_pct, 1), round(tire.rim_in, 1))
+
+
+def _vehicle_configuration_identity_key(
+    config: VehicleConfiguration,
+) -> tuple[object, ...]:
+    return (
+        _normalize_label(config.brand),
+        _normalize_label(config.model_name),
+        _normalize_label(config.variant_name),
+        config.drivetrain,
+        config.fuel_type,
+        _normalize_label(config.transmission_name),
+        _round_ratio(config.top_gear_ratio),
+        _round_ratio(config.final_drive_front),
+        _round_ratio(config.final_drive_rear),
+        _tire_signature(config.default_tire),
+    )
+
+
+def _vehicle_configuration_fuzzy_label_key(
+    config: VehicleConfiguration,
+) -> tuple[str, str, str]:
+    return (
+        _normalize_label(config.brand),
+        _normalize_label(config.model_name),
+        _normalize_label(config.variant_name),
+    )
+
+
+def _validate_vehicle_configuration_duplicates(
+    configs: Sequence[VehicleConfiguration],
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    by_identity: dict[tuple[object, ...], list[VehicleConfiguration]] = {}
+    by_fuzzy_label: dict[tuple[str, str, str], list[VehicleConfiguration]] = {}
+    for config in configs:
+        if not config.id:
+            continue
+        by_identity.setdefault(_vehicle_configuration_identity_key(config), []).append(config)
+        by_fuzzy_label.setdefault(_vehicle_configuration_fuzzy_label_key(config), []).append(config)
+
+    for group in by_identity.values():
+        if len(group) <= 1:
+            continue
+        peers = sorted(str(other.id) for other in group)
+        for config in group:
+            row_id = str(config.id)
+            others = [pid for pid in peers if pid != row_id]
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="duplicate_vehicle_configuration",
+                    entity=row_id,
+                    message=(
+                        f"{config.brand} {config.model_name} / {config.variant_name} "
+                        f"shares normalized identity with {', '.join(others)}"
+                    ),
+                )
+            )
+
+    for group in by_fuzzy_label.values():
+        if len(group) <= 1:
+            continue
+        identity_keys = {_vehicle_configuration_identity_key(c) for c in group}
+        if len(identity_keys) <= 1:
+            continue
+        raw_labels = {(c.brand, c.model_name, c.variant_name) for c in group}
+        if len(raw_labels) <= 1:
+            continue
+        peers = sorted(str(other.id) for other in group)
+        for config in group:
+            row_id = str(config.id)
+            others = [pid for pid in peers if pid != row_id]
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="near_duplicate_vehicle_configuration",
+                    entity=row_id,
+                    message=(
+                        f"{config.brand} {config.model_name} / {config.variant_name} "
+                        "matches another row after label normalization "
+                        f"but has different math: {', '.join(others)}"
+                    ),
+                )
+            )
 
 
 def _filter_allowlisted_issues(

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -212,3 +212,22 @@ schema file. Example VS Code setting:
 
 Schema validation and the backend loader are kept in sync. When the loader
 contract changes, update both at once.
+
+## Duplicate detection
+
+`validate_vehicle_configurations` (in
+`vibesensor.adapters.persistence.car_library_validation`) flags duplicate
+and near-duplicate exact rows after the per-row checks:
+
+- `duplicate_vehicle_configuration` (hard failure): two or more rows share
+  the same normalized identity (brand, model, variant, drivetrain, fuel
+  type, transmission, top gear, final drives, default tire signature).
+- `near_duplicate_vehicle_configuration` (advisory): two or more rows share
+  the same fuzzy label key (brand + model + variant after stripping case,
+  punctuation, and whitespace) but have different math identity. The row
+  IDs of the colliding peers are listed in the message.
+
+Both rules go through the existing
+`apps/server/vibesensor/data/car_library_validation_allowlist.json`. To
+keep an intentional duplicate or label collision, add an entry with the
+rule name, the offending row `id`, and a `reason`.


### PR DESCRIPTION
Closes #3278.

## What
`validate_vehicle_configurations` now flags two rule types after the per-row checks:

- **`duplicate_vehicle_configuration`** (hard fail): two or more rows share the same normalized identity key — brand, model, variant, drivetrain, fuel type, transmission, top gear, final drives, default tire signature. Message lists peer row IDs.
- **`near_duplicate_vehicle_configuration`** (advisory): two or more rows share the same fuzzy label key (`re.sub(r'[^a-z0-9]+', '', s.casefold())`) on brand+model+variant but differ on math identity. Catches whitespace/case/punctuation duplicates.

Both rules go through the existing `car_library_validation_allowlist.json` mechanism (rule + entity + reason) for intentional cases.

## Tests
4 new cases in `test_car_library_validation.py`:
- exact duplicate flagged on both rows
- fuzzy label collision flagged on both rows
- distinct rows produce no duplicate issues
- allowlist silences flagged duplicates

## Validation
- `pytest -q apps/server/tests` → 6996 passed
- `make lint`, `make typecheck-backend`, `make docs-lint` clean
- All 466 committed rows pass with zero false positives

Size: small.