### PR TITLE
Add websocket validator drift tests

### DIFF
--- a/apps/ui/tests/ws_payload_validator.spec.ts
+++ b/apps/ui/tests/ws_payload_validator.spec.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "vitest";
+import { wsPayloadSchema } from "../src/contracts/ws_payload_schema.generated";
+import type { LiveWsPayload } from "../src/contracts/ws_payload_types";
 import { validateLiveWsPayload } from "../src/ws_payload_validator";
 
 const basePayload = {
@@ -40,6 +42,124 @@ function makeStrengthMetrics() {
     ],
   };
 }
+
+function makeRepresentativePayload(): LiveWsPayload {
+  return {
+    ...basePayload,
+    selected_client_id: "sensor-1",
+    rotational_speeds: {
+      basis_speed_source: null,
+      wheel: { rpm: 10, mode: null, reason: null },
+      driveshaft: { rpm: 20, mode: null, reason: null },
+      engine: { rpm: 30, mode: null, reason: null },
+      order_bands: [
+        {
+          key: "1x",
+          center_hz: 40,
+          tolerance: 0.5,
+        },
+      ],
+    },
+    spectra: {
+      frame_fingerprint: "sensor-1:0:0:1",
+      freq: [10, 20, 30],
+      clients: {
+        "sensor-1": {
+          combined_spectrum_amp_g: [0.1, 0.2, 0.3],
+          strength_metrics: makeStrengthMetrics(),
+        },
+      },
+      warning: {
+        code: "shared_freq",
+        message: "Shared frequency mismatch.",
+        client_ids: ["sensor-1"],
+      },
+      alignment: {
+        aligned: true,
+        clock_synced: true,
+        overlap_ratio: 0.75,
+        sensor_count: 1,
+        shared_window_s: 0.5,
+      },
+    },
+  };
+}
+
+function requiredFields(schema: { required?: readonly string[] }): readonly string[] {
+  return schema.required ?? [];
+}
+
+type RepresentativePayload = ReturnType<typeof makeRepresentativePayload>;
+type DriftBranch = {
+  label: string;
+  pathPrefix: string;
+  required: readonly string[];
+  getTarget: (payload: RepresentativePayload) => Record<string, unknown>;
+};
+
+const driftBranches: readonly DriftBranch[] = [
+  {
+    label: "live payload",
+    pathPrefix: "",
+    required: requiredFields(wsPayloadSchema),
+    getTarget: (payload) => payload as unknown as Record<string, unknown>,
+  },
+  {
+    label: "client row",
+    pathPrefix: "/clients/0",
+    required: requiredFields(wsPayloadSchema.$defs.ClientApiRow),
+    getTarget: (payload) => payload.clients[0] as unknown as Record<string, unknown>,
+  },
+  {
+    label: "rotational speeds",
+    pathPrefix: "/rotational_speeds",
+    required: requiredFields(wsPayloadSchema.$defs.RotationalSpeedsPayload),
+    getTarget: (payload) => payload.rotational_speeds as unknown as Record<string, unknown>,
+  },
+  {
+    label: "rotational speed value",
+    pathPrefix: "/rotational_speeds/wheel",
+    required: requiredFields(wsPayloadSchema.$defs.RotationalSpeedValuePayload),
+    getTarget: (payload) => payload.rotational_speeds!.wheel as unknown as Record<string, unknown>,
+  },
+  {
+    label: "order band",
+    pathPrefix: "/rotational_speeds/order_bands/0",
+    required: requiredFields(wsPayloadSchema.$defs.OrderBandPayload),
+    getTarget: (payload) =>
+      payload.rotational_speeds!.order_bands![0] as unknown as Record<string, unknown>,
+  },
+  {
+    label: "warning",
+    pathPrefix: "/spectra/warning",
+    required: requiredFields(wsPayloadSchema.$defs.FrequencyWarningPayload),
+    getTarget: (payload) => payload.spectra!.warning as unknown as Record<string, unknown>,
+  },
+  {
+    label: "alignment",
+    pathPrefix: "/spectra/alignment",
+    required: requiredFields(wsPayloadSchema.$defs.AlignmentInfoPayload),
+    getTarget: (payload) => payload.spectra!.alignment as unknown as Record<string, unknown>,
+  },
+  {
+    label: "strength metrics",
+    pathPrefix: "/spectra/clients/sensor-1/strength_metrics",
+    required: requiredFields(wsPayloadSchema.$defs.VibrationStrengthMetrics),
+    getTarget: (payload) =>
+      payload.spectra!.clients!["sensor-1"].strength_metrics as unknown as Record<string, unknown>,
+  },
+  {
+    label: "strength peak",
+    pathPrefix: "/spectra/clients/sensor-1/strength_metrics/top_peaks/0",
+    required: requiredFields(wsPayloadSchema.$defs.StrengthPeak),
+    getTarget: (payload) =>
+      payload.spectra!.clients!["sensor-1"].strength_metrics.top_peaks[0] as unknown as Record<string, unknown>,
+  },
+];
+
+const requiredFieldCases = driftBranches.flatMap((branch) =>
+  branch.required.map((field) => ({ ...branch, field })),
+);
 
 describe("validateLiveWsPayload", () => {
   test("accepts a schema-valid payload", () => {
@@ -146,4 +266,31 @@ describe("validateLiveWsPayload", () => {
       }),
     ).toThrow(/Invalid websocket payload: \/spectra\/frame_fingerprint/);
   });
+
+  test("accepts a representative payload built from schema-driven branches", () => {
+    expect(validateLiveWsPayload(makeRepresentativePayload())).toMatchObject({
+      clients: [{ id: "sensor-1" }],
+      rotational_speeds: {
+        order_bands: [{ key: "1x" }],
+        wheel: { rpm: 10 },
+      },
+      selected_client_id: "sensor-1",
+      spectra: {
+        alignment: { clock_synced: true },
+        frame_fingerprint: "sensor-1:0:0:1",
+        warning: { code: "shared_freq" },
+      },
+    });
+  });
+
+  test.each(requiredFieldCases)(
+    "rejects missing schema-derived required $field in $label",
+    ({ field, getTarget, pathPrefix }) => {
+      const payload = structuredClone(makeRepresentativePayload());
+      delete getTarget(payload)[field];
+      expect(() => validateLiveWsPayload(payload)).toThrow(
+        new RegExp(`Invalid websocket payload: ${pathPrefix}/${field}`),
+      );
+    },
+  );
 });


### PR DESCRIPTION
## What changed
- add a representative WebSocket payload in `apps/ui/tests/ws_payload_validator.spec.ts` that spans the high-value nested branches the manual validator mirrors
- import the generated `wsPayloadSchema` and derive required-field cases from it for the live payload, client row, rotational-speed, warning/alignment, and strength-metrics branches
- assert the manual validator accepts the representative payload and rejects schema-derived missing-required-field variants at the expected paths

## Why
- the runtime validator in `apps/ui/src/ws_payload_validator.ts` is still a manual mirror of the generated WebSocket contract
- existing tests covered handpicked failures, but not broader contract drift against the generated schema

## Validation
- `make format`
- `make ui-typecheck`
- `make ui-test`

## Risks / tradeoffs / edge cases
- no runtime code changed; this is a test-only PR
- the drift suite deliberately stays focused on high-value required branches instead of becoming a second full JSON Schema validator

Closes #3312