### PR TITLE
Add orphaned test inventory guard

### DIFF
--- a/apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
+++ b/apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import importlib.util
-import sys
 from types import ModuleType
 
 import pytest
-from _paths import REPO_ROOT
-
-_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+from test_support.check_hygiene_loader import load_check_hygiene_module
 
 _CHECK_ENTRYPOINTS = (
     pytest.param("check_ci_command_sync", id="ci-command-sync"),
@@ -37,25 +33,14 @@ _CHECK_ENTRYPOINTS = (
         id="frontend-generated-contract-boundaries",
     ),
     pytest.param("check_frontend_raw_html_boundaries", id="frontend-raw-html-boundaries"),
+    pytest.param("check_test_inventory_ownership", id="test-inventory-ownership"),
     pytest.param("check_runtime_policy_drift", id="runtime-policy-drift"),
 )
 
 
-def _load_check_hygiene_module() -> ModuleType:
-    spec = importlib.util.spec_from_file_location(
-        "check_hygiene_test_entrypoints",
-        _CHECK_HYGIENE,
-    )
-    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_HYGIENE}"
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
 @pytest.fixture(scope="module")
 def hygiene_module() -> ModuleType:
-    return _load_check_hygiene_module()
+    return load_check_hygiene_module("check_hygiene_test_entrypoints")
 
 
 @pytest.mark.parametrize("check_name", _CHECK_ENTRYPOINTS)

