### PR TITLE
Merge UI smoke layout micro-regression specs into representative responsive journeys

### DIFF
--- a/apps/ui/tests/smoke.car-wizard.spec.ts
+++ b/apps/ui/tests/smoke.car-wizard.spec.ts
@@ -98,91 +98,6 @@ test("closes the add car wizard from Escape on the focused input and restores fo
   await expect(page.locator("#addCarBtn")).toBeFocused();
 });
 
-test("uses the full mobile viewport and keeps the final action visible on short screens", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 667 });
-  await installCommonRoutes(page, {
-    settingsHandler: createSettingsHandlerFromMap({
-      "/api/settings/cars": {
-        cars: [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }],
-        active_car_id: "car-1",
-      },
-    }),
-  });
-  await page.route("**/api/car-library/**", async (route) => {
-    const path = requestPath(route);
-    if (path === "/api/car-library/brands") {
-      await fulfillJson(route, { brands: ["BMW"] });
-      return;
-    }
-    if (path === "/api/car-library/types") {
-      await fulfillJson(route, { types: ["SUV"] });
-      return;
-    }
-    if (path === "/api/car-library/models") {
-      await fulfillJson(route, {
-        models: [{
-          model: "X5",
-          tire_width_mm: 275,
-          tire_aspect_pct: 40,
-          rim_in: 21,
-          variants: [],
-          gearboxes: [],
-          tire_options: [],
-        }],
-      });
-      return;
-    }
-    await fulfillJson(route, { brands: [], types: [], models: [] });
-  });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
-  await page.locator("#addCarBtn").click();
-  await page.locator("#wizardBrandList .wiz-opt").click();
-  await page.locator("#wizardTypeList .wiz-opt").click();
-  await page.locator("#wizardCustomModel").fill("X5 M60i");
-  await page.locator("#wizardCustomModelBtn").click();
-
-  const wizard = page.locator("#addCarWizard");
-  await expect(wizard).toBeVisible();
-  await expect(page.locator("#wizardManualAddBtn")).toBeVisible();
-
-  const box = await wizard.boundingBox();
-  if (!box) {
-    throw new Error("Expected mobile wizard to have a bounding box");
-  }
-  expect(Math.round(box.x)).toBe(0);
-  expect(Math.round(box.y)).toBe(0);
-  expect(Math.abs(Math.round(box.width) - 390)).toBeLessThanOrEqual(1);
-
-  const overflowMetrics = await wizard.evaluate((wizardElement) => {
-    const steps = wizardElement.querySelector<HTMLElement>(".wizard-steps");
-    if (!steps) {
-      throw new Error("Expected wizard steps container");
-    }
-    const stepsStyle = window.getComputedStyle(steps);
-    return {
-      stepsOverflowY: stepsStyle.overflowY,
-      wizardClientHeight: Math.round(wizardElement.clientHeight),
-      wizardScrollHeight: Math.round(wizardElement.scrollHeight),
-    };
-  });
-
-  expect(overflowMetrics.stepsOverflowY).toBe("auto");
-  expect(overflowMetrics.wizardScrollHeight).toBeLessThanOrEqual(overflowMetrics.wizardClientHeight + 2);
-
-  await wizard.evaluate((wizardElement) => {
-    wizardElement.scrollTop = wizardElement.scrollHeight;
-  });
-  await activateWizardCloseButton(page);
-  await page.locator("#addCarBtn").click();
-
-  await expect(page.locator("#addCarWizard")).toBeVisible();
-  await expect(wizard.evaluate((wizardElement) => Math.round(wizardElement.scrollTop))).resolves.toBeLessThanOrEqual(1);
-});
-
 test("keeps the manual branch deliberate while summarizing selections and activating the new car", async ({ page }) => {
   const cars = [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }];
   let activeCarId = "car-1";
@@ -298,7 +213,8 @@ test("keeps the manual branch deliberate while summarizing selections and activa
   await expect(newRow.locator(".car-active-pill")).toHaveAttribute("data-state", "active");
 });
 
-test("keeps the final Add Car action visible for the library branch until the user finishes", async ({ page }) => {
+test("completes the library branch on a short mobile screen without losing the final action", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 667 });
   const cars = [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }];
   let activeCarId = "car-1";
   let createdCarName = "";
