### PR TITLE
Add optional fail threshold to loc check

### DIFF
--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -84,3 +84,57 @@ def test_main_falls_back_to_repo_walk_outside_git_checkout(
     assert "scripts/helper.sh" in stdout
     assert "node_modules/pkg/index.js" not in stdout
     assert "artifacts/generated.py" not in stdout
+
+
+def test_main_fails_when_optional_loc_threshold_is_exceeded(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text(
+        "print('one')\nprint('two')\nprint('three')\n",
+        encoding="utf-8",
+    )
+    (repo_root / "scripts").mkdir()
+    (repo_root / "scripts" / "helper.sh").write_text("echo hi\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main(["--fail-over", "2"]) == 1
+
+    stdout = capsys.readouterr().out
+    assert "FAIL: 1 source file(s) exceed 2 lines:" in stdout
+    assert "src/main.py" in stdout
+    assert "scripts/helper.sh" not in stdout.split("FAIL:", 1)[1]
+
+
+def test_main_passes_when_optional_loc_threshold_is_not_exceeded(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text(
+        "print('one')\nprint('two')\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main(["--fail-over", "2"]) == 0

--- a/tools/dev/loc_check.py
+++ b/tools/dev/loc_check.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
 """File-length advisory for maintainability.
 
-This script intentionally does not enforce LoC limits.
-It reports the longest tracked source files as a refactoring signal only.
+This script reports the longest tracked source files as a refactoring signal.
+Callers can optionally fail when files exceed a given LoC threshold.
 
 Guidance:
 - Keep files short where practical.
 - Do not split files mechanically when doing so hurts readability,
   discoverability, or long-term maintainability.
 
-Exit code is always 0.
+Exit code is 0 by default, or non-zero when ``--fail-over`` is provided and
+one or more files exceed that threshold.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
@@ -40,6 +42,25 @@ EXCLUDE_DIRS = {
 
 # Data files that are intentionally large (JSON extracted from code)
 EXCLUDE_FILES: set[str] = set()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report the longest source files and optionally fail when files "
+            "exceed a line-count threshold."
+        )
+    )
+    parser.add_argument(
+        "--fail-over",
+        type=int,
+        default=None,
+        help="Exit non-zero when one or more checked files exceed this line count.",
+    )
+    args = parser.parse_args(argv)
+    if args.fail_over is not None and args.fail_over < 0:
+        parser.error("--fail-over must be zero or greater")
+    return args
 
 
 def _walk_files(repo_root: Path) -> list[str]:
@@ -83,7 +104,8 @@ def _should_check(path: str) -> bool:
     return True
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
     repo_root = Path(__file__).resolve().parents[2]
     files = [f for f in _tracked_files(repo_root) if _should_check(f)]
     measured: list[tuple[str, int]] = []
@@ -105,6 +127,20 @@ def main() -> int:
     print(f"Showing top {min(TOP_N, len(measured))} longest source files:")
     for path, loc in measured[:TOP_N]:
         print(f"   {loc:5d}  {path}")
+
+    if args.fail_over is not None:
+        offenders = [(path, loc) for path, loc in measured if loc > args.fail_over]
+        if offenders:
+            print(
+                f"\nFAIL: {len(offenders)} source file(s) exceed {args.fail_over} lines:"
+            )
+            for path, loc in offenders:
+                print(f"   {loc:5d}  {path}")
+            print(
+                "\nSuggestion: refactor or split these files only when it "
+                "improves clarity and maintainability."
+            )
+            return 1
 
     print(
         "\nSuggestion: refactor large files when it improves clarity; "


### PR DESCRIPTION
## What changed
- add an optional `--fail-over N` flag to `tools/dev/loc_check.py`
- keep the current advisory report and exit code unchanged by default
- fail with a clear offender list when the optional threshold is provided and one or more files exceed it
- extend `apps/server/tests/hygiene/test_loc_check.py` to cover the passing and failing threshold modes

## Why
- `loc_check.py` already computes exact line counts, but it could only surface drift as advisory output
- an opt-in threshold lets callers enforce a limit without changing the current default workflow

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_loc_check.py`
- `python3 tools/dev/loc_check.py`
- `python3 tools/dev/loc_check.py --fail-over 2000`
- `make lint`

## Risks / tradeoffs / edge cases
- default behavior stays advisory; callers must opt in explicitly to strict enforcement
- the threshold is strictly `>` the configured value, matching the issue wording about files being over the limit

Closes #3315