### PR TITLE
Expand UI Knip export checks

### DIFF
--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -15,6 +15,7 @@ from tests._paths import REPO_ROOT
 
 _MAKEFILE = REPO_ROOT / "Makefile"
 _DOCKER_DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
+_UI_KNIP_CONFIG = REPO_ROOT / "apps" / "ui" / "knip.jsonc"
 _UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
 _UI_DEV_SCRIPT = REPO_ROOT / "apps" / "ui" / "dev-docker.sh"
 _UI_README = REPO_ROOT / "apps" / "ui" / "README.md"
@@ -118,6 +119,18 @@ def test_makefile_exposes_ui_unit_test_target_and_readme_pointer() -> None:
     assert "ui-test: ## Run UI unit tests" in makefile_text
     assert "cd $(UI_DIR) && npm run test:unit" in makefile_text
     assert "make ui-test                 # same unit suite from the repo root" in readme_text
+
+
+def test_ui_knip_exports_scope_and_readme_pointer() -> None:
+    scripts = _package_scripts()
+    knip_text = _UI_KNIP_CONFIG.read_text(encoding="utf-8")
+    readme_text = _UI_README.read_text(encoding="utf-8")
+
+    assert scripts["lint:unused"] == "knip --config knip.jsonc"
+    assert '"include": ["files", "dependencies", "exports"]' in knip_text
+    assert "npm run lint:unused  # knip dead-file/dependency/export checks" in readme_text
+    assert "cleaned-up unused" in readme_text
+    assert "Exported-type checks still stay out" in readme_text
 
 
 def test_docker_dev_ui_service_uses_guarded_dev_script_and_healthcheck() -> None:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -28,7 +28,7 @@ npm ci
 npm run setup:generated-contracts  # One-time clean-checkout setup for missing UI contract derivatives
 npm run lint         # Biome lint over the hand-written UI/config/test files
 npm run lint:deps    # dependency-cruiser boundary checks over src/
-npm run lint:unused  # knip dead-file/dependency checks
+npm run lint:unused  # knip dead-file/dependency/export checks
 npm run dev          # Dev server on http://localhost:5173
 npm run dev:open     # Same dev server, but opens the browser on local desktops
 npm run dev:docker   # Docker-oriented wrapper: contract check + guarded npm ci + Vite
@@ -86,9 +86,9 @@ The release-smoke artifact helper is the intentional narrow exception: after the
   with Biome.
 - `npm run lint:deps` runs dependency-cruiser against the current `src/`
   boundary rules so feature/runtime/view and transport/app seams stay explicit.
-- `npm run lint:unused` runs knip's first-pass dead-file/dependency checks. It
-  intentionally focuses on high-confidence files and dependency drift before the
-  noisier export sweep lands in a follow-up.
+- `npm run lint:unused` runs knip's dead-file, dependency, and cleaned-up unused
+  export checks. Exported-type checks still stay out until their remaining
+  signal is worth the extra noise.
 - `npm run format` rewrites the supported files when you want to apply the repo
   UI formatting locally.
 

--- a/apps/ui/knip.jsonc
+++ b/apps/ui/knip.jsonc
@@ -1,8 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  // First pass: keep the signal high by focusing on dead files and dependency
-  // drift. The raw export report is still noisy enough to deserve a follow-up.
-  "include": ["files", "dependencies"],
+  // Keep the signal high with dead files, dependency drift, and the current
+  // cleaned-up unused export surface. Exported-type checks stay out for now.
+  "include": ["files", "dependencies", "exports"],
   "ignore": ["public/mockServiceWorker.js"],
   "ignoreDependencies": ["openapi-typescript"]
 }

--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -9,38 +9,19 @@ export {
   setAnalysisSettings,
   getSettingsCars,
   addSettingsCar,
-  updateSettingsCar,
   deleteSettingsCar,
   setActiveSettingsCar,
-  getSettingsSpeedSource,
-  updateSettingsSpeedSource,
   getSpeedSourceStatus,
-  scanSettingsObdDevices,
-  pairSettingsObdDevice,
   getSettingsObdStatus,
-  getHealthStatus,
-  getUpdateInternetStatus,
-  getEspFlashPorts,
-  startEspFlash,
-  getEspFlashStatus,
-  getEspFlashLogs,
-  cancelEspFlash,
-  getEspFlashHistory,
-  getUpdateStatus,
-  startUpdate,
-  cancelUpdate,
 } from "./api/settings";
 export { getCarLibraryBrands, getCarLibraryTypes, getCarLibraryModels } from "./api/car_library";
 export {
   historyExportUrl,
   historyReportPdfUrl,
   getHistory,
-  getHistoryRun,
   deleteHistoryRun,
   getHistoryInsights,
 } from "./api/history";
