### PR TITLE
Move small numeric summary helpers into shared diagnostics utility

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_math_utils.py
+++ b/apps/server/tests/use_cases/diagnostics/test_math_utils.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _max_or_none,
+    _mean_or_none,
+    _min_or_none,
+    _ratio_or_zero,
+    _stddev_or_none,
+)
+
+
+def test_summary_numeric_helpers_return_none_for_empty_iterables() -> None:
+    assert _mean_or_none(()) is None
+    assert _max_or_none(()) is None
+    assert _min_or_none(()) is None
+    assert _stddev_or_none(()) is None
+
+
+def test_summary_numeric_helpers_preserve_expected_values() -> None:
+    values = (1.0, 2.0, 5.0)
+
+    assert _mean_or_none(values) == pytest.approx(8.0 / 3.0)
+    assert _max_or_none(values) == 5.0
+    assert _min_or_none(values) == 1.0
+    assert _stddev_or_none(values) == pytest.approx(1.699673171197595)
+
+
+@pytest.mark.parametrize(
+    ("numerator", "denominator", "expected"),
+    [
+        (3, 0, 0.0),
+        (3, -2, 0.0),
+        (3, 2, 1.5),
+        (2.5, 4, 0.625),
+    ],
+)
+def test_ratio_or_zero_handles_zero_and_positive_denominators(
+    numerator: int | float,
+    denominator: int | float,
+    expected: float,
+) -> None:
+    assert _ratio_or_zero(numerator, denominator) == pytest.approx(expected)

--- a/apps/server/vibesensor/use_cases/diagnostics/math_utils.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/math_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from math import isfinite, sqrt
 
 
@@ -11,6 +11,44 @@ def _mean(values: Sequence[float]) -> float:
     if not values:
         return 0.0
     return sum(values) / len(values)
+
+
+def _mean_or_none(values: Iterable[float]) -> float | None:
+    items = tuple(values)
+    if not items:
+        return None
+    return sum(float(value) for value in items) / len(items)
+
+
+def _max_or_none(values: Iterable[float]) -> float | None:
+    items = tuple(values)
+    if not items:
+        return None
+    return max(float(value) for value in items)
+
+
+def _min_or_none(values: Iterable[float]) -> float | None:
+    items = tuple(values)
+    if not items:
+        return None
+    return min(float(value) for value in items)
+
+
+def _stddev_or_none(values: Iterable[float]) -> float | None:
+    items = tuple(values)
+    if not items:
+        return None
+    mean_value = _mean_or_none(items)
+    if mean_value is None:
+        return None
+    variance = sum((float(value) - mean_value) ** 2 for value in items) / len(items)
+    return sqrt(max(0.0, variance))
+
+
+def _ratio_or_zero(numerator: int | float, denominator: int | float) -> float:
+    if denominator <= 0:
+        return 0.0
+    return float(numerator) / float(denominator)
 
 
 def _corr_abs(x_vals: Sequence[float], y_vals: Sequence[float]) -> float | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -15,6 +15,19 @@ from vibesensor.use_cases.diagnostics._artifact_bundles import (
     build_single_artifact_bundle_parts,
 )
 from vibesensor.use_cases.diagnostics._ranking_utils import dominant_weighted_value
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _max_or_none,
+    _min_or_none,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _mean_or_none as _mean,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _ratio_or_zero as _ratio,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _stddev_or_none as _stddev,
+)
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderTracePhaseSupport,
     OrderTracePoint,
@@ -27,11 +40,6 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     _drift_score,
     _lock_score,
     _longest_contiguous_match_run,
-    _max_or_none,
-    _mean,
-    _min_or_none,
-    _ratio,
-    _stddev,
     whole_run_order_trace_summaries_to_jsonl_bytes,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from math import sqrt
 
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.whole_run_analysis import (
@@ -20,6 +19,19 @@ from vibesensor.use_cases.diagnostics._jsonl_sidecars import (
     jsonl_objects_from_bytes,
 )
 from vibesensor.use_cases.diagnostics._ranking_utils import dominant_weighted_value
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _max_or_none,
+    _min_or_none,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _mean_or_none as _mean,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _ratio_or_zero as _ratio,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _stddev_or_none as _stddev,
+)
 from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
     order_hypotheses_by_key,
     ordered_order_hypothesis_keys,
