### PR TITLE
Add fresh-checkout UI contract derivative setup path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,10 @@ jobs:
         working-directory: apps/ui
         run: node ../../tools/ui/ensure_ui_bootstrap.mjs
 
+      - name: Materialize missing UI generated contract derivatives
+        working-directory: apps/ui
+        run: npm run setup:generated-contracts
+
       - name: Authoritative contract sync check
         run: make sync-contracts CHECK=1
 

--- a/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
+++ b/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
@@ -12,6 +12,12 @@ from pathlib import Path
 from tests._paths import REPO_ROOT
 
 _UI_BOOTSTRAP_HELPER = REPO_ROOT / "tools" / "ui" / "ensure_ui_bootstrap.mjs"
+_GENERATED_DERIVATIVE_RELATIVE_PATHS = (
+    "src/generated/http_api_contracts.ts",
+    "src/contracts/ws_payload_types.ts",
+    "src/contracts/ws_payload_schema.generated.ts",
+    "src/constants.ts",
+)
 
 
 def _write_fake_npm(bin_dir: Path) -> Path:
@@ -44,6 +50,19 @@ def _prepare_ui_dir(tmp_path: Path) -> Path:
     ui_dir.mkdir()
     (ui_dir / "package-lock.json").write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
     return ui_dir
+
+
+def _mark_npm_ci_current(ui_dir: Path) -> None:
+    (ui_dir / "node_modules").mkdir()
+    lock_hash = hashlib.sha256((ui_dir / "package-lock.json").read_bytes()).hexdigest()
+    (ui_dir / ".npm-ci-lock.sha256").write_text(f"{lock_hash}\n", encoding="utf-8")
+
+
+def _write_generated_derivatives(ui_dir: Path) -> None:
+    for rel_path in _GENERATED_DERIVATIVE_RELATIVE_PATHS:
+        file_path = ui_dir / rel_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text("// generated\n", encoding="utf-8")
 
 
 def test_ui_bootstrap_helper_runs_npm_ci_and_marks_lock_hash(tmp_path: Path) -> None:
@@ -118,3 +137,58 @@ def test_ui_bootstrap_helper_check_mode_reports_npm_ci_need(tmp_path: Path) -> N
         "current_lock_hash": "",
         "node_modules_exists": False,
     }
