### PR TITLE
Add config preflight writability checks

### DIFF
--- a/apps/server/tests/app/test_preflight_cli.py
+++ b/apps/server/tests/app/test_preflight_cli.py
@@ -136,3 +136,24 @@ def test_preflight_cli_reports_unwritable_runtime_path(
     assert captured.out == ""
     assert "logging.history_db_path is not writable" in captured.err
     assert str(blocked_dir) in captured.err
+
+
+def test_missing_parent_path_does_not_probe_higher_ancestors(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    real_access = os.access
+
+    def _mock_access(path: str | os.PathLike[str], mode: int) -> bool:
+        if Path(path) == tmp_path:
+            return False
+        return real_access(path, mode)
+
+    monkeypatch.setattr(preflight.os, "access", _mock_access)
+
+    preflight._validate_writable_path(
+        preflight._WritablePathCheck(
+            "logging.history_db_path",
+            tmp_path / "missing" / "history.db",
+        )
+    )

--- a/apps/server/tests/app/test_preflight_cli.py
+++ b/apps/server/tests/app/test_preflight_cli.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import pytest
 
-from vibesensor.cli.preflight import main
+from vibesensor.app.config_loader import load_config
+from vibesensor.cli import preflight
 
 
 def test_preflight_cli_dump_defaults(monkeypatch, capsys) -> None:
     monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", "--dump-defaults"])
 
-    assert main() == 0
+    assert preflight.main() == 0
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -27,7 +29,7 @@ def test_preflight_cli_requires_config_without_dump_defaults(monkeypatch) -> Non
     monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight"])
 
     with pytest.raises(SystemExit):
-        main()
+        preflight.main()
 
 
 def test_preflight_cli_rejects_dump_defaults_with_config(monkeypatch) -> None:
@@ -38,7 +40,7 @@ def test_preflight_cli_rejects_dump_defaults_with_config(monkeypatch) -> None:
     )
 
     with pytest.raises(SystemExit):
-        main()
+        preflight.main()
 
 
 def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Path) -> None:
@@ -50,7 +52,7 @@ def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Pat
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
     monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", str(config_path)])
 
-    assert main() == 0
+    assert preflight.main() == 0
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -61,3 +63,76 @@ def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Pat
     assert payload["process_settings"]["ws_debug"] is True
     assert payload["process_settings"]["repo_path"] == str(tmp_path / "repo")
     assert payload["process_settings"]["github_token_configured"] is True
+
+
+def test_writable_path_checks_include_active_runtime_targets(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "tracing:",
+                "  enabled: true",
+                "  output_path: traces/export.jsonl",
+                "update:",
+                f"  rollback_dir: {tmp_path / 'rollback'}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBESENSOR_UPDATE_STATE_PATH", str(tmp_path / "update" / "state.json"))
+    monkeypatch.setenv("VIBESENSOR_FIRMWARE_CACHE_DIR", str(tmp_path / "firmware"))
+
+    cfg = load_config(config_path)
+
+    assert [check.label for check in preflight._writable_path_checks(cfg)] == [
+        "logging.history_db_path",
+        "logging.app_log_path",
+        "ap.self_heal.state_file",
+        "tracing.output_path",
+        "update.rollback_dir",
+        "process_settings.update_state_path",
+        "process_settings.firmware_cache_dir",
+    ]
+
+
+def test_preflight_cli_reports_unwritable_runtime_path(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+) -> None:
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "logging:",
+                "  history_db_path: blocked/history.db",
+                "update:",
+                f"  rollback_dir: {tmp_path / 'rollback'}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBESENSOR_UPDATE_STATE_PATH", str(tmp_path / "update" / "state.json"))
+    monkeypatch.setenv("VIBESENSOR_FIRMWARE_CACHE_DIR", str(tmp_path / "firmware"))
+
+    real_access = os.access
+
+    def _mock_access(path: str | os.PathLike[str], mode: int) -> bool:
+        if Path(path) == blocked_dir:
+            return False
+        return real_access(path, mode)
+
+    monkeypatch.setattr(preflight.os, "access", _mock_access)
+    monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", str(config_path)])
+
+    assert preflight.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "logging.history_db_path is not writable" in captured.err
+    assert str(blocked_dir) in captured.err

--- a/apps/server/vibesensor/cli/preflight.py
+++ b/apps/server/vibesensor/cli/preflight.py
@@ -2,13 +2,25 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from vibesensor.app.config_defaults import documented_default_config
 from vibesensor.app.config_loader import load_config
 from vibesensor.app.config_schema import AppConfig
 from vibesensor.shared.constants.ui import UI_HEAVY_PUSH_HZ, UI_PUSH_HZ
-from vibesensor.shared.process_settings import summarize_process_settings
+from vibesensor.shared.process_settings import load_update_env_settings, summarize_process_settings
+
+_DIR_WRITE_ACCESS = os.W_OK | os.X_OK
+
+
+@dataclass(frozen=True, slots=True)
+class _WritablePathCheck:
+    label: str
+    path: Path
+    expects_directory: bool = False
 
 
 def summarize(cfg: AppConfig) -> dict[str, object]:
@@ -33,6 +45,85 @@ def summarize(cfg: AppConfig) -> dict[str, object]:
     }
 
 
