### PR TITLE
Centralize frontend logging behind ui logger

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,4 +1,5 @@
 import type { AdaptedPayload } from "../../transport/live_models";
+import { uiLogger } from "../../ui_logger";
 import {
   applyLivePayloadUpdate,
   type AppState,
@@ -84,10 +85,10 @@ export class UiLiveTransportController {
     this.disposeWsStateSync = disposers.wsStateSync;
     this.disposeSelectionSync = disposers.selectionSync;
     void loadLiveTransportRuntime().catch((error) => {
-      console.error("[VibeSensor] Failed to preload websocket transport runtime.", error);
+      uiLogger.error("[VibeSensor] Failed to preload websocket transport runtime.", error);
     });
     void this.preloadPayloadAdapter().catch((error) => {
-      console.error("[VibeSensor] Failed to preload live payload adapter.", error);
+      uiLogger.error("[VibeSensor] Failed to preload live payload adapter.", error);
     });
   }
 
@@ -189,16 +190,16 @@ export class UiLiveTransportController {
     }
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
     void this.preloadPayloadAdapter().catch((error) => {
-      console.error("[VibeSensor] Failed to preload live payload adapter.", error);
+      uiLogger.error("[VibeSensor] Failed to preload live payload adapter.", error);
     });
     if (isDemoMode) {
       void this.startDemoMode().catch((error) => {
-        console.error("[VibeSensor] Failed to start demo transport mode.", error);
+        uiLogger.error("[VibeSensor] Failed to start demo transport mode.", error);
       });
       return;
     }
     void this.connectWs().catch((error) => {
-      console.error("[VibeSensor] Failed to load websocket transport runtime.", error);
+      uiLogger.error("[VibeSensor] Failed to load websocket transport runtime.", error);
     });
   }
 

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -6,6 +6,7 @@ import {
   setSettingsLanguage,
   setSettingsSpeedUnit,
 } from "../../api/settings";
+import { uiLogger } from "../../ui_logger";
 import { serverStateQueryKeys } from "../features/server_state_query_keys";
 import type { SettingsFeedbackMessage } from "../views/settings_feedback";
 import type { ShellState } from "../ui_app_state";
