### PR TITLE
Simplify history projection payload assembly

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -19,6 +19,7 @@ from vibesensor.adapters.history import (
     ProjectedHistoryRunService,
     build_projected_run_details_json,
     project_history_insights,
+    project_history_run_record,
 )
 from vibesensor.domain import CarSnapshot, RunStatus
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
@@ -484,6 +485,55 @@ def test_build_run_details_json_projects_canonical_nested_run_context() -> None:
     assert float(metadata["analysis_settings_snapshot"]["tire_width_mm"]) == pytest.approx(255.0)
     assert "reference_context" not in metadata
     assert "tire_circumference_m" not in metadata
+
+
+def test_run_record_and_export_details_share_projected_metadata_and_analysis() -> None:
+    run = _stored_run(
+        {
+            "run_id": "run-1",
+            "metadata": {
+                "analysis_settings_snapshot": {
+                    "tire_width_mm": 255.0,
+                    "tire_aspect_pct": 40.0,
+                    "rim_in": 19.0,
+                    "final_drive_ratio": 3.15,
+                    "current_gear_ratio": 0.81,
+                },
+                "active_car_snapshot": {
+                    "id": "car-1",
+                    "name": "Primary",
+                    "type": "sedan",
+                },
+            },
+            "analysis": {
+                "findings": [
+                    {
+                        "finding_id": "F001",
+                        "suspected_source": "wheel/tire",
+                        "strongest_location": "front-left",
+                        "confidence": 0.71,
+                    },
+                ],
+                "top_causes": [],
+                "most_likely_origin": {},
+                "test_plan": [],
+                "run_suitability": [],
+                "_internal": {"secret": True},
+            },
+        }
+    )
+
+    run_record = project_history_run_record(run)
+    exported_payload = json.loads(
+        build_projected_run_details_json(
+            run,
+            sample_count=5,
+            run_id="run-1",
+        )
+    )
+
+    assert run_record["metadata"] == exported_payload["metadata"]
+    assert run_record["analysis"] == exported_payload["analysis"]
 
 
 def test_project_history_insights_keeps_non_projectable_analysis_shape() -> None:

--- a/apps/server/vibesensor/adapters/history/projection.py
+++ b/apps/server/vibesensor/adapters/history/projection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import cast
 
 from vibesensor.shared.boundaries.analysis_payloads import (
@@ -17,6 +17,7 @@ from vibesensor.shared.boundaries.runs.metadata import (
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.history.exports import serialize_run_details_json
 from vibesensor.use_cases.history.helpers import strip_internal_fields
 
@@ -27,30 +28,58 @@ __all__ = [
 ]
 
 
+def _project_analysis_mapping(
+    analysis: Mapping[str, object],
+    *,
+    project_projectable: Callable[[], JsonObject],
+) -> JsonObject:
+    if has_projectable_report_payload(analysis):
+        return project_projectable()
+    return cast(JsonObject, {key: value for key, value in analysis.items()})
+
+
 def _project_persisted_history_analysis(
     analysis: PersistedAnalysis,
     *,
     strip_internal: bool,
 ) -> JsonObject:
-    if has_projectable_report_payload(analysis):
-        projected, _ = project_persisted_analysis(analysis)
-    else:
-        projected = cast(JsonObject, {key: value for key, value in analysis.items()})
+    projected = _project_analysis_mapping(
+        analysis,
+        project_projectable=lambda: project_persisted_analysis(analysis)[0],
+    )
     if strip_internal:
         projected = strip_internal_fields(projected)
     return projected
 
 
 def _project_summary_analysis(analysis: Mapping[str, object]) -> JsonObject:
-    if has_projectable_report_payload(analysis):
-        projected, _ = project_analysis_summary(cast(JsonObject, dict(analysis)))
-    else:
-        projected = cast(JsonObject, {key: value for key, value in analysis.items()})
+    projected = _project_analysis_mapping(
+        analysis,
+        project_projectable=lambda: project_analysis_summary(cast(JsonObject, dict(analysis)))[0],
+    )
     return strip_internal_fields(projected)
 
 
-def _project_history_metadata(metadata: Mapping[str, object]) -> JsonObject:
+def _project_history_metadata(metadata: Mapping[str, object] | RunMetadata) -> JsonObject:
+    if isinstance(metadata, RunMetadata):
+        return run_metadata_to_json_object(metadata)
     return run_metadata_to_json_object(run_metadata_from_mapping(metadata))
+
+
+def _apply_projected_run_fields(
+    payload: JsonObject,
+    *,
+    metadata: Mapping[str, object] | RunMetadata,
+    analysis: PersistedAnalysis | None,
+    strip_internal_analysis: bool,
+) -> JsonObject:
+    payload["metadata"] = _project_history_metadata(metadata)
+    if analysis is not None:
+        payload["analysis"] = _project_persisted_history_analysis(
+            analysis,
+            strip_internal=strip_internal_analysis,
+        )
+    return payload
 
 
 def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
@@ -59,7 +88,6 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
         "run_id": run.run_id,
         "status": run.status.value,
         "sample_count": run.sample_count,
-        "metadata": run_metadata_to_json_object(run.metadata),
     }
     if run.error_message is not None:
         payload["error_message"] = run.error_message
@@ -69,12 +97,12 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
         payload["artifact_availability"] = run.artifact_availability.to_json_object()
     if run.raw_capture_finalize is not None:
         payload["raw_capture_finalize"] = run.raw_capture_finalize.to_json_object()
-    if run.analysis is not None:
-        payload["analysis"] = _project_persisted_history_analysis(
-            run.analysis,
-            strip_internal=True,
-        )
-    return payload
+    return _apply_projected_run_fields(
+        payload,
+        metadata=run.metadata,
+        analysis=run.analysis,
+        strip_internal_analysis=True,
+    )
 
 
 def project_history_insights(analysis: Mapping[str, object]) -> JsonObject:
@@ -89,17 +117,11 @@ def build_projected_run_details_json(
 ) -> str:
     """Build the exported JSON metadata document with canonical projected analysis."""
     payload = run.to_json_object()
-    payload["metadata"] = run_metadata_to_json_object(run.metadata)
-    analysis = run.analysis
-    if analysis is None:
-        return serialize_run_details_json(
-            payload,
-            sample_count=sample_count,
-            run_id=run_id,
-        )
-    payload["analysis"] = _project_persisted_history_analysis(
-        analysis,
-        strip_internal=True,
+    payload = _apply_projected_run_fields(
+        payload,
+        metadata=run.metadata,
+        analysis=run.analysis,
+        strip_internal_analysis=True,
     )
     return serialize_run_details_json(
         payload,


### PR DESCRIPTION
## What changed
- extracted one shared helper for the repeated history analysis projection branch
- extracted one shared helper for applying projected metadata plus persisted analysis to run payloads
- added a regression that compares `project_history_run_record()` and `build_projected_run_details_json()` for the same stored run

## Why
- `apps/server/vibesensor/adapters/history/projection.py` had the same metadata and persisted-analysis projection steps in both the HTTP run-record path and the exported run-details path
- the persisted and summary analysis helpers also repeated the same "project if projectable, otherwise copy" branch
- this reduces duplication without hiding where internal fields get stripped

## Validation
- `python3 -m pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_decode_project_roundtrip.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edge cases
- kept typed `RunMetadata` and `PersistedAnalysis` inputs on their native paths instead of forcing everything through raw mappings
- kept internal-field stripping explicit at the call sites
- left the surrounding export serialization and payload shells unchanged

Closes #3340
