### PR TITLE
Split frontend CI quality and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,8 @@ jobs:
           MYPYPATH: .
         run: python -m mypy --config-file pyproject.toml
 
-  frontend-typecheck:
-    name: Frontend type check
+  frontend-quality:
+    name: Frontend quality
     needs:
       - ci-scope
     if: ${{ needs.ci-scope.outputs.run_frontend_typecheck == 'true' }}
@@ -241,10 +241,6 @@ jobs:
         working-directory: apps/ui
         run: npm run lint
 
-      - name: Sync generated UI contract derivatives
-        working-directory: apps/ui
-        run: npm run sync:generated-contracts
-
       - name: UI dependency boundary checks
         working-directory: apps/ui
         run: npm run lint:deps
@@ -252,6 +248,33 @@ jobs:
       - name: UI dead code checks
         working-directory: apps/ui
         run: npm run lint:unused
+
+  frontend-typecheck:
+    name: Frontend type check
+    needs:
+      - ci-scope
+    if: ${{ needs.ci-scope.outputs.run_frontend_typecheck == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          cache-dependency-path: apps/ui/package-lock.json
+
+      - name: Install UI dependencies
+        working-directory: apps/ui
+        run: node ../../tools/ui/ensure_ui_bootstrap.mjs
+
+      - name: Sync generated UI contract derivatives
+        working-directory: apps/ui
+        run: npm run sync:generated-contracts
 
       - name: UI typecheck
         working-directory: apps/ui
@@ -408,6 +431,7 @@ jobs:
       - docs-lint
       - backend-contract-drift
       - backend-typecheck
+      - frontend-quality
       - frontend-typecheck
       - ui-build-artifact
     if: >-
@@ -421,6 +445,7 @@ jobs:
         needs.docs-lint.result != 'failure' &&
         needs.backend-contract-drift.result != 'failure' &&
         needs.backend-typecheck.result != 'failure' &&
+        needs.frontend-quality.result != 'failure' &&
         needs.frontend-typecheck.result != 'failure' &&
         needs.ui-build-artifact.result == 'success'
       }}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -153,7 +153,7 @@ Focused CI job groups and full-stack validation:
 
 ```bash
 python3 tools/tests/run_ci_parallel.py --ci-lite
-python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
+python3 tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-smoke
 python3 tools/tests/run_ci_parallel.py --job release-smoke
 make test-full-suite
 ```
@@ -181,7 +181,7 @@ cd apps/ui && npm run test:unit
 cd apps/ui && npm run build
 cd apps/ui && npm run test:visual
 cd apps/ui && npm run test:visual:audit   # optional broader visual sweep
