### PR TITLE
Consolidate whole-run JSON helpers

### DIFF
--- a/apps/server/tests/shared/types/test_whole_run_analysis.py
+++ b/apps/server/tests/shared/types/test_whole_run_analysis.py
@@ -82,6 +82,30 @@ def test_window_descriptor_from_policy_sets_sample_and_time_bounds() -> None:
     assert WholeRunWindowDescriptor.from_mapping(descriptor.to_json_object()) == descriptor
 
 
+def test_window_descriptor_from_mapping_coerces_numeric_strings() -> None:
+    descriptor = WholeRunWindowDescriptor.from_mapping(
+        {
+            "window_index": "3",
+            "sample_start": "600",
+            "sample_end": "2648",
+            "center_sample": "1624",
+            "start_t_s": "0.75",
+            "end_t_s": "3.31",
+            "center_t_s": "2.03",
+        }
+    )
+
+    assert descriptor == WholeRunWindowDescriptor(
+        window_index=3,
+        sample_start=600,
+        sample_end=2648,
+        center_sample=1624,
+        start_t_s=0.75,
+        end_t_s=3.31,
+        center_t_s=2.03,
+    )
+
+
 def test_whole_run_artifact_manifest_round_trips_with_window_policy() -> None:
     policy = WholeRunWindowPolicy.from_metadata(_metadata())
     manifest = WholeRunArtifactManifest(
@@ -171,6 +195,32 @@ def test_context_interval_round_trips_with_window_range_summary() -> None:
 
     assert restored == interval
     assert restored.window_count == 7
+
+
+def test_context_interval_from_mapping_defaults_invalid_numeric_fields() -> None:
+    interval = WholeRunContextInterval.from_mapping(
+        {
+            "segment_index": "2",
+            "phase": "acceleration",
+            "load_state": "transient",
+            "start_window_index": "8",
+            "end_window_index": "14",
+            "start_t_s": "bad",
+            "end_t_s": "5.5",
+            "full_context_window_count": "bad",
+            "partial_context_window_count": 2,
+            "missing_context_window_count": None,
+        }
+    )
+
+    assert interval.segment_index == 2
+    assert interval.start_window_index == 8
+    assert interval.end_window_index == 14
+    assert interval.start_t_s is None
+    assert interval.end_t_s == pytest.approx(5.5)
+    assert interval.full_context_window_count == 0
+    assert interval.partial_context_window_count == 2
+    assert interval.missing_context_window_count == 0
 
 
 def test_context_interval_rejects_inverted_window_ranges() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.shared.types.history_analysis_contracts import (
     OrderHarmonicEvidenceSummaryResponse,
     OrderTracePhaseSupportResponse,
@@ -106,6 +108,35 @@ def test_order_trace_summary_round_trips_nested_compact_contracts() -> None:
     )
 
     assert OrderTraceSummary.from_mapping(summary.to_json_object()) == summary
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("exemplar_interval_index", 2.5),
+        ("dominant_phase", 7),
+        ("mean_relative_error", "bad"),
+    ],
+)
+def test_order_trace_summary_drops_invalid_optional_values(field: str, value: object) -> None:
+    payload = OrderTraceSummary(
+        hypothesis_key="engine_2x",
+        suspected_source="engine",
+        order_family="engine",
+        order_label="2x engine",
+        total_window_count=128,
+        eligible_window_count=96,
+        matched_window_count=52,
+        support_ratio=52 / 96,
+        reference_coverage_ratio=96 / 128,
+        longest_contiguous_support_window_count=12,
+        contiguous_support_ratio=12 / 96,
+    ).to_json_object()
+    payload[field] = value
+
+    restored = OrderTraceSummary.from_mapping(payload)
+
+    assert getattr(restored, field) is None
 
 
 def test_history_order_trace_response_contracts_expose_named_summary_fields() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.shared.types.history_analysis_contracts import (
     SpatialEvidenceSummaryResponse,
     SpatialLocationSummaryResponse,
@@ -70,6 +72,32 @@ def test_spatial_evidence_summary_round_trips_nested_compact_contracts() -> None
     )
 
     assert SpatialEvidenceSummary.from_mapping(summary.to_json_object()) == summary
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("dominant_location", 7, "optional text field must be a string or null"),
+        ("coherence_ratio", "bad", "optional numeric field must be a number or null"),
+    ],
+)
+def test_spatial_evidence_summary_rejects_invalid_optional_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    payload = SpatialEvidenceSummary(
+        candidate_key="wheel",
+        suspected_source="wheel/tire",
+        proof_basis="supporting_windows_raw_backed",
+        total_window_count=128,
+        supporting_window_count=42,
+        supporting_sensor_count=4,
+    ).to_json_object()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        SpatialEvidenceSummary.from_mapping(payload)
 
 
 def test_history_spatial_response_contracts_expose_named_summary_fields() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarReferenceResponse,
     DiagnosisFactorDetailsResponse,