+
+
+def test_ui_bootstrap_helper_materializes_missing_generated_contracts_when_requested(
+    tmp_path: Path,
+) -> None:
+    ui_dir = _prepare_ui_dir(tmp_path)
+    _mark_npm_ci_current(ui_dir)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_npm(bin_dir)
+    log_path = tmp_path / "npm.log"
+
+    result = subprocess.run(
+        ["node", str(_UI_BOOTSTRAP_HELPER), "--ensure-generated-contracts"],
+        cwd=ui_dir,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "FAKE_NPM_LOG": str(log_path),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert log_path.read_text(encoding="utf-8").splitlines() == ["run sync:generated-contracts"]
+
+
+def test_ui_bootstrap_helper_skips_generated_contract_sync_when_derivatives_exist(
+    tmp_path: Path,
+) -> None:
+    ui_dir = _prepare_ui_dir(tmp_path)
+    _mark_npm_ci_current(ui_dir)
+    _write_generated_derivatives(ui_dir)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_npm(bin_dir)
+    log_path = tmp_path / "npm.log"
+
+    result = subprocess.run(
+        ["node", str(_UI_BOOTSTRAP_HELPER), "--ensure-generated-contracts"],
+        cwd=ui_dir,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "FAKE_NPM_LOG": str(log_path),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert not log_path.exists()

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -25,6 +25,7 @@ running the UI commands below. Native frontend work follows [`.nvmrc`](../../.nv
 ```bash
 cd apps/ui
 npm ci
+npm run setup:generated-contracts  # One-time clean-checkout setup for missing UI contract derivatives
 npm run lint         # Biome lint over the hand-written UI/config/test files
 npm run lint:deps    # dependency-cruiser boundary checks over src/
 npm run lint:unused  # knip dead-file/dependency checks
@@ -72,6 +73,8 @@ It then regenerates the UI-only derivative artifacts:
 - `src/constants.ts`
 
 Those derivative outputs are materialized locally from the tracked inputs and are no longer a committed source-of-truth surface. Explicit owner flows such as `test:smoke`, `dev:docker`, `make ui-typecheck`, and release/UI-build helpers call `npm run sync:generated-contracts` when they need the files on disk.
+
+Fresh checkouts can materialize only the missing derivative files with `npm run setup:generated-contracts`. That setup command is safe to rerun, reuses the shared UI bootstrap helper, and intentionally leaves the authoritative `make sync-contracts` / `npm run sync:generated-contracts` refresh flow unchanged for stale-derivative updates.
 
 `npm run build` and `npm run typecheck` no longer regenerate those files automatically. They run `npm run check:contracts` first and fail fast with guidance to `make sync-contracts` if the local derivative copy is missing or stale. CI contract drift and human-facing regeneration should still use `make sync-contracts`.
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "sync:contracts": "node ../../tools/config/sync_contract_artifacts.mjs",
     "sync:generated-contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs",
+    "setup:generated-contracts": "node ../../tools/ui/ensure_ui_bootstrap.mjs --ensure-generated-contracts",
     "check:contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs --check",
     "lint": "biome lint .",
     "lint:deps": "depcruise --config .dependency-cruiser.cjs src",

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -17,6 +17,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 _UI_BOOTSTRAP_HELPER_WORKFLOW_CMD = "node ../../tools/ui/ensure_ui_bootstrap.mjs"
+_UI_DERIVATIVE_SETUP_WORKFLOW_CMD = "npm run setup:generated-contracts"
 
 TEXT_EXTS = {
     ".py",
@@ -1165,6 +1166,7 @@ def check_contract_sync_entrypoint() -> list[str]:
     expected_scripts = {
         "sync:contracts": "node ../../tools/config/sync_contract_artifacts.mjs",
         "sync:generated-contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs",
+        "setup:generated-contracts": "node ../../tools/ui/ensure_ui_bootstrap.mjs --ensure-generated-contracts",
         "check:contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs --check",
         "build": "npm run check:contracts && vite build",
         "build:prevalidated-contracts": "vite build",
@@ -1227,6 +1229,14 @@ def check_contract_sync_entrypoint() -> list[str]:
                     error_message=(
                         "backend-contract-drift must install UI dependencies from apps/ui before running "
                         "the authoritative contract sync check."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    working_directory="apps/ui",
+                    run=_UI_DERIVATIVE_SETUP_WORKFLOW_CMD,
+                    error_message=(
+                        "backend-contract-drift must materialize missing UI contract derivatives on "
+                        "fresh checkouts before running the authoritative contract sync check."
                     ),
                 ),
                 WorkflowStepRequirement(

--- a/tools/ui/ensure_ui_bootstrap.mjs
+++ b/tools/ui/ensure_ui_bootstrap.mjs
@@ -5,12 +5,17 @@ import { spawnSync } from 'node:child_process';
 
 function parseArgs(argv) {
 	let checkMode = false;
+	let ensureGeneratedContracts = false;
 	let skipNpmCi = false;
 	let logPrefix = '[ui:bootstrap]';
 	for (let index = 2; index < argv.length; index += 1) {
 		const arg = argv[index];
 		if (arg === '--check') {
 			checkMode = true;
+			continue;
+		}
+		if (arg === '--ensure-generated-contracts') {
+			ensureGeneratedContracts = true;
 			continue;
 		}
 		if (arg === '--skip-npm-ci') {
@@ -28,8 +33,15 @@ function parseArgs(argv) {
 		}
 		throw new Error(`Unknown argument: ${arg}`);
 	}
-	return { checkMode, skipNpmCi, logPrefix };
+	return { checkMode, ensureGeneratedContracts, skipNpmCi, logPrefix };
 }
+
+const GENERATED_CONTRACT_DERIVATIVES = [
+	'src/generated/http_api_contracts.ts',
+	'src/contracts/ws_payload_types.ts',
+	'src/contracts/ws_payload_schema.generated.ts',
+	'src/constants.ts',
+];
 
 function sha256File(filePath) {
 	return createHash('sha256').update(readFileSync(filePath)).digest('hex');
@@ -74,8 +86,35 @@ function ensureUiBootstrap(uiDir, status, logPrefix) {
 	writeFileSync(status.lockHashFile, `${status.lockHash}\n`, 'utf8');
 }
 
+function missingGeneratedContracts(uiDir) {
+	return GENERATED_CONTRACT_DERIVATIVES.filter(
+		(relPath) => !existsSync(resolve(uiDir, relPath)),
+	);
+}
+
+function ensureGeneratedContractsPresent(uiDir, logPrefix) {
+	if (missingGeneratedContracts(uiDir).length === 0) {
+		return;
+	}
+	console.log(
+		`${logPrefix} Running npm run sync:generated-contracts because generated UI contract derivatives are missing.`,
+	);
+	const result = spawnSync('npm', ['run', 'sync:generated-contracts'], {
+		cwd: uiDir,
+		stdio: 'inherit',
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		throw new Error(
+			`npm run sync:generated-contracts failed with exit code ${result.status ?? 1}`,
+		);
+	}
+}
+
 function main() {
-	const { checkMode, skipNpmCi, logPrefix } = parseArgs(process.argv);
+	const { checkMode, ensureGeneratedContracts, skipNpmCi, logPrefix } = parseArgs(process.argv);
 	const uiDir = process.cwd();
 	const status = uiBootstrapStatus(uiDir, skipNpmCi);
 	if (checkMode) {
@@ -90,6 +129,9 @@ function main() {
 		return;
 	}
 	ensureUiBootstrap(uiDir, status, logPrefix);
+	if (ensureGeneratedContracts) {
+		ensureGeneratedContractsPresent(uiDir, logPrefix);
+	}
 }
 
 try {


### PR DESCRIPTION
## What changed
- add npm run setup:generated-contracts as the explicit fresh-checkout setup command
- extend the shared UI bootstrap helper so it materializes only missing UI derivative files by reusing npm run sync:generated-contracts
- run that setup step in backend-contract-drift before the authoritative non-mutating contract check
- update README guidance and hygiene coverage for the new setup path

## Why
- UI derivative files are intentionally gitignored, but fresh checkouts still need them on disk before direct UI imports and contract-drift checks can run
- #3303 needs --check to stay non-mutating, so setup has to happen in a separate explicit path
- this gives both humans and CI one clean way to materialize missing derivatives without weakening the authoritative check

## Validation
- python -m pytest -q apps/server/tests/hygiene/test_ui_bootstrap_helper.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
- cd apps/ui && npm run setup:generated-contracts
- make ui-typecheck
- cd apps/ui && npm run build
- make lint

## Risks / tradeoffs / edge cases
- backend-contract-drift now does one extra setup step on fresh checkouts, but it is a cheap no-op once the derivative files exist
- the setup command only fills missing derivatives; stale derivatives still fail the authoritative check on purpose

## Follow-up
- after this merges, rebase PR #3345 for #3303 and take it green

Closes #3304