### PR TITLE
Fix stale Weekly Pi Image validation path

### DIFF
--- a/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
+++ b/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
@@ -89,3 +89,14 @@ def test_server_systemd_uses_console_script_entrypoint() -> None:
         "ExecStart=__VENV_DIR__/bin/vibesensor-server --config /etc/vibesensor/config.yaml"
         in service_text
     )
+
+
+@pytest.mark.smoke
+def test_pi_image_validation_checks_current_packaged_static_data_layout() -> None:
+    validation_text = (
+        REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "image_validation.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "vehicle_configurations" in validation_text
+    assert "car_sources" in validation_text
+    assert "car_library.json" not in validation_text

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -267,8 +267,23 @@ validate_image_artifact() {
     exit 1
   fi
 
-  if [ ! -f "${venv_data_dir}/car_library.json" ]; then
-    echo "Validation failed: missing ${venv_data_dir}/car_library.json"
+  if [ ! -d "${venv_data_dir}/vehicle_configurations" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/vehicle_configurations"
+    exit 1
+  fi
+
+  if ! find "${venv_data_dir}/vehicle_configurations" -type f -name "*.json" | grep -q .; then
+    echo "Validation failed: no vehicle configuration shards found under ${venv_data_dir}/vehicle_configurations"
+    exit 1
+  fi
+
+  if [ ! -d "${venv_data_dir}/car_sources" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/car_sources"
+    exit 1
+  fi
+
+  if ! find "${venv_data_dir}/car_sources" -maxdepth 1 -type f -name "*.json" | grep -q .; then
+    echo "Validation failed: no car source packs found under ${venv_data_dir}/car_sources"
     exit 1
   fi
 


### PR DESCRIPTION
## What changed
- update infra/pi-image/pi-gen/lib/image_validation.sh to validate the current packaged static-data layout inside the installed vibesensor wheel
- require vehicle_configurations shards and car_sources packs instead of the removed car_library.json
- add a hygiene smoke test so pi-image validation cannot drift back to the deleted path

## Why
The weekly Pi image workflow was not failing in the image build itself. It built the image, then the post-build validator failed on a stale check for site-packages/vibesensor/data/car_library.json. The packaged runtime now ships shard directories, not that monolithic file.

## Validation
- pytest -q apps/server/tests/hygiene/test_pi_image_static_guardrails.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py
- make lint

## Risk / tradeoffs
- validation now matches the current runtime packaging contract instead of the pre-shard layout
- still fails closed if the image is missing packaged vehicle shards or source packs