@@ -381,17 +297,42 @@ test("keeps the final Add Car action visible for the library branch until the us
   await page.locator("#wizardTypeList .wiz-opt").click();
   await page.locator("#wizardModelList .wiz-opt").click();
 
+  const wizard = page.locator("#addCarWizard");
   await expect(page.locator("#wizardProgressText")).toContainText("Step 5 of 5");
   await expect(page.locator("#wizardActionHint")).toContainText("Choose a library gearbox or edit the manual specs to finish.");
   await expect(page.locator("#wizardManualAddBtn")).toBeDisabled();
 
+  const box = await wizard.boundingBox();
+  if (!box) {
+    throw new Error("Expected mobile wizard to have a bounding box");
+  }
+  expect(Math.round(box.x)).toBe(0);
+  expect(Math.round(box.y)).toBe(0);
+  expect(Math.abs(Math.round(box.width) - 390)).toBeLessThanOrEqual(1);
+
+  const overflowMetrics = await wizard.evaluate((wizardElement) => {
+    const steps = wizardElement.querySelector<HTMLElement>(".wizard-steps");
+    if (!steps) {
+      throw new Error("Expected wizard steps container");
+    }
+    const stepsStyle = window.getComputedStyle(steps);
+    return {
+      stepsOverflowY: stepsStyle.overflowY,
+      wizardClientHeight: Math.round(wizardElement.clientHeight),
+      wizardScrollHeight: Math.round(wizardElement.scrollHeight),
+    };
+  });
+
+  expect(overflowMetrics.stepsOverflowY).toBe("auto");
+  expect(overflowMetrics.wizardScrollHeight).toBeLessThanOrEqual(overflowMetrics.wizardClientHeight + 2);
+
   await page.locator("#wizardGearboxList .wiz-opt").click();
 
-  await expect(page.locator("#addCarWizard")).toBeVisible();
+  await expect(wizard).toBeVisible();
   await expect(page.locator("#wizardActionHint")).toContainText("Library path selected");
   await expect(page.locator("#wizardManualAddBtn")).toBeEnabled();
-  await page.locator("#addCarWizard").evaluate((wizard) => {
-    wizard.scrollTop = wizard.scrollHeight;
+  await wizard.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
   });
   await expect(page.locator("#wizardManualAddBtn")).toBeVisible();
 

--- a/apps/ui/tests/smoke.settings-alignment.spec.ts
+++ b/apps/ui/tests/smoke.settings-alignment.spec.ts
@@ -30,13 +30,23 @@ const readyStrengthMetrics = {
   top_peaks: [],
 };
 
-test("analysis uncertainty inputs stay aligned when the middle label wraps", async ({ page }) => {
+test("settings desktop journey keeps analysis controls and car actions aligned", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 });
+  const readyAspects = {
+    tire_width_mm: 245,
+    tire_aspect_pct: 40,
+    rim_in: 19,
+    final_drive_ratio: 3.3,
+    current_gear_ratio: 0.84,
+  };
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
       if (requestPath(route).startsWith("/api/settings/cars")) {
         await fulfillJson(route, {
-          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          cars: [
+            { id: "car-1", name: "Active Car", type: "sedan", aspects: readyAspects },
+            { id: "car-2", name: "Inactive Car", type: "suv", aspects: readyAspects },
+          ],
           active_car_id: "car-1",
         });
         return;
@@ -50,8 +60,8 @@ test("analysis uncertainty inputs stay aligned when the middle label wraps", asy
   await installFakeWebSocket(page);
   await page.goto("/");
   await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
 
+  await page.locator('[data-settings-tab="analysisTab"]').click();
   const speedLabel = page.locator('label[for="speedUncertaintyInput"]');
   const tireLabel = page.locator('label[for="tireDiameterUncertaintyInput"]');
   const finalDriveLabel = page.locator('label[for="finalDriveUncertaintyInput"]');
@@ -78,35 +88,7 @@ test("analysis uncertainty inputs stay aligned when the middle label wraps", asy
   expect(tireLabelBox.height).toBeGreaterThan(speedLabelBox.height);
   expect(Math.abs(speedTop - tireTop)).toBeLessThanOrEqual(1);
   expect(Math.abs(finalDriveTop - tireTop)).toBeLessThanOrEqual(1);
-});
 
-test("manage cars delete button stays in the same visible column across rows", async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 800 });
-  const readyAspects = {
-    tire_width_mm: 245,
-    tire_aspect_pct: 40,
-    rim_in: 19,
-    final_drive_ratio: 3.3,
-    current_gear_ratio: 0.84,
-  };
-  await installCommonRoutes(page, {
-    settingsHandler: async (route) => {
-      if (requestPath(route).startsWith("/api/settings/cars")) {
-        await fulfillJson(route, {
-          cars: [
-            { id: "car-1", name: "Active Car", type: "sedan", aspects: readyAspects },
-            { id: "car-2", name: "Inactive Car", type: "suv", aspects: readyAspects },
-          ],
-          active_car_id: "car-1",
-        });
-        return;
-      }
-      await fulfillJson(route, {});
-    },
-  });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="carTab"]').click();
 
   const activeRow = page.locator('#carListBody tr[data-car-id="car-1"]');
@@ -133,52 +115,13 @@ test("manage cars delete button stays in the same visible column across rows", a
   expect(Math.abs(activeDeleteRight - inactiveDeleteRight)).toBeLessThanOrEqual(1);
 });
 