@@ -98,6 +100,31 @@ def test_whole_run_diagnosis_summary_round_trips_nested_compact_contracts() -> N
     )
 
     assert WholeRunDiagnosisSummary.from_mapping(summary.to_json_object()) == summary
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("support_score", "bad", "optional numeric field must be a number or null"),
+        ("supporting_window_count", 1.5, "optional int field must be an int or null"),
+        ("dominant_location", 7, "optional text field must be a string or null"),
+    ],
+)
+def test_whole_run_diagnosis_summary_rejects_invalid_optional_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    payload = WholeRunDiagnosisSummary(
+        diagnosis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        rank=1,
+        data_basis="raw_backed",
+    ).to_json_object()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        WholeRunDiagnosisSummary.from_mapping(payload)
 
 
 def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> None:

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -9,6 +9,24 @@ from typing import Literal
 from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_json_helpers import (
+    coerce_float_or_default as _float_from_json,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    coerce_float_or_none as _float_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    coerce_int_or_default as _int_from_json,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    coerce_int_or_none as _int_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    json_text_or_default as _str_from_json,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    json_text_or_none as _str_or_none,
+)
 
 __all__ = [
     "WHOLE_RUN_ARTIFACT_SCHEMA_VERSION",
@@ -418,52 +436,6 @@ class WholeRunContextInterval:
             partial_context_window_count=_int_from_json(data.get("partial_context_window_count")),
             missing_context_window_count=_int_from_json(data.get("missing_context_window_count")),
         )
-
-
-def _int_or_none(value: JsonValue | object) -> int | None:
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, (int, float, str)):
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-    return None
-
-
-def _int_from_json(value: JsonValue | object, default: int = 0) -> int:
-    parsed = _int_or_none(value)
-    return parsed if parsed is not None else default
-
-
-def _float_from_json(value: JsonValue | object, default: float = 0.0) -> float:
-    if isinstance(value, bool) or value is None:
-        return default
-    if isinstance(value, (int, float, str)):
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return default
-    return default
-
-
-def _float_or_none(value: JsonValue | object) -> float | None:
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, (int, float, str)):
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-    return None
-
-
-def _str_from_json(value: JsonValue | object, default: str = "") -> str:
-    return value if isinstance(value, str) else default
-
-
-def _str_or_none(value: JsonValue | object) -> str | None:
-    return value if isinstance(value, str) else None
 
 
 def _driving_phase_from_json(value: JsonValue | object) -> DrivingPhase:

