### PR TITLE
Deduplicate nested list-of-mapping contract decoding

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -139,6 +139,61 @@ def test_order_trace_summary_drops_invalid_optional_values(field: str, value: ob
     assert getattr(restored, field) is None
 
 
+def test_order_trace_summary_skips_non_mapping_nested_rows() -> None:
+    payload = OrderTraceSummary(
+        hypothesis_key="engine_2x",
+        suspected_source="engine",
+        order_family="engine",
+        order_label="2x engine",
+        total_window_count=8,
+        eligible_window_count=6,
+        matched_window_count=3,
+        support_ratio=0.5,
+        reference_coverage_ratio=0.75,
+        longest_contiguous_support_window_count=2,
+        contiguous_support_ratio=2 / 6,
+    ).to_json_object()
+    payload["support_intervals"] = [
+        {
+            "interval_index": 0,
+            "start_window_index": 1,
+            "end_window_index": 2,
+            "matched_window_count": 2,
+            "support_ratio": 1.0,
+        },
+        "skip-me",
+    ]
+    payload["phase_support"] = [
+        {
+            "phase": "cruise",
+            "eligible_window_count": 4,
+            "matched_window_count": 2,
+            "support_ratio": 0.5,
+        },
+        7,
+    ]
+    payload["harmonic_summaries"] = [
+        {
+            "harmonic": 2,
+            "order_label": "2x engine",
+            "eligible_window_count": 6,
+            "matched_window_count": 3,
+            "support_ratio": 0.5,
+            "reference_coverage_ratio": 0.75,
+            "contiguous_support_ratio": 2 / 6,
+            "lock_score": 0.6,
+            "drift_score": 0.4,
+        },
+        [],
+    ]
+
+    restored = OrderTraceSummary.from_mapping(payload)
+
+    assert [interval.interval_index for interval in restored.support_intervals] == [0]
+    assert [row.phase for row in restored.phase_support] == ["cruise"]
+    assert [summary.harmonic for summary in restored.harmonic_summaries] == [2]
+
+
 def test_history_order_trace_response_contracts_expose_named_summary_fields() -> None:
     assert set(OrderTraceSupportIntervalResponse.__annotations__) == {
         "interval_index",

--- a/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
@@ -100,6 +100,31 @@ def test_spatial_evidence_summary_rejects_invalid_optional_values(
         SpatialEvidenceSummary.from_mapping(payload)
 
 
+def test_spatial_evidence_summary_skips_non_mapping_location_rows() -> None:
+    payload = SpatialEvidenceSummary(
+        candidate_key="wheel",
+        suspected_source="wheel/tire",
+        proof_basis="supporting_windows_raw_backed",
+        total_window_count=12,
+        supporting_window_count=4,
+        supporting_sensor_count=2,
+    ).to_json_object()
+    payload["location_summaries"] = [
+        {
+            "location": "Front Left",
+            "sensor_ids": ["front-left"],
+            "supporting_window_count": 3,
+            "support_ratio": 0.75,
+            "coherent_window_count": 2,
+        },
+        "skip-me",
+    ]
+
+    restored = SpatialEvidenceSummary.from_mapping(payload)
+
+    assert [summary.location for summary in restored.location_summaries] == ["Front Left"]
+
+
 def test_history_spatial_response_contracts_expose_named_summary_fields() -> None:
     assert set(SpatialLocationSummaryResponse.__annotations__) == {
         "location",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -127,6 +127,47 @@ def test_whole_run_diagnosis_summary_rejects_invalid_optional_values(
         WholeRunDiagnosisSummary.from_mapping(payload)
 
 
+def test_whole_run_diagnosis_summary_skips_non_mapping_nested_rows() -> None:
+    payload = WholeRunDiagnosisSummary(
+        diagnosis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        rank=1,
+        data_basis="raw_backed",
+    ).to_json_object()
+    payload["exemplar_references"] = [
+        {"kind": "whole_run_context_interval", "context_segment_index": 2},
+        "skip-me",
+    ]
+    payload["support_factors"] = [
+        {
+            "factor_key": "raw_backed",
+            "polarity": "support",
+            "severity": "high",
+            "weight": 0.1,
+        },
+        3,
+    ]
+    payload["counterevidence_factors"] = [
+        {
+            "factor_key": "incomplete_reference",
+            "polarity": "counterevidence",
+            "severity": "low",
+            "weight": 0.05,
+        },
+        None,
+    ]
+
+    restored = WholeRunDiagnosisSummary.from_mapping(payload)
+
+    assert [reference.kind for reference in restored.exemplar_references] == [
+        "whole_run_context_interval"
+    ]
+    assert [factor.factor_key for factor in restored.support_factors] == ["raw_backed"]
+    assert [factor.factor_key for factor in restored.counterevidence_factors] == [
+        "incomplete_reference"
+    ]
+
+
 def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> None:
     assert set(DiagnosisExemplarReferenceResponse.__annotations__) == {
         "kind",

--- a/apps/server/vibesensor/shared/types/whole_run_json_helpers.py
+++ b/apps/server/vibesensor/shared/types/whole_run_json_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 
@@ -142,3 +144,14 @@ def json_text_or_default(value: JsonValue | object, default: str = "") -> str:
 
 def json_text_or_none(value: JsonValue | object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def tuple_from_mapping_list_field[T](
+    data: JsonObject,
+    field_name: str,
+    row_from_mapping: Callable[[JsonObject], T],
+) -> tuple[T, ...]:
+    raw_rows = data.get(field_name)
+    if not isinstance(raw_rows, list):
+        return ()
+    return tuple(row_from_mapping(row) for row in raw_rows if isinstance(row, dict))

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -37,6 +37,9 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 from vibesensor.shared.types.whole_run_json_helpers import (
     set_optional_value as _set_optional,
 )
+from vibesensor.shared.types.whole_run_json_helpers import (
+    tuple_from_mapping_list_field as _tuple_from_mapping_list_field,
+)
 
 __all__ = [
     "OrderHarmonicEvidenceSummary",
@@ -376,9 +379,21 @@ class OrderTraceSummary:
                 "longest_contiguous_support_window_count",
             ),
             contiguous_support_ratio=_required_float(data, "contiguous_support_ratio"),
-            support_intervals=_support_intervals(data.get("support_intervals")),
-            phase_support=_phase_support_rows(data.get("phase_support")),
-            harmonic_summaries=_harmonic_summaries(data.get("harmonic_summaries")),
+            support_intervals=_tuple_from_mapping_list_field(
+                data,
+                "support_intervals",
+                OrderTraceSupportInterval.from_mapping,
+            ),
+            phase_support=_tuple_from_mapping_list_field(
+                data,
+                "phase_support",
+                OrderTracePhaseSupport.from_mapping,
+            ),
+            harmonic_summaries=_tuple_from_mapping_list_field(
+                data,
+                "harmonic_summaries",
+                OrderHarmonicEvidenceSummary.from_mapping,
+            ),
             stable_frequency_min_hz=_optional_float(data.get("stable_frequency_min_hz")),
             stable_frequency_max_hz=_optional_float(data.get("stable_frequency_max_hz")),
             exemplar_interval_index=_optional_int(data.get("exemplar_interval_index")),
@@ -393,30 +408,6 @@ class OrderTraceSummary:
             mean_vibration_strength_db=_optional_float(data.get("mean_vibration_strength_db")),
             ref_sources=_text_tuple(data.get("ref_sources")),
         )
-
-
-def _support_intervals(value: object) -> tuple[OrderTraceSupportInterval, ...]:
-    if not isinstance(value, list):
-        return ()
-    return tuple(
-        OrderTraceSupportInterval.from_mapping(item) for item in value if isinstance(item, dict)
-    )
-
-
-def _phase_support_rows(value: object) -> tuple[OrderTracePhaseSupport, ...]:
-    if not isinstance(value, list):
-        return ()
-    return tuple(
-        OrderTracePhaseSupport.from_mapping(item) for item in value if isinstance(item, dict)
-    )
-
-
-def _harmonic_summaries(value: object) -> tuple[OrderHarmonicEvidenceSummary, ...]:
-    if not isinstance(value, list):
-        return ()
-    return tuple(
-        OrderHarmonicEvidenceSummary.from_mapping(item) for item in value if isinstance(item, dict)
-    )
 
 
 def _text_tuple(value: object) -> tuple[str, ...]:

--- a/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
@@ -31,6 +31,9 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 from vibesensor.shared.types.whole_run_json_helpers import (
     set_optional_value as _set_optional,
 )
+from vibesensor.shared.types.whole_run_json_helpers import (
+    tuple_from_mapping_list_field as _tuple_from_mapping_list_field,
+)
 
 __all__ = [
     "LocationProofBasis",
@@ -206,16 +209,6 @@ class SpatialEvidenceSummary:
 
     @classmethod
     def from_mapping(cls, data: JsonObject) -> SpatialEvidenceSummary:
-        raw_location_summaries = data.get("location_summaries")
-        location_summaries = (
-            tuple(
-                SpatialLocationSummary.from_mapping(row)
-                for row in raw_location_summaries
-                if isinstance(row, dict)
-            )
-            if isinstance(raw_location_summaries, list)
-            else ()
-        )
         return cls(
             candidate_key=_required_text(data, "candidate_key"),
             suspected_source=_required_text(data, "suspected_source"),
@@ -231,7 +224,11 @@ class SpatialEvidenceSummary:
             dominance_ratio=_optional_float(data.get("dominance_ratio")),
             ambiguous_location=_required_bool(data, "ambiguous_location"),
             weak_spatial_separation=_required_bool(data, "weak_spatial_separation"),
-            location_summaries=location_summaries,
+            location_summaries=_tuple_from_mapping_list_field(
+                data,
+                "location_summaries",
+                SpatialLocationSummary.from_mapping,
+            ),
         )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -41,6 +41,9 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 from vibesensor.shared.types.whole_run_json_helpers import (
     set_optional_value as _set_optional,
 )
+from vibesensor.shared.types.whole_run_json_helpers import (
+    tuple_from_mapping_list_field as _tuple_from_mapping_list_field,
+)
 
 __all__ = [
     "DiagnosisExemplarReference",
@@ -317,36 +320,6 @@ class WholeRunDiagnosisSummary:
 
     @classmethod
     def from_mapping(cls, data: JsonObject) -> WholeRunDiagnosisSummary:
-        raw_exemplars = data.get("exemplar_references")
-        exemplars = (
-            tuple(
-                DiagnosisExemplarReference.from_mapping(row)
-                for row in raw_exemplars
-                if isinstance(row, dict)
-            )
-            if isinstance(raw_exemplars, list)
-            else ()
-        )
-        raw_support_factors = data.get("support_factors")
-        support_factors = (
-            tuple(
-                DiagnosisFactor.from_mapping(row)
-                for row in raw_support_factors
-                if isinstance(row, dict)
-            )
-            if isinstance(raw_support_factors, list)
-            else ()
-        )
-        raw_counter_factors = data.get("counterevidence_factors")
-        counter_factors = (
-            tuple(
-                DiagnosisFactor.from_mapping(row)
-                for row in raw_counter_factors
-                if isinstance(row, dict)
-            )
-            if isinstance(raw_counter_factors, list)
-            else ()
-        )
         return cls(
             diagnosis_key=_required_text(data, "diagnosis_key"),
             suspected_source=_required_text(data, "suspected_source"),
@@ -380,9 +353,21 @@ class WholeRunDiagnosisSummary:
             has_reference_gap=_required_bool(data, "has_reference_gap"),
             uses_summary_fallback=_required_bool(data, "uses_summary_fallback"),
             fallback_reason=_optional_text(data.get("fallback_reason")),
-            exemplar_references=exemplars,
-            support_factors=support_factors,
-            counterevidence_factors=counter_factors,
+            exemplar_references=_tuple_from_mapping_list_field(
+                data,
+                "exemplar_references",
+                DiagnosisExemplarReference.from_mapping,
+            ),
+            support_factors=_tuple_from_mapping_list_field(
+                data,
+                "support_factors",
+                DiagnosisFactor.from_mapping,
+            ),
+            counterevidence_factors=_tuple_from_mapping_list_field(
+                data,
+                "counterevidence_factors",
+                DiagnosisFactor.from_mapping,
+            ),
         )
 
 


### PR DESCRIPTION
Closes #3338.

## What changed
- added one shared `tuple_from_mapping_list_field(...)` helper in `whole_run_json_helpers`
- rewired whole-run order, diagnosis, and spatial contract decoders to use that helper instead of repeating the same list/dict filtering loop
- added focused regressions that prove non-mapping nested rows are still skipped in all three contract families

## Why
- remove repeated nested list-of-mapping decode ceremony from the whole-run contract modules
- keep the existing behavior for non-list payloads and non-dict rows while making the callers shorter

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py`
- `make typecheck-backend`
- `make lint`

## Risks, tradeoffs, edge cases
- the helper is intentionally narrow: it only owns list/dict row filtering and nested `from_mapping()` dispatch
- text-list decoding like `ref_sources` stays local because it is a different shape
- no payload schema or validation messages were widened