-python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-unit --job ui-smoke
+python3 tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
 ```
 
 The UI has three test layers; pick the one that matches the seam under test:
@@ -200,9 +200,11 @@ The UI has three test layers; pick the one that matches the seam under test:
   `npm run test:visual:update` only for intentional baseline changes.
 - `npm run test:visual:audit` is the opt-in four-project visual audit sweep
   when you need dark/tablet coverage on purpose instead of in the default lane.
-- `frontend-typecheck` is the UI contract/type/tooling gate: it syncs generated
-  contract artifacts, then runs Biome, dependency-cruiser, knip, and TypeScript.
-  `ui-unit` runs the Vitest suite and `ui-smoke` is the CI browser path. Use
+- `frontend-quality` is the UI lint/tooling gate: it runs Biome,
+  dependency-cruiser, and knip. `frontend-typecheck` is the generated-contract
+  and TypeScript gate: it syncs generated contract artifacts, then runs
+  `npm run typecheck`. `ui-unit` runs the Vitest suite and `ui-smoke` is the CI
+  browser path. Use `act -j frontend-quality -W .github/workflows/ci.yml`,
   `act -j frontend-typecheck -W .github/workflows/ci.yml`,
   `act -j ui-unit -W .github/workflows/ci.yml`, or
   `act -j ui-smoke -W .github/workflows/ci.yml` when you need GitHub-workflow
@@ -298,6 +300,7 @@ act -j backend-preflight -W .github/workflows/ci.yml
 act -j docs-lint -W .github/workflows/ci.yml
 act -j backend-contract-drift -W .github/workflows/ci.yml
 act -j backend-typecheck -W .github/workflows/ci.yml
+act -j frontend-quality -W .github/workflows/ci.yml
 act -j frontend-typecheck -W .github/workflows/ci.yml
 act -j backend-tests -W .github/workflows/ci.yml
 act -j ui-smoke -W .github/workflows/ci.yml
@@ -335,6 +338,7 @@ No secrets are currently required. If needed in the future, copy
 | `docs-lint` | ✅ Fully supported | — |
 | `backend-contract-drift` | ✅ Fully supported | — |
 | `backend-typecheck` | ✅ Fully supported | — |
+| `frontend-quality` | ✅ Fully supported | — |
 | `frontend-typecheck` | ✅ Fully supported | — |
 | `ui-smoke` | ✅ Fully supported | — |
 | `release-smoke` | ✅ Fully supported | — |
@@ -364,7 +368,7 @@ rules explicit, documented, and test-backed.
 The current gating contract is:
 
 - docs-only markdown changes run `docs-lint` without the backend, frontend, release, firmware, or e2e stacks
-- frontend-only changes run `repo-hygiene`, `frontend-typecheck`, `ui-smoke`, and `release-smoke`
+- frontend-only changes run `repo-hygiene`, `frontend-quality`, `frontend-typecheck`, `ui-unit`, `ui-smoke`, and `release-smoke`
 - backend-only changes run the split backend quality gates, `backend-typecheck`, `backend-tests`, `release-smoke`, and `e2e`
 - firmware-only changes run `firmware-native-tests`
 - workflow / CI meta changes such as `.github/workflows/ci.yml`, `Makefile`, version pins, Dockerfiles, and workflow-manifest tooling fall back to the full stack
@@ -408,7 +412,8 @@ workflow-backed CI manifest:
 - `docs-lint`: docs misuse and markdown-link validation.
 - `backend-contract-drift`: WS schema and HTTP API contract drift checks.
 - `backend-typecheck`: mypy on the `vibesensor` backend package; package discovery keeps new backend files checked by default without an internal module denylist.
-- `frontend-typecheck`: `npm run typecheck` in `apps/ui/`.
+- `frontend-quality`: `npm run lint`, `npm run lint:deps`, and `npm run lint:unused` in `apps/ui/`.
+- `frontend-typecheck`: `npm run sync:generated-contracts` and `npm run typecheck` in `apps/ui/`.
 - `release-smoke`: builds packaged UI and a server wheel, then runs the release smoke validator against the built artifact.
 - `ui-smoke`, `backend-tests` (matrix job emitting shard `1/5` through `5/5` checks), `e2e`: required test jobs.
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -93,6 +93,8 @@ def check_path_indirections() -> tuple[list[str], list[str]]:
 
 _BACKEND_TEST_MATRIX_JOB = "backend-tests"
 _CI_SCOPE_JOB = "ci-scope"
+_FRONTEND_QUALITY_JOB = "frontend-quality"
+_FRONTEND_TYPECHECK_JOB = "frontend-typecheck"
 _UI_BUILD_ARTIFACT_JOB = "ui-build-artifact"
 _BACKEND_QUALITY_JOBS = (
     "backend-lint",
@@ -107,11 +109,12 @@ _RELEASE_SMOKE_QUALITY_NEEDS = (
     _CI_SCOPE_JOB,
     *_BACKEND_QUALITY_JOBS,
     "backend-typecheck",
-    "frontend-typecheck",
+    _FRONTEND_QUALITY_JOB,
+    _FRONTEND_TYPECHECK_JOB,
     _UI_BUILD_ARTIFACT_JOB,
 )
-_UI_SMOKE_NEEDS = (_CI_SCOPE_JOB, "frontend-typecheck")
-_UI_BUILD_ARTIFACT_NEEDS = (_CI_SCOPE_JOB, "frontend-typecheck")
+_UI_SMOKE_NEEDS = (_CI_SCOPE_JOB, _FRONTEND_TYPECHECK_JOB)
+_UI_BUILD_ARTIFACT_NEEDS = (_CI_SCOPE_JOB, _FRONTEND_TYPECHECK_JOB)
 _BACKEND_TEST_SHARD_JOBS = (
     "backend-tests-1",
     "backend-tests-2",
@@ -1249,7 +1252,42 @@ def check_contract_sync_entrypoint() -> list[str]:
             ),
         )
 
-    frontend_typecheck_steps = _workflow_job_steps(jobs, "frontend-typecheck")
+    frontend_quality_steps = _workflow_job_steps(jobs, _FRONTEND_QUALITY_JOB)
+    if frontend_quality_steps is not None:
+        _extend_step_requirement_errors(
+            errors,
+            frontend_quality_steps,
+            (
+                WorkflowStepRequirement(
+                    working_directory="apps/ui",
+                    run="npm run lint",
+                    error_message=("frontend-quality must run UI lint in apps/ui."),
+                ),
+                WorkflowStepRequirement(
+                    working_directory="apps/ui",
+                    run="npm run lint:deps",
+                    error_message=(
+                        "frontend-quality must run UI dependency boundary checks in apps/ui."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    working_directory="apps/ui",
+                    run="npm run lint:unused",
+                    error_message=(
+                        "frontend-quality must run UI dead-code checks in apps/ui."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    run="npm run typecheck",
+                    forbidden=True,
+                    error_message=(
+                        "frontend-quality must not run npm run typecheck; that gate belongs in frontend-typecheck."
+                    ),
+                ),
+            ),
+        )
+
+    frontend_typecheck_steps = _workflow_job_steps(jobs, _FRONTEND_TYPECHECK_JOB)
     if frontend_typecheck_steps is not None:
         _extend_step_requirement_errors(
             errors,
@@ -1269,6 +1307,27 @@ def check_contract_sync_entrypoint() -> list[str]:
                     error_message=(
                         "frontend-typecheck must explicitly sync generated UI contract derivatives before "
                         "running npm run typecheck."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    run="npm run lint",
+                    forbidden=True,
+                    error_message=(
+                        "frontend-typecheck must not run npm run lint; that gate belongs in frontend-quality."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    run="npm run lint:deps",
+                    forbidden=True,
+                    error_message=(
+                        "frontend-typecheck must not run npm run lint:deps; that gate belongs in frontend-quality."
+                    ),
+                ),
+                WorkflowStepRequirement(
+                    run="npm run lint:unused",
+                    forbidden=True,
+                    error_message=(
+                        "frontend-typecheck must not run npm run lint:unused; that gate belongs in frontend-quality."
                     ),
                 ),
             ),
@@ -1571,7 +1630,7 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
         and _workflow_job_needs(release_smoke) != _RELEASE_SMOKE_QUALITY_NEEDS
     ):
         errors.append(
-            "release-smoke must depend on ci-scope, the split quality jobs, backend-typecheck, frontend-typecheck, and ui-build-artifact."
+            "release-smoke must depend on ci-scope, the split quality jobs, backend-typecheck, frontend-quality, frontend-typecheck, and ui-build-artifact."
         )
     ui_build_artifact = jobs.get(_UI_BUILD_ARTIFACT_JOB)
     if (
@@ -1596,7 +1655,12 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
     ):
         errors.append("ui-smoke must depend on ci-scope and frontend-typecheck.")
 
-    for job_name in (*_BACKEND_QUALITY_JOBS, "backend-typecheck", "frontend-typecheck"):
+    for job_name in (
+        *_BACKEND_QUALITY_JOBS,
+        "backend-typecheck",
+        _FRONTEND_QUALITY_JOB,
+        _FRONTEND_TYPECHECK_JOB,
+    ):
         raw_job = jobs.get(job_name)
         if (
             isinstance(raw_job, Mapping)


### PR DESCRIPTION
## What changed
- add a separate `frontend-quality` job for UI lint, dependency-boundary checks, and knip
- keep `frontend-typecheck` focused on generated-contract sync plus TypeScript typecheck
- let `ui-unit`, `ui-smoke`, and `ui-build-artifact` wait only on `frontend-typecheck`
- update hygiene guardrails and testing docs to match the new workflow graph

## Why
- the old `frontend-typecheck` job serialized unrelated lint/tooling work ahead of the fast UI test lanes
- splitting the jobs shortens the critical path for frontend feedback without dropping any required checks

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_ci_path_rules.py`
- `make docs-lint`
- `make lint`
- `act` validation could not run here because this environment does not have `act` or Docker

## Risks / tradeoffs
- `frontend-quality` failures no longer block UI tests from starting, but they still remain required checks before merge
- `frontend-typecheck` stays the minimum safety gate for generated contracts and TypeScript before the test and artifact lanes

## Follow-ups
- Closes #3325
