### PR TITLE
Add ESP32-C3 firmware build env

### DIFF
--- a/firmware/esp/HARDENING.md
+++ b/firmware/esp/HARDENING.md
@@ -107,8 +107,13 @@ dedicated sampling task.
 cd firmware/esp
 python3 ../../tools/firmware/generate_protocol_contract_fixtures.py --check
 pio run -e m5stack_atom
+pio run -e esp32-c3-devkitm-1
 pio test -e native
 ```
+
+`esp32-c3-devkitm-1` is an experimental compile-only target. It helps catch
+single-core and board-specific build assumptions, but the runtime pin defaults
+still target the ATOM Lite layout.
 
 ## Runtime counters/status to monitor
 

--- a/firmware/esp/README.md
+++ b/firmware/esp/README.md
@@ -1,8 +1,10 @@
 # ESP32 Firmware
 
-PlatformIO firmware for M5Stack ATOM Lite (ESP32-PICO) that reads an ADXL345
-accelerometer at 800 Hz and streams 100 ms sample frames to the Pi server over
-UDP.
+PlatformIO firmware for the M5Stack ATOM Lite (ESP32-PICO) that reads an
+ADXL345 accelerometer at 800 Hz and streams 100 ms sample frames to the Pi
+server over UDP. The default build target stays on the ATOM Lite, and the repo
+also carries an experimental ESP32-C3 compile-only environment to catch
+board-specific assumptions earlier.
 
 ## Features
 
@@ -78,11 +80,25 @@ firmware/esp/
 
 ## Build and Flash
 
+Default ATOM Lite build and flash path:
+
 ```bash
 cd firmware/esp
-pio run -t upload
+pio run -e m5stack_atom -t upload
 pio device monitor
 ```
+
+Experimental ESP32-C3 compile coverage:
+
+```bash
+cd firmware/esp
+pio run -e esp32-c3-devkitm-1
+```
+
+The ESP32-C3 environment is compile coverage only for now. It keeps the current
+runtime defaults from `src/runtime_config.h`, which still assume the ATOM Lite
+LED and ADXL345 pin mapping. Override those settings before treating a C3 build
+as real hardware support.
 
 ## Configure
 

--- a/firmware/esp/platformio.ini
+++ b/firmware/esp/platformio.ini
@@ -30,6 +30,21 @@ build_flags =
   ; -D VIBESENSOR_WIFI_SCAN_INTERVAL_MS=20000
   ; -D VIBESENSOR_SAMPLING_TASK_CORE=0
 
+[env:esp32-c3-devkitm-1]
+platform = espressif32@6.13.0
+board = esp32-c3-devkitm-1
+framework = arduino
+; Experimental compile-coverage target only. Runtime pin and LED defaults still
+; match the ATOM Lite layout in `src/runtime_config.h`.
+platform_packages =
+  framework-arduinoespressif32@3.20017.0
+monitor_speed = 115200
+lib_ldf_mode = deep+
+lib_deps =
+  ${PROJECT_DIR}/lib/Adafruit_NeoPixel
+build_flags =
+  -D CORE_DEBUG_LEVEL=0
+
 [env:native]
 platform = native
 test_framework = unity


### PR DESCRIPTION
## What changed
- add an explicit `esp32-c3-devkitm-1` PlatformIO environment beside the existing ATOM Lite target
- keep `default_envs = m5stack_atom` unchanged
- document the new `pio run -e esp32-c3-devkitm-1` path as experimental compile coverage only

## Why
- the repo only built the ATOM Lite target today, so ESP32-C3 board assumptions were easy to miss
- an explicit C3 env gives lightweight compile coverage without pretending the current Atom pin defaults are proven on C3 hardware

## Validation
- `cd firmware/esp && pio run`
- `cd firmware/esp && pio run -e esp32-c3-devkitm-1`
- `make docs-lint`

## Risks / tradeoffs
- the new env is intentionally compile-only for now; runtime pin and LED defaults still target the ATOM Lite layout
- CI stays unchanged so this adds local/release build coverage without increasing PR-time cost

## Follow-ups
- Closes #3323
