### PR TITLE
Extract whole-run JSONL sidecar helpers

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
 from vibesensor.use_cases.diagnostics.whole_run_context import (
@@ -59,3 +61,11 @@ def test_build_whole_run_context_artifact_bundle_round_trips_labels_and_interval
 
 def test_whole_run_context_labels_from_jsonl_bytes_handles_empty_payload() -> None:
     assert whole_run_context_labels_from_jsonl_bytes(b"") == ()
+
+
+def test_whole_run_context_labels_from_jsonl_bytes_rejects_non_object_rows() -> None:
+    with pytest.raises(
+        ValueError,
+        match="whole-run context label line must decode to a JSON object",
+    ):
+        whole_run_context_labels_from_jsonl_bytes(b"[]\n")

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
@@ -10,6 +10,8 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     summarize_whole_run_order_traces,
+    whole_run_order_trace_summaries_from_jsonl_bytes,
+    whole_run_order_trace_summaries_to_jsonl_bytes,
 )
 
 
@@ -129,6 +131,26 @@ def test_summarize_whole_run_order_traces_distinguishes_strong_and_weak_lock() -
     assert strong.strongest_location == "Front Left"
     assert strong.harmonic_summaries[0].lock_score == strong.lock_score
     assert weak.harmonic_summaries[0].relative_error_stddev is not None
+
+
+def test_whole_run_order_trace_summaries_jsonl_round_trip() -> None:
+    labels = tuple(_label(index) for index in range(2))
+    points = tuple(
+        _point(
+            index,
+            matched=True,
+            relative_error=0.01,
+            peak_intensity_db=18.0,
+            vibration_strength_db=12.0,
+            strongest_location="Front Left",
+        )
+        for index in range(2)
+    )
+
+    summaries = summarize_whole_run_order_traces(points=points, context_labels=labels)
+    payload = whole_run_order_trace_summaries_to_jsonl_bytes(summaries)
+
+    assert whole_run_order_trace_summaries_from_jsonl_bytes(payload) == summaries
 
 
 def test_summarize_whole_run_order_traces_degrades_partial_reference_explicitly() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
@@ -21,6 +21,8 @@ from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
     WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
     build_whole_run_spatial_coherence_artifact_bundle,
     summarize_whole_run_spatial_coherence,
+    whole_run_spatial_evidence_windows_from_jsonl_bytes,
+    whole_run_spatial_evidence_windows_to_jsonl_bytes,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunWindowSpectralSummary,
@@ -277,6 +279,38 @@ def test_build_whole_run_spatial_coherence_artifact_bundle_is_deterministic() ->
     assert first.artifact_contents == second.artifact_contents
     assert first.windows == second.windows
     assert first.summaries == second.summaries
+
+
+def test_whole_run_spatial_evidence_windows_jsonl_round_trip() -> None:
+    windows = (
+        SpatialEvidenceWindow(
+            candidate_key="wheel_1x",
+            suspected_source="wheel/tire",
+            window_index=0,
+            sensor_id="sensor-front",
+            location="front-left",
+            supporting=True,
+            coherent=True,
+            peak_intensity_db=32.0,
+            vibration_strength_db=28.0,
+            matched_frequency_hz=10.0,
+            coherence_score=1.0,
+        ),
+        SpatialEvidenceWindow(
+            candidate_key="wheel_1x",
+            suspected_source="wheel/tire",
+            window_index=0,
+            sensor_id="sensor-rear",
+            location="rear-left",
+            supporting=False,
+            coherent=False,
+            vibration_strength_db=20.0,
+        ),
+    )
+
+    payload = whole_run_spatial_evidence_windows_to_jsonl_bytes(windows)
+
+    assert whole_run_spatial_evidence_windows_from_jsonl_bytes(payload) == windows
 
 
 def test_summarize_whole_run_spatial_coherence_builds_clear_hotspot_location_summary() -> None:

--- a/apps/server/vibesensor/use_cases/diagnostics/_jsonl_sidecars.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_jsonl_sidecars.py
@@ -1,0 +1,41 @@
+"""Shared JSONL sidecar serialization helpers for whole-run diagnostics artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Protocol
+
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
+
+
+class _JsonSidecarObject(Protocol):
+    def to_json_object(self) -> JsonObject: ...
+
+
+def jsonl_bytes_from_objects(objects: Sequence[_JsonSidecarObject]) -> bytes:
+    if not objects:
+        return b""
+    lines = [safe_json_dumps(obj.to_json_object()).encode("utf-8") for obj in objects]
+    return b"\n".join(lines) + b"\n"
+
+
+def jsonl_objects_from_bytes[T](
+    payload: bytes,
+    *,
+    context: str,
+    line_description: str,
+    from_mapping: Callable[[JsonObject], T],
+) -> tuple[T, ...]:
+    if not payload:
+        return ()
+    objects: list[T] = []
+    for raw_line in payload.decode("utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parsed = safe_json_loads(line, context=context)
+        if not is_json_object(parsed):
+            raise ValueError(f"{line_description} must decode to a JSON object")
+        objects.append(from_mapping(parsed))
+    return tuple(objects)

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -7,13 +7,15 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from math import sqrt
 
-from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.whole_run_analysis import (
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
+    jsonl_bytes_from_objects,
+    jsonl_objects_from_bytes,
 )
 from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis, _order_hypotheses
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
@@ -142,10 +144,7 @@ def whole_run_order_trace_summaries_to_jsonl_bytes(
 ) -> bytes:
     """Serialize compact whole-run order-trace summaries into sidecar JSONL bytes."""
 
-    if not summaries:
-        return b""
-    lines = [safe_json_dumps(summary.to_json_object()).encode("utf-8") for summary in summaries]
-    return b"\n".join(lines) + b"\n"
+    return jsonl_bytes_from_objects(summaries)
 
 
 def whole_run_order_trace_summaries_from_jsonl_bytes(
@@ -153,18 +152,12 @@ def whole_run_order_trace_summaries_from_jsonl_bytes(
 ) -> tuple[OrderTraceSummary, ...]:
     """Reconstruct compact whole-run order-trace summaries from persisted JSONL bytes."""
 
-    if not payload:
-        return ()
-    summaries: list[OrderTraceSummary] = []
-    for raw_line in payload.decode("utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parsed = safe_json_loads(line, context="whole-run order trace summaries")
-        if not is_json_object(parsed):
-            raise ValueError("whole-run order trace summary line must decode to a JSON object")
-        summaries.append(OrderTraceSummary.from_mapping(parsed))
-    return tuple(summaries)
+    return jsonl_objects_from_bytes(
+        payload,
+        context="whole-run order trace summaries",
+        line_description="whole-run order trace summary line",
+        from_mapping=OrderTraceSummary.from_mapping,
+    )
 
 
 def _summarize_hypothesis_trace(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import cast
 
-from vibesensor.shared.json_utils import safe_json_dumps
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
@@ -14,6 +13,7 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
 )
+from vibesensor.use_cases.diagnostics._jsonl_sidecars import jsonl_bytes_from_objects
 from vibesensor.use_cases.diagnostics._reference_resolution import _tire_reference_from_context
 from vibesensor.use_cases.diagnostics._sensor_locations import (
     client_locations_by_sensor,
@@ -144,10 +144,7 @@ def build_whole_run_order_trace_artifact_bundle(
 def order_trace_points_to_jsonl_bytes(points: Sequence[OrderTracePoint]) -> bytes:
     """Serialize dense whole-run order traces into sidecar JSONL bytes."""
 
-    if not points:
-        return b""
-    lines = [safe_json_dumps(point.to_json_object()).encode("utf-8") for point in points]
-    return b"\n".join(lines) + b"\n"
+    return jsonl_bytes_from_objects(points)
 
 
 def _hypothesis_trace_points(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
@@ -9,9 +9,7 @@ from dataclasses import dataclass
 from math import isfinite
 
 from vibesensor.domain import DrivingPhase, speed_bin_label
-from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import (
     WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
@@ -23,6 +21,10 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunContextWindowLabel,
     WholeRunRpmValidity,
     WholeRunSpeedValidity,
+)
+from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
+    jsonl_bytes_from_objects,
+    jsonl_objects_from_bytes,
 )
 
 from ._reference_resolution import _effective_engine_rpm, _tire_reference_from_context
@@ -135,10 +137,7 @@ def whole_run_context_labels_to_jsonl_bytes(
 ) -> bytes:
     """Serialize whole-run context labels into the sidecar JSONL format."""
 
-    if not labels:
-        return b""
-    lines = [safe_json_dumps(label.to_json_object()).encode("utf-8") for label in labels]
-    return b"\n".join(lines) + b"\n"
+    return jsonl_bytes_from_objects(labels)
 
 
 def whole_run_context_labels_from_jsonl_bytes(
@@ -146,19 +145,12 @@ def whole_run_context_labels_from_jsonl_bytes(
 ) -> tuple[WholeRunContextWindowLabel, ...]:
     """Reconstruct persisted whole-run context labels from sidecar JSONL bytes."""
 
-    if not payload:
-        return ()
-    labels: list[WholeRunContextWindowLabel] = []
-    text = payload.decode("utf-8")
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parsed = safe_json_loads(line, context="whole-run context labels")
-        if not is_json_object(parsed):
-            raise ValueError("whole-run context label line must decode to a JSON object")
-        labels.append(WholeRunContextWindowLabel.from_mapping(parsed))
-    return tuple(labels)
+    return jsonl_objects_from_bytes(
+        payload,
+        context="whole-run context labels",
+        line_description="whole-run context label line",
+        from_mapping=WholeRunContextWindowLabel.from_mapping,
+    )
 
 
 def normalize_whole_run_context_labels(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -8,13 +8,15 @@ from dataclasses import dataclass
 from statistics import mean as _mean
 
 from vibesensor.domain import LocationHotspot
-from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.whole_run_analysis import (
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
+    jsonl_bytes_from_objects,
+    jsonl_objects_from_bytes,
 )
 from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.use_cases.diagnostics.location_scoring import (
@@ -241,10 +243,7 @@ def whole_run_spatial_evidence_windows_to_jsonl_bytes(
 ) -> bytes:
     """Serialize dense whole-run spatial evidence rows into sidecar JSONL bytes."""
 
-    if not windows:
-        return b""
-    lines = [safe_json_dumps(window.to_json_object()).encode("utf-8") for window in windows]
-    return b"\n".join(lines) + b"\n"
+    return jsonl_bytes_from_objects(windows)
 
 
 def whole_run_spatial_evidence_windows_from_jsonl_bytes(
@@ -252,18 +251,12 @@ def whole_run_spatial_evidence_windows_from_jsonl_bytes(
 ) -> tuple[SpatialEvidenceWindow, ...]:
     """Reconstruct persisted dense whole-run spatial evidence rows from JSONL bytes."""
 
-    if not payload:
-        return ()
-    windows: list[SpatialEvidenceWindow] = []
-    for raw_line in payload.decode("utf-8").splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parsed = safe_json_loads(line, context="whole-run spatial evidence windows")
-        if not is_json_object(parsed):
-            raise ValueError("whole-run spatial evidence line must decode to a JSON object")
-        windows.append(SpatialEvidenceWindow.from_mapping(parsed))
-    return tuple(windows)
+    return jsonl_objects_from_bytes(
+        payload,
+        context="whole-run spatial evidence windows",
+        line_description="whole-run spatial evidence line",
+        from_mapping=SpatialEvidenceWindow.from_mapping,
+    )
 
 
 def _candidate_window_rows(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal, cast
 
-from vibesensor.shared.json_utils import i18n_ref, safe_json_dumps, safe_json_loads
+from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.raw_capture_timeline import (
     RawSensorTimeline,
     raw_timeline_has_unverified_sync,
@@ -23,6 +23,10 @@ from vibesensor.shared.types.raw_capture import (
     RawRunCapture,
 )
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
+    jsonl_bytes_from_objects,
+    jsonl_objects_from_bytes,
+)
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.vibration_strength import StrengthPeak
 
@@ -388,10 +392,7 @@ def build_whole_run_warnings(
 def whole_run_window_spectral_summaries_to_jsonl_bytes(
     summaries: Sequence[WholeRunWindowSpectralSummary],
 ) -> bytes:
-    if not summaries:
-        return b""
-    lines = [safe_json_dumps(summary.to_json_object()).encode("utf-8") for summary in summaries]
-    return b"\n".join(lines) + b"\n"
+    return jsonl_bytes_from_objects(summaries)
 
 
 def whole_run_window_spectral_summaries_from_jsonl_bytes(
@@ -399,19 +400,12 @@ def whole_run_window_spectral_summaries_from_jsonl_bytes(
 ) -> tuple[WholeRunWindowSpectralSummary, ...]:
     """Reconstruct persisted whole-run spectral summaries from sidecar JSONL bytes."""
 
-    if not payload:
-        return ()
-    summaries: list[WholeRunWindowSpectralSummary] = []
-    text = payload.decode("utf-8")
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parsed = safe_json_loads(line, context="whole-run spectral summaries")
-        if not is_json_object(parsed):
-            raise ValueError("whole-run spectral summary line must decode to a JSON object")
-        summaries.append(WholeRunWindowSpectralSummary.from_mapping(parsed))
-    return tuple(summaries)
+    return jsonl_objects_from_bytes(
+        payload,
+        context="whole-run spectral summaries",
+        line_description="whole-run spectral summary line",
+        from_mapping=WholeRunWindowSpectralSummary.from_mapping,
+    )
 
 
 def whole_run_spectral_summaries_by_sensor(


### PR DESCRIPTION
## What changed
- add `vibesensor.use_cases.diagnostics._jsonl_sidecars` for whole-run JSONL sidecar encoding and decoding
- switch whole-run context labels, order trace summaries, spatial evidence windows, spectral summaries, and order trace points to the shared helper
- add focused regressions for context non-object rows plus order-summary and spatial-evidence JSONL round trips

## Why
- these whole-run sidecar modules repeated the same JSONL encode/decode loops in parallel
- that duplication made it easy for byte format or error text to drift between callers
- one diagnostics-owned helper removes the repetition without introducing a repo-wide serialization framework

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py apps/server/tests/use_cases/diagnostics/test_whole_run_spectral_projection.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- helper scope stays inside diagnostics on purpose; this is shared sidecar plumbing, not a generic JSONL abstraction for the whole repo
- callers still own their context labels and line-specific non-object error text so behavior does not flatten into one generic message

Closes #3333