@@ -344,41 +356,3 @@ def _dominant_context_value(
 
 def _dominant_value(*, values: Iterable[tuple[str, float]]) -> str | None:
     return dominant_weighted_value(values=values)
-
-
-def _mean(values: Iterable[float]) -> float | None:
-    items = tuple(values)
-    if not items:
-        return None
-    return sum(float(value) for value in items) / len(items)
-
-
-def _max_or_none(values: Iterable[float]) -> float | None:
-    items = tuple(values)
-    if not items:
-        return None
-    return max(float(value) for value in items)
-
-
-def _min_or_none(values: Iterable[float]) -> float | None:
-    items = tuple(values)
-    if not items:
-        return None
-    return min(float(value) for value in items)
-
-
-def _stddev(values: Iterable[float]) -> float | None:
-    items = tuple(values)
-    if not items:
-        return None
-    mean_value = _mean(items)
-    if mean_value is None:
-        return None
-    variance = sum((float(value) - mean_value) ** 2 for value in items) / len(items)
-    return sqrt(max(0.0, variance))
-
-
-def _ratio(numerator: int, denominator: int) -> float:
-    if denominator <= 0:
-        return 0.0
-    return numerator / denominator

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from statistics import mean as _mean
 
 from vibesensor.domain import LocationHotspot
 from vibesensor.shared.time_utils import utc_now_iso
@@ -24,6 +23,11 @@ from vibesensor.use_cases.diagnostics._ranking_utils import sortable_optional_me
 from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.use_cases.diagnostics.location_scoring import (
     NEAR_TIE_DOMINANCE_THRESHOLD,
+)
+from vibesensor.use_cases.diagnostics.math_utils import (
+    _max_or_none,
+    _mean_or_none,
+    _ratio_or_zero,
 )
 from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
     order_hypothesis_path_compliance_by_key,
@@ -211,10 +215,9 @@ def summarize_whole_run_spatial_coherence(
                     {row.sensor_id for row in candidate_rows if row.supporting}
                 ),
                 coherent_window_count=coherent_window_count,
-                coherence_ratio=(
-                    coherent_window_count / supporting_window_count
-                    if supporting_window_count > 0
-                    else 0.0
+                coherence_ratio=_ratio_or_zero(
+                    coherent_window_count,
+                    supporting_window_count,
                 ),
                 dominant_location=dominant_location,
                 runner_up_location=runner_up_location,
@@ -394,13 +397,11 @@ def _build_location_summary(
         location=location,
         sensor_ids=tuple(sorted({row.sensor_id for row in rows})),
         supporting_window_count=len(support_windows),
-        support_ratio=(
-            len(support_windows) / supporting_window_count if supporting_window_count > 0 else 0.0
-        ),
+        support_ratio=_ratio_or_zero(len(support_windows), supporting_window_count),
         coherent_window_count=len(coherent_windows),
-        coherence_ratio=(len(coherent_windows) / len(support_windows) if support_windows else 0.0),
-        peak_intensity_db=max(peak_intensities) if peak_intensities else None,
-        mean_vibration_strength_db=(_mean(vibration_strengths) if vibration_strengths else None),
+        coherence_ratio=_ratio_or_zero(len(coherent_windows), len(support_windows)),
+        peak_intensity_db=_max_or_none(peak_intensities),
+        mean_vibration_strength_db=_mean_or_none(vibration_strengths),
     )
 
 


### PR DESCRIPTION
## What changed
- moved the shared summary numerics into `apps/server/vibesensor/use_cases/diagnostics/math_utils.py`
- rewired whole-run order scoring, order family summaries, and spatial coherence to use the shared helpers
- added focused tests for empty iterables and zero-denominator ratios

## Why
- `whole_run_scoring.py` still owned generic helpers like mean-or-none, min/max-or-none, stddev, and safe ratio
- `whole_run_family_summaries.py` was importing those numerics from the scoring module
- this keeps the generic math shared while leaving lock score, drift score, location ambiguity, and spatial separation in their owning modules

## Validation
- `python3 -m pytest -q apps/server/tests/use_cases/diagnostics/test_math_utils.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edge cases
- kept existing empty-input behavior the same: summary aggregates still return `None`
- kept zero and negative denominators pinned to `0.0`
- did not move domain scoring formulas or other non-generic math into the shared helper module

Closes #3339
