### PR TITLE
Fix Weekly Pi Image shard checks under pipefail

### DIFF
--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -272,7 +272,11 @@ validate_image_artifact() {
     exit 1
   fi
 
-  if ! find "${venv_data_dir}/vehicle_configurations" -type f -name "*.json" | grep -q .; then
+  local first_vehicle_shard=""
+  first_vehicle_shard="$(
+    find "${venv_data_dir}/vehicle_configurations" -type f -name "*.json" -print -quit
+  )"
+  if [ -z "${first_vehicle_shard}" ]; then
     echo "Validation failed: no vehicle configuration shards found under ${venv_data_dir}/vehicle_configurations"
     exit 1
   fi
@@ -282,7 +286,11 @@ validate_image_artifact() {
     exit 1
   fi
 
-  if ! find "${venv_data_dir}/car_sources" -maxdepth 1 -type f -name "*.json" | grep -q .; then
+  local first_car_source=""
+  first_car_source="$(
+    find "${venv_data_dir}/car_sources" -maxdepth 1 -type f -name "*.json" -print -quit
+  )"
+  if [ -z "${first_car_source}" ]; then
     echo "Validation failed: no car source packs found under ${venv_data_dir}/car_sources"
     exit 1
   fi


### PR DESCRIPTION
## What changed
- replace the `find ... | grep -q .` probes in `infra/pi-image/pi-gen/lib/image_validation.sh`
- use `find -print -quit` captured into shell variables for `vehicle_configurations` and `car_sources`

## Why
The first fix corrected the stale `car_library.json` path, but the workflow still failed because the new presence checks ran under `set -euo pipefail`. `grep -q` exited after the first match, `find` took SIGPIPE, and the validator treated that as failure.

## Validation
- `pytest -q apps/server/tests/hygiene/test_pi_image_static_guardrails.py apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `make lint`
