### PR TITLE
Forward check mode to UI derivative sync

### DIFF
--- a/tools/config/sync_contract_artifacts.mjs
+++ b/tools/config/sync_contract_artifacts.mjs
@@ -44,7 +44,10 @@ async function main() {
 		contractReferenceScript,
 		...checkArgs,
 	]);
-	runCommand('UI contract derivative sync', process.execPath, [uiDerivativeSyncScript]);
+	runCommand('UI contract derivative sync', process.execPath, [
+		uiDerivativeSyncScript,
+		...checkArgs,
+	]);
 
 	if (checkMode) {
 		console.log('All contract artifacts are up to date.');


### PR DESCRIPTION
## What changed
- forwarded the parent `--check` flag from `tools/config/sync_contract_artifacts.mjs` into the `sync_shared_contracts_to_ui.mjs` subprocess
- left normal non-check sync behavior unchanged

## Why
- #3303 reported that `sync_contract_artifacts.mjs --check` was still mutating generated UI derivative files because the UI derivative sync subprocess was always run in write mode

## Validation
- `node tools/config/sync_contract_artifacts.mjs --check`
- `node tools/config/sync_contract_artifacts.mjs`
- `make ui-typecheck`
- `make lint`

## Risks, tradeoffs, edge cases
- this stays a tiny argument-propagation fix; the UI derivative generator itself is unchanged
- there was no safe existing direct script-behavior harness to extend without mutating real generated files under parallel pytest, so validation stays on the authoritative sync/check entrypoints

## Follow-ups / out of scope
- none

Closes #3303
