### PR TITLE
Stabilize simulated-ingestion test waits

### DIFF
--- a/apps/server/tests/integration/test_ingest_backpressure_metrics.py
+++ b/apps/server/tests/integration/test_ingest_backpressure_metrics.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
+from test_support.core import async_wait_until
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.persistence.history_db import (
@@ -138,6 +139,37 @@ def _ready_health_state() -> RuntimeHealthState:
     return health_state
 
 
+def _backpressure_wait_state(
+    proto: DataDatagramProtocol,
+    ingest_diagnostics: IngestDiagnosticsCollector,
+    websocket: AsyncMock,
+) -> dict[str, object]:
+    udp = ingest_diagnostics.udp_snapshot()
+    raw_capture = ingest_diagnostics.raw_capture_snapshot()
+    ws_publish = ingest_diagnostics.ws_publish_snapshot()
+    return {
+        "udp_queue_size": proto._queue.qsize(),
+        "udp_processed_datagrams": udp.processed_datagrams,
+        "udp_queue_depth": udp.queue_depth,
+        "raw_capture_queue_depth": raw_capture.queue_depth,
+        "ws_publish_ticks": ws_publish.total_publish_ticks,
+        "ws_active_connections": ws_publish.active_connections,
+        "ws_send_count": websocket.send_text.await_count,
+    }
+
+
+async def _assert_async_wait_until(
+    description: str,
+    predicate: Callable[[], object],
+    *,
+    timeout_s: float = 2.0,
+    state: Callable[[], object],
+) -> None:
+    assert await async_wait_until(predicate, timeout_s=timeout_s), (
+        f"Timed out waiting for {description}; state={state()}"
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("sensor_count", [1, 2, 5], ids=["one-sensor", "two-sensor", "five-sensor"])
 async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
@@ -217,6 +249,7 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
         start_mono = snapshot.start_mono_s
         seq_by_sensor = {sensor.client_id.hex(): 1 for sensor in sensors}
         deferred_late_seq_by_sensor: dict[str, int] = {}
+        expected_processed_datagrams = 0
 
         for step in range(48):
             speed_kmh = 35.0 + (step % 12) * 4.0
@@ -238,6 +271,7 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
                     wheel_hz,
                 )
                 proto.datagram_received(packet, ("127.0.0.1", 7000 + index))
+                expected_processed_datagrams += 1
                 seq_by_sensor[sensor_id] = current_seq + 1
                 if index == 0 and step in (12, 30) and sensor_id in deferred_late_seq_by_sensor:
                     proto.datagram_received(
@@ -250,9 +284,20 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
                         ),
                         ("127.0.0.1", 7000 + index),
                     )
+                    expected_processed_datagrams += 1
 
             if step % 2 == 1:
-                await asyncio.sleep(0)
+                await _assert_async_wait_until(
+                    f"udp processing to reach {expected_processed_datagrams} datagrams",
+                    lambda expected=expected_processed_datagrams: (
+                        ingest_diagnostics.udp_snapshot().processed_datagrams >= expected
+                    ),
+                    state=lambda: _backpressure_wait_state(
+                        proto,
+                        ingest_diagnostics,
+                        websocket,
+                    ),
+                )
                 processor.compute_all(
                     registry.active_client_ids(),
                     sample_rates_hz=_sample_rates(registry),
@@ -264,7 +309,15 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
                     start_mono,
                 )
             if step % 6 == 5:
-                await asyncio.sleep(0.01)
+                await _assert_async_wait_until(
+                    "udp queue drain after the current burst",
+                    lambda: proto._queue.qsize() == 0,
+                    state=lambda: _backpressure_wait_state(
+                        proto,
+                        ingest_diagnostics,
+                        websocket,
+                    ),
+                )
 
         await asyncio.wait_for(proto._queue.join(), timeout=10.0)
         processor.compute_all(
@@ -277,7 +330,20 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
             start_utc,
             start_mono,
         )
