### PR TITLE
Trim duplicate vibration strength tests

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
@@ -17,23 +17,18 @@ from vibesensor.strength_bands import (
 # -- bucket_for_strength -------------------------------------------------------
 
 
-def test_bucket_below_threshold_returns_l0() -> None:
-    assert bucket_for_strength(vibration_strength_db=0.0) == "l0"
-    assert bucket_for_strength(vibration_strength_db=5.0) == "l0"
-
-
-def test_bucket_l1_threshold() -> None:
-    assert bucket_for_strength(vibration_strength_db=8.0) == "l1"
-
-
-def test_bucket_l5_threshold() -> None:
-    assert bucket_for_strength(vibration_strength_db=46.0) == "l5"
-
-
-def test_bucket_returns_highest_matching() -> None:
-    # Meets L1-L3 thresholds → returns L3
-    result = bucket_for_strength(vibration_strength_db=26.0)
-    assert result == "l3"
+@pytest.mark.parametrize(
+    ("vibration_strength_db", "expected"),
+    [
+        pytest.param(0.0, "l0", id="zero"),
+        pytest.param(5.0, "l0", id="below-first-threshold"),
+        pytest.param(8.0, "l1", id="l1-threshold"),
+        pytest.param(26.0, "l3", id="highest-matching-threshold"),
+        pytest.param(46.0, "l5", id="l5-threshold"),
+    ],
+)
+def test_bucket_examples(vibration_strength_db: float, expected: str) -> None:
+    assert bucket_for_strength(vibration_strength_db=vibration_strength_db) == expected
 
 
 def test_batch_buckets_match_scalar_helper() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -8,29 +8,10 @@ import pytest
 import vibesensor.vibration_strength as vibration_strength_module
 from vibesensor.vibration_strength import (
     compute_vibration_strength_db,
-    median,
     peak_band_rms_amp_g,
     strength_floor_amp_g,
     vibration_strength_db_scalar,
 )
-
-# -- median ------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("values", "expected"),
-    [
-        pytest.param([], 0.0, id="empty_returns_zero"),
-        pytest.param([7.0], 7.0, id="single_element"),
-        pytest.param([3.0, 1.0, 2.0], 2.0, id="odd_count"),
-        pytest.param([1.0, 2.0, 3.0, 4.0], 2.5, id="even_count_true_median"),
-        pytest.param([1.0, 3.0], 2.0, id="two_elements"),
-        pytest.param([4.0, 1.0, 3.0, 2.0], 2.5, id="even_unsorted"),
-    ],
-)
-def test_median(values: list[float], expected: float) -> None:
-    assert median(values) == expected
-
 
 # -- strength_floor_amp_g ----------------------------------------------------
 
@@ -564,29 +545,3 @@ def test_batch_vibration_strength_db_matches_scalar() -> None:
     )
 
     vibration_strength_module.np.testing.assert_allclose(batch, expected)
-
-
-def test_strength_db_equal_band_and_floor() -> None:
-    # When band_rms == floor_rms the result should be ~0 dB
-    db = vibration_strength_db_scalar(
-        peak_band_rms_amp_g=1.0,
-        floor_amp_g=1.0,
-    )
-    assert abs(db) < 0.01
-
-
-def test_strength_db_band_much_above_floor() -> None:
-    db = vibration_strength_db_scalar(
-        peak_band_rms_amp_g=10.0,
-        floor_amp_g=1.0,
-    )
-    assert db > 15.0  # ~20 dB
-
-
-def test_strength_db_floor_zero_returns_finite() -> None:
-    db = vibration_strength_db_scalar(
-        peak_band_rms_amp_g=1e-6,
-        floor_amp_g=0.0,
-    )
-    assert db > 0
-    assert db < 200

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
@@ -128,19 +128,9 @@ class TestComputeVibrationStrengthBoundaries:
 class TestVibrationStrengthDbScalar:
     """Direct unit tests for the dB scalar computation."""
 
-    def test_equal_peak_and_floor_returns_near_zero(self) -> None:
-        """When peak == floor, dB should be ~0."""
-        db = vibration_strength_db_scalar(peak_band_rms_amp_g=0.01, floor_amp_g=0.01)
-        assert abs(db) < 0.5
-
     def test_large_peak_gives_positive_db(self) -> None:
         db = vibration_strength_db_scalar(peak_band_rms_amp_g=1.0, floor_amp_g=0.001)
         assert db > 30.0
-
-    def test_zero_floor_zero_peak_returns_finite(self) -> None:
-        db = vibration_strength_db_scalar(peak_band_rms_amp_g=0.0, floor_amp_g=0.0)
-        assert math.isfinite(db)
-        assert abs(db) < 0.01
 
     @pytest.mark.parametrize(
         ("peak", "floor", "kwargs"),


### PR DESCRIPTION
Closes #3381

## What changed
- removed the duplicate median table and generic scalar example tests from `test_strength_scoring.py`
- dropped the scalar boundary examples in `test_vibration_strength_boundaries.py` that are already covered by the invariant/property suite
- merged the bucket threshold examples in `test_strength_bands_extended.py` into one parameterized table

## Why
- the scalar formula and helper invariants already have stronger owners
- the scoring file should stay about pipeline/scoring behavior, not reassert the generic scalar contract
- the bucket examples are easier to scan and maintain as one table

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_invariants.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py`
- `python -m pytest -q --collect-only apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_invariants.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py`
- `make lint`

## Risks, tradeoffs, edge cases
- this intentionally removes duplicate example coverage, so fewer files re-check the same scalar/bucket behavior
- the stronger invariant/property tests and the remaining boundary-specific examples still protect the metric behavior
