### PR TITLE
Run UI unit tests for changed UI source files

### DIFF
--- a/apps/server/tests/hygiene/test_run_changed.py
+++ b/apps/server/tests/hygiene/test_run_changed.py
@@ -94,6 +94,25 @@ def test_plan_commands_combines_docs_ui_and_hygiene_checks() -> None:
     )
 
 
+def test_plan_commands_runs_ui_unit_tests_for_changed_ui_source_files() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(("apps/ui/src/ws_payload_validator.ts",))
+
+    assert commands == (
+        module.PlannedCommand("ui-test", ("make", "ui-test")),
+        module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),
+    )
+
+
+def test_plan_commands_keeps_non_source_ui_changes_on_typecheck_only() -> None:
+    module = _load_run_changed_module()
+
+    commands = module._plan_commands(("apps/ui/package.json",))
+
+    assert commands == (module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),)
+
+
 def test_plan_commands_falls_back_to_make_test_for_unmapped_backend_changes() -> None:
     module = _load_run_changed_module()
 

--- a/tools/tests/run_changed.py
+++ b/tools/tests/run_changed.py
@@ -127,6 +127,7 @@ def _mirrored_backend_test_target(path: str) -> str | None:
 def _plan_commands(changed_files: tuple[str, ...]) -> tuple[PlannedCommand, ...]:
     docs_changed = False
     ui_changed = False
+    ui_unit_test_changed = False
     backend_fallback = False
     pytest_targets: set[str] = set()
 
@@ -150,6 +151,8 @@ def _plan_commands(changed_files: tuple[str, ...]) -> tuple[PlannedCommand, ...]
 
         if normalized.startswith("apps/ui/"):
             ui_changed = True
+            if normalized.startswith("apps/ui/src/"):
+                ui_unit_test_changed = True
             continue
 
         if normalized in HYGIENE_TRIGGER_PATHS or normalized.startswith(
@@ -164,6 +167,8 @@ def _plan_commands(changed_files: tuple[str, ...]) -> tuple[PlannedCommand, ...]
     commands: list[PlannedCommand] = []
     if docs_changed:
         commands.append(PlannedCommand("docs-lint", ("make", "docs-lint")))
+    if ui_unit_test_changed:
+        commands.append(PlannedCommand("ui-test", ("make", "ui-test")))
     if ui_changed:
         commands.append(PlannedCommand("ui-typecheck", ("make", "ui-typecheck")))
     if backend_fallback:


### PR DESCRIPTION
## What changed
- teach tools/tests/run_changed.py to add make ui-test when changed files include apps/ui/src/**
- keep make ui-typecheck for broader UI changes
- add focused planner tests for the new source-file case and the existing non-source UI case

## Why
- changed-file validation already understands UI changes, but it only ran make ui-typecheck
- source changes under apps/ui/src should also hit the fast UI unit suite so frontend regressions are less likely to slip through the heuristic runner
- non-source UI changes should not pay that extra cost unnecessarily

## Validation
- python -m pytest -q apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
- make lint

## Risks / tradeoffs / edge cases
- only apps/ui/src/** changes trigger ui-test; broader apps/ui changes still get ui-typecheck only by design
- this keeps the changed-file runner fast, but future UI seams outside src may need an explicit trigger if the policy expands

Closes #3306