### PR TITLE
Remove stale car validation allowlist entries

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_library_validation.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_validation.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from vibesensor.adapters.persistence.car_library import load_car_library
 from vibesensor.adapters.persistence.car_library_validation import (
+    load_car_library_validation_allowlist,
     validate_car_library_rows,
     validate_vehicle_configurations,
 )
+from vibesensor.adapters.persistence.vehicle_configurations import load_vehicle_configurations
 from vibesensor.domain import (
     AxleTireSetup,
     TireSpec,
@@ -251,3 +254,17 @@ def test_validate_vehicle_configurations_allowlist_silences_duplicate() -> None:
     issues = validate_vehicle_configurations([a, b], allowlist=allowlist)
 
     assert not [i for i in issues if i.rule == "duplicate_vehicle_configuration"]
+
+
+def test_bundled_allowlist_entries_match_live_validation_issues() -> None:
+    allowlist = load_car_library_validation_allowlist()
+    vehicle_issue_keys = {
+        (issue.rule, issue.entity)
+        for issue in validate_vehicle_configurations(load_vehicle_configurations(), allowlist={})
+    }
+    row_issue_keys = {
+        (issue.rule, issue.entity)
+        for issue in validate_car_library_rows(load_car_library(), allowlist={})
+    }
+
+    assert sorted(set(allowlist) - (vehicle_issue_keys | row_issue_keys)) == []

--- a/apps/server/vibesensor/data/car_library_validation_allowlist.json
+++ b/apps/server/vibesensor/data/car_library_validation_allowlist.json
@@ -1,14 +1,3 @@
 {
-  "allowances": [
-    {
-      "rule": "pure_ev_requires_single_speed",
-      "entity": "BMW|X1 (U11, 2023-2026)|iX1 xDrive30",
-      "reason": "Legacy row still inherits shared non-EV gearbox data until an exact EV drivetrain row is captured."
-    },
-    {
-      "rule": "pure_ev_requires_single_speed",
-      "entity": "BMW|X2 (U10, 2024-2026)|iX2 xDrive30",
-      "reason": "Legacy row still inherits shared non-EV gearbox data until an exact EV drivetrain row is captured."
-    }
-  ]
+  "allowances": []
 }


### PR DESCRIPTION
## What changed
- remove the two stale EV gearbox allowances from `car_library_validation_allowlist.json`
- add a focused regression that bundled allowlist keys must still match live validation issues

## Why
- the underlying U10/U11 EV rows are already clean without the allowlist
- deleting dead allowances is better than enriching stale entries, and the new test stops the file from drifting again

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/adapters/persistence/test_car_library_validation.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_library_source_evidence.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- behavior stays the same because validation is already clean without these allowances
- the new guard will fail future PRs if allowlist entries outlive the issues they were meant to suppress

## Follow-ups
- Closes #3322
