### PR TITLE
Add pytest marker policy guard

### DIFF
--- a/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
@@ -76,7 +76,6 @@ class TestParseActiveConnDevice:
 
 
 class TestParseIp:
-    @pytest.mark.smoke
     def test_extracts_first_inet_cidr(self) -> None:
         output = "    inet 192.168.4.1/24 brd 192.168.4.255 scope global wlan0\n"
         assert parse_ip(output) == "192.168.4.1/24"

--- a/apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
+++ b/apps/server/tests/hygiene/test_check_hygiene_entrypoints.py
@@ -34,6 +34,7 @@ _CHECK_ENTRYPOINTS = (
     ),
     pytest.param("check_frontend_raw_html_boundaries", id="frontend-raw-html-boundaries"),
     pytest.param("check_test_inventory_ownership", id="test-inventory-ownership"),
+    pytest.param("check_test_marker_policy", id="test-marker-policy"),
     pytest.param("check_runtime_policy_drift", id="runtime-policy-drift"),
 )
 

--- a/apps/server/tests/hygiene/test_test_marker_policy.py
+++ b/apps/server/tests/hygiene/test_test_marker_policy.py
@@ -1,0 +1,107 @@
+"""Guard: pytest marker usage stays within the documented policy."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+from test_support.check_hygiene_loader import load_check_hygiene_module
+
+
+@pytest.fixture(scope="module")
+def hygiene_module() -> ModuleType:
+    return load_check_hygiene_module("check_hygiene_test_marker_policy")
+
+
+def test_test_marker_policy_guard_passes_for_current_repo(
+    hygiene_module: ModuleType,
+) -> None:
+    assert hygiene_module.check_test_marker_policy() == []
+
+
+def test_smoke_marker_outside_allowlist_fails(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.marker_policy_errors(
+        {
+            "apps/server/tests/use_cases/demo/test_demo.py": {
+                "smoke": {"test_demo_path"},
+            }
+        },
+        tracked_e2e_files=(),
+        tracked_benchmark_files=(),
+        smoke_allowlist={},
+        long_sim_allowlist={},
+        e2e_file_exemptions={},
+    )
+
+    assert errors == [
+        "apps/server/tests/use_cases/demo/test_demo.py::test_demo_path is marked smoke "
+        "but is not listed in tools/dev/test_marker_policy_allowlist.yml under smoke; "
+        "remove pytest.mark.smoke or document why it belongs in the compact critical path."
+    ]
+
+
+def test_e2e_outside_tests_e2e_requires_long_sim(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.marker_policy_errors(
+        {
+            "apps/server/tests/integration/test_live_server.py": {
+                "e2e": {"TestLiveServer"},
+            }
+        },
+        tracked_e2e_files=(),
+        tracked_benchmark_files=(),
+        smoke_allowlist={},
+        long_sim_allowlist={},
+        e2e_file_exemptions={},
+    )
+
+    assert errors == [
+        "apps/server/tests/integration/test_live_server.py::TestLiveServer is marked e2e "
+        "outside apps/server/tests_e2e/ but is not marked long_sim; add "
+        "pytest.mark.long_sim so fast E2E lanes keep excluding it."
+    ]
+
+
+def test_tests_e2e_file_exemption_skips_module_level_e2e_requirement(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.marker_policy_errors(
+        {
+            "apps/server/tests_e2e/test_special_case.py": {},
+        },
+        tracked_e2e_files=("apps/server/tests_e2e/test_special_case.py",),
+        tracked_benchmark_files=(),
+        smoke_allowlist={},
+        long_sim_allowlist={},
+        e2e_file_exemptions={
+            "apps/server/tests_e2e/test_special_case.py": "Intentional non-pytest fixture shell."
+        },
+    )
+
+    assert errors == []
+
+
+def test_benchmark_marker_outside_benchmark_file_fails(
+    hygiene_module: ModuleType,
+) -> None:
+    errors = hygiene_module.marker_policy_errors(
+        {
+            "apps/server/tests/integration/test_perf.py": {
+                "benchmark": {"test_perf_regression"},
+            }
+        },
+        tracked_e2e_files=(),
+        tracked_benchmark_files=(),
+        smoke_allowlist={},
+        long_sim_allowlist={},
+        e2e_file_exemptions={},
+    )
+
+    assert errors == [
+        "apps/server/tests/integration/test_perf.py::test_perf_regression is marked "
+        "benchmark but does not live in apps/server/tests/**/benchmark_*.py; move it "
+        "into an explicit benchmark file or remove pytest.mark.benchmark."
+    ]

--- a/apps/server/tests/shared/types/test_domain_models.py
+++ b/apps/server/tests/shared/types/test_domain_models.py
@@ -82,7 +82,6 @@ class TestCarPersistedDict:
         car = car_from_persistence_dict({"name": long})
         assert len(car.name) <= 64
 
-    @pytest.mark.smoke
     def test_roundtrip(self) -> None:
         car = car_from_persistence_dict({"id": "x", "name": "Test", "type": "suv"})
         d = car_to_persistence_dict(car)
@@ -168,7 +167,6 @@ class TestSensorConfig:
 
 
 class TestSpeedSourceConfig:
-    @pytest.mark.smoke
     def test_default(self) -> None:
         ssc = SpeedSourceConfig.default()
         assert ssc.speed_source == "gps"
@@ -300,7 +298,6 @@ class TestRunMetadata:
         assert rm.raw_sample_rate_hz is None
         assert rm.feature_interval_s is None
 
-    @pytest.mark.smoke
     def test_roundtrip(self) -> None:
         rm = RunMetadata.create(
             run_id="r4",
@@ -353,7 +350,6 @@ class TestSensorFrame:
     def _frame(self, **overrides: Any) -> SensorFrame:
         return sensor_frame_from_mapping(self._minimal_record(**overrides))
 
-    @pytest.mark.smoke
     def test_from_dict_basic(self) -> None:
         sf = self._frame()
         assert sf.run_id == "run1"

--- a/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py
+++ b/apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py
@@ -190,7 +190,6 @@ class TestSensorNameNormalization:
         result.encode("utf-8")
         assert len(result.encode("utf-8")) <= 32
 
-    @pytest.mark.smoke
     def test_sanitize_name_empty_returns_empty(self) -> None:
         from vibesensor.infra.runtime.client_metadata import sanitize_client_name
 

--- a/apps/server/tests/use_cases/diagnostics/test_findings_helpers.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_helpers.py
@@ -18,7 +18,6 @@ class TestWeightedPercentile:
     def test_empty_returns_none(self) -> None:
         assert _weighted_percentile([], 0.5) is None
 
-    @pytest.mark.smoke
     def test_single_element(self) -> None:
         assert _weighted_percentile([(10.0, 1.0)], 0.5) == 10.0
 
@@ -89,7 +88,6 @@ class TestSpeedProfileFromPoints:
     def test_empty(self) -> None:
         assert _speed_profile_from_points([]) == (None, None, None)
 
-    @pytest.mark.smoke
     def test_peak_speed_uses_highest_amplitude_point(self) -> None:
         points = [(80.0, 0.06), (90.0, 0.08), (100.0, 0.04)]
         peak_speed, _band, _label = _speed_profile_from_points(points)

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
@@ -19,7 +19,6 @@ _NAN = float("nan")
 
 
 class TestComputeVibrationStrengthBoundaries:
-    @pytest.mark.smoke
     def test_empty_input(self) -> None:
         result = compute_vibration_strength_db(
             freq_hz=[],
@@ -76,7 +75,6 @@ class TestComputeVibrationStrengthBoundaries:
         assert math.isfinite(result["vibration_strength_db"]), f"{label}: dB not finite"
         assert "strength_bucket" in result, f"{label}: missing strength_bucket"
 
-    @pytest.mark.smoke
     def test_clear_peak(self) -> None:
         """One clear peak in the middle: should produce positive dB."""
         freq = [float(i) for i in range(20)]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,7 @@
 - Use `cd apps/ui && npm run dev:mock` for the optional browser-worker MSW mode when you need to exercise the UI without a live backend HTTP stack. That mode keeps unmocked HTTP requests on bypass, does not mock WebSockets, and has a dedicated smoke entrypoint at `cd apps/ui && npm run test:smoke:mock`.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py`, and repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`; both run via `make lint`.
 - Committed test-looking files are inventory-guarded in `tools/dev/check_hygiene.py`. New `test_*.py`, `*.spec.ts`, `benchmark_*.py`, and `firmware/esp/test/**/test_main.cpp` files must either map to a runner or, for intentional standalone benchmark scripts, carry a reason in `tools/dev/test_inventory_allowlist.yml`.
+- Pytest marker usage is also guardrailed in `tools/dev/check_hygiene.py`, with compact-path `smoke`, opt-in `long_sim`, and any `tests_e2e` file exemptions documented in `tools/dev/test_marker_policy_allowlist.yml`. The fast E2E lane uses `e2e and not long_sim`.
 - Oversized tracked test/spec files are guarded in `tools/dev/check_hygiene.py` with the allowlist at `tools/dev/oversized_test_allowlist.yml`. Files at or above the shared threshold must either be split or carry an explicit allowlist reason, and the hygiene output always prints the current largest tracked test/spec files.
 - `make sync-contracts` is the authoritative contract/doc regeneration path; `make lint` and the `backend-contract-drift` CI job run it in `--check` mode.
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -228,12 +228,17 @@ _OVERSIZED_TEST_DEFAULT_REPORT_LIMIT = 10
 _OVERSIZED_TEST_UI_SUFFIXES = {".ts", ".tsx", ".js", ".jsx"}
 _OVERSIZED_TEST_IGNORED_PARTS = {"snapshots", "test-results"}
 _TEST_INVENTORY_ALLOWLIST_PATH = ROOT / "tools" / "dev" / "test_inventory_allowlist.yml"
+_TEST_MARKER_POLICY_ALLOWLIST_PATH = (
+    ROOT / "tools" / "dev" / "test_marker_policy_allowlist.yml"
+)
 _UI_ROOT = ROOT / "apps" / "ui"
 _UI_TESTS_DIR = _UI_ROOT / "tests"
 _UI_VITEST_CONFIG = _UI_ROOT / "vitest.config.ts"
 _UI_PLAYWRIGHT_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.config.ts"
 _UI_PLAYWRIGHT_MOCK_SMOKE_CONFIG = _UI_ROOT / "playwright.smoke.msw.config.ts"
 _UI_PLAYWRIGHT_VISUAL_CONFIG = _UI_ROOT / "playwright.config.ts"
+_MARKER_POLICY_NODE_MODULE = "__module__"
+_MARKER_POLICY_MARKERS = ("smoke", "e2e", "long_sim", "benchmark")
 _IMPORT_FROM_RE = re.compile(r"""\bfrom\s+["']([^"']+)["']""")
 _SIDE_EFFECT_IMPORT_RE = re.compile(r"""\bimport\s+["']([^"']+)["']""")
 _EMPTY_INNERHTML_ASSIGNMENT_RE = re.compile(
@@ -785,6 +790,363 @@ def check_test_inventory_ownership() -> list[str]:
                 f"but is already owned by {list(runner_owners)}; remove the stale allowlist entry."
             )
 
+    return errors
+
+
+def _is_pytest_mark(expr: ast.expr, marker: str) -> bool:
+    if isinstance(expr, ast.Call):
+        return _is_pytest_mark(expr.func, marker)
+    if not isinstance(expr, ast.Attribute) or expr.attr != marker:
+        return False
+    base = expr.value
+    return (
+        isinstance(base, ast.Attribute)
+        and base.attr == "mark"
+        and isinstance(base.value, ast.Name)
+        and base.value.id == "pytest"
+    )
+
+
+def _pytestmark_values(statements: Sequence[ast.stmt]) -> list[ast.expr]:
+    values: list[ast.expr] = []
+    for stmt in statements:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in stmt.targets
+        ):
+            continue
+        raw_value = stmt.value
+        if isinstance(raw_value, (ast.List, ast.Tuple)):
+            values.extend(raw_value.elts)
+        else:
+            values.append(raw_value)
+    return values
+
+
+def _marker_policy_test_files() -> list[Path]:
+    files: list[Path] = []
+    for path in _git_tracked_files():
+        rel_path = path.relative_to(ROOT).as_posix()
+        if path.suffix != ".py":
+            continue
+        if rel_path.startswith("apps/server/tests/") or rel_path.startswith(
+            "apps/server/tests_e2e/"
+        ):
+            files.append(path)
+    return sorted(files)
+
+
+def _collect_test_marker_usage() -> tuple[dict[str, dict[str, set[str]]], list[str]]:
+    errors: list[str] = []
+    usage: dict[str, dict[str, set[str]]] = {}
+
+    for path in _marker_policy_test_files():
+        rel_path = path.relative_to(ROOT).as_posix()
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+            errors.append(
+                f"{rel_path} could not be parsed for marker policy checks: {exc}"
+            )
+            continue
+
+        file_usage = {marker: set() for marker in _MARKER_POLICY_MARKERS}
+
+        for expr in _pytestmark_values(tree.body):
+            for marker in _MARKER_POLICY_MARKERS:
+                if _is_pytest_mark(expr, marker):
+                    file_usage[marker].add(_MARKER_POLICY_NODE_MODULE)
+
+        for stmt in tree.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for marker in _MARKER_POLICY_MARKERS:
+                    if any(_is_pytest_mark(dec, marker) for dec in stmt.decorator_list):
+                        file_usage[marker].add(stmt.name)
+                continue
+
+            if not isinstance(stmt, ast.ClassDef):
+                continue
+
+            for marker in _MARKER_POLICY_MARKERS:
+                if any(_is_pytest_mark(dec, marker) for dec in stmt.decorator_list):
+                    file_usage[marker].add(stmt.name)
+
+            for expr in _pytestmark_values(stmt.body):
+                for marker in _MARKER_POLICY_MARKERS:
+                    if _is_pytest_mark(expr, marker):
+                        file_usage[marker].add(stmt.name)
+
+            for child in stmt.body:
+                if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                node_id = f"{stmt.name}::{child.name}"
+                for marker in _MARKER_POLICY_MARKERS:
+                    if any(
+                        _is_pytest_mark(dec, marker) for dec in child.decorator_list
+                    ):
+                        file_usage[marker].add(node_id)
+
+        usage[rel_path] = {
+            marker: nodes for marker, nodes in file_usage.items() if nodes
+        }
+
+    return usage, errors
+
+
+def _load_marker_node_allowlist_section(
+    loaded: Mapping[str, object],
+    key: str,
+) -> tuple[dict[tuple[str, str], str], list[str]]:
+    errors: list[str] = []
+    section = loaded.get(key)
+    allowlist: dict[tuple[str, str], str] = {}
+    if not isinstance(section, Mapping):
+        return allowlist, [
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} must define {key} as a mapping of file path -> node id -> reason."
+        ]
+
+    for raw_path, raw_nodes in section.items():
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(
+                f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} contains a non-string {key} file path."
+            )
+            continue
+        rel_path = raw_path.strip()
+        if not isinstance(raw_nodes, Mapping):
+            errors.append(
+                f"{rel_path} in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)}::{key} must map node ids to reasons."
+            )
+            continue
+        for raw_node, raw_reason in raw_nodes.items():
+            if not isinstance(raw_node, str) or not raw_node.strip():
+                errors.append(
+                    f"{rel_path} in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)}::{key} contains a non-string node id."
+                )
+                continue
+            if not isinstance(raw_reason, str) or not raw_reason.strip():
+                errors.append(
+                    f"{rel_path}::{raw_node} in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)}::{key} must include a non-empty reason."
+                )
+                continue
+            allowlist[(rel_path, raw_node.strip())] = raw_reason.strip()
+    return allowlist, errors
+
+
+def _load_marker_file_allowlist_section(
+    loaded: Mapping[str, object],
+    key: str,
+) -> tuple[dict[str, str], list[str]]:
+    errors: list[str] = []
+    section = loaded.get(key)
+    allowlist: dict[str, str] = {}
+    if not isinstance(section, Mapping):
+        return allowlist, [
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} must define {key} as a mapping of file path -> reason."
+        ]
+
+    for raw_path, raw_reason in section.items():
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(
+                f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} contains a non-string {key} file path."
+            )
+            continue
+        if not isinstance(raw_reason, str) or not raw_reason.strip():
+            errors.append(
+                f"{raw_path} in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)}::{key} must include a non-empty reason."
+            )
+            continue
+        allowlist[raw_path.strip()] = raw_reason.strip()
+    return allowlist, errors
+
+
+def _load_test_marker_policy_allowlist() -> tuple[
+    dict[tuple[str, str], str],
+    dict[tuple[str, str], str],
+    dict[str, str],
+    list[str],
+]:
+    errors: list[str] = []
+    if not _TEST_MARKER_POLICY_ALLOWLIST_PATH.exists():
+        return (
+            {},
+            {},
+            {},
+            [
+                f"Missing test-marker policy allowlist at {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)}."
+            ],
+        )
+
+    loaded = yaml.safe_load(
+        _TEST_MARKER_POLICY_ALLOWLIST_PATH.read_text(encoding="utf-8")
+    )
+    if not isinstance(loaded, Mapping):
+        return (
+            {},
+            {},
+            {},
+            [
+                f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} must load as a mapping."
+            ],
+        )
+
+    smoke_allowlist, smoke_errors = _load_marker_node_allowlist_section(loaded, "smoke")
+    long_sim_allowlist, long_sim_errors = _load_marker_node_allowlist_section(
+        loaded, "long_sim"
+    )
+    e2e_file_exemptions, e2e_errors = _load_marker_file_allowlist_section(
+        loaded, "e2e_file_exemptions"
+    )
+    errors.extend(smoke_errors)
+    errors.extend(long_sim_errors)
+    errors.extend(e2e_errors)
+    return smoke_allowlist, long_sim_allowlist, e2e_file_exemptions, errors
+
+
+def _marker_usage_nodes(
+    marker_usage: Mapping[str, Mapping[str, set[str]]],
+    marker: str,
+) -> set[tuple[str, str]]:
+    nodes: set[tuple[str, str]] = set()
+    for rel_path, file_usage in marker_usage.items():
+        for node_id in file_usage.get(marker, set()):
+            nodes.add((rel_path, node_id))
+    return nodes
+
+
+def _marker_node_label(rel_path: str, node_id: str) -> str:
+    if node_id == _MARKER_POLICY_NODE_MODULE:
+        return f"{rel_path} [module]"
+    return f"{rel_path}::{node_id}"
+
+
+def marker_policy_errors(
+    marker_usage: Mapping[str, Mapping[str, set[str]]],
+    *,
+    tracked_e2e_files: Sequence[str],
+    tracked_benchmark_files: Sequence[str],
+    smoke_allowlist: Mapping[tuple[str, str], str],
+    long_sim_allowlist: Mapping[tuple[str, str], str],
+    e2e_file_exemptions: Mapping[str, str],
+) -> list[str]:
+    errors: list[str] = []
+
+    actual_smoke = _marker_usage_nodes(marker_usage, "smoke")
+    expected_smoke = set(smoke_allowlist)
+    for rel_path, node_id in sorted(expected_smoke - actual_smoke):
+        errors.append(
+            f"{_marker_node_label(rel_path, node_id)} is listed in "
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} under smoke "
+            "but is not marked smoke; restore pytest.mark.smoke or remove the stale allowlist entry."
+        )
+    for rel_path, node_id in sorted(actual_smoke - expected_smoke):
+        errors.append(
+            f"{_marker_node_label(rel_path, node_id)} is marked smoke but is not listed in "
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} under smoke; "
+            "remove pytest.mark.smoke or document why it belongs in the compact critical path."
+        )
+
+    actual_long_sim = _marker_usage_nodes(marker_usage, "long_sim")
+    expected_long_sim = set(long_sim_allowlist)
+    for rel_path, node_id in sorted(expected_long_sim - actual_long_sim):
+        errors.append(
+            f"{_marker_node_label(rel_path, node_id)} is listed in "
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} under long_sim "
+            "but is not marked long_sim; restore pytest.mark.long_sim or remove the stale allowlist entry."
+        )
+    for rel_path, node_id in sorted(actual_long_sim - expected_long_sim):
+        errors.append(
+            f"{_marker_node_label(rel_path, node_id)} is marked long_sim but is not listed in "
+            f"{_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} under long_sim; "
+            "remove pytest.mark.long_sim or document why it must stay out of fast E2E lanes."
+        )
+
+    e2e_nodes = _marker_usage_nodes(marker_usage, "e2e")
+    tracked_e2e_file_set = set(tracked_e2e_files)
+    for rel_path, _reason in sorted(e2e_file_exemptions.items()):
+        if rel_path not in tracked_e2e_file_set:
+            errors.append(
+                f"{rel_path} is listed in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} "
+                "under e2e_file_exemptions but is not a tracked apps/server/tests_e2e test file."
+            )
+
+    for rel_path in sorted(tracked_e2e_file_set):
+        has_module_e2e = (rel_path, _MARKER_POLICY_NODE_MODULE) in e2e_nodes
+        if rel_path in e2e_file_exemptions:
+            if has_module_e2e:
+                errors.append(
+                    f"{rel_path} is exempted in {_TEST_MARKER_POLICY_ALLOWLIST_PATH.relative_to(ROOT)} "
+                    "under e2e_file_exemptions but already has module-level pytest.mark.e2e; remove the stale exemption."
+                )
+            continue
+        if not has_module_e2e:
+            errors.append(
+                f"{rel_path} lives under apps/server/tests_e2e/ but is missing module-level pytest.mark.e2e; "
+                "add pytestmark = pytest.mark.e2e or document a file exemption."
+            )
+
+    for rel_path, node_id in sorted(e2e_nodes):
+        if rel_path.startswith("apps/server/tests_e2e/"):
+            continue
+        if (rel_path, node_id) not in actual_long_sim:
+            errors.append(
+                f"{_marker_node_label(rel_path, node_id)} is marked e2e outside apps/server/tests_e2e/ "
+                "but is not marked long_sim; add pytest.mark.long_sim so fast E2E lanes keep excluding it."
+            )
+
+    benchmark_nodes = _marker_usage_nodes(marker_usage, "benchmark")
+    tracked_benchmark_file_set = set(tracked_benchmark_files)
+    for rel_path in sorted(tracked_benchmark_file_set):
+        if not marker_usage.get(rel_path, {}).get("benchmark", set()):
+            errors.append(
+                f"{rel_path} matches apps/server/tests/**/benchmark_*.py but has no pytest.mark.benchmark tests; "
+                "add the benchmark marker or rename/move the file."
+            )
+    for rel_path, node_id in sorted(benchmark_nodes):
+        if rel_path in tracked_benchmark_file_set:
+            continue
+        errors.append(
+            f"{_marker_node_label(rel_path, node_id)} is marked benchmark but does not live in "
+            "apps/server/tests/**/benchmark_*.py; move it into an explicit benchmark file or remove pytest.mark.benchmark."
+        )
+
+    return errors
+
+
+def check_test_marker_policy() -> list[str]:
+    smoke_allowlist, long_sim_allowlist, e2e_file_exemptions, allowlist_errors = (
+        _load_test_marker_policy_allowlist()
+    )
+    marker_usage, parse_errors = _collect_test_marker_usage()
+    errors = list(allowlist_errors)
+    errors.extend(parse_errors)
+    if parse_errors:
+        return errors
+
+    tracked_e2e_files = sorted(
+        rel_path
+        for rel_path in marker_usage
+        if rel_path.startswith("apps/server/tests_e2e/")
+        and Path(rel_path).name.startswith("test_")
+    )
+    tracked_benchmark_files = sorted(
+        rel_path
+        for rel_path in marker_usage
+        if rel_path.startswith("apps/server/tests/")
+        and Path(rel_path).name.startswith("benchmark_")
+    )
+
+    errors.extend(
+        marker_policy_errors(
+            marker_usage,
+            tracked_e2e_files=tracked_e2e_files,
+            tracked_benchmark_files=tracked_benchmark_files,
+            smoke_allowlist=smoke_allowlist,
+            long_sim_allowlist=long_sim_allowlist,
+            e2e_file_exemptions=e2e_file_exemptions,
+        )
+    )
     return errors
 
 
@@ -2918,6 +3280,11 @@ _LIST_CHECK_SPECS = (
         runner=check_test_inventory_ownership,
         failure_heading="Test inventory ownership drift detected:",
         success_message="Committed test-looking files all map to a runner or documented benchmark exception.",
+    ),
+    ListCheckSpec(
+        runner=check_test_marker_policy,
+        failure_heading="Test marker policy drift detected:",
+        success_message="Pytest marker policy checks passed.",
     ),
 )
 

--- a/tools/dev/test_marker_policy_allowlist.yml
+++ b/tools/dev/test_marker_policy_allowlist.yml
@@ -1,0 +1,29 @@
+smoke:
+  apps/server/tests/hygiene/test_hotspot_script_guardrails.py:
+    test_hotspot_script_has_no_runtime_apt_get: Hotspot bootstrap must stay in the compact offline-first critical path.
+    test_hotspot_script_prefers_repo_venv_hotspot_config_cli: Hotspot config CLI wiring is part of the critical provisioning path.
+    test_hotspot_script_err_trap_logs_to_stderr: Hotspot failure reporting must stay observable in the compact guardrail path.
+  apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py:
+    test_install_pi_requires: Pi install artifact prerequisites stay in the compact install path.
+    test_server_pyproject_includes_esp_flash_and_firmware_cache_entrypoints: Offline install CLIs stay in the compact install path.
+    test_firmware_uses_vendored_neopixel_library_for_offline_builds: Offline firmware packaging stays in the compact install path.
+  apps/server/tests/hygiene/test_pi_image_static_guardrails.py:
+    test_build_wrapper_asserts_requirement: Pi-image build wrapper requirements stay in the compact image guard path.
+    test_pi_gen_pipeline_split_files_exist: Pi-image pipeline layout stays in the compact image guard path.
+    test_server_systemd_uses_console_script_entrypoint: Packaged server startup wiring stays in the compact image guard path.
+    test_pi_image_validation_checks_current_packaged_static_data_layout: Pi-image validation stays in the compact static-data guard path.
+  apps/server/tests/hygiene/test_runtime_smoke.py:
+    test_smoke_health_route_registered: The health route stays in the minimal runtime smoke path.
+  apps/server/tests/integration/test_contract_analysis_persistence_http.py:
+    __module__: The persistence-to-HTTP bridge stays in the compact contract smoke lane.
+  apps/server/tests/integration/test_contract_analysis_report.py:
+    __module__: The analysis-to-report bridge stays in the compact contract smoke lane.
+  apps/server/tests/integration/test_contract_persistence_analysis.py:
+    __module__: The persistence-to-analysis bridge stays in the compact contract smoke lane.
+long_sim:
+  apps/server/tests/integration/test_report_pipeline.py:
+    TestPdfReportValidation: The realistic 20-second PDF validation suite must stay out of fast E2E lanes.
+    TestPdfLanguageParity: The realistic 20-second EN/NL PDF parity suite must stay out of fast E2E lanes.
+  apps/server/tests/integration/test_sim_ingestion.py:
+    TestSimulatorIngestion: The live-server simulator ingestion suite must stay out of fast E2E lanes.
+e2e_file_exemptions: {}


### PR DESCRIPTION
## What changed
- add an AST-backed `check_test_marker_policy()` hygiene lane in `tools/dev/check_hygiene.py`
- add `tools/dev/test_marker_policy_allowlist.yml` as the single documented source of intentional `smoke`, `long_sim`, and `tests_e2e` marker exceptions
- add focused marker-policy tests and remove stray `pytest.mark.smoke` usage from ordinary unit-test files

## Why
- keep the compact smoke lane small and intentional
- keep fast E2E semantics explicit (`e2e and not long_sim`)
- fail fast when benchmark or E2E marker usage drifts out of the documented policy

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/hygiene/test_ui_test_runner_ownership.py apps/server/tests/hygiene/test_test_inventory_ownership.py apps/server/tests/hygiene/test_test_marker_policy.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py apps/server/tests/shared/types/test_domain_models.py apps/server/tests/use_cases/diagnostics/test_diagnosis_robustness_runtime_inputs.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py`
- `python tools/dev/check_hygiene.py`
- `make lint`

## Risks / tradeoffs / edge cases
- the allowlist is now the explicit owner for legitimate `smoke` and `long_sim` exceptions, so future exceptions need a deliberate entry instead of an ad hoc marker
- the guard is intentionally AST-based, so it enforces normal `pytest.mark.*` syntax rather than supporting dynamic marker construction

## Follow-ups
- none

Closes #3384