--- a/apps/server/tests/hygiene/test_test_inventory_ownership.py
+++ b/apps/server/tests/hygiene/test_test_inventory_ownership.py
@@ -1,0 +1,94 @@
+"""Guard: committed test-looking files stay owned by a runner."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+from test_support.check_hygiene_loader import load_check_hygiene_module
+
+
+@pytest.fixture(scope="module")
+def hygiene_module() -> ModuleType:
+    return load_check_hygiene_module("check_hygiene_test_inventory")
+
+
+def test_test_inventory_guard_passes_for_current_repo(
+    hygiene_module: ModuleType,
+) -> None:
+    assert hygiene_module.check_test_inventory_ownership() == []
+
+
+def test_unowned_test_inventory_paths_report_runner_guidance(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.inventory_errors_for_test_paths(
+        (
+            "tools/test_orphan.py",
+            "apps/ui/specs/orphan.spec.ts",
+            "tools/tests/benchmark_new.py",
+        ),
+        ui_runner_specs={},
+        benchmark_allowlist={},
+    )
+
+    assert any(
+        "tools/test_orphan.py" in error and "apps/server/tests/" in error for error in errors
+    )
+    assert any(
+        "apps/ui/specs/orphan.spec.ts" in error and "apps/ui/vitest.config.ts" in error
+        for error in errors
+    )
+    assert any(
+        "tools/tests/benchmark_new.py" in error
+        and "tools/dev/test_inventory_allowlist.yml" in error
+        for error in errors
+    )
+
+
+def test_allowlisted_benchmark_scripts_do_not_fail(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.inventory_errors_for_test_paths(
+        ("tools/tests/benchmark_custom.py",),
+        ui_runner_specs={},
+        benchmark_allowlist={"tools/tests/benchmark_custom.py": "Standalone benchmark harness."},
+    )
+
+    assert errors == []
+
+
+def test_production_modules_named_like_tests_are_ignored(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.inventory_errors_for_test_paths(
+        (
+            "apps/server/vibesensor/domain/test_plan.py",
+            "apps/server/vibesensor/domain/test_run.py",
+            "apps/server/vibesensor/shared/boundaries/summary_fields/test_plan.py",
+        ),
+        ui_runner_specs={},
+        benchmark_allowlist={},
+    )
+
+    assert errors == []
+
+
+def test_multiply_owned_ui_specs_fail_with_runner_guidance(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.inventory_errors_for_test_paths(
+        ("apps/ui/tests/shared.spec.ts",),
+        ui_runner_specs={
+            "vitest": {"tests/shared.spec.ts"},
+            "playwright-smoke": {"tests/shared.spec.ts"},
+        },
+        benchmark_allowlist={},
+    )
+
+    assert errors == [
+        "apps/ui/tests/shared.spec.ts is owned by multiple UI runners "
+        "['playwright-smoke', 'vitest']; tighten apps/ui/vitest.config.ts "
+        "include/exclude or the Playwright testMatch patterns so exactly one "
+        "runner owns it."
+    ]

--- a/apps/server/tests/hygiene/test_ui_test_runner_ownership.py
+++ b/apps/server/tests/hygiene/test_ui_test_runner_ownership.py
@@ -2,18 +2,11 @@
 
 from __future__ import annotations
 
-import ast
-import re
-from pathlib import Path
+from types import ModuleType
 
-from tests._paths import REPO_ROOT
+import pytest
+from test_support.check_hygiene_loader import load_check_hygiene_module
 
-_UI_ROOT = REPO_ROOT / "apps" / "ui"
-_UI_TESTS_DIR = _UI_ROOT / "tests"
-_VITEST_CONFIG = _UI_ROOT / "vitest.config.ts"
-_PLAYWRIGHT_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.config.ts"
-_PLAYWRIGHT_MOCK_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.msw.config.ts"
-_PLAYWRIGHT_VISUAL_CONFIG = _UI_ROOT / "playwright.config.ts"
 _FOLLOW_UP_PLAYWRIGHT_SPECS = {
     "tests/smoke.realtime-logging-summary.spec.ts",
     "tests/smoke.settings-car-feedback-reset.spec.ts",
@@ -22,62 +15,14 @@ _FOLLOW_UP_PLAYWRIGHT_SPECS = {
 }
 
 
-def _config_array_literal(config_path: Path, key: str) -> list[str]:
-    config_text = config_path.read_text(encoding="utf-8")
-    match = re.search(rf"{key}:\s*(\[[^\]]+\])", config_text)
-    assert match is not None
-    normalized_literal = re.sub(r"//.*", "", match.group(1))
-    return [str(pattern) for pattern in ast.literal_eval(normalized_literal)]
+@pytest.fixture(scope="module")
+def hygiene_module() -> ModuleType:
+    return load_check_hygiene_module("check_hygiene_ui_runner_ownership")
 
 
-def _config_string_literal(config_path: Path, key: str) -> str:
-    config_text = config_path.read_text(encoding="utf-8")
-    match = re.search(rf'{key}:\s*"([^"]+)"', config_text)
-    assert match is not None
-    return str(match.group(1))
-
-
-def _resolve_ui_globs(*patterns: str) -> set[str]:
-    resolved: set[str] = set()
-    for pattern in patterns:
-        for path in _UI_ROOT.glob(pattern):
-            if path.is_file():
-                resolved.add(path.relative_to(_UI_ROOT).as_posix())
-    return resolved
-
-
-def _resolve_runner_specs(config_path: Path) -> set[str]:
-    test_dir = _config_string_literal(config_path, "testDir")
-    test_match_patterns = _config_array_literal(config_path, "testMatch")
-    return _resolve_ui_globs(*(f"{test_dir}/{pattern}" for pattern in test_match_patterns))
-
-
-def _all_ui_specs() -> set[str]:
-    return {
-        path.relative_to(_UI_ROOT).as_posix()
-        for path in _UI_TESTS_DIR.glob("**/*.spec.*")
-        if path.is_file()
-    }
-
-
-def _runner_owned_specs() -> dict[str, set[str]]:
-    vitest_include = _resolve_ui_globs(
-        *_config_array_literal(_VITEST_CONFIG, "include"),
-    )
-    vitest_exclude = _resolve_ui_globs(
-        *_config_array_literal(_VITEST_CONFIG, "exclude"),
-    )
-    return {
-        "vitest": vitest_include - vitest_exclude,
-        "playwright-smoke": _resolve_runner_specs(_PLAYWRIGHT_SMOKE_CONFIG),
-        "playwright-mock-smoke": _resolve_runner_specs(_PLAYWRIGHT_MOCK_SMOKE_CONFIG),
-        "playwright-visual": _resolve_runner_specs(_PLAYWRIGHT_VISUAL_CONFIG),
-    }
-
-
-def test_ui_specs_have_exactly_one_runner_owner() -> None:
-    all_specs = _all_ui_specs()
-    runner_specs = _runner_owned_specs()
+def test_ui_specs_have_exactly_one_runner_owner(hygiene_module: ModuleType) -> None:
+    all_specs = hygiene_module.all_ui_specs()
+    runner_specs = hygiene_module.ui_runner_owned_specs()
 
     unowned: dict[str, list[str]] = {}
     multiply_owned: dict[str, list[str]] = {}
@@ -96,8 +41,10 @@ def test_ui_specs_have_exactly_one_runner_owner() -> None:
     assert not multiply_owned, f"UI specs owned by multiple runners: {multiply_owned}"
 
 
-def test_follow_up_browser_specs_stay_playwright_owned() -> None:
-    runner_specs = _runner_owned_specs()
+def test_follow_up_browser_specs_stay_playwright_owned(
+    hygiene_module: ModuleType,
+) -> None:
+    runner_specs = hygiene_module.ui_runner_owned_specs()
     smoke_specs = runner_specs["playwright-smoke"]
 
     missing = _FOLLOW_UP_PLAYWRIGHT_SPECS - smoke_specs

--- a/apps/server/tests/test_support/check_hygiene_loader.py
+++ b/apps/server/tests/test_support/check_hygiene_loader.py
@@ -1,0 +1,22 @@
+"""Helpers for loading tools/dev/check_hygiene.py in hygiene tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_CHECK_HYGIENE = REPO_ROOT / "tools" / "dev" / "check_hygiene.py"
+
+
+def load_check_hygiene_module(
+    module_name: str = "check_hygiene_local_test",
+) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, _CHECK_HYGIENE)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_HYGIENE}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,7 @@
 - Use the shared MSW helpers under `apps/ui/tests/msw/` for frontend HTTP-boundary tests; they normalize relative `/api/...` requests onto the test origin and fail unhandled requests loudly by default.
 - Use `cd apps/ui && npm run dev:mock` for the optional browser-worker MSW mode when you need to exercise the UI without a live backend HTTP stack. That mode keeps unmocked HTTP requests on bypass, does not mock WebSockets, and has a dedicated smoke entrypoint at `cd apps/ui && npm run test:smoke:mock`.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py`, and repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`; both run via `make lint`.
