### PR TITLE
Extract shared order hypothesis catalog helpers

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_hypothesis_catalog.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_hypothesis_catalog.py
@@ -1,0 +1,31 @@
+"""Focused regressions for shared whole-run order-hypothesis catalog helpers."""
+
+from __future__ import annotations
+
+from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
+    order_hypotheses_by_key,
+    order_hypothesis_path_compliance_by_key,
+    ordered_order_hypothesis_keys,
+)
+
+
+def test_ordered_order_hypothesis_keys_preserves_catalog_order_and_unknown_tail() -> None:
+    assert ordered_order_hypothesis_keys(
+        ("engine_2x", "custom_b", "wheel_1x", "driveshaft_2x", "custom_a")
+    ) == (
+        "wheel_1x",
+        "driveshaft_2x",
+        "engine_2x",
+        "custom_a",
+        "custom_b",
+    )
+
+
+def test_order_hypothesis_catalog_helpers_follow_physics_catalog() -> None:
+    hypotheses_by_key = order_hypotheses_by_key()
+    path_compliance_by_key = order_hypothesis_path_compliance_by_key()
+
+    assert hypotheses_by_key["wheel_1x"].order_label_base == "wheel"
+    assert hypotheses_by_key["engine_2x"].order == 2
+    assert path_compliance_by_key["wheel_1x"] == 1.5
+    assert path_compliance_by_key["engine_1x"] == 1.0

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/_hypothesis_catalog.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/_hypothesis_catalog.py
@@ -1,0 +1,24 @@
+"""Shared catalog helpers for whole-run order-hypothesis consumers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis, _order_hypotheses
+
+
+def order_hypotheses_by_key() -> dict[str, OrderHypothesis]:
+    return {hypothesis.key: hypothesis for hypothesis in _order_hypotheses()}
+
+
+def order_hypothesis_path_compliance_by_key() -> dict[str, float]:
+    return {hypothesis.key: hypothesis.path_compliance for hypothesis in _order_hypotheses()}
+
+
+def ordered_order_hypothesis_keys(keys: Iterable[str]) -> tuple[str, ...]:
+    catalog = _order_hypotheses()
+    pending_keys = set(keys)
+    ordered_keys = [hypothesis.key for hypothesis in catalog if hypothesis.key in pending_keys]
+    known_keys = {hypothesis.key for hypothesis in catalog}
+    ordered_keys.extend(sorted(key for key in pending_keys if key not in known_keys))
+    return tuple(ordered_keys)

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -19,7 +19,11 @@ from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
     jsonl_objects_from_bytes,
 )
-from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis, _order_hypotheses
+from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
+    order_hypotheses_by_key,
+    ordered_order_hypothesis_keys,
+)
+from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderHarmonicEvidenceSummary,
     OrderTracePoint,
@@ -106,17 +110,9 @@ def summarize_whole_run_order_traces(
     for point in points:
         points_by_hypothesis[point.hypothesis_key].append(point)
 
-    hypothesis_catalog = {hypothesis.key: hypothesis for hypothesis in _order_hypotheses()}
-    ordered_keys = [
-        hypothesis.key
-        for hypothesis in _order_hypotheses()
-        if hypothesis.key in points_by_hypothesis
-    ]
-    ordered_keys.extend(
-        sorted(key for key in points_by_hypothesis if key not in hypothesis_catalog)
-    )
+    hypothesis_catalog = order_hypotheses_by_key()
     summaries: list[OrderTraceSummary] = []
-    for hypothesis_key in ordered_keys:
+    for hypothesis_key in ordered_order_hypothesis_keys(points_by_hypothesis):
         hypothesis_points = tuple(
             sorted(points_by_hypothesis[hypothesis_key], key=lambda point: point.window_index)
         )

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -24,12 +24,15 @@ from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.use_cases.diagnostics.location_scoring import (
     NEAR_TIE_DOMINANCE_THRESHOLD,
 )
+from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
+    order_hypothesis_path_compliance_by_key,
+    ordered_order_hypothesis_keys,
+)
 from vibesensor.use_cases.diagnostics.orders.matching import (
     best_order_peak_match,
     filtered_peak_pairs,
     order_peak_tolerance_hz,
 )
-from vibesensor.use_cases.diagnostics.orders.physics import _order_hypotheses
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WholeRunOrderTraceArtifactBundle,
@@ -127,15 +130,13 @@ def build_whole_run_spatial_evidence_windows(
     """Join order candidates against aligned sensor windows into dense spatial rows."""
 
     windows_by_index = {window.window_index: window for window in alignment_matrix.windows}
-    path_compliance_by_key = {
-        hypothesis.key: hypothesis.path_compliance for hypothesis in _order_hypotheses()
-    }
+    path_compliance_by_key = order_hypothesis_path_compliance_by_key()
     points_by_candidate: dict[str, list[OrderTracePoint]] = defaultdict(list)
     for point in order_points:
         if point.eligible and point.predicted_hz is not None and point.predicted_hz > 0:
             points_by_candidate[point.hypothesis_key].append(point)
     candidate_rows: list[SpatialEvidenceWindow] = []
-    for candidate_key in _ordered_candidate_keys(points_by_candidate):
+    for candidate_key in ordered_order_hypothesis_keys(points_by_candidate):
         candidate_points = sorted(
             points_by_candidate[candidate_key],
             key=lambda point: point.window_index,
@@ -169,7 +170,7 @@ def summarize_whole_run_spatial_coherence(
         rows_by_candidate[row.candidate_key].append(row)
         source_by_candidate.setdefault(row.candidate_key, row.suspected_source)
     summaries: list[SpatialEvidenceSummary] = []
-    for candidate_key in _ordered_candidate_keys(rows_by_candidate):
+    for candidate_key in ordered_order_hypothesis_keys(rows_by_candidate):
         candidate_rows = sorted(
             rows_by_candidate[candidate_key],
             key=lambda row: (row.window_index, row.sensor_id),
@@ -337,19 +338,6 @@ def _window_coherence_score(
     coverage_ratio = len(supporting_matches) / max(1, full_sensor_count)
     spread_score = max(0.0, 1.0 - (spread_hz / max(1e-9, tolerance_hz)))
     return max(0.0, min(1.0, coverage_ratio * spread_score))
-
-
-def _ordered_candidate_keys(rows_by_candidate: Mapping[str, object]) -> tuple[str, ...]:
-    catalog_order = {hypothesis.key: index for index, hypothesis in enumerate(_order_hypotheses())}
-    return tuple(
-        sorted(
-            rows_by_candidate,
-            key=lambda candidate_key: (
-                catalog_order.get(candidate_key, len(catalog_order)),
-                candidate_key,
-            ),
-        )
-    )
 
 
 def _peak_intensity_db(peak: Mapping[str, object]) -> float | None:


### PR DESCRIPTION
Closes #3335

## What changed
- add `apps/server/vibesensor/use_cases/diagnostics/orders/_hypothesis_catalog.py` for shared order-hypothesis lookup, path-compliance lookup, and known-first stable key ordering
- switch `orders/whole_run_scoring.py` to the shared hypothesis lookup and ordering helpers
- switch `whole_run_spatial_coherence.py` to the shared path-compliance lookup and ordering helpers
- add focused helper regressions in `apps/server/tests/use_cases/diagnostics/test_order_hypothesis_catalog.py`

## Why
- whole-run scoring and spatial coherence were both rebuilding the same `_order_hypotheses()`-derived catalog maps and ordering rules
- this keeps one code path for catalog derivation without changing order physics or touching modules that only iterate the catalog directly

## Validation/tests
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_hypothesis_catalog.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py`
- `make typecheck-backend`
- `make lint`

## Risks, tradeoffs, edge cases
- helper stays narrow to catalog derivation; direct `_order_hypotheses()` iteration in unrelated modules stays unchanged
- unknown candidate keys still fall back to alphabetical ordering after known catalog keys
- unknown candidate path compliance still falls back to `1.0` at the spatial call site
- no changes to the hypothesis physics definitions themselves