### PR TITLE
Centralize whole-run artifact manifest construction

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
@@ -48,6 +48,23 @@ def test_build_whole_run_context_artifact_bundle_round_trips_labels_and_interval
     assert artifact is not None
     assert artifact.relative_path == "context/window-labels.jsonl"
     assert artifact.record_count == 4
+    assert bundle.manifest.to_json_object() == {
+        "schema_version": bundle.manifest.schema_version,
+        "storage_type": bundle.manifest.storage_type,
+        "run_id": "run-context-artifacts",
+        "relative_dir": "whole-run-artifacts/run-context-artifacts",
+        "window_policy": bundle.manifest.window_policy.to_json_object(),
+        "total_window_count": 4,
+        "artifacts": [
+            {
+                "artifact_key": WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+                "relative_path": "context/window-labels.jsonl",
+                "file_format": "jsonl",
+                "record_count": 4,
+            }
+        ],
+        "created_at": "2025-01-01T00:00:01Z",
+    }
     assert len(bundle.labels) == 4
     assert len(bundle.intervals) >= 1
     assert bundle.intervals[0].start_window_index == 0

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py
@@ -3,16 +3,30 @@
 from __future__ import annotations
 
 from vibesensor.domain import DrivingPhase
-from vibesensor.shared.types.whole_run_analysis import WholeRunContextWindowLabel
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderTraceFamily,
     OrderTracePoint,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
+    WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
+    build_whole_run_order_family_summary_artifact_bundle,
     summarize_whole_run_order_trace_families,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+    WholeRunOrderTraceSummaryArtifactBundle,
     summarize_whole_run_order_traces,
+    whole_run_order_trace_summaries_from_jsonl_bytes,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
 )
 
 
@@ -35,6 +49,38 @@ def _label(
         speed_source="gps",
         engine_rpm=1800.0 if phase == DrivingPhase.CRUISE else 2200.0,
         engine_rpm_source="obd2",
+    )
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=200,
+        window_size_samples=256,
+        stride_samples=100,
+        overlap_samples=156,
+        feature_interval_s=0.5,
+    )
+
+
+def _order_trace_bundle(points: tuple[OrderTracePoint, ...]) -> WholeRunOrderTraceArtifactBundle:
+    return WholeRunOrderTraceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-order-families",
+            relative_dir="whole-run-artifacts/run-order-families",
+            window_policy=_window_policy(),
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+                    relative_path="orders/traces.jsonl",
+                    file_format="jsonl",
+                    record_count=len(points),
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: b""},
+        points=points,
     )
 
 
@@ -153,3 +199,73 @@ def test_summarize_whole_run_order_trace_families_builds_phase_and_interval_roll
     assert summary.strongest_location == "Front Left"
     assert summary.stable_frequency_min_hz == 11.8
     assert summary.stable_frequency_max_hz == 24.6