-test("live strongest signal stat stays aligned with peer summary metrics", async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 1280 });
-  await page.goto("/?demo=1");
-
-  const dataFreshnessStat = page.locator("#liveDataFreshness");
-  const strongestSignalStat = page.locator("#liveStrongestSignal");
-  const dataFreshnessLabel = dataFreshnessStat.locator(".stat__label");
-  const strongestSignalLabel = strongestSignalStat.locator(".stat__label");
-  const dataFreshnessValue = dataFreshnessStat.locator("[data-value]");
-  const strongestSignalValue = strongestSignalStat.locator("[data-value]");
-  const speedValue = page.locator("#speed");
-
-  await expect(strongestSignalStat).not.toHaveClass(/stat--spotlight/);
-  await expect(strongestSignalLabel).toHaveText("Strongest signal");
-  await expect(dataFreshnessValue).toBeVisible();
-  await expect(strongestSignalValue).toBeVisible();
-  await expect(speedValue).toBeVisible();
-
-  const [
-    dataFreshnessLabelTop,
-    strongestSignalLabelTop,
-    speedLabelTop,
-    dataFreshnessValueTop,
-    strongestSignalValueTop,
-    speedValueTop,
-  ] = await Promise.all([
-    dataFreshnessLabel.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-    strongestSignalLabel.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-    speedValue.evaluate((el) =>
-      Math.round((el.previousElementSibling as HTMLElement).getBoundingClientRect().top),
-    ),
-    dataFreshnessValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-    strongestSignalValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-    speedValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
-  ]);
-
-  expect(Math.abs(dataFreshnessLabelTop - strongestSignalLabelTop)).toBeLessThanOrEqual(1);
-  expect(Math.abs(speedLabelTop - strongestSignalLabelTop)).toBeLessThanOrEqual(1);
-  expect(Math.abs(dataFreshnessValueTop - strongestSignalValueTop)).toBeLessThanOrEqual(1);
-  expect(Math.abs(speedValueTop - strongestSignalValueTop)).toBeLessThanOrEqual(1);
-});
-
-test("dashboard removes repeated ready and online status badges while keeping status cues", async ({ page }) => {
+test("dashboard desktop journey keeps summary stats and sensor cards readable", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await installCommonRoutes(page, {
-    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+    locations: [
+      { code: "front_left_wheel", label: "Front Left Wheel" },
+      { code: "engine_bay", label: "Engine Bay" },
+    ],
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
         await fulfillJson(route, {
@@ -208,57 +151,6 @@ test("dashboard removes repeated ready and online status badges while keeping st
         speed: { state: "pass", reasonKey: "speed_stable", details: { dwell_elapsed_s: 8 } },
       }),
     });
-  });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
-      clients: [
-        {
-          id: "001122334455",
-          name: "Front Left",
-          connected: true,
-          sample_rate_hz: 1000,
-          last_seen_age_ms: 10,
-          dropped_frames: 0,
-          frames_total: 100,
-          location_code: "front_left_wheel",
-          mac_address: "001122334455",
-          firmware_version: "fw-1.0.0",
-        },
-      ],
-      spectra: {
-        clients: {
-          "001122334455": {
-            freq: [1, 2, 3],
-            combined_spectrum_amp_g: [0.1, 0.2, 0.15],
-            strength_metrics: readyStrengthMetrics,
-          },
-        },
-      },
-    },
-  });
-  await page.goto("/");
-
-  await expect(page.locator(".site-header__status")).toBeHidden();
-  await expect(page.locator("#liveRunHealth")).toBeHidden();
-  await expect(page.locator("#loggingStatus")).toBeHidden();
-  await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
-  await expect(page.locator('#liveSensorRoster .live-sensor-card__status-dot[data-status="online"]')).toHaveCount(1);
-
-  await page.locator("#tab-history").click();
-  await expect(page.locator(".site-header__status")).toBeVisible();
-
-  await page.locator("#tab-dashboard").click();
-  await expect(page.locator(".site-header__status")).toBeHidden();
-});
-
-test("sensor coverage cards keep only location labels and a shared left alignment", async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 900 });
-  await installCommonRoutes(page, {
-    locations: [
-      { code: "front_left_wheel", label: "Front Left Wheel" },
-      { code: "engine_bay", label: "Engine Bay" },
-    ],
   });
   await installFakeWebSocket(page, {
     payload: {
@@ -301,10 +193,60 @@ test("sensor coverage cards keep only location labels and a shared left alignmen
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
+      spectra: {
+        clients: {
+          "sensor-alpha": {
+            freq: [1, 2, 3],
+            combined_spectrum_amp_g: [0.1, 0.2, 0.15],
+            strength_metrics: readyStrengthMetrics,
+          },
+        },
+      },
     },
   });
   await page.goto("/");
+
+  const dataFreshnessStat = page.locator("#liveDataFreshness");
+  const strongestSignalStat = page.locator("#liveStrongestSignal");
+  const dataFreshnessLabel = dataFreshnessStat.locator(".stat__label");
+  const strongestSignalLabel = strongestSignalStat.locator(".stat__label");
+  const dataFreshnessValue = dataFreshnessStat.locator("[data-value]");
+  const strongestSignalValue = strongestSignalStat.locator("[data-value]");
+  const speedValue = page.locator("#speed");
+
+  await expect(strongestSignalStat).not.toHaveClass(/stat--spotlight/);
+  await expect(strongestSignalLabel).toHaveText("Strongest signal");
+  await expect(dataFreshnessValue).toBeVisible();
+  await expect(strongestSignalValue).toBeVisible();
+  await expect(speedValue).toBeVisible();
+
+  const [
+    dataFreshnessLabelTop,
+    strongestSignalLabelTop,
+    speedLabelTop,
+    dataFreshnessValueTop,
+    strongestSignalValueTop,
+    speedValueTop,
+  ] = await Promise.all([
+    dataFreshnessLabel.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+    strongestSignalLabel.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+    speedValue.evaluate((el) =>
+      Math.round((el.previousElementSibling as HTMLElement).getBoundingClientRect().top),
+    ),
+    dataFreshnessValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+    strongestSignalValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+    speedValue.evaluate((el) => Math.round(el.getBoundingClientRect().top)),
+  ]);
+
+  expect(Math.abs(dataFreshnessLabelTop - strongestSignalLabelTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(speedLabelTop - strongestSignalLabelTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(dataFreshnessValueTop - strongestSignalValueTop)).toBeLessThanOrEqual(1);
+  expect(Math.abs(speedValueTop - strongestSignalValueTop)).toBeLessThanOrEqual(1);
+
+  await expect(page.locator(".site-header__status")).toBeHidden();
+  await expect(page.locator("#loggingStatus")).toBeHidden();
+  await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
+  await expect(page.locator('#liveSensorRoster .live-sensor-card__status-dot[data-status="online"]')).toHaveCount(3);
 
   const frontCard = page.locator("#liveSensorRoster article").nth(0);
   const engineCard = page.locator("#liveSensorRoster article").nth(1);
@@ -339,4 +281,10 @@ test("sensor coverage cards keep only location labels and a shared left alignmen
 
   expect(Math.abs(frontOffset - engineOffset)).toBeLessThanOrEqual(1);
   expect(Math.abs(frontOffset - unassignedOffset)).toBeLessThanOrEqual(1);
+
+  await page.locator("#tab-history").click();
+  await expect(page.locator(".site-header__status")).toBeVisible();
+
+  await page.locator("#tab-dashboard").click();
+  await expect(page.locator(".site-header__status")).toBeHidden();
 });


### PR DESCRIPTION
Closes #3374

## What changed
- collapsed `apps/ui/tests/smoke.settings-alignment.spec.ts` from five narrow layout/chrome checks to two broader desktop journeys
- folded the standalone short-screen wizard layout smoke into the existing library-branch journey in `apps/ui/tests/smoke.car-wizard.spec.ts`
- kept `apps/ui/tests/smoke.history-layout.spec.ts` as the representative mobile history coverage

## Why
- the old smoke specs repeated similar responsive layout assertions across too many tiny browser tests
- broader journey coverage still catches major breakage while cutting smoke maintenance and count

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.settings-alignment.spec.ts tests/smoke.history-layout.spec.ts tests/smoke.car-wizard.spec.ts`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light --list tests/smoke*.spec.ts`

## Risks / tradeoffs
- this intentionally trades a few pixel-level smoke assertions for broader responsive journeys
- `make ui-typecheck` still fails on pre-existing unrelated frontend lint debt elsewhere under `apps/ui`

## Notes
- smoke collection drops from 67 to 63 tests across the same 15 smoke files