+- Committed test-looking files are inventory-guarded in `tools/dev/check_hygiene.py`. New `test_*.py`, `*.spec.ts`, `benchmark_*.py`, and `firmware/esp/test/**/test_main.cpp` files must either map to a runner or, for intentional standalone benchmark scripts, carry a reason in `tools/dev/test_inventory_allowlist.yml`.
 - Oversized tracked test/spec files are guarded in `tools/dev/check_hygiene.py` with the allowlist at `tools/dev/oversized_test_allowlist.yml`. Files at or above the shared threshold must either be split or carry an explicit allowlist reason, and the hygiene output always prints the current largest tracked test/spec files.
 - `make sync-contracts` is the authoritative contract/doc regeneration path; `make lint` and the `backend-contract-drift` CI job run it in `--check` mode.
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import re
@@ -226,6 +227,13 @@ _OVERSIZED_TEST_DEFAULT_LIMIT = 700
 _OVERSIZED_TEST_DEFAULT_REPORT_LIMIT = 10
 _OVERSIZED_TEST_UI_SUFFIXES = {".ts", ".tsx", ".js", ".jsx"}
 _OVERSIZED_TEST_IGNORED_PARTS = {"snapshots", "test-results"}
+_TEST_INVENTORY_ALLOWLIST_PATH = ROOT / "tools" / "dev" / "test_inventory_allowlist.yml"
+_UI_ROOT = ROOT / "apps" / "ui"
+_UI_TESTS_DIR = _UI_ROOT / "tests"
+_UI_VITEST_CONFIG = _UI_ROOT / "vitest.config.ts"
+_UI_PLAYWRIGHT_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.config.ts"
+_UI_PLAYWRIGHT_MOCK_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.msw.config.ts"
+_UI_PLAYWRIGHT_VISUAL_CONFIG = _UI_ROOT / "playwright.config.ts"
 _IMPORT_FROM_RE = re.compile(r"""\bfrom\s+["']([^"']+)["']""")
 _SIDE_EFFECT_IMPORT_RE = re.compile(r"""\bimport\s+["']([^"']+)["']""")
 _EMPTY_INNERHTML_ASSIGNMENT_RE = re.compile(
@@ -486,6 +494,298 @@ def check_oversized_test_files() -> tuple[list[str], list[str]]:
         )[:report_limit]
     ]
     return errors, report