+
+
+def test_build_whole_run_order_family_summary_artifact_bundle_preserves_manifest_shape() -> None:
+    labels = tuple(_label(index) for index in range(4))
+    points = tuple(
+        _point(
+            index,
+            hypothesis_key="wheel_1x",
+            harmonic=1,
+            order_label="1x wheel",
+            matched=True,
+            matched_hz=12.0 + index,
+            relative_error=0.02,
+            peak_intensity_db=18.0,
+            vibration_strength_db=12.0,
+            strongest_location="Front Left",
+        )
+        for index in range(4)
+    )
+    candidate_summaries = summarize_whole_run_order_traces(points=points, context_labels=labels)
+    order_trace_bundle = _order_trace_bundle(points)
+    order_trace_summary_bundle = WholeRunOrderTraceSummaryArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-order-families",
+            relative_dir="whole-run-artifacts/run-order-families",
+            window_policy=_window_policy(),
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+                    relative_path="orders/trace-summaries.jsonl",
+                    file_format="jsonl",
+                    record_count=len(candidate_summaries),
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY: b""},
+        summaries=candidate_summaries,
+    )
+
+    bundle = build_whole_run_order_family_summary_artifact_bundle(
+        order_trace_bundle=order_trace_bundle,
+        order_trace_summary_bundle=order_trace_summary_bundle,
+        context_labels=tuple(reversed(labels)),
+    )
+
+    assert bundle.manifest.to_json_object() == {
+        "schema_version": bundle.manifest.schema_version,
+        "storage_type": bundle.manifest.storage_type,
+        "run_id": "run-order-families",
+        "relative_dir": "whole-run-artifacts/run-order-families",
+        "window_policy": bundle.manifest.window_policy.to_json_object(),
+        "total_window_count": 4,
+        "artifacts": [
+            {
+                "artifact_key": WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
+                "relative_path": "orders/family-summaries.jsonl",
+                "file_format": "jsonl",
+                "record_count": len(bundle.summaries),
+            }
+        ],
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+    assert (
+        whole_run_order_trace_summaries_from_jsonl_bytes(
+            bundle.artifact_contents[WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY]
+        )
+        == bundle.summaries
+    )

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
@@ -3,15 +3,26 @@
 from __future__ import annotations
 
 from vibesensor.domain import DrivingPhase
-from vibesensor.shared.types.whole_run_analysis import WholeRunContextWindowLabel
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderTraceFamily,
     OrderTracePoint,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+    build_whole_run_order_trace_summary_artifact_bundle,
     summarize_whole_run_order_traces,
     whole_run_order_trace_summaries_from_jsonl_bytes,
     whole_run_order_trace_summaries_to_jsonl_bytes,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
 )
 
 
@@ -34,6 +45,38 @@ def _label(
         speed_source="obd2",
         engine_rpm=1800.0,
         engine_rpm_source="obd2",
+    )
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=200,
+        window_size_samples=256,
+        stride_samples=100,
+        overlap_samples=156,
+        feature_interval_s=0.5,
+    )
+
+
+def _order_trace_bundle(points: tuple[OrderTracePoint, ...]) -> WholeRunOrderTraceArtifactBundle:
+    return WholeRunOrderTraceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-order-scoring",
+            relative_dir="whole-run-artifacts/run-order-scoring",
+            window_policy=_window_policy(),
+            total_window_count=2,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+                    relative_path="orders/traces.jsonl",
+                    file_format="jsonl",
+                    record_count=len(points),
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: b""},
+        points=points,
     )
 
 
@@ -151,6 +194,50 @@ def test_whole_run_order_trace_summaries_jsonl_round_trip() -> None:
     payload = whole_run_order_trace_summaries_to_jsonl_bytes(summaries)
 
     assert whole_run_order_trace_summaries_from_jsonl_bytes(payload) == summaries
