### PR TITLE
Keep hotspot restore running after cleanup failures

### DIFF
--- a/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
@@ -115,3 +115,24 @@ async def test_restore_hotspot_exhausts_retries_and_records_issue(
         and issue.message == "Failed to restore hotspot after retries"
         for issue in tracker.status.issues
     )
+
+
+@pytest.mark.asyncio
+async def test_restore_hotspot_still_attempts_ap_recovery_after_cleanup_failure(
+    tmp_path: Path,
+) -> None:
+    recovery, runner, tracker = _build_recovery(tmp_path)
+    runner.set_response("connection down VibeSensor-Uplink", 10, "", "down failed")
+
+    assert await recovery.restore_hotspot() is True
+    assert any(
+        "Transient uplink cleanup failed before hotspot restore; attempting AP recovery anyway"
+        in line
+        for line in tracker.status.log_tail
+    )
+    assert any("down failed" in line for line in tracker.status.log_tail)
+
+    commands = [" ".join(call[0]) for call in runner.calls]
+    assert "connection down VibeSensor-Uplink" in commands[0]
+    assert "connection delete VibeSensor-Uplink" in commands[1]
+    assert "connection up VibeSensor-AP" in commands[2]

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
@@ -17,6 +17,10 @@ class _RetryableHotspotRestoreError(Exception):
         self.returncode = returncode
 
 
+class _TransientUplinkCleanupError(Exception):
+    """Best-effort uplink cleanup failed before hotspot restore."""
+
+
 class UpdateHotspotRecovery:
     """Manage the updater's hotspot shutdown and restoration lifecycle."""
 
@@ -50,23 +54,46 @@ class UpdateHotspotRecovery:
     async def cleanup_uplink(self) -> None:
         """Tear down any transient updater uplink connection state."""
 
-        await self._commands.run(
+        failures: list[str] = []
+        down_result = await self._commands.run(
             ["nmcli", "connection", "down", self._config.uplink_connection_name],
             phase="restore",
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
-        await self._commands.run(
+        if down_result.returncode != 0:
+            detail = down_result.stderr.strip() or down_result.stdout.strip() or "no output"
+            failures.append(
+                "connection down "
+                f"{self._config.uplink_connection_name} failed "
+                f"(rc={down_result.returncode}): {detail}",
+            )
+        delete_result = await self._commands.run(
             ["nmcli", "connection", "delete", self._config.uplink_connection_name],
             phase="restore",
             timeout=self._config.nmcli_timeout_s,
             sudo=True,
         )
+        if delete_result.returncode != 0:
+            detail = delete_result.stderr.strip() or delete_result.stdout.strip() or "no output"
+            failures.append(
+                "connection delete "
+                f"{self._config.uplink_connection_name} failed "
+                f"(rc={delete_result.returncode}): {detail}",
+            )
+        if failures:
+            raise _TransientUplinkCleanupError("; ".join(failures))
 
     async def restore_hotspot(self) -> bool:
         """Re-enable the hotspot, retrying within the configured restore budget."""
 
-        await self.cleanup_uplink()
+        try:
+            await self.cleanup_uplink()
+        except _TransientUplinkCleanupError as exc:
+            self._status.log(
+                "Transient uplink cleanup failed before hotspot restore; "
+                f"attempting AP recovery anyway ({exc})",
+            )
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(self._config.hotspot_restore_retries),

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_session.py
@@ -173,8 +173,6 @@ class UpdateWifiSession:
         prefix: str,
         failure_message: str,
     ) -> None:
-        self._status.log(f"{prefix}: cleaning up uplink connection")
-        await self._hotspot.cleanup_uplink()
         self._status.log(f"{prefix}: restoring hotspot")
         restored = await self._restore_hotspot()
         if restored:


### PR DESCRIPTION
## What changed
- make `cleanup_uplink()` collect nonzero `nmcli` cleanup failures into one explicit transient-cleanup error
- let `restore_hotspot()` log that cleanup detail and still attempt AP recovery anyway
- add a focused hotspot recovery test that proves cleanup failure is reported and `connection up VibeSensor-AP` is still attempted

## Why
- hotspot availability is the critical recovery action
- transient uplink cleanup failures should not block the AP restore attempt
- cleanup failures still need to stay visible instead of being silently ignored

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py apps/server/tests/use_cases/updates/wifi/test_wifi_session.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edge cases
- cleanup failures are now surfaced in the update log even when hotspot restore succeeds
- restore retry behavior itself is unchanged; only the cleanup/reporting boundary moved

Closes #3318