### PR TITLE
Support loc check outside git

### DIFF
--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -1,0 +1,86 @@
+"""Guard loc_check git and non-git file discovery."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_LOC_CHECK = REPO_ROOT / "tools" / "dev" / "loc_check.py"
+
+
+def _load_loc_check_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("loc_check_test_module", _LOC_CHECK)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_LOC_CHECK}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
+    module = _load_loc_check_module()
+    repo_root = Path("/tmp/nonexistent")
+
+    def _fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        assert args == (
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "ls-files",
+                "--cached",
+            ],
+        )
+        assert kwargs["check"] is True
+        assert kwargs["text"] is True
+        assert kwargs["capture_output"] is True
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout="apps/server/main.py\nREADME.md\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    assert module._tracked_files(repo_root) == ["apps/server/main.py", "README.md"]
+
+
+def test_main_falls_back_to_repo_walk_outside_git_checkout(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text("print('hello')\n", encoding="utf-8")
+    (repo_root / "scripts").mkdir()
+    (repo_root / "scripts" / "helper.sh").write_text("echo hi\n", encoding="utf-8")
+    (repo_root / "node_modules" / "pkg").mkdir(parents=True)
+    (repo_root / "node_modules" / "pkg" / "index.js").write_text(
+        "console.log('ignore')\n", encoding="utf-8"
+    )
+    (repo_root / "artifacts").mkdir()
+    (repo_root / "artifacts" / "generated.py").write_text("print('ignore')\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main() == 0
+
+    stdout = capsys.readouterr().out
+    assert "src/main.py" in stdout
+    assert "scripts/helper.sh" in stdout
+    assert "node_modules/pkg/index.js" not in stdout
+    assert "artifacts/generated.py" not in stdout

--- a/tools/dev/loc_check.py
+++ b/tools/dev/loc_check.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 TOP_N = 25
 
@@ -33,20 +34,40 @@ EXCLUDE_DIRS = {
     "artifacts",
     ".venv",
     ".git",
+    ".pytest_cache",
+    ".ruff_cache",
 }
 
 # Data files that are intentionally large (JSON extracted from code)
 EXCLUDE_FILES: set[str] = set()
 
 
-def _tracked_files() -> list[str]:
-    result = subprocess.run(
-        ["git", "ls-files", "--cached"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.splitlines()
+def _walk_files(repo_root: Path) -> list[str]:
+    files: list[str] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root)
+        if any(part in EXCLUDE_DIRS for part in rel.parts):
+            continue
+        files.append(rel.as_posix())
+    return files
+
+
+def _tracked_files(repo_root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "--cached"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tracked = [line for line in result.stdout.splitlines() if line]
+        if tracked:
+            return tracked
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    return _walk_files(repo_root)
 
 
 def _should_check(path: str) -> bool:
@@ -63,12 +84,13 @@ def _should_check(path: str) -> bool:
 
 
 def main() -> int:
-    files = [f for f in _tracked_files() if _should_check(f)]
+    repo_root = Path(__file__).resolve().parents[2]
+    files = [f for f in _tracked_files(repo_root) if _should_check(f)]
     measured: list[tuple[str, int]] = []
 
     for path in files:
         try:
-            with open(path) as fh:
+            with open(repo_root / path) as fh:
                 loc = sum(1 for _ in fh)
         except (OSError, UnicodeDecodeError):
             continue
@@ -80,7 +102,7 @@ def main() -> int:
         "ℹ️  File-length advisory: keep files short where practical, "
         "without hurting human maintainability."
     )
-    print(f"Showing top {min(TOP_N, len(measured))} longest tracked source files:")
+    print(f"Showing top {min(TOP_N, len(measured))} longest source files:")
     for path, loc in measured[:TOP_N]:
         print(f"   {loc:5d}  {path}")
 


### PR DESCRIPTION
## What changed
- add a git-first, repo-walk fallback in `tools/dev/loc_check.py` so file discovery still works without `.git` metadata
- read measured files relative to the resolved repo root instead of assuming the current working directory is the repo root
- add `apps/server/tests/hygiene/test_loc_check.py` covering both the git-backed path and the non-git fallback path

## Why
- `loc_check.py` only worked when `git ls-files` was available and the script was run from the repo root
- extracted source archives and other non-git working trees need the same kind of fallback `docs_lint.py` already uses

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_loc_check.py`
- `python3 tools/dev/loc_check.py`
- `make lint`

## Risks / tradeoffs / edge cases
- git-backed behavior stays first when git metadata exists
- the fallback intentionally skips obvious generated/vendor directories instead of trying to mirror every git ignore rule

Closes #3314