-        await asyncio.sleep(0.1)
+        await _assert_async_wait_until(
+            "raw-capture drain and websocket publish metrics",
+            lambda: (
+                ingest_diagnostics.raw_capture_snapshot().queue_depth == 0
+                and ingest_diagnostics.ws_publish_snapshot().total_publish_ticks > 0
+                and websocket.send_text.await_count > 0
+            ),
+            timeout_s=5.0,
+            state=lambda: _backpressure_wait_state(
+                proto,
+                ingest_diagnostics,
+                websocket,
+            ),
+        )
 
         health = await asyncio.to_thread(
             build_system_health_snapshot,

--- a/apps/server/tests/integration/test_sim_ingestion.py
+++ b/apps/server/tests/integration/test_sim_ingestion.py
@@ -18,13 +18,13 @@ import json
 import os
 import subprocess
 import sys
-import time
 from typing import Any
 from urllib.request import Request, urlopen
 
 import pytest
 from _paths import SERVER_ROOT
 from pypdf import PdfReader
+from test_support.core import wait_until
 
 ROOT = SERVER_ROOT.parent
 
@@ -78,29 +78,65 @@ def _history_run_ids() -> set[str]:
     return {str(r["run_id"]) for r in data.get("runs", [])}
 
 
-def _wait_for_run_persisted(run_id: str, *, timeout_s: float = 15.0) -> bool:
-    """Poll history every 0.25s until run ID appears or timeout expires."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if run_id in _history_run_ids():
-            return True
-        time.sleep(0.25)
-    return False
+def _recording_status() -> dict[str, Any]:
+    """Return the current recording status payload."""
+    return _api_json("/api/recording/status")
+
+
+def _wait_for_recording_idle(*, timeout_s: float = 5.0) -> dict[str, Any]:
+    """Wait until the server reports no active recording session."""
+    last_status: dict[str, Any] = {}
+
+    def _recording_is_idle() -> bool:
+        nonlocal last_status
+        last_status = _recording_status()
+        return not str(last_status.get("run_id") or "").strip()
+
+    assert wait_until(_recording_is_idle, timeout_s=timeout_s, step_s=0.1), (
+        f"Recording session did not become idle within {timeout_s}s: {last_status}"
+    )
+    return last_status
+
+
+def _wait_for_run_persisted(
+    run_id: str,
+    *,
+    timeout_s: float = 15.0,
+) -> tuple[bool, set[str]]:
+    """Wait until *run_id* appears in history and return the last seen run IDs."""
+    latest_run_ids: set[str] = set()
+
+    def _run_seen() -> bool:
+        nonlocal latest_run_ids
+        latest_run_ids = _history_run_ids()
+        return run_id in latest_run_ids
+
+    persisted = wait_until(_run_seen, timeout_s=timeout_s, step_s=0.25)
+    return persisted, latest_run_ids
 
 
 def _wait_for_analysis(run_id: str, *, timeout_s: float = 120.0) -> dict[str, Any]:
     """Poll until the insights payload reflects completed current analysis."""
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
+    last_payload: dict[str, Any] | None = None
+    last_error: str | None = None
+
+    def _analysis_complete() -> bool:
+        nonlocal last_payload, last_error
         try:
-            data = _api_json(f"/api/history/{run_id}/insights")
-            status = data.get("status", "")
-            if status == "complete":
-                return data
-        except Exception:
-            pass
-        time.sleep(2.0)
-    raise AssertionError(f"Run {run_id} did not complete within {timeout_s}s")
+            last_payload = _api_json(f"/api/history/{run_id}/insights")
+            last_error = None
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            return False
+        return str(last_payload.get("status") or "") == "complete"
+
+    if wait_until(_analysis_complete, timeout_s=timeout_s, step_s=1.0):
+        assert last_payload is not None
+        return last_payload
+    raise AssertionError(
+        f"Run {run_id} did not complete within {timeout_s}s; "
+        f"last_payload={last_payload}; last_error={last_error}"
+    )
 
 
 def _server_is_reachable() -> bool:
@@ -130,7 +166,7 @@ class TestSimulatorIngestion:
         # Reset any stale active recording session first so this test controls
         # the run lifecycle deterministically.
         _api_post_json("/api/recording/stop")
-        time.sleep(0.5)
+        _wait_for_recording_idle()
 
         pre_runs = _history_run_ids()
         start_status = _api_post_json("/api/recording/start")
@@ -167,10 +203,9 @@ class TestSimulatorIngestion:
         _api_post_json("/api/recording/stop")
 
         # Wait for server to persist the run ID before continuing.
-        persisted = _wait_for_run_persisted(started_run_id)
+        persisted, post_runs = _wait_for_run_persisted(started_run_id)
 
         # Prefer the explicit started run id; fallback to history diff if needed.
-        post_runs = _history_run_ids()
         if persisted and started_run_id in post_runs:
             self.run_id = started_run_id
         else:
@@ -179,7 +214,7 @@ class TestSimulatorIngestion:
                 pytest.skip(
                     "Server is reachable but did not persist a new history run after logging "
                     "start/stop; skip simulator-ingestion e2e in this environment "
-                    f"(started={started_run_id})",
+                    f"(started={started_run_id}, visible_runs={sorted(post_runs)})",
                 )
             self.run_id = sorted(new_runs)[-1]
 


### PR DESCRIPTION
Closes #3389

## What changed
- replaced the direct settle sleeps in `apps/server/tests/integration/test_sim_ingestion.py` with explicit waits for recording-idle, history persistence, and analysis completion
- replaced the async settle sleeps in `apps/server/tests/integration/test_ingest_backpressure_metrics.py` with bounded waits on processed datagram counts, udp queue drain, raw-capture drain, and websocket publish activity
- added timeout diagnostics that report the last visible recorder or ingest state instead of failing on a blind sleep timeout

## Why
- fixed sleeps in simulated-ingestion tests are flaky under CI load and waste time when the system is already ready
- the recorder, UDP ingest path, and ws diagnostics already expose the readiness signals these tests need

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/integration/test_ingest_backpressure_metrics.py apps/server/tests/integration/test_sim_ingestion.py` (`3 passed, 8 skipped`; long-sim skipped without a live server)
- `python -m pytest -q apps/server/tests/integration/test_ingest_backpressure_metrics.py`
- `make lint`

## Risks / tradeoffs / edge cases
- the long-sim file still depends on a live server; this change only makes its waits state-driven once the server is present
- the new waits poll explicit recorder and ingest state, so regressions now fail with concrete last-seen state instead of arbitrary elapsed time
- runtime code is unchanged

## Follow-ups
- none
