### PR TITLE
Skip redundant Playwright installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,8 @@ jobs:
           cache: "npm"
           cache-dependency-path: apps/ui/package-lock.json
 
-      - uses: actions/cache@v5
+      - id: playwright-browser-cache
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('apps/ui/package-lock.json') }}
@@ -356,13 +357,16 @@ jobs:
         working-directory: apps/ui
         run: node ../../tools/ui/ensure_ui_bootstrap.mjs
 
+      - name: Install Playwright Chromium (cache miss)
+        if: ${{ steps.playwright-browser-cache.outputs.cache-hit != 'true' }}
+        working-directory: apps/ui
+        run: npx playwright install chromium
+
       - name: UI smoke tests
         working-directory: apps/ui
         env:
           PLAYWRIGHT_SMOKE_WORKERS: 4
-        run: |
-          npx playwright install chromium
-          npm run test:smoke
+        run: npm run test:smoke
 
       - name: Upload UI smoke test artifacts
         if: failure()

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -133,3 +133,38 @@ def test_ui_smoke_failure_artifact_contract() -> None:
     assert upload_step["with"]["path"] == f"apps/ui/{_smoke_output_dir()}/"
     assert upload_step["with"]["if-no-files-found"] == "ignore"
     assert upload_step["with"]["retention-days"] == 5
+
+
+def test_ui_smoke_playwright_cache_hit_install_contract() -> None:
+    workflow = _ci_workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    ui_smoke_job = jobs["ui-smoke"]
+    assert isinstance(ui_smoke_job, dict)
+    steps = ui_smoke_job["steps"]
+    assert isinstance(steps, list)
+
+    cache_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("uses") == "actions/cache@v5"
+        and step.get("with", {}).get("path") == "~/.cache/ms-playwright"
+    )
+    assert cache_step["id"] == "playwright-browser-cache"
+
+    install_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Install Playwright Chromium (cache miss)"
+    )
+    assert install_step["if"] == "${{ steps.playwright-browser-cache.outputs.cache-hit != 'true' }}"
+    assert install_step["working-directory"] == "apps/ui"
+    assert install_step["run"] == "npx playwright install chromium"
+
+    smoke_step = next(
+        step for step in steps if isinstance(step, dict) and step.get("name") == "UI smoke tests"
+    )
+    assert smoke_step["working-directory"] == "apps/ui"
+    assert smoke_step["env"]["PLAYWRIGHT_SMOKE_WORKERS"] == 4
+    assert smoke_step["run"] == "npm run test:smoke"

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1778,10 +1778,41 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
     ui_smoke = jobs.get("ui-smoke") if isinstance(jobs, Mapping) else None
     steps = ui_smoke.get("steps") if isinstance(ui_smoke, Mapping) else None
     playwright_cache_ok = False
+    playwright_install_step_ok = False
+    ui_smoke_command_ok = False
     if isinstance(steps, list):
         for step in steps:
             if not isinstance(step, Mapping):
                 continue
+            step_name = step.get("name")
+            step_run = step.get("run")
+            step_working_directory = step.get("working-directory")
+            step_env = step.get("env") if isinstance(step.get("env"), Mapping) else None
+            normalized_command = ""
+            if isinstance(step_run, str):
+                cwd_prefix = ""
+                if isinstance(step_working_directory, str) and step_working_directory:
+                    cwd_prefix = f"cd {step_working_directory} && "
+                normalized_command = (
+                    f"{cwd_prefix}{_normalize_env(step_env)}"
+                    f"{_normalize_shell_command(step_run.strip())}"
+                )
+            if (
+                isinstance(step_name, str)
+                and step_name == "Install Playwright Chromium (cache miss)"
+                and step.get("if")
+                == "${{ steps.playwright-browser-cache.outputs.cache-hit != 'true' }}"
+                and normalized_command
+                == "cd apps/ui && npx playwright install chromium"
+            ):
+                playwright_install_step_ok = True
+            if (
+                isinstance(step_name, str)
+                and step_name == "UI smoke tests"
+                and normalized_command
+                == "cd apps/ui && env PLAYWRIGHT_SMOKE_WORKERS=4 npm run test:smoke"
+            ):
+                ui_smoke_command_ok = True
             uses = step.get("uses")
             if not isinstance(uses, str) or not uses.startswith("actions/cache@"):
                 continue
@@ -1791,17 +1822,25 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
             path = with_data.get("path")
             key = with_data.get("key")
             if (
-                isinstance(path, str)
+                step.get("id") == "playwright-browser-cache"
+                and isinstance(path, str)
                 and path.strip() == "~/.cache/ms-playwright"
                 and isinstance(key, str)
                 and "ms-playwright" in key
                 and "package-lock.json" in key
             ):
                 playwright_cache_ok = True
-                break
     if not playwright_cache_ok:
         errors.append(
-            "ui-smoke must cache ~/.cache/ms-playwright with a package-lock-based actions/cache key."
+            "ui-smoke must cache ~/.cache/ms-playwright with id playwright-browser-cache and a package-lock-based actions/cache key."
+        )
+    if not playwright_install_step_ok:
+        errors.append(
+            "ui-smoke must install Playwright Chromium in a separate cache-miss-only step."
+        )
+    if not ui_smoke_command_ok:
+        errors.append(
+            "ui-smoke must keep the smoke step focused on npm run test:smoke."
         )
 
     backend_job = (


### PR DESCRIPTION
## What changed
- give the ui-smoke Playwright cache step an explicit id
- move Chromium installation into its own cache-miss-only step after UI dependency setup
- keep the smoke step focused on `npm run test:smoke` and add workflow guardrails/tests for that contract

## Why
- ui-smoke already caches `~/.cache/ms-playwright`, but it still ran `npx playwright install chromium` inside the smoke step on every run
- using the cache-hit signal lets warm-cache runs skip the redundant install work while cold-cache runs still install Chromium safely
- splitting the install step also makes the CI log clearly show whether the browser install was skipped or performed

## Validation
- make format
- python -m pytest -q apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
- make lint

## Risks / tradeoffs / edge cases
- the skip path depends on the Playwright cache-hit signal, so restore-key misses still run install as intended
- the install step stays after UI dependency setup so cold-cache runs still have the Playwright CLI available
- no browser/runtime behavior changed beyond skipping redundant warm-cache installation work

Closes #3328