+
+
+def _config_array_literal(config_path: Path, key: str) -> list[str]:
+    config_text = config_path.read_text(encoding="utf-8")
+    match = re.search(rf"{key}:\s*(\[[^\]]+\])", config_text)
+    if match is None:
+        raise ValueError(
+            f"{config_path.relative_to(ROOT)} is missing a {key} array literal."
+        )
+    normalized_literal = re.sub(r"//.*", "", match.group(1))
+    try:
+        parsed = ast.literal_eval(normalized_literal)
+    except (SyntaxError, ValueError) as exc:
+        raise ValueError(
+            f"{config_path.relative_to(ROOT)} has an unreadable {key} array literal."
+        ) from exc
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, str) for item in parsed
+    ):
+        raise ValueError(
+            f"{config_path.relative_to(ROOT)} must define {key} as a list of strings."
+        )
+    return [str(pattern) for pattern in parsed]
+
+
+def _config_string_literal(config_path: Path, key: str) -> str:
+    config_text = config_path.read_text(encoding="utf-8")
+    match = re.search(rf'{key}:\s*"([^"]+)"', config_text)
+    if match is None:
+        raise ValueError(
+            f'{config_path.relative_to(ROOT)} is missing a "{key}" string literal.'
+        )
+    return str(match.group(1))
+
+
+def _resolve_ui_globs(*patterns: str) -> set[str]:
+    resolved: set[str] = set()
+    for pattern in patterns:
+        for path in _UI_ROOT.glob(pattern):
+            if path.is_file():
+                resolved.add(path.relative_to(_UI_ROOT).as_posix())
+    return resolved
+
+
+def _resolve_playwright_specs(config_path: Path) -> set[str]:
+    test_dir = _config_string_literal(config_path, "testDir")
+    test_match_patterns = _config_array_literal(config_path, "testMatch")
+    return _resolve_ui_globs(
+        *(f"{test_dir}/{pattern}" for pattern in test_match_patterns)
+    )
+
+
+def all_ui_specs() -> set[str]:
+    return {
+        path.relative_to(_UI_ROOT).as_posix()
+        for path in _UI_TESTS_DIR.glob("**/*.spec.ts")
+        if path.is_file()
+    }
+
+
+def ui_runner_owned_specs() -> dict[str, set[str]]:
+    vitest_include = _resolve_ui_globs(
+        *_config_array_literal(_UI_VITEST_CONFIG, "include")
+    )
+    vitest_exclude = _resolve_ui_globs(
+        *_config_array_literal(_UI_VITEST_CONFIG, "exclude")
+    )
+    return {
+        "vitest": vitest_include - vitest_exclude,
+        "playwright-smoke": _resolve_playwright_specs(_UI_PLAYWRIGHT_SMOKE_CONFIG),
+        "playwright-mock-smoke": _resolve_playwright_specs(
+            _UI_PLAYWRIGHT_MOCK_SMOKE_CONFIG
+        ),
+        "playwright-visual": _resolve_playwright_specs(_UI_PLAYWRIGHT_VISUAL_CONFIG),
+    }
+
+
+def _load_test_inventory_allowlist() -> tuple[dict[str, str], list[str]]:
+    errors: list[str] = []
+    if not _TEST_INVENTORY_ALLOWLIST_PATH.exists():
+        return (
+            {},
+            [
+                f"Missing test-inventory allowlist at {_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)}."
+            ],
+        )
+
+    loaded = yaml.safe_load(_TEST_INVENTORY_ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(loaded, Mapping):
+        return (
+            {},
+            [
+                f"{_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} must load as a mapping."
+            ],
+        )
+
+    allowlist: dict[str, str] = {}
+    raw_allowlist = loaded.get("allowlist")
+    if not isinstance(raw_allowlist, Mapping):
+        errors.append(
+            f"{_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} must define allowlist as a mapping of path -> reason."
+        )
+        return allowlist, errors
+
+    for raw_path, raw_reason in raw_allowlist.items():
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(
+                f"{_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} contains a non-string allowlist path."
+            )
+            continue
+        if not isinstance(raw_reason, str) or not raw_reason.strip():
+            errors.append(
+                f"{raw_path} in {_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} must include a non-empty reason."
+            )
+            continue
+        rel_path = raw_path.strip()
+        candidate = Path(rel_path)
+        if candidate.suffix != ".py" or not candidate.name.startswith("benchmark_"):
+            errors.append(
+                f"{rel_path} in {_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} must point to a benchmark_*.py script."
+            )
+            continue
+        allowlist[rel_path] = raw_reason.strip()
+
+    stale_allowlist = sorted(
+        rel_path for rel_path in allowlist if not (ROOT / rel_path).is_file()
+    )
+    if stale_allowlist:
+        errors.append(
+            f"{_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} contains missing files: {', '.join(stale_allowlist)}"
+        )
+    return allowlist, errors
+
+
+def _is_test_inventory_candidate(rel_path: str) -> bool:
+    path = Path(rel_path)
+    name = path.name
+    if rel_path.startswith("apps/server/vibesensor/"):
+        return False
+    if name.startswith("test_") and path.suffix == ".py":
+        return True
+    if rel_path.endswith(".spec.ts"):
+        return True
+    if name.startswith("benchmark_") and path.suffix == ".py":
+        return True
+    if rel_path.startswith("firmware/esp/test/") and name == "test_main.cpp":
+        return True
+    return False
+
+
+def _test_inventory_candidates() -> list[str]:
+    candidates: set[str] = set()
+    for path in _git_tracked_files():
+        rel_path = path.relative_to(ROOT).as_posix()
+        if _is_test_inventory_candidate(rel_path):
+            candidates.add(rel_path)
+    return sorted(candidates)
+
+
+def _test_inventory_owners(
+    rel_path: str,
+    *,
+    ui_runner_specs: Mapping[str, set[str]],
+    benchmark_allowlist: Mapping[str, str],
+) -> tuple[str, ...]:
+    owners: list[str] = []
+    name = Path(rel_path).name
+    if rel_path.endswith(".spec.ts"):
+        if rel_path.startswith("apps/ui/"):
+            ui_rel_path = rel_path.removeprefix("apps/ui/")
+            owners.extend(
+                runner_name
+                for runner_name, owned_specs in ui_runner_specs.items()
+                if ui_rel_path in owned_specs
+            )
+        return tuple(sorted(owners))
+    if name.startswith("test_") and rel_path.endswith(".py"):
+        if rel_path.startswith("apps/server/tests/"):
+            owners.append("backend-pytest")
+        elif rel_path.startswith("apps/server/tests_e2e/"):
+            owners.append("e2e-pytest")
+        return tuple(owners)
+    if name.startswith("benchmark_") and rel_path.endswith(".py"):
+        if rel_path.startswith("apps/server/tests/"):
+            owners.append("backend-pytest-benchmark")
+        if rel_path in benchmark_allowlist:
+            owners.append("allowlisted-benchmark-script")
+        return tuple(owners)
+    if rel_path.startswith("firmware/esp/test/") and name == "test_main.cpp":
+        owners.append("firmware-native")
+    return tuple(owners)
+
+
+def _test_inventory_guidance(rel_path: str) -> str:
+    name = Path(rel_path).name
+    if rel_path.endswith(".spec.ts"):
+        return (
+            "Move it under apps/ui/tests/ and update apps/ui/vitest.config.ts or the "
+            "Playwright testMatch config in apps/ui/playwright.smoke.config.ts, "
+            "apps/ui/playwright.smoke.msw.config.ts, or apps/ui/playwright.config.ts "
+            "so exactly one UI runner owns it."
+        )
+    if name.startswith("test_") and rel_path.endswith(".py"):
+        return (
+            "Move it under apps/server/tests/ or apps/server/tests_e2e/ so pytest owns "
+            "it, or rename it if it is a helper module."
+        )
+    if name.startswith("benchmark_") and rel_path.endswith(".py"):
+        return (
+            "Move it under apps/server/tests/**/benchmark_*.py so the explicit "
+            f"pytest-benchmark lane owns it, or document it in "
+            f"{_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} as an intentional "
+            "standalone benchmark script."
+        )
+    if rel_path.startswith("firmware/esp/test/") and name == "test_main.cpp":
+        return (
+            "Keep firmware native suites under firmware/esp/test/<suite>/test_main.cpp "
+            "so the PlatformIO native runner can collect them."
+        )
+    return "Rename it if it is a helper module, or wire it into an owned test runner."
+
+
+def inventory_errors_for_test_paths(
+    candidate_paths: Sequence[str],
+    *,
+    ui_runner_specs: Mapping[str, set[str]] | None = None,
+    benchmark_allowlist: Mapping[str, str] | None = None,
+) -> list[str]:
+    resolved_ui_runner_specs = (
+        dict(ui_runner_specs)
+        if ui_runner_specs is not None
+        else ui_runner_owned_specs()
+    )
+    resolved_benchmark_allowlist = (
+        dict(benchmark_allowlist) if benchmark_allowlist is not None else {}
+    )
+
+    errors: list[str] = []
+    for rel_path in sorted(set(candidate_paths)):
+        if not _is_test_inventory_candidate(rel_path):
+            continue
+        owners = _test_inventory_owners(
+            rel_path,
+            ui_runner_specs=resolved_ui_runner_specs,
+            benchmark_allowlist=resolved_benchmark_allowlist,
+        )
+        if rel_path.endswith(".spec.ts") and len(owners) > 1:
+            errors.append(
+                f"{rel_path} is owned by multiple UI runners {list(owners)}; tighten "
+                "apps/ui/vitest.config.ts include/exclude or the Playwright "
+                "testMatch patterns so exactly one runner owns it."
+            )
+            continue
+        if not owners:
+            errors.append(
+                f"{rel_path} looks like a test but is not owned by any configured runner; "
+                f"{_test_inventory_guidance(rel_path)}"
+            )
+    return errors
+
+
+def check_test_inventory_ownership() -> list[str]:
+    benchmark_allowlist, allowlist_errors = _load_test_inventory_allowlist()
+    errors = list(allowlist_errors)
+
+    try:
+        runner_specs = ui_runner_owned_specs()
+    except ValueError as exc:
+        errors.append(str(exc))
+        return errors
+
+    errors.extend(
+        inventory_errors_for_test_paths(
+            _test_inventory_candidates(),
+            ui_runner_specs=runner_specs,
+            benchmark_allowlist=benchmark_allowlist,
+        )
+    )
+
+    for rel_path in sorted(benchmark_allowlist):
+        runner_owners = _test_inventory_owners(
+            rel_path,
+            ui_runner_specs=runner_specs,
+            benchmark_allowlist={},
+        )
+        if runner_owners:
+            errors.append(
+                f"{rel_path} is listed in {_TEST_INVENTORY_ALLOWLIST_PATH.relative_to(ROOT)} "
+                f"but is already owned by {list(runner_owners)}; remove the stale allowlist entry."
+            )
+
+    return errors
 
 
 def _load_runtime_support_matrix_rows() -> dict[str, RuntimeSupportMatrixRow]:
@@ -2613,6 +2913,11 @@ _LIST_CHECK_SPECS = (
         runner=check_frontend_component_use_computed_guardrails,
         failure_heading="Frontend component useComputed guardrail drift detected:",
         success_message="Frontend component useComputed guardrails passed.",
+    ),
+    ListCheckSpec(
+        runner=check_test_inventory_ownership,
+        failure_heading="Test inventory ownership drift detected:",
+        success_message="Committed test-looking files all map to a runner or documented benchmark exception.",
     ),
 )
 

