### PR TITLE
Run firmware native tests for backend UDP codec changes

### DIFF
--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -84,6 +84,46 @@ def test_firmware_only_changes_run_only_firmware_native_checks() -> None:
     assert selection.e2e is False
 
 
+def test_backend_udp_protocol_changes_also_run_firmware_native_checks() -> None:
+    module = _load_ci_path_rules_module()
+
+    for changed_path in (
+        "apps/server/vibesensor/adapters/udp/protocol.py",
+        "apps/server/vibesensor/adapters/udp/protocol_validator.py",
+    ):
+        selection = module.workflow_job_selection((changed_path,))
+        assert selection.backend_lint is True
+        assert selection.backend_static_guards is True
+        assert selection.backend_preflight is True
+        assert selection.backend_contract_drift is True
+        assert selection.backend_typecheck is True
+        assert selection.backend_tests is True
+        assert selection.release_smoke is True
+        assert selection.e2e is True
+        assert selection.firmware_native_tests is True
+        assert selection.frontend_typecheck is False
+        assert selection.ui_smoke is False
+
+
+def test_non_protocol_backend_udp_changes_do_not_run_firmware_native_checks() -> None:
+    module = _load_ci_path_rules_module()
+
+    selection = module.workflow_job_selection(
+        ("apps/server/vibesensor/adapters/udp/udp_data_rx.py",)
+    )
+    assert selection.backend_lint is True
+    assert selection.backend_static_guards is True
+    assert selection.backend_preflight is True
+    assert selection.backend_contract_drift is True
+    assert selection.backend_typecheck is True
+    assert selection.backend_tests is True
+    assert selection.release_smoke is True
+    assert selection.e2e is True
+    assert selection.firmware_native_tests is False
+    assert selection.frontend_typecheck is False
+    assert selection.ui_smoke is False
+
+
 def test_workflow_changes_fall_back_to_full_stack() -> None:
     module = _load_ci_path_rules_module()
 

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -28,6 +28,10 @@ FULL_STACK_TRIGGER_FILES = {
 }
 FULL_STACK_TRIGGER_PREFIXES = (".github/",)
 FIRMWARE_TRIGGER_PREFIXES = ("firmware/", "tools/firmware/")
+FIRMWARE_NATIVE_BACKEND_TRIGGER_FILES = {
+    "apps/server/vibesensor/adapters/udp/protocol.py",
+    "apps/server/vibesensor/adapters/udp/protocol_validator.py",
+}
 PYTHON_TOOL_PREFIX = "tools/"
 DOCS_LINT_TOOL_FILES = {"tools/dev/docs_lint.py"}
 REPO_HYGIENE_TOOL_FILES = {"tools/dev/check_hygiene.py"}
@@ -168,6 +172,10 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         or backend_changed
         or frontend_changed
         or release_tool_changed,
-        firmware_native_tests=full_stack or firmware_changed,
+        firmware_native_tests=full_stack
+        or firmware_changed
+        or any(
+            path in FIRMWARE_NATIVE_BACKEND_TRIGGER_FILES for path in non_docs_paths
+        ),
         e2e=full_stack or backend_changed or frontend_changed or e2e_tool_changed,
     )


### PR DESCRIPTION
## What changed
- add a narrow backend trigger set for `apps/server/vibesensor/adapters/udp/protocol.py` and `apps/server/vibesensor/adapters/udp/protocol_validator.py`
- wire that set into `firmware_native_tests` selection in `tools/tests/ci_path_rules.py`
- extend `apps/server/tests/hygiene/test_ci_path_rules.py` with positive coverage for those two files and a negative coverage case for `udp_data_rx.py`

## Why
- firmware protocol fixture generation imports the backend UDP codec path directly
- backend protocol changes could drift firmware expectations without running the native firmware tests
- the trigger must stay narrow so unrelated backend changes do not fan out into firmware native CI

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_ci_path_rules.py`
- explicit selector check for `protocol.py`, `protocol_validator.py`, and `udp_data_rx.py`
- `make lint`

## Risks / tradeoffs / edge cases
- the rule is intentionally explicit, not prefix-based; if fixture generation starts depending on another backend UDP module later, this allowlist will need to grow deliberately
- unrelated backend UDP transport files still do not trigger firmware native tests, which is the intended narrow behavior

Closes #3316