### PR TITLE
Shrink create_app bootstrap wiring

### DIFF
--- a/apps/server/tests/app/test_runtime_state.py
+++ b/apps/server/tests/app/test_runtime_state.py
@@ -1,0 +1,91 @@
+"""Focused tests for app-owned runtime composition helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from vibesensor.app.runtime_state import RuntimeState
+from vibesensor.infra.runtime.health_state import RuntimeHealthState
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        logging=SimpleNamespace(
+            history_db_path="/tmp/history.db",
+            shutdown_analysis_timeout_s=12.5,
+        ),
+        udp=SimpleNamespace(
+            data_host="0.0.0.0",
+            data_port=9000,
+            data_queue_maxsize=321,
+        ),
+        gps=SimpleNamespace(
+            gpsd_host="gpsd.local",
+            gpsd_port=2947,
+        ),
+    )
+
+
+def test_runtime_state_projects_lifecycle_runtime() -> None:
+    registry = object()
+    processor = object()
+    control_plane = object()
+    worker_pool = object()
+    settings_reader = object()
+    gps_monitor = object()
+    obd_runner = object()
+    history_db = object()
+    processing_loop_state = object()
+    health_state = RuntimeHealthState()
+    ingest_diagnostics = object()
+    processing_loop = object()
+    ws_hub = object()
+    ws_broadcast = object()
+    run_recorder = object()
+    update_manager = object()
+    esp_flash_manager = object()
+    state = RuntimeState(
+        config=_config(),
+        registry=registry,
+        processor=processor,
+        control_plane=control_plane,
+        worker_pool=worker_pool,
+        settings_reader=settings_reader,
+        gps_monitor=gps_monitor,
+        obd_runner=obd_runner,
+        history_db=history_db,
+        processing_loop_state=processing_loop_state,
+        health_state=health_state,
+        ingest_diagnostics=ingest_diagnostics,
+        processing_loop=processing_loop,
+        ws_hub=ws_hub,
+        ws_broadcast=ws_broadcast,
+        run_recorder=run_recorder,
+        update_manager=update_manager,
+        esp_flash_manager=esp_flash_manager,
+    )
+
+    lifecycle_runtime = state.lifecycle_runtime()
+
+    assert lifecycle_runtime.health_state is health_state
+    assert lifecycle_runtime.history_db_path == "/tmp/history.db"
+    assert lifecycle_runtime.udp_data_host == "0.0.0.0"
+    assert lifecycle_runtime.udp_data_port == 9000
+    assert lifecycle_runtime.udp_data_queue_maxsize == 321
+    assert lifecycle_runtime.gpsd_host == "gpsd.local"
+    assert lifecycle_runtime.gpsd_port == 2947
+    assert lifecycle_runtime.shutdown_analysis_timeout_s == 12.5
+    assert lifecycle_runtime.registry is registry
+    assert lifecycle_runtime.processor is processor
+    assert lifecycle_runtime.ingest_diagnostics is ingest_diagnostics
+    assert lifecycle_runtime.control_plane is control_plane
+    assert lifecycle_runtime.processing_loop is processing_loop
+    assert lifecycle_runtime.ws_hub is ws_hub
+    assert lifecycle_runtime.ws_broadcast is ws_broadcast
+    assert lifecycle_runtime.run_recorder is run_recorder
+    assert lifecycle_runtime.gps_monitor is gps_monitor
+    assert lifecycle_runtime.obd_runner is obd_runner
+    assert lifecycle_runtime.update_manager is update_manager
+    assert lifecycle_runtime.esp_flash_manager is esp_flash_manager
+    assert lifecycle_runtime.worker_pool is worker_pool
+    assert lifecycle_runtime.history_db is history_db

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -28,7 +28,7 @@ from vibesensor.adapters.http.middleware import install_request_logging_middlewa
 from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.config_loader import load_config
 from vibesensor.app.container import build_runtime
-from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
+from vibesensor.infra.runtime.lifecycle import LifecycleManager
 from vibesensor.shared.process_settings import (
     CONFIG_PATH_ENV,
     export_config_path_env,
@@ -64,30 +64,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     configure_tracing(config.tracing)
     runtime = build_runtime(config)
     lifecycle = LifecycleManager(
-        runtime=LifecycleRuntime(
-            health_state=runtime.lifecycle.health_state,
-            history_db_path=config.logging.history_db_path,
-            udp_data_host=config.udp.data_host,
-            udp_data_port=config.udp.data_port,
-            udp_data_queue_maxsize=config.udp.data_queue_maxsize,
-            gpsd_host=config.gps.gpsd_host,
-            gpsd_port=config.gps.gpsd_port,
-            shutdown_analysis_timeout_s=config.logging.shutdown_analysis_timeout_s,
-            registry=runtime.lifecycle.registry,
-            processor=runtime.lifecycle.processor,
-            control_plane=runtime.lifecycle.control_plane,
-            processing_loop=runtime.lifecycle.processing_loop,
-            ws_hub=runtime.lifecycle.ws_hub,
-            ws_broadcast=runtime.lifecycle.ws_broadcast,
-            run_recorder=runtime.lifecycle.run_recorder,
-            gps_monitor=runtime.lifecycle.gps_monitor,
-            obd_runner=runtime.lifecycle.obd_runner,
-            update_manager=runtime.lifecycle.update_manager,
-            esp_flash_manager=runtime.lifecycle.esp_flash_manager,
-            worker_pool=runtime.lifecycle.worker_pool,
-            history_db=runtime.lifecycle.history_db,
-            ingest_diagnostics=runtime.lifecycle.ingest_diagnostics,
-        ),
+        runtime=runtime.lifecycle.lifecycle_runtime(),
         start_udp_receiver=start_udp_data_receiver,
     )
 

--- a/apps/server/vibesensor/app/runtime_state.py
+++ b/apps/server/vibesensor/app/runtime_state.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
     from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
     from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
     from vibesensor.adapters.websocket.hub import WebSocketHub
-    from vibesensor.infra.runtime.lifecycle import LifecycleHistoryDb, LifecycleObdRunner
+    from vibesensor.infra.runtime.lifecycle import (
+        LifecycleHistoryDb,
+        LifecycleObdRunner,
+        LifecycleRuntime,
+    )
 
 
 @dataclass(slots=True)
@@ -52,6 +56,36 @@ class RuntimeState:
     run_recorder: RunRecorder
     update_manager: UpdateManager
     esp_flash_manager: EspFlashManager
+
+    def lifecycle_runtime(self) -> LifecycleRuntime:
+        """Project the lifecycle-owned dependency bag for LifecycleManager."""
+
+        from vibesensor.infra.runtime.lifecycle import LifecycleRuntime
+
+        return LifecycleRuntime(
+            health_state=self.health_state,
+            history_db_path=self.config.logging.history_db_path,
+            udp_data_host=self.config.udp.data_host,
+            udp_data_port=self.config.udp.data_port,
+            udp_data_queue_maxsize=self.config.udp.data_queue_maxsize,
+            gpsd_host=self.config.gps.gpsd_host,
+            gpsd_port=self.config.gps.gpsd_port,
+            shutdown_analysis_timeout_s=self.config.logging.shutdown_analysis_timeout_s,
+            registry=self.registry,
+            processor=self.processor,
+            ingest_diagnostics=self.ingest_diagnostics,
+            control_plane=self.control_plane,
+            processing_loop=self.processing_loop,
+            ws_hub=self.ws_hub,
+            ws_broadcast=self.ws_broadcast,
+            run_recorder=self.run_recorder,
+            gps_monitor=self.gps_monitor,
+            obd_runner=self.obd_runner,
+            update_manager=self.update_manager,
+            esp_flash_manager=self.esp_flash_manager,
+            worker_pool=self.worker_pool,
+            history_db=self.history_db,
+        )
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## What changed
- moved the stable `RuntimeState -> LifecycleRuntime` projection into `apps/server/vibesensor/app/runtime_state.py`
- replaced the hand-wired `LifecycleRuntime(...)` block in `apps/server/vibesensor/app/bootstrap.py` with one call to `runtime.lifecycle.lifecycle_runtime()`
- added a focused app test that pins the lifecycle-runtime projection without relying on bootstrap source shape

## Why
- #3298 asked for a smaller bootstrap composition boundary, not another wrapper that just hides the same long field threading
- before this change, `create_app()` rebuilt the lifecycle dependency bag by hand even though `RuntimeState` already owned those inputs

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/app/test_runtime_state.py apps/server/tests/app/test_app_lifecycle.py apps/server/tests/app/test_app_main.py apps/server/tests/app/test_import_purity.py`
- `make typecheck-backend`
- `make lint`

## Risks, tradeoffs, edge cases
- the projection still stays explicit, but it now lives on the runtime bundle that owns the fields instead of in bootstrap
- startup/shutdown behavior, router wiring, tracing/logging setup, and static asset serving are unchanged because the lifecycle manager and lifespan flow were not redesigned

## Follow-ups / out of scope
- none

Closes #3298
