### PR TITLE
Isolate updater tests from host state

### DIFF
--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -69,6 +69,23 @@ def mock_which(name: str) -> str | None:
     return None
 
 
+@contextmanager
+def patch_validation_environment(
+    *,
+    tool_lookup: Callable[[str], str | None] = mock_which,
+    effective_uid: int = 1000,
+) -> Iterator[None]:
+    """Patch updater validation to a deterministic non-root test environment."""
+
+    sudo_prefix = [] if effective_uid == 0 else ["sudo", "-n"]
+    with (
+        patch("shutil.which", tool_lookup),
+        patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=effective_uid),
+        patch("vibesensor.use_cases.updates.privilege._sudo_prefix", return_value=sudo_prefix),
+    ):
+        yield
+
+
 def seed_runtime_artifacts(repo: Path, mgr: UpdateManager, *, valid: bool = True) -> None:
     (repo / "apps" / "ui" / "src").mkdir(parents=True, exist_ok=True)
     (repo / "apps" / "server" / "vibesensor" / "static").mkdir(parents=True, exist_ok=True)
@@ -117,20 +134,23 @@ async def run_update(
     *,
     transport: UpdateTransport = UpdateTransport.wifi,
     timeout: float = 10,
+    tool_lookup: Callable[[str], str | None] = mock_which,
+    effective_uid: int = 1000,
 ) -> None:
-    if transport == UpdateTransport.usb_internet:
-        mgr.start(transport=transport)
-    else:
-        mgr.start(ssid, password, transport=transport)
-    task = mgr.job_task
-    assert task is not None
-    await asyncio.wait_for(task, timeout=timeout)
+    with patch_validation_environment(tool_lookup=tool_lookup, effective_uid=effective_uid):
+        if transport == UpdateTransport.usb_internet:
+            mgr.start(transport=transport)
+        else:
+            mgr.start(ssid, password, transport=transport)
+        task = mgr.job_task
+        assert task is not None
+        await asyncio.wait_for(task, timeout=timeout)
 
 
 @contextmanager
 def patch_release_fetcher(current_version: str = "2025.6.15") -> Iterator[MagicMock]:
     with (
-        patch("shutil.which", mock_which),
+        patch_validation_environment(),
         patch("vibesensor.__version__", current_version),
     ):
         mock_fetcher = MagicMock()

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -10,8 +10,8 @@ import pytest
 from _update_manager_test_helpers import (
     assert_hotspot_restored,
     make_mock_release,
-    mock_which,
     patch_release_fetcher,
+    patch_validation_environment,
     run_update,
     seed_runtime_artifacts,
     setup_update_env,
@@ -100,15 +100,11 @@ class TestUpdateManagerAsync:
     async def test_no_sudo_fails_gracefully(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path, sudo_ok=False, rollback=False)
         runner.set_response("python3 -c pass", 1, "", "sudo: a password is required")
-        with (
-            patch("shutil.which", mock_which),
-            patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
-            patch(
-                "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver.resolve",
-                side_effect=AssertionError("release resolution should not run without privileges"),
-            ),
+        with patch(
+            "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver.resolve",
+            side_effect=AssertionError("release resolution should not run without privileges"),
         ):
-            await run_update(manager, "TestNet", "pass")
+            await run_update(manager, "TestNet", "pass", effective_uid=1000)
         assert manager.status.state == UpdateState.failed
         assert (
             "privileg"
@@ -125,8 +121,7 @@ class TestUpdateManagerAsync:
             "",
             "Error: Connection activation failed",
         )
-        with patch("shutil.which", mock_which):
-            await run_update(manager, "BadNet", "wrong")
+        await run_update(manager, "BadNet", "wrong")
         assert manager.status.state == UpdateState.failed
         assert_hotspot_restored(runner)
 
@@ -209,8 +204,7 @@ class TestUpdateManagerAsync:
     async def test_secure_ssid_requires_password(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path)
         runner.set_response("dev wifi list", 0, "Pim:WPA2\n")
-        with patch("shutil.which", mock_which):
-            await run_update(manager, "Pim", "")
+        await run_update(manager, "Pim", "")
         assert manager.status.state == UpdateState.failed
 
     async def test_password_is_applied_via_connection_modify(self, tmp_path) -> None:
@@ -286,10 +280,7 @@ class TestUpdateManagerAsync:
 
     async def test_disk_check_failure_aborts_update(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path)
-        with (
-            patch("shutil.which", mock_which),
-            patch("shutil.disk_usage", side_effect=OSError("statfs failed")),
-        ):
+        with patch("shutil.disk_usage", side_effect=OSError("statfs failed")):
             await run_update(manager, "TestNet", "pass")
 
         assert manager.status.state == UpdateState.failed
@@ -450,7 +441,7 @@ class TestUpdateManagerAsync:
 
     async def test_timeout_handling(self, tmp_path) -> None:
         with (
-            patch("shutil.which", mock_which),
+            patch_validation_environment(),
             patch("vibesensor.use_cases.updates.runtime.UPDATE_TIMEOUT_S", 0.5),
             patch("vibesensor.use_cases.updates.wifi.wifi_config.HOTSPOT_RESTORE_RETRIES", 1),
         ):
@@ -571,6 +562,5 @@ class TestUpdateManagerAsync:
         def which_without(name: str) -> str | None:
             return None if name == missing_tool else f"/usr/bin/{name}"
 
-        with patch("shutil.which", which_without):
-            await run_update(manager, "TestNet", "pass")
+        await run_update(manager, "TestNet", "pass", tool_lookup=which_without)
         assert manager.status.state == UpdateState.failed

--- a/apps/server/tests/use_cases/updates/test_update_manager_core.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_core.py
@@ -4,10 +4,9 @@ import asyncio
 import tempfile
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
-from _update_manager_test_helpers import FakeRunner, cancel_task, mock_which
+from _update_manager_test_helpers import FakeRunner, cancel_task, patch_validation_environment
 
 from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -61,14 +60,13 @@ class TestUpdateManager:
         runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
-        with patch("shutil.which", mock_which):
+        with patch_validation_environment():
             manager.start("TestNet", "pass123")
             assert manager.status.state == UpdateState.running
             with pytest.raises(UpdateError, match="already in progress"):
                 manager.start("OtherNet", "pass456")
-
-        manager.cancel()
-        await cancel_task(manager)
+            manager.cancel()
+            await cancel_task(manager)
 
     def test_cancel_returns_false_when_idle(self) -> None:
         manager, _ = self.make_manager()
@@ -90,11 +88,10 @@ class TestUpdateManager:
         runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
-        with patch("shutil.which", mock_which):
+        with patch_validation_environment():
             manager.start("TestNet", "pass")
             assert manager.cancel() is True
-
-        await cancel_task(manager)
+            await cancel_task(manager)
 
     @pytest.mark.asyncio
     async def test_status_to_payload_never_leaks_password(self) -> None:
@@ -102,11 +99,11 @@ class TestUpdateManager:
         runner.set_response("python3 -c pass", 0)
         manager, _ = self.make_manager(runner=runner)
 
-        with patch("shutil.which", mock_which):
+        with patch_validation_environment():
             manager.start("TestNet", "supersecret")
 
-        assert "supersecret" not in str(update_status_to_builtins(manager.status))
-        await cancel_task(manager)
+            assert "supersecret" not in str(update_status_to_builtins(manager.status))
+            await cancel_task(manager)
 
     @pytest.mark.asyncio
     async def test_start_sets_ssid_and_timestamps(self) -> None:
@@ -115,10 +112,10 @@ class TestUpdateManager:
         manager, _ = self.make_manager(runner=runner)
 
         before = time.time()
-        with patch("shutil.which", mock_which):
+        with patch_validation_environment():
             manager.start("MyWifi", "pw")
-        after = time.time()
+            after = time.time()
 
-        assert manager.status.ssid == "MyWifi"
-        assert before <= manager.status.started_at <= after
-        await cancel_task(manager)
+            assert manager.status.ssid == "MyWifi"
+            assert before <= manager.status.started_at <= after
+            await cancel_task(manager)

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from _update_manager_test_helpers import patch_validation_environment
 
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import (
@@ -65,11 +66,6 @@ class FakeRunner(CommandRunner):
 # ---------------------------------------------------------------------------
 # Shared helpers / fixtures
 # ---------------------------------------------------------------------------
-
-
-def _mock_which(name: str) -> str | None:
-    """Fake ``shutil.which`` recognising only ``nmcli`` and ``python3``."""
-    return f"/usr/bin/{name}" if name in ("nmcli", "python3") else None
 
 
 def _running_status(
@@ -305,7 +301,7 @@ class TestNoSecretsInPersistedFile:
 
         secret_password = "SuperSecret!WiFi#Password42"
 
-        with patch("shutil.which", _mock_which):
+        with patch_validation_environment():
             mgr.start("TestNet", secret_password)
             assert mgr.job_task is not None
             with contextlib.suppress(TimeoutError, asyncio.CancelledError):
@@ -507,7 +503,7 @@ class TestPersistenceDuringLifecycle:
         runner.set_response("nmcli", 1, "", "not available")
         mgr = make_mgr()
 
-        with patch("shutil.which", _mock_which):
+        with patch_validation_environment():
             mgr.start("TestNet", "")
             loaded = store.load()
             assert loaded is not None
@@ -526,8 +522,7 @@ class TestPersistenceDuringLifecycle:
         mgr = make_mgr()
 
         with (
-            patch("shutil.which", _mock_which),
-            patch("vibesensor.use_cases.updates.validation.os.geteuid", return_value=1000),
+            patch_validation_environment(),
             patch(
                 "vibesensor.use_cases.updates.release_resolution.ServerReleaseResolver.resolve",
                 side_effect=AssertionError("release resolution should not run without privileges"),

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -344,7 +344,7 @@ No secrets are currently required. If needed in the future, copy
 | `frontend-typecheck` | ✅ Fully supported | — |
 | `ui-smoke` | ✅ Fully supported | — |
 | `release-smoke` | ✅ Fully supported | — |
-| `backend-tests` | ⚠️ Mostly works | This matrix job emits the `Backend tests (shard 1/5)` through `Backend tests (shard 5/5)` checks. The same 5 update-module tests that depend on system-level features (sudo, network interfaces) may fail inside the `act` container. All other tests pass. |
+| `backend-tests` | ✅ Fully supported | This matrix job emits the `Backend tests (shard 1/5)` through `Backend tests (shard 5/5)` checks. Update-module workflow tests now patch tool lookup and privilege checks through shared fakes, so missing `nmcli` or non-root host state does not create `act`-only flakes. |
 | `e2e` | ✅ Fully supported | Runs isolated server subprocess shards directly; no Docker-in-Docker dependency. |
 
 ### Relationship to `run_ci_parallel.py`


### PR DESCRIPTION
## What changed
- centralize updater workflow test tool/privilege fakes in `apps/server/tests/use_cases/updates/_update_manager_test_helpers.py`
- make `run_update()` and `patch_release_fetcher()` hold that fake validation environment for the full async workflow lifetime
- rewire the remaining direct `manager.start()` updater tests to keep the fake environment open until task completion or cancellation
- remove the stale `docs/testing.md` note that said `backend-tests` still flakes under `act` because of updater host capabilities

## Why
- updater workflow tests were already mostly mocked, but some of them still depended on short-lived `shutil.which()` patches around task creation
- that left a race where the async workflow could fall back to real host tool or privilege state after the patch exited
- the `act` docs warning no longer matched reality once the suite was made deterministic

## Validation
- `make format`
- `python -m pytest -q apps/server/tests/use_cases/updates`
- `make lint`
- `make docs-lint`

## Risks / tradeoffs
- the shared helper now models updater validation as a deterministic non-root environment with fake tool availability, so tests that need different validation behavior must override `tool_lookup` or `effective_uid` explicitly
- this does not add a separate host-only lane because the current updater tests are mockable and now deterministic in the default backend lane

Closes #3391
