### PR TITLE
Stabilize E2E readiness waits

### DIFF
--- a/apps/server/tests_e2e/e2e_helpers.py
+++ b/apps/server/tests_e2e/e2e_helpers.py
@@ -102,6 +102,10 @@ def api_bytes(
     )
 
 
+def recording_status(base_url: str) -> dict:
+    return api_json(base_url, "/api/recording/status")
+
+
 def pdf_text(pdf_bytes: bytes) -> str:
     reader = PdfReader(io.BytesIO(pdf_bytes))
     return "\n".join(filter(None, (page.extract_text() for page in reader.pages))).lower()
@@ -178,6 +182,7 @@ def wait_for(
     timeout_s: float,
     interval_s: float = 0.5,
     message: str,
+    state: Callable[[], object] | None = None,
 ):
     deadline = time.monotonic() + timeout_s
     last = None
@@ -185,6 +190,36 @@ def wait_for(
         last = predicate()
         if last:
             return last
+        if state is not None:
+            last = state()
+        time.sleep(interval_s)
+    raise AssertionError(f"{message}; last={last!r}")
+
+
+def wait_for_stable(
+    predicate,
+    *,
+    timeout_s: float,
+    stable_for_s: float,
+    interval_s: float = 0.5,
+    message: str,
+    state: Callable[[], object] | None = None,
+):
+    deadline = time.monotonic() + timeout_s
+    stable_since: float | None = None
+    last = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            now = time.monotonic()
+            if stable_since is None:
+                stable_since = now
+            elif (now - stable_since) >= stable_for_s:
+                return last
+        else:
+            stable_since = None
+        if state is not None:
+            last = state()
         time.sleep(interval_s)
     raise AssertionError(f"{message}; last={last!r}")
 
@@ -206,11 +241,93 @@ def wait_run_status(
         timeout_s=timeout_s,
         interval_s=0.5,
         message=f"Run {run_id} did not reach statuses {statuses}",
+        state=lambda: api_json(base_url, f"/api/history/{run_id}", expected_status=(200, 404)),
     )
 
 
 def history_run_ids(base_url: str) -> set[str]:
     return {str(item["run_id"]) for item in api_json(base_url, "/api/history").get("runs", [])}
+
+
+def _artifact_wait_state(
+    base_url: str,
+    run_id: str,
+    *,
+    last_response: ApiResponse | None,
+) -> dict[str, object]:
+    run = api_json(base_url, f"/api/history/{run_id}", expected_status=(200, 404))
+    state = {
+        "run_id": run_id,
+        "history_status": run.get("status"),
+        "error_message": run.get("error_message"),
+        "sample_count": run.get("sample_count"),
+    }
+    if last_response is not None:
+        state["artifact_status"] = last_response.status
+        state["artifact_body_preview"] = last_response.body[:160].decode(
+            "utf-8",
+            errors="replace",
+        )
+    return state
+
+
+def wait_export_ready(base_url: str, run_id: str, *, timeout_s: float = 30.0) -> ApiResponse:
+    last_response: ApiResponse | None = None
+
+    def _check() -> ApiResponse | None:
+        nonlocal last_response
+        last_response = api_bytes(
+            base_url,
+            f"/api/history/{run_id}/export",
+            expected_status=(200, 404, 422),
+        )
+        return last_response if last_response.status == 200 else None
+
+    return wait_for(
+        _check,
+        timeout_s=timeout_s,
+        interval_s=0.5,
+        message=f"Export for run {run_id} did not become available",
+        state=lambda: _artifact_wait_state(
+            base_url,
+            run_id,
+            last_response=last_response,
+        ),
+    )
+
+
+def wait_report_pdf_ready(
+    base_url: str,
+    run_id: str,
+    *,
+    lang: str | None = None,
+    timeout_s: float = 30.0,
+) -> ApiResponse:
+    path = f"/api/history/{run_id}/report.pdf"
+    if lang:
+        path = f"{path}?lang={lang}"
+    last_response: ApiResponse | None = None
+
+    def _check() -> ApiResponse | None:
+        nonlocal last_response
+        last_response = api_bytes(
+            base_url,
+            path,
+            expected_status=(200, 404, 422),
+        )
+        return last_response if last_response.status == 200 else None
+
+    return wait_for(
+        _check,
+        timeout_s=timeout_s,
+        interval_s=0.5,
+        message=f"Report PDF for run {run_id} did not become available",
+        state=lambda: _artifact_wait_state(
+            base_url,
+            run_id,
+            last_response=last_response,
+        ),
+    )
 
 
 def parse_export_zip(raw: bytes) -> tuple[dict, list[dict[str, str]], set[str]]:

--- a/apps/server/tests_e2e/test_e2e_docker_exports.py
+++ b/apps/server/tests_e2e/test_e2e_docker_exports.py
@@ -12,9 +12,9 @@ from tests_e2e._docker_edge_helpers import (
     _wait_complete,
 )
 from tests_e2e.e2e_helpers import (
-    api_bytes,
     api_json,
     parse_export_zip,
+    wait_export_ready,
 )
 
 pytestmark = pytest.mark.e2e
@@ -30,7 +30,7 @@ def test_export_history_consistency_e2e(e2e_env: dict[str, str]) -> None:
         summary_rows = api_json(base, "/api/history")["runs"]
         summary = next(item for item in summary_rows if str(item["run_id"]) == run_id)
 
-        export_resp = api_bytes(base, f"/api/history/{run_id}/export")
+        export_resp = wait_export_ready(base, run_id)
         assert str(export_resp.headers.get("content-type", "")).startswith("application/zip")
         assert f"{run_id}.zip" in str(export_resp.headers.get("content-disposition", ""))
 

--- a/apps/server/tests_e2e/test_e2e_docker_run_quality.py
+++ b/apps/server/tests_e2e/test_e2e_docker_run_quality.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from tests_e2e._docker_edge_helpers import (
@@ -16,12 +14,15 @@ from tests_e2e._docker_edge_helpers import (
     _wait_complete,
 )
 from tests_e2e.e2e_helpers import (
-    api_bytes,
     api_json,
     history_run_ids,
     parse_export_zip,
     pdf_text,
+    recording_status,
     wait_for,
+    wait_for_stable,
+    wait_export_ready,
+    wait_report_pdf_ready,
 )
 
 pytestmark = pytest.mark.e2e
@@ -30,12 +31,29 @@ pytestmark = pytest.mark.e2e
 def test_no_data_or_short_run_behavior_e2e(e2e_env: dict[str, str]) -> None:
     base = e2e_env["base_url"]
     _cleanup_clients(base)
-    wait_for(
-        lambda: not api_json(base, "/api/clients").get("clients"),
-        timeout_s=5.0,
-        message="simulator clients did not quiesce before empty-run check",
+
+    def _quiescence_state() -> dict[str, object]:
+        status = recording_status(base)
+        clients = api_json(base, "/api/clients").get("clients", [])
+        return {
+            "client_ids": [client.get("id") for client in clients],
+            "run_id": status.get("run_id"),
+            "analysis_in_progress": status.get("analysis_in_progress"),
+            "last_completed_run_id": status.get("last_completed_run_id"),
+        }
+
+    def _quiescent_state() -> dict[str, object] | None:
+        state = _quiescence_state()
+        return state if not state["client_ids"] and state["run_id"] is None else None
+
+    wait_for_stable(
+        _quiescent_state,
+        timeout_s=15.0,
+        stable_for_s=2.5,
+        interval_s=0.25,
+        message="simulator clients or active recording did not stay quiescent before empty-run check",
+        state=_quiescence_state,
     )
-    time.sleep(2.5)
     before = history_run_ids(base)
 
     first = api_json(base, "/api/recording/start", method="POST")
@@ -58,7 +76,7 @@ def test_no_data_or_short_run_behavior_e2e(e2e_env: dict[str, str]) -> None:
     run = _wait_complete(base, run_short)
     assert run["status"] in {"complete", "error"}
     if run["status"] == "complete":
-        pdf = api_bytes(base, f"/api/history/{run_short}/report.pdf")
+        pdf = wait_report_pdf_ready(base, run_short)
         assert pdf.body.startswith(b"%PDF-")
     _cleanup_run(base, run_short)
 
@@ -79,11 +97,11 @@ def test_representative_report_pipeline_smoke_e2e(e2e_env: dict[str, str]) -> No
         insights = api_json(base, f"/api/history/{run_id}/insights")
         assert insights.get("findings"), "reduced-sensor run produced no findings"
 
-        export_resp = api_bytes(base, f"/api/history/{run_id}/export")
+        export_resp = wait_export_ready(base, run_id)
         _, rows, _ = parse_export_zip(export_resp.body)
         assert rows, "reduced-sensor export has no rows"
 
-        pdf_resp = api_bytes(base, f"/api/history/{run_id}/report.pdf")
+        pdf_resp = wait_report_pdf_ready(base, run_id)
         text = pdf_text(pdf_resp.body)
         assert "vibesensor diagnostic report" in text
         _assert_no_placeholders(text)

--- a/apps/server/tests_e2e/test_e2e_docker_runtime_settings.py
+++ b/apps/server/tests_e2e/test_e2e_docker_runtime_settings.py
@@ -10,9 +10,9 @@ from tests_e2e._docker_edge_helpers import (
     _wait_complete,
 )
 from tests_e2e.e2e_helpers import (
-    api_bytes,
     api_json,
     parse_export_zip,
+    wait_export_ready,
 )
 
 pytestmark = pytest.mark.e2e
@@ -54,7 +54,7 @@ def test_speed_source_transitions_and_invalid_values(e2e_env: dict[str, str]) ->
         complete = _wait_complete(base, run_id)
         assert complete["status"] == "complete"
 
-        export_resp = api_bytes(base, f"/api/history/{run_id}/export")
+        export_resp = wait_export_ready(base, run_id)
         _, rows, _ = parse_export_zip(export_resp.body)
         speed_values = [float(r["speed_kmh"]) for r in rows if r.get("speed_kmh") not in (None, "")]
         assert speed_values

--- a/apps/server/tests_e2e/test_e2e_docker_user_journeys.py
+++ b/apps/server/tests_e2e/test_e2e_docker_user_journeys.py
@@ -18,6 +18,8 @@ from tests_e2e.e2e_helpers import (
     parse_export_zip,
     pdf_text,
     run_simulator,
+    wait_export_ready,
+    wait_report_pdf_ready,
     wait_run_status,
 )
 
@@ -221,7 +223,7 @@ def test_e2e_docker_user_journeys(journey_group: str) -> None:
             wait_run_status(base_url, run_id_2)
             created_run_ids.append(run_id_2)
 
-            export_resp = api_bytes(base_url, f"/api/history/{run_id_2}/export")
+            export_resp = wait_export_ready(base_url, run_id_2)
             assert str(export_resp.headers.get("content-type", "")).startswith("application/zip")
             run_details, rows, names = parse_export_zip(export_resp.body)
             assert names == {f"{run_id_2}.json", f"{run_id_2}_raw.csv"}
@@ -272,8 +274,8 @@ def test_e2e_docker_user_journeys(journey_group: str) -> None:
             assert "SUITABILITY_CHECK_SPEED_VARIATION" in checks_nl
             assert "SUITABILITY_CHECK_SPEED_VARIATION" in checks_en
 
-            pdf_nl = api_bytes(base_url, f"/api/history/{run_id_3}/report.pdf?lang=nl")
-            pdf_en = api_bytes(base_url, f"/api/history/{run_id_3}/report.pdf?lang=en")
+            pdf_nl = wait_report_pdf_ready(base_url, run_id_3, lang="nl")
+            pdf_en = wait_report_pdf_ready(base_url, run_id_3, lang="en")
             assert str(pdf_nl.headers.get("content-type", "")).startswith("application/pdf")
             assert str(pdf_en.headers.get("content-type", "")).startswith("application/pdf")
             text_nl = pdf_text(pdf_nl.body)

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -346,7 +346,10 @@ def _wait_health(
             RuntimeError,
         ) as exc:
             last_error = exc
-            time.sleep(0.5)
+            try:
+                server_process.wait(timeout=0.5)
+            except subprocess.TimeoutExpired:
+                pass
     raise RuntimeError(
         f"Shard server did not become ready before timeout. Last error: {last_error}"
     )


### PR DESCRIPTION
Closes #3390

## What changed
- added shared stable-condition and artifact-availability helpers in `apps/server/tests_e2e/e2e_helpers.py`
- replaced the blind quiet-window sleep in `apps/server/tests_e2e/test_e2e_docker_run_quality.py` with a stable quiescence probe over `/api/clients` and `/api/recording/status`
- rewired successful export/report fetches in the retained Docker E2E tests to wait for real artifact availability before asserting on the body
- changed `tools/tests/run_e2e_parallel.py` to wait on the shard server process between health probes instead of using a blind half-second sleep

## Why
- fixed sleeps and immediate success-path artifact fetches are common E2E flake sources under CI load
- the E2E surface already exposes the readiness signals these tests need; the helpers should use them directly

## Validation
- `make format`
- `python3 tools/tests/run_e2e_parallel.py --fast-e2e --shards 1`
- `make lint`

## Risks / tradeoffs / edge cases
- this keeps the E2E waits bounded, but they now fail with the last observed run/artifact state instead of an arbitrary timeout
- current negative-path 404/422 assertions stay direct; only success paths were rewired to wait for readiness
- runtime code is unchanged

## Follow-ups
- none