--- a/apps/server/vibesensor/shared/types/whole_run_json_helpers.py
+++ b/apps/server/vibesensor/shared/types/whole_run_json_helpers.py
@@ -1,0 +1,144 @@
+"""Shared JSON helpers for whole-run contracts and persisted artifacts."""
+
+from __future__ import annotations
+
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
+
+
+def set_optional_value(payload: JsonObject, key: str, value: JsonValue | None) -> None:
+    if value is not None:
+        payload[key] = value
+
+
+def non_empty_text_or_none(
+    value: object,
+    *,
+    strict: bool = False,
+    invalid_message: str = "optional text field must be a string or null",
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        if strict:
+            raise ValueError(invalid_message)
+        return None
+    text = value.strip()
+    return text or None
+
+
+def required_non_empty_text(
+    data: JsonObject,
+    field_name: str,
+    *,
+    invalid_message: str,
+) -> str:
+    text = non_empty_text_or_none(data.get(field_name))
+    if text is None:
+        raise ValueError(invalid_message)
+    return text
+
+
+def required_bool_field(
+    data: JsonObject,
+    field_name: str,
+    *,
+    invalid_message: str,
+) -> bool:
+    value = data.get(field_name)
+    if not isinstance(value, bool):
+        raise ValueError(invalid_message)
+    return value
+
+
+def required_int_field(
+    data: JsonObject,
+    field_name: str,
+    *,
+    invalid_message: str,
+) -> int:
+    value = data.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(invalid_message)
+    return value
+
+
+def required_float_field(
+    data: JsonObject,
+    field_name: str,
+    *,
+    invalid_message: str,
+) -> float:
+    value = optional_float_or_none(data.get(field_name))
+    if value is None:
+        raise ValueError(invalid_message)
+    return value
+
+
+def optional_int_or_none(
+    value: object,
+    *,
+    strict: bool = False,
+    invalid_message: str = "optional int field must be an int or null",
+) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        if strict:
+            raise ValueError(invalid_message)
+        return None
+    return value
+
+
+def optional_float_or_none(
+    value: object,
+    *,
+    strict: bool = False,
+    invalid_message: str = "optional numeric field must be a number or null",
+) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if strict:
+            raise ValueError(invalid_message)
+        return None
+    return float(value)
+
+
+def coerce_int_or_none(value: JsonValue | object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def coerce_int_or_default(value: JsonValue | object, default: int = 0) -> int:
+    parsed = coerce_int_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def coerce_float_or_none(value: JsonValue | object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def coerce_float_or_default(value: JsonValue | object, default: float = 0.0) -> float:
+    parsed = coerce_float_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def json_text_or_default(value: JsonValue | object, default: str = "") -> str:
+    return value if isinstance(value, str) else default
+
+
+def json_text_or_none(value: JsonValue | object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -12,7 +12,31 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, cast
 
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import (
+    non_empty_text_or_none as _non_empty_text_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    optional_float_or_none as _optional_float_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    optional_int_or_none as _optional_int_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_bool_field as _required_bool_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_float_field as _required_float_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_int_field as _required_int_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_non_empty_text as _required_non_empty_text,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    set_optional_value as _set_optional,
+)
 
 __all__ = [
     "OrderHarmonicEvidenceSummary",
@@ -402,50 +426,47 @@ def _text_tuple(value: object) -> tuple[str, ...]:
 
 
 def _required_text(data: JsonObject, field: str) -> str:
-    value = _optional_text(data.get(field))
-    if value is None:
-        raise ValueError(f"{field} requires a non-empty string")
-    return value
+    return _required_non_empty_text(
+        data,
+        field,
+        invalid_message=f"{field} requires a non-empty string",
+    )
 
 
 def _optional_text(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    return text or None
+    return _non_empty_text_or_none(value)
 
 
 def _required_bool(data: JsonObject, field: str) -> bool:
-    value = data.get(field)
-    if not isinstance(value, bool):
-        raise ValueError(f"{field} requires a boolean value")
-    return value
+    return _required_bool_field(
+        data,
+        field,
+        invalid_message=f"{field} requires a boolean value",
+    )
 
 
 def _required_int(data: JsonObject, field: str) -> int:
-    value = data.get(field)
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(f"{field} requires an integer value")
-    return value
+    return _required_int_field(
+        data,
+        field,
+        invalid_message=f"{field} requires an integer value",
+    )
 
 
 def _required_float(data: JsonObject, field: str) -> float:
-    value = _optional_float(data.get(field))
-    if value is None:
-        raise ValueError(f"{field} requires a numeric value")
-    return value
+    return _required_float_field(
+        data,
+        field,
+        invalid_message=f"{field} requires a numeric value",
+    )
 
 
 def _optional_int(value: object) -> int | None:
-    if isinstance(value, bool) or not isinstance(value, int):
-        return None
-    return value
+    return _optional_int_or_none(value)
 
 
 def _optional_float(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    return float(value)
+    return _optional_float_or_none(value)
 
 
 def _order_family(value: object) -> OrderTraceFamily:
@@ -473,8 +494,3 @@ def _require_text(value: str, *, field_name: str) -> None:
 def _require_ratio(value: float, *, field_name: str) -> None:
     if not 0.0 <= value <= 1.0:
         raise ValueError(f"{field_name} must be in [0, 1]")
-
-
-def _set_optional(payload: JsonObject, field: str, value: object) -> None:
-    if value is not None:
-        payload[field] = cast(JsonValue, value)

--- a/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
@@ -12,7 +12,25 @@ from dataclasses import dataclass
 from typing import cast
 
 from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import (
+    non_empty_text_or_none as _non_empty_text_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    optional_float_or_none as _optional_float_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_bool_field as _required_bool_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_float_field as _required_float_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_int_field as _required_int_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    set_optional_value as _set_optional,
+)
 
 __all__ = [
     "LocationProofBasis",
@@ -240,24 +258,27 @@ def _required_text(data: JsonObject, field_name: str) -> str:
 
 
 def _required_int(data: JsonObject, field_name: str) -> int:
-    value = data.get(field_name)
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError(f"{field_name} must be an int")
-    return value
+    return _required_int_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be an int",
+    )
 
 
 def _required_float(data: JsonObject, field_name: str) -> float:
-    value = data.get(field_name)
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError(f"{field_name} must be a number")
-    return float(value)
+    return _required_float_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be a number",
+    )
 
 
 def _required_bool(data: JsonObject, field_name: str) -> bool:
-    value = data.get(field_name)
-    if not isinstance(value, bool):
-        raise ValueError(f"{field_name} must be a bool")
-    return value
+    return _required_bool_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be a bool",
+    )
 
 
 def _required_proof_basis(value: object) -> LocationProofBasis:
@@ -271,28 +292,14 @@ def _required_proof_basis(value: object) -> LocationProofBasis:
 
 
 def _optional_float(value: object) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError("optional numeric field must be a number or null")
-    return float(value)
+    return _optional_float_or_none(value, strict=True)
 
 
 def _optional_text(value: object) -> str | None:
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise ValueError("optional text field must be a string or null")
-    text = value.strip()
-    return text or None
+    return _non_empty_text_or_none(value, strict=True)
 
 
 def _text_tuple(value: object) -> tuple[str, ...]:
     if not isinstance(value, list):
         return ()
     return tuple(str(item).strip() for item in value if str(item).strip())
-
-
-def _set_optional(payload: JsonObject, key: str, value: JsonValue | None) -> None:
-    if value is not None:
-        payload[key] = value

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -19,7 +19,28 @@ from vibesensor.shared.types.history_analysis_contracts import (
     LocationProofBasis,
     WholeRunDiagnosisDataBasis,
 )
-from vibesensor.shared.types.json_types import JsonObject, JsonValue
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import (
+    non_empty_text_or_none as _non_empty_text_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    optional_float_or_none as _optional_float_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    optional_int_or_none as _optional_int_or_none,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_bool_field as _required_bool_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_float_field as _required_float_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    required_int_field as _required_int_field,
+)
+from vibesensor.shared.types.whole_run_json_helpers import (
+    set_optional_value as _set_optional,
+)
 
 __all__ = [
     "DiagnosisExemplarReference",
@@ -381,24 +402,27 @@ def _required_text(data: JsonObject, field_name: str) -> str:
 
 
 def _required_int(data: JsonObject, field_name: str) -> int:
-    value = data.get(field_name)
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError(f"{field_name} must be an int")
-    return value
+    return _required_int_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be an int",
+    )
 
 
 def _required_bool(data: JsonObject, field_name: str) -> bool:
-    value = data.get(field_name)
-    if not isinstance(value, bool):
-        raise ValueError(f"{field_name} must be a bool")
-    return value
+    return _required_bool_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be a bool",
+    )
 
 
 def _required_numeric(data: JsonObject, field_name: str) -> float:
-    value = data.get(field_name)
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError(f"{field_name} must be a number")
-    return float(value)
+    return _required_float_field(
+        data,
+        field_name,
+        invalid_message=f"{field_name} must be a number",
+    )
 
 
 def _required_exemplar_kind(value: object) -> DiagnosisExemplarKind:
@@ -487,30 +511,12 @@ def _optional_proof_basis(value: object) -> LocationProofBasis | None:
 
 
 def _optional_float(value: object) -> float | None:
-    if value is None:
-        return None
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ValueError("optional numeric field must be a number or null")
-    return float(value)
+    return _optional_float_or_none(value, strict=True)
 
 
 def _optional_int(value: object) -> int | None:
-    if value is None:
-        return None
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError("optional int field must be an int or null")
-    return value
+    return _optional_int_or_none(value, strict=True)
 
 
 def _optional_text(value: object) -> str | None:
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise ValueError("optional text field must be a string or null")
-    text = value.strip()
-    return text or None
-
-
-def _set_optional(payload: JsonObject, key: str, value: JsonValue | None) -> None:
-    if value is not None:
-        payload[key] = value
+    return _non_empty_text_or_none(value, strict=True)


### PR DESCRIPTION
## What changed
- add `vibesensor.shared.types.whole_run_json_helpers` for whole-run JSON field parsing and optional payload insertion
- switch order, diagnosis, spatial, and whole-run artifact contracts to the shared helpers while keeping separate lenient, strict, and coercing entrypoints
- add regression tests for lenient optional drop-to-None parsing, strict invalid-optional rejection, and coercing/defaulting artifact parsing

## Why
- these modules repeated the same helper families in parallel
- the code was easy to drift even though some behaviors were intentionally different
- one small shared module keeps the shared parts together without forcing one parsing mode on every caller

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/shared/types/test_whole_run_analysis.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- required-text behavior is intentionally still not identical across all modules; order keeps trimmed required-text parsing, while diagnosis/spatial keep their prior preserve-input behavior
- helper scope stays whole-run-specific on purpose; nested-list decoding and literal-set consolidation stay with follow-up issues

Closes #3332