### PR TITLE
Clarify USB internet no-op lifecycle hooks

### DIFF
--- a/apps/server/tests/use_cases/updates/test_usb_internet.py
+++ b/apps/server/tests/use_cases/updates/test_usb_internet.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from _update_manager_test_helpers import FakeRunner
+from test_support.update_status import build_update_status_harness
 
+from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
+from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+from vibesensor.use_cases.updates.transport.usb_internet import UpdateUsbInternetSession
 from vibesensor.use_cases.updates.usb_status import UsbInternetStatusService
 from vibesensor.use_cases.updates.usb_status_inspection import parse_nmcli_device_status
+from vibesensor.use_cases.updates.wifi import build_default_wifi_config
 
 
 def _make_usb_interface(
@@ -89,6 +96,32 @@ class _UsbActivationFailureRunner(FakeRunner):
         return self.default_response
 
 
+def _usb_request() -> UpdateRequest:
+    return UpdateRequest(
+        transport=UpdateTransport.usb_internet,
+        ssid=None,
+        password="",
+    )
+
+
+def _build_usb_session(
+    tmp_path: Path,
+) -> tuple[UpdateUsbInternetSession, AsyncMock, FakeRunner, UpdateStatusTracker]:
+    runner = FakeRunner()
+    tracker = build_update_status_harness(tmp_path / "state.json")
+    status_service = AsyncMock()
+    session = UpdateUsbInternetSession(
+        status_service=status_service,
+        commands=UpdateCommandExecutor(runner=runner),
+        status=tracker,
+        config=build_default_wifi_config(
+            ap_con_name="VibeSensor-AP",
+            wifi_ifname="wlan0",
+        ),
+    )
+    return session, status_service, runner, tracker
+
+
 def test_parse_nmcli_device_status_normalizes_missing_connection_name() -> None:
     statuses = parse_nmcli_device_status("usb0:ethernet:connected:--\n")
 
@@ -96,6 +129,41 @@ def test_parse_nmcli_device_status_normalizes_missing_connection_name() -> None:
     assert statuses["usb0"].device_type == "ethernet"
     assert statuses["usb0"].state == "connected"
     assert statuses["usb0"].connection_name is None
+
+
+@pytest.mark.asyncio
+async def test_usb_internet_lifecycle_noops_preserve_existing_status_state(tmp_path: Path) -> None:
+    session, status_service, runner, tracker = _build_usb_session(tmp_path)
+    tracker.start_job(_usb_request())
+    tracker.transition(UpdatePhase.connecting_usb_internet)
+    tracker.set_uplink_interface("usb0")
+    before = (
+        tracker.status.state,
+        tracker.status.phase,
+        tracker.status.uplink_interface,
+        list(tracker.status.log_tail),
+        list(tracker.status.issues),
+        tracker.status.updated_at,
+        tracker.status.phase_started_at,
+    )
+
+    assert await session.abort_preparation() is None
+    assert await session.complete_success() is None
+    assert await session.cleanup_after_update() is None
+    assert await session.recover_interrupted_update(tracker.status) is None
+
+    after = (
+        tracker.status.state,
+        tracker.status.phase,
+        tracker.status.uplink_interface,
+        list(tracker.status.log_tail),
+        list(tracker.status.issues),
+        tracker.status.updated_at,
+        tracker.status.phase_started_at,
+    )
+    assert after == before
+    assert runner.calls == []
+    status_service.snapshot.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/updates/transport/usb_internet.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/usb_internet.py
@@ -89,7 +89,8 @@ class UpdateUsbInternetSession:
         return self
 
     async def abort_preparation(self) -> None:
-        pass
+        """No-op: prepare only validates an already-present external uplink."""
+        return None
 
     async def ensure_uplink_ready(self) -> None:
         decision = _classify_usb_internet(await self._status_service.snapshot(activate=True))
@@ -109,10 +110,13 @@ class UpdateUsbInternetSession:
         )
 
     async def complete_success(self) -> None:
+        """No-op: the USB transport does not own the reused uplink on success."""
         return None
 
     async def cleanup_after_update(self) -> None:
-        pass
+        """No-op: there is no transport-local USB state to tear down after updates."""
+        return None
 
     async def recover_interrupted_update(self, _status: UpdateJobStatus) -> None:
-        pass
+        """No-op: interrupted USB updates have no session-owned setup to restore."""
+        return None


### PR DESCRIPTION
## What changed
- replace the bare no-op USB internet lifecycle hooks with concise docstrings that explain why they intentionally do nothing
- keep `complete_success()` explicit as a no-op for the same reason
- add a focused USB session test that proves those lifecycle hooks preserve tracker state and avoid extra status/command side effects

## Why
- `UpdateUsbInternetSession` only validates and reuses an already-present external uplink
- bare `pass` lifecycle methods looked unfinished and were easy to misread as missing cleanup/setup work
- the change should make that intent obvious without changing transport behavior

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/updates/test_usb_internet.py apps/server/tests/use_cases/updates/test_transport_coordinator.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edge cases
- this does not add new USB transport behavior; it only documents and protects the existing no-op contract
- if the USB path ever starts owning setup or teardown work later, these tests will need to change with that design

Closes #3317