--- a/tools/dev/test_inventory_allowlist.yml
+++ b/tools/dev/test_inventory_allowlist.yml
@@ -1,0 +1,3 @@
+allowlist:
+  tools/tests/benchmark_pipeline.py: Standalone throughput harness; the collected regression benchmark lives in apps/server/tests/infra/workers/benchmark_compute_all.py.
+  tools/tests/benchmark_update_status_codec.py: Standalone single-shot codec timing harness; the collected regression benchmark lives in apps/server/tests/use_cases/updates/benchmark_update_status_codec.py.


### PR DESCRIPTION
Closes #3383

## What changed
- added shared UI runner-inventory helpers and a new `check_test_inventory_ownership()` lane in `tools/dev/check_hygiene.py`
- added `tools/dev/test_inventory_allowlist.yml` for intentional standalone benchmark scripts
- rewired the existing UI runner-ownership test to use the shared hygiene helpers
- added focused hygiene coverage for unowned, multiply-owned, allowlisted, and production-name-collision cases
- documented the new guard and allowlist in `docs/testing.md`

## Why
- the repo already had a UI-only ownership audit, but the actual runner inventory knowledge was split across tests, docs, and convention
- the new hygiene lane makes orphaned committed test-looking files visible from one place and tells the developer which runner/config needs to be updated
- standalone benchmark scripts stay explicit documented exceptions instead of silently bypassing collection
- production modules like `apps/server/vibesensor/domain/test_plan.py` are real domain code, not tests, so the candidate scan excludes the backend package to avoid false positives

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/hygiene/test_ui_test_runner_ownership.py apps/server/tests/hygiene/test_test_inventory_ownership.py`
- `python tools/dev/check_hygiene.py`
- `make lint`

## Risks, tradeoffs, edge cases
- this is a pattern-and-config inventory guard, not a runner bootstrap check; that keeps lint fast and stable, but it relies on the configured file-selection contracts staying truthful
- the candidate scan intentionally excludes `apps/server/vibesensor/**` because that package already uses domain names like `test_plan.py`; if more production roots start using `test_*.py` names, the inventory boundary may need another explicit exclusion instead of guessing from filenames alone
