### PR TITLE
Reduce history run tracing boilerplate

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -29,7 +29,7 @@ from vibesensor.shared.run_context_warning import (
     WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
 )
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
-from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
@@ -43,11 +43,18 @@ class _HistoryDbStub:
     run: dict[str, Any] | None = None
     delete_result: tuple[bool, str | None] = (True, None)
     samples: list[dict[str, Any]] | None = None
+    runs: list[HistoryRunListEntry] | None = None
+    list_runs_error: Exception | None = None
 
     async def aget_run(self, run_id: str) -> StoredHistoryRun | None:
         if self.run is None:
             return None
         return _stored_run(dict(self.run))
+
+    async def alist_runs(self) -> list[HistoryRunListEntry]:
+        if self.list_runs_error is not None:
+            raise self.list_runs_error
+        return list(self.runs or [])
 
     async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
         return self.delete_result
@@ -251,6 +258,21 @@ async def test_report_service_exports_tracing_spans(tmp_path: Path) -> None:
     spans = {item["name"]: item for item in read_trace_output(trace_path)}
     assert spans["history.report.build_pdf"]["attributes"]["vibesensor.cache_hit"] is False
     assert spans["history.report.load_request"]["attributes"]["vibesensor.report_lang"] == "nl"
+
+
+@pytest.mark.asyncio
+async def test_run_service_marks_error_span_when_list_runs_fails(tmp_path: Path) -> None:
+    service = HistoryRunService(_HistoryDbStub(list_runs_error=RuntimeError("db offline")))
+
+    with configured_trace_output(tmp_path) as trace_path:
+        with pytest.raises(RuntimeError, match="db offline"):
+            await service.list_runs()
+
+    spans = {item["name"]: item for item in read_trace_output(trace_path)}
+    span = spans["history.runs.list"]
+    assert span["status"] == "error"
+    assert span["status_description"] == "RuntimeError: db offline"
+    assert any(event["name"] == "exception" for event in span["events"])
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Never, cast
 
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import Span, SpanKind
 
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.summary_fields.warnings import localize_warning_list
@@ -21,6 +23,15 @@ from vibesensor.use_cases.history.helpers import (
 )
 
 
+@contextmanager
+def _mark_history_span_errors(span: Span) -> Iterator[None]:
+    try:
+        yield
+    except Exception as exc:
+        mark_span_error(span, exc)
+        raise
+
+
 class HistoryRunService:
     """Run queries and delete operations used by history endpoints."""
 
@@ -31,11 +42,8 @@ class HistoryRunService:
 
     async def list_runs(self) -> list[HistoryRunListEntry]:
         with start_span(__name__, "history.runs.list", kind=SpanKind.INTERNAL) as span:
-            try:
+            with _mark_history_span_errors(span):
                 runs = await self._history_db.alist_runs()
-            except Exception as exc:
-                mark_span_error(span, exc)
-                raise
             span.set_attribute("vibesensor.run_count", len(runs))
             return runs
 
@@ -46,11 +54,8 @@ class HistoryRunService:
             kind=SpanKind.INTERNAL,
             attributes={"vibesensor.run_id": run_id},
         ) as span:
-            try:
+            with _mark_history_span_errors(span):
                 run = await async_require_run(self._history_db, run_id)
-            except Exception as exc:
-                mark_span_error(span, exc)
-                raise
             span.set_attribute("vibesensor.run_status", run.status.value)
             return run
 
@@ -69,7 +74,7 @@ class HistoryRunService:
                 "vibesensor.requested_lang": requested_lang or "",
             },
         ) as span:
-            try:
+            with _mark_history_span_errors(span):
                 run = await async_require_run(self._history_db, run_id)
                 if (
                     run.lifecycle is not None
@@ -95,9 +100,6 @@ class HistoryRunService:
                 )
                 analysis["run_id"] = run.run_id or run_id
                 analysis["status"] = RunStatus.COMPLETE.value
-            except Exception as exc:
-                mark_span_error(span, exc)
-                raise
             span.set_attribute("vibesensor.analysis_ready", True)
             span.set_attribute("vibesensor.response_lang", response_lang)
             return analysis
@@ -109,7 +111,7 @@ class HistoryRunService:
             kind=SpanKind.INTERNAL,
             attributes={"vibesensor.run_id": run_id},
         ) as span:
-            try:
+            with _mark_history_span_errors(span):
                 deleted, reason = await self._history_db.adelete_run_if_safe(run_id)
                 if deleted:
                     span.set_attribute("vibesensor.deleted", True)
@@ -117,9 +119,6 @@ class HistoryRunService:
                 span.set_attribute("vibesensor.deleted", False)
                 span.set_attribute("vibesensor.delete_reason", reason or "")
                 raise_delete_run_error(reason)
-            except Exception as exc:
-                mark_span_error(span, exc)
-                raise
 
 
 def raise_delete_run_error(reason: str | None) -> Never:


### PR DESCRIPTION
## What changed
- replace the repeated history-run `mark_span_error(...); raise` wrappers with one tiny local tracing context helper
- keep the list/get/insights/delete business logic inline in `HistoryRunService`
- add a focused tracing regression proving a failing `list_runs()` call still exports an error span and still propagates the exception

## Why
- the service repeated the same tracing error shell in several methods even though the actual behavior was already correct
- this keeps the tracing semantics unchanged while reducing local noise in the history run service

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/use_cases/history/test_history_async_offloading.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- behavior should stay the same; the change only centralizes span error marking for the existing `Exception` paths
- the helper stays local to `runs.py` to avoid introducing a broader abstraction for a single service shape

## Follow-ups
- Closes #3320
