### PR TITLE
Replace repeated dominant-value ranking helpers with one utility

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_ranking_utils.py
+++ b/apps/server/tests/use_cases/diagnostics/test_ranking_utils.py
@@ -1,0 +1,35 @@
+"""Focused regressions for shared diagnostics ranking helpers."""
+
+from __future__ import annotations
+
+from vibesensor.use_cases.diagnostics._ranking_utils import (
+    dominant_weighted_value,
+    sortable_optional_metric,
+)
+
+
+def test_dominant_weighted_value_keeps_count_weight_and_value_tiebreaks() -> None:
+    assert (
+        dominant_weighted_value(
+            values=(
+                ("front-left", 1.0),
+                ("rear-right", 5.0),
+                ("front-left", 0.5),
+            )
+        )
+        == "front-left"
+    )
+    assert (
+        dominant_weighted_value(
+            values=(
+                ("alpha", 1.0),
+                ("bravo", 1.0),
+            )
+        )
+        == "bravo"
+    )
+
+
+def test_sortable_optional_metric_sends_missing_values_last() -> None:
+    assert sortable_optional_metric(4.5) == 4.5
+    assert sortable_optional_metric(None) == float("-inf")

--- a/apps/server/vibesensor/use_cases/diagnostics/_ranking_utils.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_ranking_utils.py
@@ -1,0 +1,24 @@
+"""Shared ranking helpers for diagnostics summarization."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+
+
+def dominant_weighted_value(*, values: Iterable[tuple[str, float]]) -> str | None:
+    items = tuple(values)
+    if not items:
+        return None
+    counts = Counter(value for value, _weight in items)
+    weights: dict[str, float] = defaultdict(float)
+    for value, weight in items:
+        weights[value] += float(weight)
+    return max(
+        counts,
+        key=lambda value: (counts[value], weights[value], value),
+    )
+
+
+def sortable_optional_metric(value: float | None) -> float:
+    return value if value is not None else float("-inf")

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -14,6 +14,7 @@ from vibesensor.shared.types.whole_run_analysis import (
 from vibesensor.use_cases.diagnostics._artifact_bundles import (
     build_single_artifact_bundle_parts,
 )
+from vibesensor.use_cases.diagnostics._ranking_utils import dominant_weighted_value
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderTracePhaseSupport,
     OrderTracePoint,
@@ -23,7 +24,6 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     WholeRunOrderTraceSummaryArtifactBundle,
     _dominant_context_value,
-    _dominant_value,
     _drift_score,
     _lock_score,
     _longest_contiguous_match_run,
@@ -212,7 +212,7 @@ def _family_summary(
         for point in matched_points
         if point.vibration_strength_db is not None
     )
-    strongest_location = _dominant_value(
+    strongest_location = dominant_weighted_value(
         values=(
             (
                 point.strongest_location,
@@ -437,7 +437,7 @@ def _dominant_load_state(
                 point.peak_intensity_db if point.peak_intensity_db is not None else 0.0,
             )
         )
-    return _dominant_value(values=ranked_values)
+    return dominant_weighted_value(values=ranked_values)
 
 
 def _point_rank(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import Counter, defaultdict
+from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from math import sqrt
@@ -19,6 +19,7 @@ from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
     jsonl_objects_from_bytes,
 )
+from vibesensor.use_cases.diagnostics._ranking_utils import dominant_weighted_value
 from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
     order_hypotheses_by_key,
     ordered_order_hypothesis_keys,
@@ -342,17 +343,7 @@ def _dominant_context_value(
 
 
 def _dominant_value(*, values: Iterable[tuple[str, float]]) -> str | None:
-    items = tuple(values)
-    if not items:
-        return None
-    counts = Counter(value for value, _weight in items)
-    weights: dict[str, float] = defaultdict(float)
-    for value, weight in items:
-        weights[value] += float(weight)
-    return max(
-        counts,
-        key=lambda value: (counts[value], weights[value], value),
-    )
+    return dominant_weighted_value(values=values)
 
 
 def _mean(values: Iterable[float]) -> float | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -20,6 +20,7 @@ from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_bytes_from_objects,
     jsonl_objects_from_bytes,
 )
+from vibesensor.use_cases.diagnostics._ranking_utils import sortable_optional_metric
 from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.use_cases.diagnostics.location_scoring import (
     NEAR_TIE_DOMINANCE_THRESHOLD,
@@ -369,8 +370,8 @@ def _summarize_location_support(
                 -summary.support_ratio,
                 -summary.coherent_window_count,
                 -(summary.coherence_ratio or 0.0),
-                -_sortable_metric(summary.mean_vibration_strength_db),
-                -_sortable_metric(summary.peak_intensity_db),
+                -sortable_optional_metric(summary.mean_vibration_strength_db),
+                -sortable_optional_metric(summary.peak_intensity_db),
                 summary.location.lower(),
             ),
         )
@@ -456,7 +457,3 @@ def _weak_spatial_separation(
         return False
     threshold = LocationHotspot.weak_spatial_threshold(len(location_summaries))
     return dominance_ratio < threshold
-
-
-def _sortable_metric(value: float | None) -> float:
-    return value if value is not None else float("-inf")


### PR DESCRIPTION
Closes #3336

## What changed
- add `apps/server/vibesensor/use_cases/diagnostics/_ranking_utils.py` for the shared weighted dominant-value helper and optional-metric sort helper
- switch `orders/whole_run_scoring.py` to the shared dominant-value helper
- switch `whole_run_spatial_coherence.py` to the shared optional-metric sort helper
- update `orders/whole_run_family_summaries.py` as the direct blast-radius consumer of scoring's previous dominant-value helper
- add focused utility regressions in `apps/server/tests/use_cases/diagnostics/test_ranking_utils.py`

## Why
- scoring and family summaries were sharing a generic dominant-value helper through the scoring module, while spatial coherence kept its own small ranking helper
- this moves the genuinely shared ranking primitives into one diagnostics utility without pulling the domain-specific formulas out of their owner modules

## Validation/tests
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_ranking_utils.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py`
- `make typecheck-backend`
- `make lint`

## Risks, tradeoffs, edge cases
- helper stays narrow to ranking primitives; `_lock_score`, `_drift_score`, `_dominant_context_value`, and spatial-separation rules stay local
- the weighted dominant-value helper preserves the old deterministic tiebreak order: count, then weight, then string value
- optional metric sorting still sends `None` values to the end by mapping them to `-inf`
