### PR TITLE
Add a top-level ui-test make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts regen-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -122,3 +122,6 @@ ui-lint: ## Run UI lint checks
 
 ui-typecheck: ## Materialize UI-derived contracts, then run lint and TypeScript type checking
 	cd $(UI_DIR) && npm run sync:generated-contracts && npm run lint && npm run lint:deps && npm run lint:unused && npm run typecheck
+
+ui-test: ## Run UI unit tests
+	cd $(UI_DIR) && npm run test:unit

--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -17,6 +17,7 @@ _MAKEFILE = REPO_ROOT / "Makefile"
 _DOCKER_DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
 _UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
 _UI_DEV_SCRIPT = REPO_ROOT / "apps" / "ui" / "dev-docker.sh"
+_UI_README = REPO_ROOT / "apps" / "ui" / "README.md"
 
 
 def _package_scripts() -> dict[str, str]:
@@ -108,6 +109,15 @@ def test_make_dev_target_wraps_docker_dev_compose() -> None:
     assert (
         "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build" in makefile_text
     )
+
+
+def test_makefile_exposes_ui_unit_test_target_and_readme_pointer() -> None:
+    makefile_text = _MAKEFILE.read_text(encoding="utf-8")
+    readme_text = _UI_README.read_text(encoding="utf-8")
+
+    assert "ui-test: ## Run UI unit tests" in makefile_text
+    assert "cd $(UI_DIR) && npm run test:unit" in makefile_text
+    assert "make ui-test                 # same unit suite from the repo root" in readme_text
 
 
 def test_docker_dev_ui_service_uses_guarded_dev_script_and_healthcheck() -> None:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -507,6 +507,7 @@ browser, navigation, or visual snapshots.
 ```bash
 npm run test:unit            # run the Vitest unit suite once
 npm run test:unit:watch      # watch mode during local iteration
+make ui-test                 # same unit suite from the repo root
 ```
 
 Vitest auto-discovers `tests/**/*.spec.ts` and excludes the Playwright-owned


### PR DESCRIPTION
## What changed
- add make ui-test as a thin repo-root wrapper over npm run test:unit
- keep make test unchanged and backend-focused
- mention the new target in the existing UI test-command section
- add a focused hygiene test that pins the Makefile target and README pointer

## Why
- UI unit tests already exist, but they were only discoverable through npm scripts inside apps/ui
- a repo-root make target makes local validation more symmetric with other top-level commands without broadening make test

## Validation
- python -m pytest -q apps/server/tests/hygiene/test_dev_workflow.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
- make ui-test
- make lint

## Risks / tradeoffs / edge cases
- this adds only a thin wrapper; the underlying UI test ownership stays on npm run test:unit
- make test stays backend-only on purpose, so callers who want UI unit coverage still need the explicit ui-test target

Closes #3305