### PR TITLE
Replace repeated literal validation sets with shared constants

### DIFF
--- a/apps/server/tests/shared/types/test_whole_run_analysis.py
+++ b/apps/server/tests/shared/types/test_whole_run_analysis.py
@@ -223,6 +223,24 @@ def test_context_interval_from_mapping_defaults_invalid_numeric_fields() -> None
     assert interval.missing_context_window_count == 0
 
 
+def test_context_window_label_from_mapping_defaults_invalid_literal_states() -> None:
+    label = WholeRunContextWindowLabel.from_mapping(
+        {
+            "window_index": 3,
+            "phase": "cruise",
+            "context_coverage": "bad",
+            "speed_validity": "sensor_fusion",
+            "rpm_validity": "derived",
+            "load_state": "pulling",
+        }
+    )
+
+    assert label.context_coverage == "missing"
+    assert label.speed_validity == "missing"
+    assert label.rpm_validity == "missing"
+    assert label.load_state == "unknown"
+
+
 def test_context_interval_rejects_inverted_window_ranges() -> None:
     with pytest.raises(ValueError, match="end_window_index >= start_window_index"):
         WholeRunContextInterval(

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -39,6 +39,23 @@ def test_order_trace_point_round_trips_json_shape() -> None:
     assert OrderTracePoint.from_mapping(point.to_json_object()) == point
 
 
+def test_order_trace_point_rejects_unsupported_order_family() -> None:
+    payload = OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=42,
+        eligible=True,
+        matched=True,
+    ).to_json_object()
+    payload["order_family"] = "axle"
+
+    with pytest.raises(ValueError, match="Unsupported order_family"):
+        OrderTracePoint.from_mapping(payload)
+
+
 def test_order_trace_summary_round_trips_nested_compact_contracts() -> None:
     summary = OrderTraceSummary(
         hypothesis_key="engine_2x",

--- a/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
@@ -125,6 +125,21 @@ def test_spatial_evidence_summary_skips_non_mapping_location_rows() -> None:
     assert [summary.location for summary in restored.location_summaries] == ["Front Left"]
 
 
+def test_spatial_evidence_summary_rejects_unsupported_proof_basis() -> None:
+    payload = SpatialEvidenceSummary(
+        candidate_key="wheel",
+        suspected_source="wheel/tire",
+        proof_basis="supporting_windows_raw_backed",
+        total_window_count=128,
+        supporting_window_count=42,
+        supporting_sensor_count=4,
+    ).to_json_object()
+    payload["proof_basis"] = "sensor_vote"
+
+    with pytest.raises(ValueError, match="supported location proof basis"):
+        SpatialEvidenceSummary.from_mapping(payload)
+
+
 def test_history_spatial_response_contracts_expose_named_summary_fields() -> None:
     assert set(SpatialLocationSummaryResponse.__annotations__) == {
         "location",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -168,6 +168,60 @@ def test_whole_run_diagnosis_summary_skips_non_mapping_nested_rows() -> None:
     ]
 
 
+def test_diagnosis_exemplar_reference_rejects_unsupported_kind() -> None:
+    with pytest.raises(ValueError, match="supported diagnosis exemplar kind"):
+        DiagnosisExemplarReference.from_mapping({"kind": "bad-kind"})
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("factor_key", "bad-factor", "supported diagnosis factor key"),
+        ("polarity", "neutral", "supported diagnosis factor polarity"),
+        ("severity", "urgent", "supported diagnosis factor severity"),
+    ],
+)
+def test_diagnosis_factor_rejects_unsupported_literal_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    payload = DiagnosisFactor(
+        factor_key="raw_backed",
+        polarity="support",
+        severity="high",
+        weight=0.10,
+    ).to_json_object()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        DiagnosisFactor.from_mapping(payload)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("data_basis", "derived_only", "supported whole-run diagnosis data basis"),
+        ("location_proof_basis", "sensor_vote", "supported location proof basis"),
+    ],
+)
+def test_whole_run_diagnosis_summary_rejects_unsupported_literal_values(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    payload = WholeRunDiagnosisSummary(
+        diagnosis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        rank=1,
+        data_basis="raw_backed",
+    ).to_json_object()
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        WholeRunDiagnosisSummary.from_mapping(payload)
+
+
 def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> None:
     assert set(DiagnosisExemplarReferenceResponse.__annotations__) == {
         "kind",

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -47,6 +47,10 @@ __all__ = [
     "DataQualityRequiredMissingPctResponse",
     "DataQualityResponse",
     "DataQualitySpeedCoverageResponse",
+    "DIAGNOSIS_EXEMPLAR_KIND_VALUES",
+    "DIAGNOSIS_FACTOR_KEY_VALUES",
+    "DIAGNOSIS_FACTOR_POLARITY_VALUES",
+    "DIAGNOSIS_FACTOR_SEVERITY_VALUES",
     "DiagnosisFactorDetailsResponse",
     "DiagnosisFactorKey",
     "DiagnosisFactorPolarity",
@@ -55,8 +59,10 @@ __all__ = [
     "FindingPayload",
     "DiagnosisExemplarKind",
     "DiagnosisExemplarReferenceResponse",
+    "LOCATION_PROOF_BASIS_VALUES",
     "LocationIntensitySummaryResponse",
     "LocationProofBasis",
+    "WHOLE_RUN_DIAGNOSIS_DATA_BASIS_VALUES",
     "WholeRunDiagnosisDataBasis",
     "WholeRunDiagnosisSummaryResponse",
     "OutlierSummaryResponse",
@@ -123,6 +129,55 @@ type LocationProofBasis = Literal[
     "supporting_windows_raw_backed",
     "supporting_windows_summary_only",
 ]
+
+DIAGNOSIS_EXEMPLAR_KIND_VALUES: frozenset[DiagnosisExemplarKind] = frozenset(
+    {"order_support_interval", "whole_run_context_interval", "spatial_location"}
+)
+DIAGNOSIS_FACTOR_KEY_VALUES: frozenset[DiagnosisFactorKey] = frozenset(
+    {
+        "raw_backed",
+        "repeated_support",
+        "sustained_support",
+        "stable_frequency",
+        "tight_order_lock",
+        "localized_support",
+        "clean_signal",
+        "user_confirmed_vehicle_data",
+        "summary_only",
+        "raw_replay_incomplete",
+        "legacy_context",
+        "speed_context_gaps",
+        "rpm_context_gaps",
+        "sparse_support",
+        "brief_support",
+        "drifting_frequency",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "noisy_signal",
+        "weak_spatial",
+        "close_alternative",
+        "incomplete_reference",
+        "secondary_vehicle_data",
+        "approximate_vehicle_data",
+        "unverified_vehicle_data",
+    }
+)
+DIAGNOSIS_FACTOR_POLARITY_VALUES: frozenset[DiagnosisFactorPolarity] = frozenset(
+    {"support", "counterevidence"}
+)
+DIAGNOSIS_FACTOR_SEVERITY_VALUES: frozenset[DiagnosisFactorSeverity] = frozenset(
+    {"low", "medium", "high"}
+)
+WHOLE_RUN_DIAGNOSIS_DATA_BASIS_VALUES: frozenset[WholeRunDiagnosisDataBasis] = frozenset(
+    {"raw_backed", "partial_raw_backed", "summary_only"}
+)
+LOCATION_PROOF_BASIS_VALUES: frozenset[LocationProofBasis] = frozenset(
+    {
+        "whole_run_summary",
+        "supporting_windows_raw_backed",
+        "supporting_windows_summary_only",
+    }
+)
 
 
 _FORBID_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isclose
-from typing import Literal
+from typing import Literal, cast
 
 from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
@@ -31,6 +31,10 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 __all__ = [
     "WHOLE_RUN_ARTIFACT_SCHEMA_VERSION",
     "WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME",
+    "WHOLE_RUN_CONTEXT_COVERAGE_VALUES",
+    "WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES",
+    "WHOLE_RUN_RPM_VALIDITY_VALUES",
+    "WHOLE_RUN_SPEED_VALIDITY_VALUES",
     "WholeRunArtifactFile",
     "WholeRunArtifactManifest",
     "WholeRunContextCoverage",
@@ -51,6 +55,19 @@ type WholeRunContextCoverage = Literal["full", "partial", "missing"]
 type WholeRunSpeedValidity = Literal["measured", "assumed", "missing"]
 type WholeRunRpmValidity = Literal["measured", "estimated", "missing"]
 type WholeRunContextLoadState = Literal["idle", "steady", "transient", "unknown"]
+
+WHOLE_RUN_CONTEXT_COVERAGE_VALUES: frozenset[WholeRunContextCoverage] = frozenset(
+    {"full", "partial", "missing"}
+)
+WHOLE_RUN_SPEED_VALIDITY_VALUES: frozenset[WholeRunSpeedValidity] = frozenset(
+    {"measured", "assumed", "missing"}
+)
+WHOLE_RUN_RPM_VALIDITY_VALUES: frozenset[WholeRunRpmValidity] = frozenset(
+    {"measured", "estimated", "missing"}
+)
+WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES: frozenset[WholeRunContextLoadState] = frozenset(
+    {"idle", "steady", "transient", "unknown"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -454,37 +471,27 @@ def _bool_from_json(value: JsonValue | object) -> bool:
 
 def _context_coverage_from_json(value: JsonValue | object) -> WholeRunContextCoverage:
     raw = _str_or_none(value)
-    if raw == "full":
-        return "full"
-    if raw == "partial":
-        return "partial"
+    if raw in WHOLE_RUN_CONTEXT_COVERAGE_VALUES:
+        return cast(WholeRunContextCoverage, raw)
     return "missing"
 
 
 def _speed_validity_from_json(value: JsonValue | object) -> WholeRunSpeedValidity:
     raw = _str_or_none(value)
-    if raw == "measured":
-        return "measured"
-    if raw == "assumed":
-        return "assumed"
+    if raw in WHOLE_RUN_SPEED_VALIDITY_VALUES:
+        return cast(WholeRunSpeedValidity, raw)
     return "missing"
 
 
 def _rpm_validity_from_json(value: JsonValue | object) -> WholeRunRpmValidity:
     raw = _str_or_none(value)
-    if raw == "measured":
-        return "measured"
-    if raw == "estimated":
-        return "estimated"
+    if raw in WHOLE_RUN_RPM_VALIDITY_VALUES:
+        return cast(WholeRunRpmValidity, raw)
     return "missing"
 
 
 def _load_state_from_json(value: JsonValue | object) -> WholeRunContextLoadState:
     raw = _str_or_none(value)
-    if raw == "idle":
-        return "idle"
-    if raw == "steady":
-        return "steady"
-    if raw == "transient":
-        return "transient"
+    if raw in WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES:
+        return cast(WholeRunContextLoadState, raw)
     return "unknown"

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -43,6 +43,7 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 
 __all__ = [
     "OrderHarmonicEvidenceSummary",
+    "ORDER_TRACE_FAMILY_VALUES",
     "OrderTraceFamily",
     "OrderTracePhaseSupport",
     "OrderTracePoint",
@@ -51,6 +52,10 @@ __all__ = [
 ]
 
 type OrderTraceFamily = Literal["wheel", "driveshaft", "engine"]
+
+ORDER_TRACE_FAMILY_VALUES: frozenset[OrderTraceFamily] = frozenset(
+    {"wheel", "driveshaft", "engine"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -462,7 +467,7 @@ def _optional_float(value: object) -> float | None:
 
 def _order_family(value: object) -> OrderTraceFamily:
     family = _optional_text(value)
-    if family not in {"wheel", "driveshaft", "engine"}:
+    if family not in ORDER_TRACE_FAMILY_VALUES:
         raise ValueError(f"Unsupported order_family {value!r}")
     return cast(OrderTraceFamily, family)
 

--- a/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
@@ -9,9 +9,11 @@ report/history-facing proof fields needed after persistence.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
-from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
+from vibesensor.shared.types.history_analysis_contracts import (
+    LOCATION_PROOF_BASIS_VALUES,
+    LocationProofBasis,
+)
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.whole_run_json_helpers import (
     non_empty_text_or_none as _non_empty_text_or_none,
@@ -279,13 +281,9 @@ def _required_bool(data: JsonObject, field_name: str) -> bool:
 
 
 def _required_proof_basis(value: object) -> LocationProofBasis:
-    if value not in {
-        "whole_run_summary",
-        "supporting_windows_raw_backed",
-        "supporting_windows_summary_only",
-    }:
+    if value not in LOCATION_PROOF_BASIS_VALUES:
         raise ValueError("proof_basis must be a supported location proof basis")
-    return cast(LocationProofBasis, value)
+    return value
 
 
 def _optional_float(value: object) -> float | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -9,9 +9,14 @@ support/counterevidence factor vocabulary.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
 from vibesensor.shared.types.history_analysis_contracts import (
+    DIAGNOSIS_EXEMPLAR_KIND_VALUES,
+    DIAGNOSIS_FACTOR_KEY_VALUES,
+    DIAGNOSIS_FACTOR_POLARITY_VALUES,
+    DIAGNOSIS_FACTOR_SEVERITY_VALUES,
+    LOCATION_PROOF_BASIS_VALUES,
+    WHOLE_RUN_DIAGNOSIS_DATA_BASIS_VALUES,
     DiagnosisExemplarKind,
     DiagnosisFactorKey,
     DiagnosisFactorPolarity,
@@ -411,13 +416,9 @@ def _required_numeric(data: JsonObject, field_name: str) -> float:
 
 
 def _required_exemplar_kind(value: object) -> DiagnosisExemplarKind:
-    if value not in {
-        "order_support_interval",
-        "whole_run_context_interval",
-        "spatial_location",
-    }:
+    if value not in DIAGNOSIS_EXEMPLAR_KIND_VALUES:
         raise ValueError("kind must be a supported diagnosis exemplar kind")
-    return cast(DiagnosisExemplarKind, value)
+    return value
 
 
 def _require_factor_key(value: DiagnosisFactorKey) -> None:
@@ -425,36 +426,9 @@ def _require_factor_key(value: DiagnosisFactorKey) -> None:
 
 
 def _required_factor_key(value: object) -> DiagnosisFactorKey:
-    if value not in {
-        "raw_backed",
-        "partial_raw_backed",
-        "repeated_support",
-        "sustained_support",
-        "stable_frequency",
-        "tight_order_lock",
-        "localized_support",
-        "clean_signal",
-        "user_confirmed_vehicle_data",
-        "summary_only",
-        "raw_replay_incomplete",
-        "legacy_context",
-        "speed_context_gaps",
-        "rpm_context_gaps",
-        "sparse_support",
-        "brief_support",
-        "drifting_frequency",
-        "loose_order_lock",
-        "mixed_support_locations",
-        "noisy_signal",
-        "weak_spatial",
-        "close_alternative",
-        "incomplete_reference",
-        "secondary_vehicle_data",
-        "approximate_vehicle_data",
-        "unverified_vehicle_data",
-    }:
+    if value not in DIAGNOSIS_FACTOR_KEY_VALUES:
         raise ValueError("factor_key must be a supported diagnosis factor key")
-    return cast(DiagnosisFactorKey, value)
+    return value
 
 
 def _require_factor_polarity(value: DiagnosisFactorPolarity) -> None:
@@ -462,9 +436,9 @@ def _require_factor_polarity(value: DiagnosisFactorPolarity) -> None:
 
 
 def _required_factor_polarity(value: object) -> DiagnosisFactorPolarity:
-    if value not in {"support", "counterevidence"}:
+    if value not in DIAGNOSIS_FACTOR_POLARITY_VALUES:
         raise ValueError("polarity must be a supported diagnosis factor polarity")
-    return cast(DiagnosisFactorPolarity, value)
+    return value
 
 
 def _require_factor_severity(value: DiagnosisFactorSeverity) -> None:
@@ -472,27 +446,23 @@ def _require_factor_severity(value: DiagnosisFactorSeverity) -> None:
 
 
 def _required_factor_severity(value: object) -> DiagnosisFactorSeverity:
-    if value not in {"low", "medium", "high"}:
+    if value not in DIAGNOSIS_FACTOR_SEVERITY_VALUES:
         raise ValueError("severity must be a supported diagnosis factor severity")
-    return cast(DiagnosisFactorSeverity, value)
+    return value
 
 
 def _required_data_basis(value: object) -> WholeRunDiagnosisDataBasis:
-    if value not in {"raw_backed", "partial_raw_backed", "summary_only"}:
+    if value not in WHOLE_RUN_DIAGNOSIS_DATA_BASIS_VALUES:
         raise ValueError("data_basis must be a supported whole-run diagnosis data basis")
-    return cast(WholeRunDiagnosisDataBasis, value)
+    return value
 
 
 def _optional_proof_basis(value: object) -> LocationProofBasis | None:
     if value is None:
         return None
-    if value not in {
-        "whole_run_summary",
-        "supporting_windows_raw_backed",
-        "supporting_windows_summary_only",
-    }:
+    if value not in LOCATION_PROOF_BASIS_VALUES:
         raise ValueError("location_proof_basis must be a supported location proof basis")
-    return cast(LocationProofBasis, value)
+    return value
 
 
 def _optional_float(value: object) -> float | None:


### PR DESCRIPTION
## What changed
- defined the allowed-value sets once next to their owning type aliases
- rewired the whole-run order, diagnosis, spatial, and shared whole-run validators to use those shared constants
- added focused regressions for unsupported literal values and whole-run fallback states

## Why
- the same literal sets were repeated inline across several contract parsers
- that duplication made drift easier between the shared type aliases and the validation helpers
- this keeps the public contract names unchanged while giving each concept one source of truth

## Validation
- `python3 -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py apps/server/tests/shared/types/test_whole_run_analysis.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edge cases
- kept accepted values unchanged
- kept whole-run context fallback behavior unchanged for invalid coverage/speed/rpm/load-state values
- did not change the public type aliases or contract field names

Closes #3341