@@ -109,7 +110,7 @@ export function createUiShellPreferencesModule(
       ) {
         await applyLanguageValue(languageResult.value.language);
       } else if (languageResult.status === "rejected") {
-        console.warn(
+        uiLogger.warn(
           "Failed to load persisted language",
           languageResult.reason,
         );
@@ -120,7 +121,7 @@ export function createUiShellPreferencesModule(
       ) {
         applySpeedUnitValue(speedUnitResult.value.speed_unit);
       } else if (speedUnitResult.status === "rejected") {
-        console.warn(
+        uiLogger.warn(
           "Failed to load persisted speed unit",
           speedUnitResult.reason,
         );

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -1,4 +1,5 @@
 import type { UiStartupFeaturePorts } from "./ui_startup_feature_ports";
+import { uiLogger } from "../../ui_logger";
 
 type StartupShell = {
   start(defaultViewId: string): void;
@@ -49,7 +50,7 @@ export class UiStartupCoordinator {
     this.features = deps.features;
     this.defaultViewId = deps.defaultViewId;
     this.isDemoMode = new URLSearchParams(window.location.search).has("demo");
-    this.warn = deps.warn ?? ((message, error) => console.warn(message, error));
+    this.warn = deps.warn ?? uiLogger.warn;
   }
 
   start(): void {

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -19,6 +19,7 @@ import { preloadRealtimeLiveOverviewPanel } from "./views/realtime_live_overview
 import { preloadRealtimeLoggingPanel } from "./views/realtime_logging_panel_lazy";
 import { preloadSpectrumPanelHost } from "./views/spectrum_panel_host_lazy";
 import { setUiLanguage } from "./ui_i18n";
+import { uiLogger } from "../ui_logger";
 
 export interface UiAppRuntime {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
@@ -121,7 +122,7 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
           resolvedBootRuntime?.start();
         })
         .catch((error) => {
-          console.error("[VibeSensor] Failed to start UI boot runtime.", error);
+          uiLogger.error("[VibeSensor] Failed to start UI boot runtime.", error);
         });
     },
   };

--- a/apps/ui/src/app/views/history_lazy_view.tsx
+++ b/apps/ui/src/app/views/history_lazy_view.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
+import { uiLogger } from "../../ui_logger";
 import type { HistoryPanelView } from "./history_table_view";
 
 export interface HistoryLazyViewProps {
@@ -41,7 +42,7 @@ export default function HistoryLazyView(props: HistoryLazyViewProps) {
       })
       .catch((error) => {
         if (!cancelled) {
-          console.error("[VibeSensor] Failed to load history view.", error);
+          uiLogger.error("[VibeSensor] Failed to load history view.", error);
         }
       });
     return () => {

--- a/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
+import { uiLogger } from "../../ui_logger";
 import type { RealtimeLiveOverviewBridge } from "./realtime_live_overview";
 
 export interface RealtimeLiveOverviewLazyProps {
@@ -42,7 +43,7 @@ export default function RealtimeLiveOverviewLazy(
       })
       .catch((error) => {
         if (!cancelled) {
-          console.error("[VibeSensor] Failed to load live overview panel.", error);
+          uiLogger.error("[VibeSensor] Failed to load live overview panel.", error);
         }
       });
     return () => {

--- a/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
+import { uiLogger } from "../../ui_logger";
 import type { RealtimeLoggingPanelBridge } from "./realtime_logging_panel";
 
 export interface RealtimeLoggingPanelLazyProps {
@@ -42,7 +43,7 @@ export default function RealtimeLoggingPanelLazy(
       })
       .catch((error) => {
         if (!cancelled) {
-          console.error("[VibeSensor] Failed to load realtime logging panel.", error);
+          uiLogger.error("[VibeSensor] Failed to load realtime logging panel.", error);
         }
       });
     return () => {

--- a/apps/ui/src/app/views/settings_lazy_view.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
+import { uiLogger } from "../../ui_logger";
 import type { AnalysisPanelView } from "./analysis_panel";
 import type { CarsPanelView } from "./cars_panel";
 import type { EspFlashPanelView } from "./esp_flash_panel";
@@ -69,7 +70,7 @@ export default function SettingsLazyView(props: SettingsLazyViewProps) {
       })
       .catch((error) => {
         if (!cancelled) {
-          console.error("[VibeSensor] Failed to load settings view.", error);
+          uiLogger.error("[VibeSensor] Failed to load settings view.", error);
         }
       });
     return () => {

--- a/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
+++ b/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "preact/hooks";
 import type { FunctionComponent } from "preact";
 
+import { uiLogger } from "../../ui_logger";
 import type { CreatedSpectrumPanel } from "./spectrum_panel";
 
 export interface SpectrumPanelHostLazyProps {
@@ -40,7 +41,7 @@ export default function SpectrumPanelHostLazy(props: SpectrumPanelHostLazyProps)
       })
       .catch((error) => {
         if (!cancelled) {
-          console.error("[VibeSensor] Failed to load spectrum panel host.", error);
+          uiLogger.error("[VibeSensor] Failed to load spectrum panel host.", error);
         }
       });
     return () => {

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -8,6 +8,7 @@ import type {
   SpectrumClientData,
   SpectrumFrameData,
 } from "./transport/live_models";
+import { uiLogger } from "./ui_logger";
 import { validateLiveWsPayload } from "./ws_payload_validator";
 
 function hasCompleteSpectrumData(
@@ -52,7 +53,7 @@ let schemaWarningLogged = false;
 function warnOnUnknownSchemaVersion(schemaVersion: string): void {
   if (schemaVersion !== EXPECTED_SCHEMA_VERSION && !schemaWarningLogged) {
     schemaWarningLogged = true;
-    console.error(
+    uiLogger.error(
       `[VibeSensor] Unknown WS payload schema_version "${schemaVersion}" ` +
       `(expected "${EXPECTED_SCHEMA_VERSION}"). The dashboard may not display correctly. ` +
       "Update the UI to match the server version.",

--- a/apps/ui/src/ui_logger.ts
+++ b/apps/ui/src/ui_logger.ts
@@ -1,0 +1,21 @@
+export interface UiLogger {
+  error(message: string, error?: unknown): void;
+  warn(message: string, error?: unknown): void;
+}
+
+export const uiLogger: UiLogger = {
+  error(message, error) {
+    if (typeof error === "undefined") {
+      console.error(message);
+      return;
+    }
+    console.error(message, error);
+  },
+  warn(message, error) {
+    if (typeof error === "undefined") {
+      console.warn(message);
+      return;
+    }
+    console.warn(message, error);
+  },
+};

--- a/apps/ui/tests/ui_logger.spec.ts
+++ b/apps/ui/tests/ui_logger.spec.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { uiLogger } from "../src/ui_logger";
+
+describe("uiLogger", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("warn forwards message-only and message-plus-error calls", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const error = new Error("warn detail");
+
+    uiLogger.warn("message only");
+    uiLogger.warn("message with error", error);
+
+    expect(warn).toHaveBeenNthCalledWith(1, "message only");
+    expect(warn).toHaveBeenNthCalledWith(2, "message with error", error);
+  });
+
+  test("error forwards message-only and message-plus-error calls", () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const error = new Error("error detail");
+
+    uiLogger.error("message only");
+    uiLogger.error("message with error", error);
+
+    expect(errorLog).toHaveBeenNthCalledWith(1, "message only");
+    expect(errorLog).toHaveBeenNthCalledWith(2, "message with error", error);
+  });
+});


### PR DESCRIPTION
## What changed
- add `apps/ui/src/ui_logger.ts` with the tiny `warn` / `error` surface the UI actually uses
- route root payload adaptation, runtime startup/failure paths, and lazy-view load failures through that shared logger
- keep the existing `UiStartupCoordinator` warn injection seam, but default it to the shared logger instead of raw `console.warn`
- add `apps/ui/tests/ui_logger.spec.ts` to pin the logger forwarding behavior

## Why
- direct `console.warn` / `console.error` ownership was scattered across the frontend
- one logger gives the UI one small logging boundary and a stable test seam for future coverage

## Validation
- `make format`
- `make ui-typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:unit`

## Risks / tradeoffs / edge cases
- this is intentionally a tiny wrapper; it does not add telemetry, buffering, or a larger logging framework
- only the current warn/error paths were centralized here; other console usage stays out of scope

Closes #3310