+
+
+def test_build_whole_run_order_trace_summary_artifact_bundle_preserves_manifest_shape() -> None:
+    labels = tuple(_label(index) for index in range(2))
+    points = tuple(
+        _point(
+            index,
+            matched=True,
+            relative_error=0.01,
+            peak_intensity_db=18.0,
+            vibration_strength_db=12.0,
+            strongest_location="Front Left",
+        )
+        for index in range(2)
+    )
+
+    bundle = build_whole_run_order_trace_summary_artifact_bundle(
+        order_trace_bundle=_order_trace_bundle(points),
+        context_labels=tuple(reversed(labels)),
+    )
+
+    assert bundle.manifest.to_json_object() == {
+        "schema_version": bundle.manifest.schema_version,
+        "storage_type": bundle.manifest.storage_type,
+        "run_id": "run-order-scoring",
+        "relative_dir": "whole-run-artifacts/run-order-scoring",
+        "window_policy": bundle.manifest.window_policy.to_json_object(),
+        "total_window_count": 2,
+        "artifacts": [
+            {
+                "artifact_key": WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+                "relative_path": "orders/trace-summaries.jsonl",
+                "file_format": "jsonl",
+                "record_count": len(bundle.summaries),
+            }
+        ],
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+    assert (
+        whole_run_order_trace_summaries_from_jsonl_bytes(
+            bundle.artifact_contents[WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY]
+        )
+        == bundle.summaries
+    )
 
 
 def test_summarize_whole_run_order_traces_degrades_partial_reference_explicitly() -> None:

--- a/apps/server/vibesensor/use_cases/diagnostics/_artifact_bundles.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_artifact_bundles.py
@@ -1,0 +1,87 @@
+"""Shared helpers for compact whole-run artifact bundle construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SingleArtifactBundleParts:
+    manifest: WholeRunArtifactManifest
+    artifact_contents: dict[str, bytes]
+
+
+def build_single_artifact_bundle_parts(
+    *,
+    artifact_key: str,
+    relative_path: str,
+    file_format: str,
+    record_count: int,
+    content_bytes: bytes,
+    created_at: str,
+    source_manifest: WholeRunArtifactManifest | None = None,
+    run_id: str | None = None,
+    relative_dir: str | None = None,
+    window_policy: WholeRunWindowPolicy | None = None,
+    total_window_count: int | None = None,
+    sensor_id: str | None = None,
+) -> SingleArtifactBundleParts:
+    artifact = WholeRunArtifactFile(
+        artifact_key=artifact_key,
+        relative_path=relative_path,
+        file_format=file_format,
+        record_count=record_count,
+        sensor_id=sensor_id,
+    )
+    resolved_run_id = run_id
+    resolved_relative_dir = relative_dir
+    resolved_window_policy = window_policy
+    resolved_total_window_count = total_window_count
+    if source_manifest is not None:
+        if resolved_run_id is None:
+            resolved_run_id = source_manifest.run_id
+        if resolved_relative_dir is None:
+            resolved_relative_dir = source_manifest.relative_dir
+        if resolved_window_policy is None:
+            resolved_window_policy = source_manifest.window_policy
+        if resolved_total_window_count is None:
+            resolved_total_window_count = source_manifest.total_window_count
+    if (
+        resolved_run_id is None
+        or resolved_relative_dir is None
+        or resolved_window_policy is None
+        or resolved_total_window_count is None
+    ):
+        raise ValueError(
+            "single-artifact bundle helper requires complete manifest fields before construction"
+        )
+    if source_manifest is not None:
+        manifest = WholeRunArtifactManifest(
+            run_id=resolved_run_id,
+            relative_dir=resolved_relative_dir,
+            window_policy=resolved_window_policy,
+            total_window_count=resolved_total_window_count,
+            artifacts=(artifact,),
+            created_at=created_at,
+            schema_version=source_manifest.schema_version,
+            storage_type=source_manifest.storage_type,
+        )
+    else:
+        manifest = WholeRunArtifactManifest(
+            run_id=resolved_run_id,
+            relative_dir=resolved_relative_dir,
+            window_policy=resolved_window_policy,
+            total_window_count=resolved_total_window_count,
+            artifacts=(artifact,),
+            created_at=created_at,
+        )
+    return SingleArtifactBundleParts(
+        manifest=manifest,
+        artifact_contents={artifact_key: content_bytes},
+    )

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass
 
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.whole_run_analysis import (
-    WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._artifact_bundles import (
+    build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderTracePhaseSupport,
@@ -79,29 +81,18 @@ def build_whole_run_order_family_summary_artifact_bundle(
         candidate_summaries=order_trace_summary_bundle.summaries,
         context_labels=ordered_labels,
     )
-    artifact = WholeRunArtifactFile(
+    parts = build_single_artifact_bundle_parts(
         artifact_key=WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
         relative_path=_WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_PATH,
         file_format="jsonl",
         record_count=len(summaries),
-    )
-    summary_manifest = WholeRunArtifactManifest(
-        run_id=manifest.run_id,
-        relative_dir=manifest.relative_dir,
-        window_policy=manifest.window_policy,
-        total_window_count=manifest.total_window_count,
-        artifacts=(artifact,),
+        source_manifest=manifest,
         created_at=created_at or manifest.created_at or utc_now_iso(),
-        schema_version=manifest.schema_version,
-        storage_type=manifest.storage_type,
+        content_bytes=whole_run_order_trace_summaries_to_jsonl_bytes(summaries),
     )
     return WholeRunOrderFamilySummaryArtifactBundle(
-        manifest=summary_manifest,
-        artifact_contents={
-            WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY: (
-                whole_run_order_trace_summaries_to_jsonl_bytes(summaries)
-            )
-        },
+        manifest=parts.manifest,
+        artifact_contents=parts.artifact_contents,
         summaries=summaries,
     )
 

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -9,9 +9,11 @@ from math import sqrt
 
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.whole_run_analysis import (
-    WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._artifact_bundles import (
+    build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
@@ -74,29 +76,18 @@ def build_whole_run_order_trace_summary_artifact_bundle(
         points=order_trace_bundle.points,
         context_labels=ordered_labels,
     )
-    artifact = WholeRunArtifactFile(
+    parts = build_single_artifact_bundle_parts(
         artifact_key=WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
         relative_path=_WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_PATH,
         file_format="jsonl",
         record_count=len(summaries),
-    )
-    summary_manifest = WholeRunArtifactManifest(
-        run_id=manifest.run_id,
-        relative_dir=manifest.relative_dir,
-        window_policy=manifest.window_policy,
-        total_window_count=manifest.total_window_count,
-        artifacts=(artifact,),
+        source_manifest=manifest,
         created_at=created_at or manifest.created_at or utc_now_iso(),
-        schema_version=manifest.schema_version,
-        storage_type=manifest.storage_type,
+        content_bytes=whole_run_order_trace_summaries_to_jsonl_bytes(summaries),
     )
     return WholeRunOrderTraceSummaryArtifactBundle(
-        manifest=summary_manifest,
-        artifact_contents={
-            WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY: (
-                whole_run_order_trace_summaries_to_jsonl_bytes(summaries)
-            )
-        },
+        manifest=parts.manifest,
+        artifact_contents=parts.artifact_contents,
         summaries=summaries,
     )
 

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -9,9 +9,9 @@ from typing import cast
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
-from vibesensor.shared.types.whole_run_analysis import (
-    WholeRunArtifactFile,
-    WholeRunArtifactManifest,
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics._artifact_bundles import (
+    build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics._jsonl_sidecars import jsonl_bytes_from_objects
 from vibesensor.use_cases.diagnostics._reference_resolution import _tire_reference_from_context
@@ -116,27 +116,19 @@ def build_whole_run_order_trace_artifact_bundle(
         if any(point.eligible for point in hypothesis_points):
             points.extend(hypothesis_points)
     point_rows = tuple(points)
-    artifact = WholeRunArtifactFile(
+    parts = build_single_artifact_bundle_parts(
         artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
         relative_path=_WHOLE_RUN_ORDER_TRACE_ARTIFACT_PATH,
         file_format="jsonl",
         record_count=len(point_rows),
-    )
-    manifest = WholeRunArtifactManifest(
+        source_manifest=spectral_manifest,
         run_id=run_id,
-        relative_dir=spectral_manifest.relative_dir,
-        window_policy=spectral_manifest.window_policy,
-        total_window_count=spectral_manifest.total_window_count,
-        artifacts=(artifact,),
         created_at=created_at or spectral_manifest.created_at or utc_now_iso(),
-        schema_version=spectral_manifest.schema_version,
-        storage_type=spectral_manifest.storage_type,
+        content_bytes=order_trace_points_to_jsonl_bytes(point_rows),
     )
     return WholeRunOrderTraceArtifactBundle(
-        manifest=manifest,
-        artifact_contents={
-            WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: order_trace_points_to_jsonl_bytes(point_rows)
-        },
+        manifest=parts.manifest,
+        artifact_contents=parts.artifact_contents,
         points=point_rows,
     )
 

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
@@ -13,7 +13,6 @@ from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import (
     WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
-    WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextCoverage,
     WholeRunContextInterval,
@@ -21,6 +20,9 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunContextWindowLabel,
     WholeRunRpmValidity,
     WholeRunSpeedValidity,
+)
+from vibesensor.use_cases.diagnostics._artifact_bundles import (
+    build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
@@ -106,27 +108,21 @@ def build_whole_run_context_artifact_bundle(
         window_plan=window_plan,
     )
     segmentation = segment_whole_run_context(labels=labels, window_plan=window_plan)
-    artifact_file = WholeRunArtifactFile(
+    parts = build_single_artifact_bundle_parts(
         artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
         relative_path=_WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_PATH,
         file_format="jsonl",
         record_count=len(segmentation.labels),
-    )
-    manifest = WholeRunArtifactManifest(
         run_id=run_id,
         relative_dir=f"{WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME}/{run_id}",
         window_policy=window_plan.policy,
         total_window_count=window_plan.total_window_count,
-        artifacts=(artifact_file,),
         created_at=created_at or utc_now_iso(),
+        content_bytes=whole_run_context_labels_to_jsonl_bytes(segmentation.labels),
     )
     return WholeRunContextArtifactBundle(
-        manifest=manifest,
-        artifact_contents={
-            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: whole_run_context_labels_to_jsonl_bytes(
-                segmentation.labels
-            )
-        },
+        manifest=parts.manifest,
+        artifact_contents=parts.artifact_contents,
         labels=segmentation.labels,
         intervals=segmentation.intervals,
     )

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -10,9 +10,11 @@ from statistics import mean as _mean
 from vibesensor.domain import LocationHotspot
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.whole_run_analysis import (
-    WholeRunArtifactFile,
     WholeRunArtifactManifest,
     WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._artifact_bundles import (
+    build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
@@ -100,29 +102,18 @@ def build_whole_run_spatial_coherence_artifact_bundle(
         order_points=order_trace_bundle.points,
     )
     summaries = summarize_whole_run_spatial_coherence(windows)
-    artifact = WholeRunArtifactFile(
+    parts = build_single_artifact_bundle_parts(
         artifact_key=WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
         relative_path=_WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_PATH,
         file_format="jsonl",
         record_count=len(windows),
-    )
-    manifest = WholeRunArtifactManifest(
-        run_id=order_trace_bundle.manifest.run_id,
-        relative_dir=order_trace_bundle.manifest.relative_dir,
-        window_policy=order_trace_bundle.manifest.window_policy,
-        total_window_count=order_trace_bundle.manifest.total_window_count,
-        artifacts=(artifact,),
+        source_manifest=order_trace_bundle.manifest,
         created_at=created_at or order_trace_bundle.manifest.created_at or utc_now_iso(),
-        schema_version=order_trace_bundle.manifest.schema_version,
-        storage_type=order_trace_bundle.manifest.storage_type,
+        content_bytes=whole_run_spatial_evidence_windows_to_jsonl_bytes(windows),
     )
     return WholeRunSpatialCoherenceArtifactBundle(
-        manifest=manifest,
-        artifact_contents={
-            WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY: (
-                whole_run_spatial_evidence_windows_to_jsonl_bytes(windows)
-            )
-        },
+        manifest=parts.manifest,
+        artifact_contents=parts.artifact_contents,
         windows=windows,
         summaries=summaries,
     )


### PR DESCRIPTION
Closes #3334

## What changed
- add `apps/server/vibesensor/use_cases/diagnostics/_artifact_bundles.py` with one narrow helper for single-artifact whole-run bundle parts
- switch whole-run context, order traces, order-trace summaries, family summaries, and spatial coherence to the helper
- add manifest-shape regressions for context, order-trace summaries, and family summaries

## Why
- five whole-run builders were still hand-building the same `WholeRunArtifactFile` -> `WholeRunArtifactManifest` -> single-entry `artifact_contents` shape
- this keeps one code path for the shared bundle plumbing without hiding the caller-owned artifact fields or validation

## Validation/tests
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py`
- `make typecheck-backend`
- `make lint`

## Risks, tradeoffs, edge cases
- helper stays intentionally narrow to single-artifact bundles; multi-artifact `whole_run_spectra.py` stays separate
- preserved created-at fallback behavior at each caller
- preserved the explicit `run_id` override in `orders/whole_run_traces.py` instead of silently copying it from the source manifest
- no domain-specific validation moved into the helper