### PR TITLE
Upload UI smoke failure artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,15 @@ jobs:
           npx playwright install chromium
           npm run test:smoke
 
+      - name: Upload UI smoke test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-smoke-test-artifacts
+          path: apps/ui/test-results/playwright-smoke/
+          if-no-files-found: ignore
+          retention-days: 5
+
   ui-build-artifact:
     name: UI build artifact
     needs:

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -7,11 +7,14 @@ import json
 import re
 import shlex
 
+import yaml
+
 from tests._paths import REPO_ROOT
 
 _UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
 _SMOKE_CONFIG = REPO_ROOT / "apps" / "ui" / "playwright.smoke.config.ts"
 _UI_TESTS_DIR = REPO_ROOT / "apps" / "ui" / "tests"
+_CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _EXPECTED_CORE_SMOKE_SPECS = {
     "smoke.bootstrap.spec.ts",
     "smoke.settings.spec.ts",
@@ -49,6 +52,19 @@ def _smoke_workers_env_contract() -> tuple[str, str]:
     match = re.search(r'process\.env\.(\w+)\s*\?\?\s*"([^"]+)"', config_text)
     assert match is not None
     return str(match.group(1)), str(match.group(2))
+
+
+def _smoke_output_dir() -> str:
+    config_text = _SMOKE_CONFIG.read_text()
+    match = re.search(r'outputDir:\s*"([^"]+)"', config_text)
+    assert match is not None
+    return str(match.group(1))
+
+
+def _ci_workflow() -> dict[str, object]:
+    loaded = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
 
 
 def _resolved_smoke_specs() -> set[str]:
@@ -89,3 +105,31 @@ def test_core_ui_smoke_specs_exist() -> None:
 
     missing = _EXPECTED_CORE_SMOKE_SPECS - smoke_specs
     assert not missing, f"Missing core smoke specs: {sorted(missing)}"
+
+
+def test_ui_smoke_failure_artifact_contract() -> None:
+    workflow = _ci_workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    ui_smoke_job = jobs["ui-smoke"]
+    assert isinstance(ui_smoke_job, dict)
+    steps = ui_smoke_job["steps"]
+    assert isinstance(steps, list)
+
+    smoke_config = _SMOKE_CONFIG.read_text(encoding="utf-8")
+    assert 'trace: "retain-on-failure"' in smoke_config
+    assert 'screenshot: "only-on-failure"' in smoke_config
+    assert 'video: "retain-on-failure"' in smoke_config
+    assert _smoke_output_dir() == "test-results/playwright-smoke"
+
+    upload_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Upload UI smoke test artifacts"
+    )
+    assert upload_step["if"] == "failure()"
+    assert upload_step["uses"] == "actions/upload-artifact@v7"
+    assert upload_step["with"]["name"] == "ui-smoke-test-artifacts"
+    assert upload_step["with"]["path"] == f"apps/ui/{_smoke_output_dir()}/"
+    assert upload_step["with"]["if-no-files-found"] == "ignore"
+    assert upload_step["with"]["retention-days"] == 5

--- a/apps/ui/playwright.smoke.config.ts
+++ b/apps/ui/playwright.smoke.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   testDir: "tests",
   // Smoke selection lives here so package.json and CI stay on one contract.
   testMatch: ["smoke*.spec.ts"],
+  outputDir: "test-results/playwright-smoke",
   timeout: 15_000,
   workers:
     Number.isFinite(configuredSmokeWorkers) && configuredSmokeWorkers > 0
@@ -16,6 +17,9 @@ export default defineConfig({
       : 1,
   use: {
     baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   webServer: {
     command: "npm run dev -- --host 127.0.0.1 --port 4173 --strictPort",


### PR DESCRIPTION
## What changed
- configure the Playwright smoke runner to retain trace, screenshot, and video output on failure in a dedicated smoke artifact directory
- upload that smoke artifact directory from the CI ui-smoke job only when the smoke run fails
- add a hygiene test that pins the smoke config and CI workflow to the same artifact path and retention contract

## Why
- UI unit failures already expose artifacts in CI, but Playwright smoke failures did not
- browser failures are much slower to diagnose without traces or screenshots from the failing run
- failure-only retention keeps the debugging signal without cluttering green runs or growing artifact storage unnecessarily

## Validation
- make format
- python -m pytest -q apps/server/tests/hygiene/test_ui_smoke_contract.py
- make ui-typecheck
- cd apps/ui && npm run test:smoke
- make lint

## Risks / tradeoffs / edge cases
- failed smoke runs now spend some extra time and disk writing Playwright diagnostics, but only on failure
- the workflow uploads the dedicated smoke artifact directory only when files exist, so green runs remain unchanged
- retention is intentionally short to keep CI storage modest

Closes #3308