+def _writable_path_checks(cfg: AppConfig) -> tuple[_WritablePathCheck, ...]:
+    update = load_update_env_settings()
+    checks: list[_WritablePathCheck] = [
+        _WritablePathCheck("logging.history_db_path", cfg.logging.history_db_path),
+    ]
+    if cfg.logging.app_log_path is not None:
+        checks.append(_WritablePathCheck("logging.app_log_path", cfg.logging.app_log_path))
+    if cfg.ap.self_heal.enabled:
+        checks.append(_WritablePathCheck("ap.self_heal.state_file", cfg.ap.self_heal.state_file))
+    if cfg.tracing.enabled:
+        checks.append(_WritablePathCheck("tracing.output_path", cfg.tracing.output_path))
+    checks.extend(
+        (
+            _WritablePathCheck(
+                "update.rollback_dir", cfg.update.rollback_dir, expects_directory=True
+            ),
+            _WritablePathCheck("process_settings.update_state_path", update.update_state_path),
+            _WritablePathCheck(
+                "process_settings.firmware_cache_dir",
+                update.firmware_cache_dir,
+                expects_directory=True,
+            ),
+        )
+    )
+    return tuple(checks)
+
+
+def _not_writable(check: _WritablePathCheck, detail: str) -> ValueError:
+    return ValueError(f"{check.label} is not writable: {detail}")
+
+
+def _nearest_existing_ancestor(path: Path) -> Path:
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            raise ValueError(f"could not find an existing parent for {path}")
+        current = parent
+    return current
+
+
+def _ensure_writable_directory(
+    check: _WritablePathCheck,
+    directory: Path,
+    *,
+    relation: str,
+) -> None:
+    if not directory.is_dir():
+        raise _not_writable(check, f"{relation} {directory} exists but is not a directory")
+    if not os.access(directory, _DIR_WRITE_ACCESS):
+        raise _not_writable(check, f"{relation} {directory} is not writable")
+
+
+def _validate_writable_path(check: _WritablePathCheck) -> None:
+    path = check.path
+    if check.expects_directory:
+        if path.exists():
+            _ensure_writable_directory(check, path, relation="directory")
+            return
+        ancestor = _nearest_existing_ancestor(path)
+        relation = "parent directory" if ancestor == path.parent else "nearest existing parent"
+        _ensure_writable_directory(check, ancestor, relation=relation)
+        return
+    if path.exists():
+        if path.is_dir():
+            raise _not_writable(check, f"path {path} exists but is a directory")
+        if not os.access(path, os.W_OK):
+            raise _not_writable(check, f"file {path} exists but is not writable")
+        return
+    ancestor = _nearest_existing_ancestor(path.parent)
+    relation = "parent directory" if ancestor == path.parent else "nearest existing parent"
+    _ensure_writable_directory(check, ancestor, relation=relation)
+
+
+def _validate_writable_runtime_paths(cfg: AppConfig) -> None:
+    for check in _writable_path_checks(cfg):
+        _validate_writable_path(check)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Validate and print resolved VibeSensor config")
     parser.add_argument("config", type=Path, nargs="?", help="Path to config YAML")
@@ -54,7 +145,12 @@ def main() -> int:
     if args.dump_defaults:
         print(json.dumps(documented_default_config(), indent=2, sort_keys=True))
         return 0
-    cfg = load_config(args.config)
+    try:
+        cfg = load_config(args.config)
+        _validate_writable_runtime_paths(cfg)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     print(json.dumps(summarize(cfg), indent=2, sort_keys=True))
     return 0
 

--- a/apps/server/vibesensor/cli/preflight.py
+++ b/apps/server/vibesensor/cli/preflight.py
@@ -76,16 +76,6 @@ def _not_writable(check: _WritablePathCheck, detail: str) -> ValueError:
     return ValueError(f"{check.label} is not writable: {detail}")
 
 
-def _nearest_existing_ancestor(path: Path) -> Path:
-    current = path
-    while not current.exists():
-        parent = current.parent
-        if parent == current:
-            raise ValueError(f"could not find an existing parent for {path}")
-        current = parent
-    return current
-
-
 def _ensure_writable_directory(
     check: _WritablePathCheck,
     directory: Path,
@@ -103,20 +93,16 @@ def _validate_writable_path(check: _WritablePathCheck) -> None:
     if check.expects_directory:
         if path.exists():
             _ensure_writable_directory(check, path, relation="directory")
-            return
-        ancestor = _nearest_existing_ancestor(path)
-        relation = "parent directory" if ancestor == path.parent else "nearest existing parent"
-        _ensure_writable_directory(check, ancestor, relation=relation)
+        elif path.parent.exists():
+            _ensure_writable_directory(check, path.parent, relation="parent directory")
         return
     if path.exists():
         if path.is_dir():
             raise _not_writable(check, f"path {path} exists but is a directory")
         if not os.access(path, os.W_OK):
             raise _not_writable(check, f"file {path} exists but is not writable")
-        return
-    ancestor = _nearest_existing_ancestor(path.parent)
-    relation = "parent directory" if ancestor == path.parent else "nearest existing parent"
-    _ensure_writable_directory(check, ancestor, relation=relation)
+    elif path.parent.exists():
+        _ensure_writable_directory(check, path.parent, relation="parent directory")
 
 
 def _validate_writable_runtime_paths(cfg: AppConfig) -> None:


### PR DESCRIPTION
## What changed
- add explicit writable runtime target checks to `vibesensor-config-preflight`
- fail with clear `Error:` messages when a checked file, directory, or existing direct parent cannot accept writes
- add focused CLI coverage for the active target list, a real permission failure path, and the missing-parent regression from CI

## Why
- preflight printed resolved config but did not catch obvious write-path permission problems until runtime
- this makes history DB, log, trace, rollback, updater state, and firmware cache misconfigurations fail early without mutating disk or guessing about missing deployment-owned path trees

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/app/test_preflight_cli.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- preflight now exits nonzero for bad writable runtime targets, so broken environments fail earlier
- checks stay non-mutating and intentionally stop at the target or its existing direct parent; missing higher-level system path trees are left to deployment/install ownership instead of being treated as current-user permission failures

## Follow-ups
- Closes #3319