### PR TITLE
Use globalThis timers in UI HTTP helper

### DIFF
--- a/apps/ui/src/api/http.ts
+++ b/apps/ui/src/api/http.ts
@@ -30,13 +30,13 @@ export async function apiJsonResponse<T = unknown>(
 ): Promise<ApiJsonResponse<T>> {
   const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: externalSignal, ...requestInit } = init ?? {};
   const timeoutController = new AbortController();
-  const timeoutId = window.setTimeout(
+  const timeoutId = globalThis.setTimeout(
     () => timeoutController.abort(new DOMException(DEFAULT_TIMEOUT_MESSAGE, "AbortError")),
     timeoutMs,
   );
   const signal = composeSignal(timeoutController.signal, externalSignal ?? undefined);
   const response = await fetch(path, { ...requestInit, signal }).finally(() => {
-    window.clearTimeout(timeoutId);
+    globalThis.clearTimeout(timeoutId);
   });
   const bodyText = await response.text();
   if (!response.ok) {


### PR DESCRIPTION
## What changed
- replace `window.setTimeout` and `window.clearTimeout` with their `globalThis` equivalents in `apps/ui/src/api/http.ts`
- keep the abort-timeout flow and request cleanup behavior unchanged

## Why
- the HTTP helper only needs the global timer APIs
- `globalThis` is easier to exercise from tests, workers, and non-browser harnesses without changing browser behavior

## Validation
- `make format`
- `make ui-typecheck`
- `make ui-test`

## Risks / tradeoffs / edge cases
- behavior should stay identical in browsers because the underlying timer APIs are the same there
- no new abstraction was added; this is a direct coupling reduction only

Closes #3313