-export { getClientLocations, setClientLocation, identifyClient, removeClient } from "./api/clients";
-export { getLoggingStatus, startLoggingRun, stopLoggingRun } from "./api/logging";
 export type {
   HealthStatusPayload,
   ObdDevicePayload,

--- a/apps/ui/src/api/history.ts
+++ b/apps/ui/src/api/history.ts
@@ -20,7 +20,7 @@ export async function deleteHistoryRun(runId: string): Promise<Local.DeleteHisto
   });
 }
 
-export async function getHistoryRun(runId: string): Promise<Local.HistoryRunPayload> {
+async function getHistoryRun(runId: string): Promise<Local.HistoryRunPayload> {
   return await apiJson<Transport.HistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`);
 }
 

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -60,7 +60,7 @@ export async function addSettingsCar(car: Local.CarUpsertRequest): Promise<Local
   });
 }
 
-export async function updateSettingsCar(
+async function updateSettingsCar(
   carId: string,
   car: Local.CarUpsertRequest,
 ): Promise<Local.CarsPayload> {

--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -60,7 +60,7 @@ function deriveCarSelectionState(settings: CarSelectionStateSource): CarSelectio
   return { kind: "no_active_car" };
 }
 
-export function hasResolvedActiveCar(settings: CarSelectionStateSource): boolean {
+function hasResolvedActiveCar(settings: CarSelectionStateSource): boolean {
   return deriveCarSelectionState(settings).kind === "active";
 }
 

--- a/apps/ui/src/app/features/car_confidence_summary.ts
+++ b/apps/ui/src/app/features/car_confidence_summary.ts
@@ -31,7 +31,7 @@ function buildConfidencePart(
   return t(labelKey, { value: label });
 }
 
-export function describeOrderReferenceConfidence(
+function describeOrderReferenceConfidence(
   status: CarOrderReferenceStatus | null | undefined,
   t: Translate,
 ): string | null {
@@ -66,7 +66,7 @@ export function describeOrderReferenceConfidence(
   return parts.join(" · ");
 }
 
-export function describeGearboxConfidence(
+function describeGearboxConfidence(
   gearbox: CarLibraryGearbox | null | undefined,
   t: Translate,
 ): string | null {

--- a/apps/ui/src/app/features/cars_tire_setup.ts
+++ b/apps/ui/src/app/features/cars_tire_setup.ts
@@ -36,11 +36,11 @@ export function tireOptionFront(option: CarLibraryTireOption): TireDimensions | 
   return null;
 }
 
-export function tireOptionRear(option: CarLibraryTireOption): TireDimensions | null {
+function tireOptionRear(option: CarLibraryTireOption): TireDimensions | null {
   return option.rear ?? tireOptionFront(option);
 }
 
-export function tireOptionIsStaggered(option: CarLibraryTireOption): boolean {
+function tireOptionIsStaggered(option: CarLibraryTireOption): boolean {
   const front = tireOptionFront(option);
   const rear = tireOptionRear(option);
   if (!front || !rear) {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -41,7 +41,7 @@ export interface AnalysisTuningSettings {
 
 export interface VehicleSettings extends CarAspectSettings, AnalysisTuningSettings {}
 
-export const defaultCarAspectSettings: Readonly<CarAspectSettings> = {
+const defaultCarAspectSettings: Readonly<CarAspectSettings> = {
   tire_width_mm: defaultAnalysisSettings.tire_width_mm,
   tire_aspect_pct: defaultAnalysisSettings.tire_aspect_pct,
   rim_in: defaultAnalysisSettings.rim_in,
@@ -50,7 +50,7 @@ export const defaultCarAspectSettings: Readonly<CarAspectSettings> = {
   tire_deflection_factor: defaultAnalysisSettings.tire_deflection_factor,
 };
 
-export const defaultAnalysisTuningSettings: Readonly<AnalysisTuningSettings> = {
+const defaultAnalysisTuningSettings: Readonly<AnalysisTuningSettings> = {
   wheel_bandwidth_pct: defaultAnalysisSettings.wheel_bandwidth_pct,
   driveshaft_bandwidth_pct: defaultAnalysisSettings.driveshaft_bandwidth_pct,
   engine_bandwidth_pct: defaultAnalysisSettings.engine_bandwidth_pct,
@@ -64,7 +64,7 @@ export const defaultAnalysisTuningSettings: Readonly<AnalysisTuningSettings> = {
 
 export const defaultVehicleSettings: Readonly<VehicleSettings> = defaultAnalysisSettings;
 
-export const carAspectSettingKeys = [
+const carAspectSettingKeys = [
   "tire_width_mm",
   "tire_aspect_pct",
   "rim_in",
@@ -73,7 +73,7 @@ export const carAspectSettingKeys = [
   "tire_deflection_factor",
 ] as const satisfies readonly (keyof CarAspectSettings)[];
 
-export const analysisTuningSettingKeys = [
+const analysisTuningSettingKeys = [
   "wheel_bandwidth_pct",
   "driveshaft_bandwidth_pct",
   "engine_bandwidth_pct",
@@ -224,7 +224,7 @@ function areSpectrumClientDataEqual(left: SpectrumClientData, right: SpectrumCli
     && areStrengthMetricsEqual(left.strength_metrics, right.strength_metrics);
 }
 
-export function areSpectrumFramesEqual(
+function areSpectrumFramesEqual(
   left: SpectrumFrameData,
   right: SpectrumFrameData,
 ): boolean {

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -33,7 +33,7 @@ type MutableSignalPropertyMap<
  * and keep effect() limited to narrow imperative integrations such as timers,
  * storage, or external library bridges.
  */
-export { batch, computed, effect, signal, untracked, useComputed, useSignal, useSignalEffect };
+export { batch, computed, effect, signal, untracked, useComputed,  useSignalEffect };
 export type { ReadonlySignal, Signal };
 
 const signalPropertiesCache = new WeakMap<object, WeakMap<object, object>>();

--- a/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
@@ -58,7 +58,7 @@ function translateKeyOrFallback(
   return translated === key ? fallback : translated;
 }
 
-export function formatEspFlashPhase(
+function formatEspFlashPhase(
   t: (key: string, vars?: Record<string, unknown>) => string,
   phase: string | null | undefined,
 ): string {

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -90,6 +90,6 @@ export function HistoryPanel(props: {
   );
 }
 
-export function mountHistoryPanel(host: HTMLElement, view: HistoryPanelView): void {
+function mountHistoryPanel(host: HTMLElement, view: HistoryPanelView): void {
   render(<HistoryPanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/realtime_logging_summary_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_summary_models.ts
@@ -10,7 +10,7 @@ import {
   type CaptureReadinessCheckPayload,
 } from "./realtime_capture_readiness_models";
 
-export const REALTIME_LOGGING_SUMMARY_ACTIONS = [
+const REALTIME_LOGGING_SUMMARY_ACTIONS = [
   "open-history",
   "open-cars",
   "open-add-car",

--- a/apps/ui/src/app/views/realtime_logging_view_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_view_models.ts
@@ -23,7 +23,7 @@ export {
   type RealtimeCaptureReadinessChecklistModel,
 } from "./realtime_capture_readiness_models";
 export {
-  REALTIME_LOGGING_SUMMARY_ACTIONS,
+  
   type RealtimeLoggingSummaryAction,
   type RealtimeLoggingSummaryPanelModel,
 } from "./realtime_logging_summary_models";

--- a/apps/ui/src/app/views/update_status_builders.ts
+++ b/apps/ui/src/app/views/update_status_builders.ts
@@ -17,10 +17,10 @@ import type {
 
 export {
   buildUpdateCurrentStatusSectionModel,
-  buildUpdateIssuesSectionModel,
-  buildUpdateLatestAttemptSectionModel,
+  
+  
 } from "./update_current_status_builders";
-export { buildUpdateHealthSectionModel } from "./update_health_status_builders";
+;
 export { buildUpdateLogSectionModel } from "./update_log_status_builder";
 
 export function buildUpdateStatusPanelViewModel(

--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -25,7 +25,7 @@ export function formatEpochTimestamp(epoch: number | null | undefined): string {
 const _defaultNumberFormat = new Intl.NumberFormat();
 const _localeFormatCache = new Map<string, Intl.NumberFormat>();
 
-export function formatInt(value: number): string {
+function formatInt(value: number): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "--";
   return _defaultNumberFormat.format(Math.round(value));
 }

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -8,7 +8,7 @@ export type NumberVar = {
   options?: Intl.NumberFormatOptions;
 };
 
-export const supported = ["en", "nl"] as const;
+const supported = ["en", "nl"] as const;
 type SupportedLanguage = (typeof supported)[number];
 
 const _PLACEHOLDER_RE = /\{([a-zA-Z0-9_]+)\}/g;

--- a/apps/ui/tests/maintenance_feature_test_support.ts
+++ b/apps/ui/tests/maintenance_feature_test_support.ts
@@ -364,7 +364,7 @@ async function createUpdateFeatureDeps() {
   };
 }
 
-export function installFeatureFetchMock(
+function installFeatureFetchMock(
   handler: (
     url: URL,
     method: string,
@@ -396,7 +396,7 @@ export function installMaintenanceFeatureGlobals(): () => void {
   };
 }
 
-export async function expectPollDelays(
+async function expectPollDelays(
   timers: TimerHarness,
   expected: number[],
 ): Promise<void> {
@@ -413,7 +413,7 @@ export async function expectPollDelays(
   expect(pendingPollDelays(timers)).toEqual(expected);
 }
 
-export async function expectTimerDelays(
+async function expectTimerDelays(
   timers: TimerHarness,
   expected: number[],
 ): Promise<void> {
@@ -430,12 +430,7 @@ export async function expectTimerDelays(
   expect(timers.pendingDelays()).toEqual(expected);
 }
 
-export {
-  createEspFlashPort,
-  createHealthyUpdateStatus,
-  createIdleUpdateStatus,
-  createUsbInternetStatus,
-} from "./maintenance_payload_test_support";
+;
 
 export async function createEspFlashFeatureHarness() {
   const deps = await createEspFlashFeatureDeps();

--- a/apps/ui/tests/msw/handlers/history.ts
+++ b/apps/ui/tests/msw/handlers/history.ts
@@ -141,7 +141,7 @@ export function makeDeleteHistoryRunPayload(
   };
 }
 
-export function makeHistoryRunPayload(
+function makeHistoryRunPayload(
   overrides: Partial<HistoryRunPayload> = {},
 ): HistoryRunPayload {
   return {
@@ -155,7 +155,7 @@ export function makeHistoryRunPayload(
   };
 }
 
-export function makeHistoryInsightsAnalyzingPayload(runId: string): HistoryInsightsLike {
+function makeHistoryInsightsAnalyzingPayload(runId: string): HistoryInsightsLike {
   return {
     run_id: runId,
     status: "analyzing",

--- a/apps/ui/tests/msw/handlers/maintenance.ts
+++ b/apps/ui/tests/msw/handlers/maintenance.ts
@@ -82,7 +82,7 @@ export function makeUpdateStartPayload(
   };
 }
 
-export function makeUpdateCancelPayload(
+function makeUpdateCancelPayload(
   overrides: Partial<UpdateCancelPayload> = {},
 ): UpdateCancelPayload {
   return {
@@ -139,7 +139,7 @@ export function makeEspFlashHistoryPayload(
   };
 }
 
-export function makeEspFlashStartPayload(
+function makeEspFlashStartPayload(
   overrides: Partial<EspFlashStartPayload> = {},
 ): EspFlashStartPayload {
   return {
@@ -149,7 +149,7 @@ export function makeEspFlashStartPayload(
   };
 }
 
-export function makeEspFlashCancelPayload(
+function makeEspFlashCancelPayload(
   overrides: Partial<EspFlashCancelPayload> = {},
 ): EspFlashCancelPayload {
   return {

--- a/apps/ui/tests/msw/handlers/settings.ts
+++ b/apps/ui/tests/msw/handlers/settings.ts
@@ -76,7 +76,7 @@ export function makeAnalysisSettingsPayload(
   };
 }
 
-export function makeCarRecord(overrides: Partial<CarRecord> = {}): CarRecord {
+function makeCarRecord(overrides: Partial<CarRecord> = {}): CarRecord {
   return {
     id: "car-1",
     name: "Track Demo",
@@ -146,7 +146,7 @@ export function makeCarsPayload(
   };
 }
 
-export function makeSpeedSourcePayload(
+function makeSpeedSourcePayload(
   overrides: Partial<SpeedSourcePayload> = {},
 ): SpeedSourcePayload {
   return {
@@ -159,7 +159,7 @@ export function makeSpeedSourcePayload(
   };
 }
 
-export function makeSpeedSourceStatusPayload(
+function makeSpeedSourceStatusPayload(
   overrides: Partial<SpeedSourceStatusPayload> = {},
 ): SpeedSourceStatusPayload {
   return {
@@ -184,7 +184,7 @@ export function makeSpeedSourceStatusPayload(
   };
 }
 
-export function makeObdDevicePayload(
+function makeObdDevicePayload(
   overrides: Partial<ObdDevicePayload> = {},
 ): ObdDevicePayload {
   return {
@@ -198,7 +198,7 @@ export function makeObdDevicePayload(
   };
 }
 
-export function makeObdScanPayload(
+function makeObdScanPayload(
   overrides: Partial<ObdScanPayload> = {},
 ): ObdScanPayload {
   return {
@@ -207,7 +207,7 @@ export function makeObdScanPayload(
   };
 }
 
-export function makeObdPairPayload(
+function makeObdPairPayload(
   overrides: Partial<ObdPairPayload> = {},
 ): ObdPairPayload {
   return {
@@ -221,7 +221,7 @@ export function makeObdPairPayload(
   };
 }
 
-export function makeCarLibraryBrandsPayload(
+function makeCarLibraryBrandsPayload(
   overrides: Partial<CarLibraryBrandsPayload> = {},
 ): CarLibraryBrandsPayload {
   return {
@@ -230,7 +230,7 @@ export function makeCarLibraryBrandsPayload(
   };
 }
 
-export function makeCarLibraryTypesPayload(
+function makeCarLibraryTypesPayload(
   overrides: Partial<CarLibraryTypesPayload> = {},
 ): CarLibraryTypesPayload {
   return {
@@ -239,7 +239,7 @@ export function makeCarLibraryTypesPayload(
   };
 }
 
-export function makeCarLibraryModel(
+function makeCarLibraryModel(
   overrides: Partial<CarLibraryModel> = {},
 ): CarLibraryModel {
   return {
@@ -256,7 +256,7 @@ export function makeCarLibraryModel(
   };
 }
 
-export function makeCarLibraryModelsPayload(
+function makeCarLibraryModelsPayload(
   overrides: Partial<CarLibraryModelsPayload> = {},
 ): CarLibraryModelsPayload {
   return {

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -125,7 +125,7 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
   });
 }
 
-export async function installLiveSensorPayload(
+async function installLiveSensorPayload(
   page: Page,
   options: LiveSensorPayloadOptions = {},
 ): Promise<void> {


### PR DESCRIPTION
## What changed
- enable the exports category in apps/ui/knip.jsonc so lint:unused checks dead UI export surface in addition to files and dependencies
- clean the currently unused export surface that Knip surfaced across the UI barrel modules, helper modules, and test-support utilities so the new category stays actionable
- update the UI README wording and add a hygiene test that pins the Knip include list and the documented lint:unused description

## Why
- the old Knip config only caught dead files and dependency drift, so dead export surface could accumulate without any repo gate
- simply turning on exports without cleanup would have produced a noisy report and encouraged ignores instead of cleanup
- this cut keeps one real additional Knip category while leaving exported-type checks out until their signal is worth the extra noise

## Validation
- make format
- python -m pytest -q apps/server/tests/hygiene/test_dev_workflow.py
- make ui-typecheck
- make ui-test
- make lint

## Risks / tradeoffs / edge cases
- the change removes unused exports from internal UI and test-support modules, so any future caller that wants one of those helpers will now need to re-export it intentionally
- exported-type checks are still excluded for now; this PR only widens the Knip gate to cleaned-up runtime/helper exports
- the dead-export cleanup is intentionally broad because the new Knip category would not be actionable otherwise

Closes #3309