### PR TITLE
Convert HTTP adapter tests to ASGI requests

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-from fastapi import FastAPI, WebSocketDisconnect
-from test_support import response_payload as _response_payload
+from fastapi import FastAPI
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
@@ -252,22 +251,6 @@ class FakeWsHub:
         self.selected_updates.append(client_id)
 
 
-class FakeWs:
-    def __init__(self, messages: list[str], selected_query: str | None = None) -> None:
-        self.query_params = {}
-        if selected_query is not None:
-            self.query_params["client_id"] = selected_query
-        self._messages = list(messages)
-
-    async def accept(self) -> None:
-        return None
-
-    async def receive_text(self) -> str:
-        if not self._messages:
-            raise WebSocketDisconnect()
-        return self._messages.pop(0)
-
-
 class FakeState:
     def __init__(
         self,
@@ -459,7 +442,7 @@ class FakeState:
         )
 
 
-def make_router_and_state(
+def _build_app_router_and_state(
     language: str = "en",
     sample_count: int = 20,
     *,
@@ -482,30 +465,30 @@ def make_router_and_state(
     app = FastAPI()
     router = create_router(state)
     app.include_router(router)
-    return router, state
+    return app, router, state
 
 
-def route_endpoint(router, path: str):
-    for route in router.routes:
-        if getattr(route, "path", "") == path:
-            return route.endpoint
-    raise AssertionError(f"Route not found: {path}")
+def make_app_and_state(
+    language: str = "en",
+    sample_count: int = 20,
+    *,
+    metadata: dict[str, Any] | None = None,
+    samples: list[dict[str, Any]] | None = None,
+    analysis: dict[str, Any] | None = None,
+    pdf_renderer: PdfRendererFn = _real_pdf_renderer,
+):
+    app, _router, state = _build_app_router_and_state(
+        language=language,
+        sample_count=sample_count,
+        metadata=metadata,
+        samples=samples,
+        analysis=analysis,
+        pdf_renderer=pdf_renderer,
+    )
+    return app, state
 
 
-def route_endpoint_with_method(router, path: str, method: str):
-    for route in router.routes:
-        if getattr(route, "path", "") != path:
-            continue
-        if method.upper() in getattr(route, "methods", set()):
-            return route.endpoint
-    raise AssertionError(f"Route not found: {method.upper()} {path}")
-
-
-def response_payload(response):
-    return _response_payload(response)
-
-
-def make_status_router(
+def make_status_app(
     *,
     status: str,
     analysis: dict[str, Any] | None,
@@ -550,17 +533,9 @@ def make_status_router(
     metadata = make_metadata(language="en")
     samples = [sample(0)]
     db = StatusDB(metadata, samples, {}, run_status=status, run_analysis=analysis)
-    return create_router(FakeState(db, FakeWsHub()))
-
-
-async def read_streaming_body(response) -> bytes:
-    chunks = []
-    async for chunk in response.body_iterator:
-        if isinstance(chunk, str):
-            chunks.append(chunk.encode("utf-8"))
-        else:
-            chunks.append(chunk)
-    return b"".join(chunks)
+    app = FastAPI()
+    app.include_router(create_router(FakeState(db, FakeWsHub())))
+    return app
 
 
 def read_export_archive(body: bytes) -> tuple[set[str], dict[str, Any], list[dict[str, str]]]:

--- a/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
@@ -6,20 +6,16 @@ import json
 import zipfile
 
 import pytest
-from _history_endpoint_helpers import (
-    make_router_and_state,
-    read_streaming_body,
-    route_endpoint,
-)
-from fastapi import HTTPException
+from _history_endpoint_helpers import make_app_and_state
+from fastapi.testclient import TestClient
 
 
-@pytest.mark.asyncio
-async def test_history_export_streams_zip_with_json_and_csv() -> None:
-    router, _ = make_router_and_state(language="en", sample_count=3)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    body = await read_streaming_body(response)
+def test_history_export_streams_zip_with_json_and_csv() -> None:
+    app, _ = make_app_and_state(language="en", sample_count=3)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         names = set(archive.namelist())
         assert names == {"run-1.json", "run-1_raw.csv"}
@@ -30,12 +26,12 @@ async def test_history_export_streams_zip_with_json_and_csv() -> None:
         assert len(rows) == 3
 
 
-@pytest.mark.asyncio
-async def test_history_export_csv_nested_values_are_json() -> None:
-    router, _ = make_router_and_state(language="en", sample_count=3)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    body = await read_streaming_body(response)
+def test_history_export_csv_nested_values_are_json() -> None:
+    app, _ = make_app_and_state(language="en", sample_count=3)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         rows = list(csv.DictReader(io.StringIO(archive.read("run-1_raw.csv").decode("utf-8"))))
     assert len(rows) == 3
@@ -47,9 +43,8 @@ async def test_history_export_csv_nested_values_are_json() -> None:
             assert all(isinstance(p, dict) for p in parsed)
 
 
-@pytest.mark.asyncio
-async def test_history_export_single_pass_fixed_columns() -> None:
-    router, state = make_router_and_state(language="en", sample_count=50)
+def test_history_export_single_pass_fixed_columns() -> None:
+    app, state = make_app_and_state(language="en", sample_count=50)
     db = state.history_db
     original_iter = db.aiter_run_samples
     call_count = 0
@@ -60,48 +55,47 @@ async def test_history_export_single_pass_fixed_columns() -> None:
         return original_iter(*args, **kwargs)
 
     db.aiter_run_samples = counting_iter
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
     assert call_count == 1
-    body = await read_streaming_body(response)
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         rows = list(csv.DictReader(io.StringIO(archive.read("run-1_raw.csv").decode("utf-8"))))
         assert len(rows) == 50
 
 
-@pytest.mark.asyncio
-async def test_history_export_uses_streaming_response() -> None:
-    from starlette.responses import StreamingResponse
+def test_history_export_uses_streaming_response() -> None:
+    app, _ = make_app_and_state(language="en", sample_count=10)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
 
-    router, _ = make_router_and_state(language="en", sample_count=10)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    assert isinstance(response, StreamingResponse)
-    assert response.media_type == "application/zip"
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
     content_length = response.headers.get("content-length")
     assert content_length is not None
     assert int(content_length) > 0
 
 
-@pytest.mark.asyncio
-async def test_history_export_csv_has_fixed_columns() -> None:
+def test_history_export_csv_has_fixed_columns() -> None:
     from vibesensor.use_cases.history.exports import EXPORT_CSV_COLUMNS
 
-    router, _ = make_router_and_state(language="en", sample_count=5)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    body = await read_streaming_body(response)
+    app, _ = make_app_and_state(language="en", sample_count=5)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         reader = csv.DictReader(io.StringIO(archive.read("run-1_raw.csv").decode("utf-8")))
         assert tuple(reader.fieldnames or []) == EXPORT_CSV_COLUMNS
 
 
-@pytest.mark.asyncio
-async def test_history_export_large_run() -> None:
-    router, _ = make_router_and_state(language="en", sample_count=1000)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    body = await read_streaming_body(response)
+def test_history_export_large_run() -> None:
+    app, _ = make_app_and_state(language="en", sample_count=1000)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         names = set(archive.namelist())
         assert "run-1_raw.csv" in names
@@ -112,34 +106,31 @@ async def test_history_export_large_run() -> None:
         assert len(rows) == 1000
 
 
-@pytest.mark.asyncio
-async def test_history_export_strips_internal_analysis_fields_from_json() -> None:
-    router, state = make_router_and_state(language="en", sample_count=3)
+def test_history_export_strips_internal_analysis_fields_from_json() -> None:
+    app, state = make_app_and_state(language="en", sample_count=3)
     state.history_db.analysis["_internal"] = {"keep": "private"}
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint("run-1")
-    body = await read_streaming_body(response)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/export")
+
+    body = response.content
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         metadata = json.loads(archive.read("run-1.json").decode("utf-8"))
     assert "_internal" not in metadata.get("analysis", {})
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("path", "lang"),
     [
-        ("/api/history/{run_id}/insights", None),
-        ("/api/history/{run_id}/report.pdf", "en"),
-        ("/api/history/{run_id}/export", None),
+        ("/api/history/run-1/insights", None),
+        ("/api/history/run-1/report.pdf", "en"),
+        ("/api/history/run-1/export", None),
     ],
 )
-async def test_history_endpoints_return_404_for_unknown_run(path: str, lang: str | None) -> None:
-    router, _ = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, path)
+def test_history_endpoints_return_404_for_unknown_run(path: str, lang: str | None) -> None:
+    app, _ = make_app_and_state(language="en")
+    request_path = path.replace("run-1", "missing-run")
+    params = None if lang is None else {"lang": lang}
+    with TestClient(app) as client:
+        response = client.get(request_path, params=params)
 
-    with pytest.raises(HTTPException) as exc_info:
-        if lang is None:
-            await endpoint("missing-run")
-        else:
-            await endpoint("missing-run", lang)
-    assert exc_info.value.status_code == 404
+    assert response.status_code == 404

--- a/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
@@ -9,14 +9,12 @@ from _history_endpoint_helpers import (
     FakeState,
     FakeWsHub,
     _real_pdf_renderer,
+    make_app_and_state,
     make_metadata,
-    make_router_and_state,
-    make_status_router,
-    response_payload,
-    route_endpoint,
+    make_status_app,
     sample,
 )
-from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from pypdf import PdfReader
 from test_support.persisted_analysis import make_persisted_analysis
 
@@ -29,49 +27,48 @@ def _pdf_text(body: bytes) -> str:
     return "\n".join(page.extract_text() or "" for page in PdfReader(BytesIO(body)).pages).lower()
 
 
-@pytest.mark.asyncio
-async def test_history_insights_returns_persisted_analysis() -> None:
-    router, _ = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
-    result = response_payload(await endpoint("run-1"))
+def test_history_insights_returns_persisted_analysis() -> None:
+    app, _ = make_app_and_state(language="en")
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
+
+    assert response.status_code == 200
+    result = response.json()
     assert result["lang"] == "en"
     assert "most_likely_origin" in result
     check_keys = {str(item.get("check_key")) for item in result.get("run_suitability", [])}
     assert "SUITABILITY_CHECK_SPEED_VARIATION" in check_keys
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_respects_lang_query() -> None:
-    router, _ = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
-    en = await endpoint("run-1", "en")
-    nl = await endpoint("run-1", "nl")
-    assert en.body.startswith(b"%PDF")
-    assert nl.body.startswith(b"%PDF")
-    assert en.body == nl.body
+def test_report_pdf_respects_lang_query() -> None:
+    app, _ = make_app_and_state(language="en")
+    with TestClient(app) as client:
+        en = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
+        nl = client.get("/api/history/run-1/report.pdf", params={"lang": "nl"})
+
+    assert en.content.startswith(b"%PDF")
+    assert nl.content.startswith(b"%PDF")
+    assert en.content == nl.content
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_respects_lang_query_with_persisted_report_template_data() -> None:
-    router, state = make_router_and_state(language="nl")
+def test_report_pdf_respects_lang_query_with_persisted_report_template_data() -> None:
+    app, state = make_app_and_state(language="nl")
     state.history_db.analysis["_report_template_data"] = {"lang": "nl", "title": "legacy"}
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+    with TestClient(app) as client:
+        nl = client.get("/api/history/run-1/report.pdf", params={"lang": "nl"})
+        en = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
-    nl = await endpoint("run-1", "nl")
-    en = await endpoint("run-1", "en")
+    assert nl.content.startswith(b"%PDF")
+    assert en.content.startswith(b"%PDF")
 
-    assert nl.body.startswith(b"%PDF")
-    assert en.body.startswith(b"%PDF")
-
-    nl_text = _pdf_text(nl.body)
-    text_from_en_request = _pdf_text(en.body)
+    nl_text = _pdf_text(nl.content)
+    text_from_en_request = _pdf_text(en.content)
     assert "vibesensor-diagnoserapport" in nl_text
     assert "vibesensor-diagnoserapport" in text_from_en_request
     assert "diagnostic worksheet" not in text_from_en_request
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
+def test_report_pdf_lang_override_when_template_data_persisted() -> None:
     metadata = make_metadata(language="nl")
     samples = [sample(i) for i in range(20)]
     analysis = summarize_run_data(metadata, samples, lang="nl", include_samples=False)
@@ -87,27 +84,26 @@ async def test_report_pdf_lang_override_when_template_data_persisted() -> None:
 
     db = FakeHistoryDB(metadata, samples, analysis)
     state = FakeState(db, FakeWsHub(), pdf_renderer=counting_renderer)
-    app = FastAPI()
-    router = create_router(state)
-    app.include_router(router)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+    app = create_router(state)
+    from fastapi import FastAPI
 
-    nl = await endpoint("run-1", "nl")
-    en = await endpoint("run-1", "en")
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(app)
+    with TestClient(fastapi_app) as client:
+        nl = client.get("/api/history/run-1/report.pdf", params={"lang": "nl"})
+        en = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
     assert render_count == 1
-
-    assert nl.body.startswith(b"%PDF")
-    assert en.body.startswith(b"%PDF")
-    nl_text = _pdf_text(nl.body)
-    text_from_en_request = _pdf_text(en.body)
+    assert nl.content.startswith(b"%PDF")
+    assert en.content.startswith(b"%PDF")
+    nl_text = _pdf_text(nl.content)
+    text_from_en_request = _pdf_text(en.content)
     assert "vibesensor-diagnoserapport" in nl_text
     assert "vibesensor-diagnoserapport" in text_from_en_request
     assert "diagnostic worksheet" not in text_from_en_request
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_reuses_cached_pdf_for_same_run_lang_and_analysis() -> None:
+def test_report_pdf_reuses_cached_pdf_for_same_run_lang_and_analysis() -> None:
     call_count = 0
 
     def fake_renderer(_prepared: object) -> bytes:
@@ -115,18 +111,16 @@ async def test_report_pdf_reuses_cached_pdf_for_same_run_lang_and_analysis() -> 
         call_count += 1
         return b"%PDF-cached"
 
-    router, _ = make_router_and_state(language="en", pdf_renderer=fake_renderer)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
-
-    first = await endpoint("run-1", "en")
-    second = await endpoint("run-1", "en")
+    app, _ = make_app_and_state(language="en", pdf_renderer=fake_renderer)
+    with TestClient(app) as client:
+        first = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
+        second = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
     assert call_count == 1
-    assert first.body == second.body == b"%PDF-cached"
+    assert first.content == second.content == b"%PDF-cached"
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_reuses_cached_pdf_across_lang_when_template_is_persisted() -> None:
+def test_report_pdf_reuses_cached_pdf_across_lang_when_template_is_persisted() -> None:
     call_count = 0
 
     def fake_renderer(_prepared: object) -> bytes:
@@ -134,19 +128,17 @@ async def test_report_pdf_reuses_cached_pdf_across_lang_when_template_is_persist
         call_count += 1
         return b"%PDF-cached-cross-lang"
 
-    router, state = make_router_and_state(language="nl", pdf_renderer=fake_renderer)
+    app, state = make_app_and_state(language="nl", pdf_renderer=fake_renderer)
     state.history_db.analysis["_report_template_data"] = {"lang": "nl", "title": "legacy"}
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
-
-    first = await endpoint("run-1", "en")
-    second = await endpoint("run-1", "nl")
+    with TestClient(app) as client:
+        first = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
+        second = client.get("/api/history/run-1/report.pdf", params={"lang": "nl"})
 
     assert call_count == 1
-    assert first.body == second.body == b"%PDF-cached-cross-lang"
+    assert first.content == second.content == b"%PDF-cached-cross-lang"
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_cache_invalidates_when_analysis_completed_at_changes() -> None:
+def test_report_pdf_cache_invalidates_when_analysis_completed_at_changes() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(20)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
@@ -177,17 +169,18 @@ async def test_report_pdf_cache_invalidates_when_analysis_completed_at_changes()
     state = FakeState(
         TimestampFlipDB(metadata, samples, analysis), FakeWsHub(), pdf_renderer=fake_renderer
     )
-    router = create_router(state)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+    from fastapi import FastAPI
 
-    await endpoint("run-1", "en")
-    await endpoint("run-1", "en")
+    app = FastAPI()
+    app.include_router(create_router(state))
+    with TestClient(app) as client:
+        client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
+        client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
     assert call_count == 2
 
 
-@pytest.mark.asyncio
-async def test_report_pdf_cache_invalidates_when_analysis_content_changes() -> None:
+def test_report_pdf_cache_invalidates_when_analysis_content_changes() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(20)]
     first_analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
@@ -225,16 +218,17 @@ async def test_report_pdf_cache_invalidates_when_analysis_content_changes() -> N
         FakeWsHub(),
         pdf_renderer=fake_renderer,
     )
-    router = create_router(state)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+    from fastapi import FastAPI
 
-    await endpoint("run-1", "en")
-    await endpoint("run-1", "en")
+    app = FastAPI()
+    app.include_router(create_router(state))
+    with TestClient(app) as client:
+        client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
+        client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
     assert call_count == 2
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "analysis", "expected_status", "expected_detail"),
     [
@@ -249,16 +243,15 @@ async def test_report_pdf_cache_invalidates_when_analysis_content_changes() -> N
         ),
     ],
 )
-async def test_report_pdf_status_and_analysis_errors(
+def test_report_pdf_status_and_analysis_errors(
     status: str,
     analysis: dict[str, object] | None,
     expected_status: int,
     expected_detail: str,
 ) -> None:
-    router = make_status_router(status=status, analysis=analysis, include_error_message=True)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+    app = make_status_app(status=status, analysis=analysis, include_error_message=True)
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/report.pdf", params={"lang": "en"})
 
-    with pytest.raises(HTTPException) as exc_info:
-        await endpoint("run-1", "en")
-    assert exc_info.value.status_code == expected_status
-    assert exc_info.value.detail == expected_detail
+    assert response.status_code == expected_status
+    assert response.json()["detail"] == expected_detail

--- a/apps/server/tests/adapters/http/test_api_history_route_state.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, replace
 
 import pytest
@@ -8,15 +7,13 @@ from _history_endpoint_helpers import (
     FakeHistoryDB,
     FakeState,
     FakeWsHub,
+    make_app_and_state,
     make_metadata,
-    make_router_and_state,
-    make_status_router,
-    response_payload,
-    route_endpoint,
-    route_endpoint_with_method,
+    make_status_app,
     sample,
 )
-from fastapi import HTTPException
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
@@ -25,8 +22,13 @@ from vibesensor.domain import CarSnapshot
 from vibesensor.shared.types.history_records import StoredHistoryRun
 
 
-@pytest.mark.asyncio
-async def test_delete_active_run_returns_409() -> None:
+def _app_from_state(state: FakeState) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_router(state))
+    return app
+
+
+def test_delete_active_run_returns_409() -> None:
     @dataclass
     class ActiveDB(FakeHistoryDB):
         async def aget_active_run_id(self) -> str | None:
@@ -40,18 +42,15 @@ async def test_delete_active_run_returns_409() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    db = ActiveDB(metadata, samples, analysis)
-    state = FakeState(db, FakeWsHub())
-    router = create_router(state)
+    app = _app_from_state(FakeState(ActiveDB(metadata, samples, analysis), FakeWsHub()))
 
-    delete_endpoint = route_endpoint_with_method(router, "/api/history/{run_id}", "DELETE")
-    with pytest.raises(HTTPException) as exc_info:
-        await delete_endpoint("run-1")
-    assert exc_info.value.status_code == 409
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
 
 
-@pytest.mark.asyncio
-async def test_delete_analyzing_run_returns_409() -> None:
+def test_delete_analyzing_run_returns_409() -> None:
     @dataclass
     class AnalyzingDB(FakeHistoryDB):
         async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
@@ -65,16 +64,14 @@ async def test_delete_analyzing_run_returns_409() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    db = AnalyzingDB(metadata, samples, analysis)
-    router = create_router(FakeState(db, FakeWsHub()))
-    delete_endpoint = route_endpoint_with_method(router, "/api/history/{run_id}", "DELETE")
+    app = _app_from_state(FakeState(AnalyzingDB(metadata, samples, analysis), FakeWsHub()))
 
-    with pytest.raises(HTTPException) as exc_info:
-        await delete_endpoint("run-1")
-    assert exc_info.value.status_code == 409
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("status", "analysis", "expected_status", "expected_detail"),
     [
@@ -83,44 +80,36 @@ async def test_delete_analyzing_run_returns_409() -> None:
         ("complete", None, 422, "No analysis available for this run"),
     ],
 )
-async def test_history_insights_status_and_analysis_errors(
+def test_history_insights_status_and_analysis_errors(
     status: str,
     analysis: dict[str, object] | None,
     expected_status: int,
     expected_detail: str | None,
 ) -> None:
-    router = make_status_router(status=status, analysis=analysis, include_error_message=False)
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
+    app = make_status_app(status=status, analysis=analysis, include_error_message=False)
 
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
+
+    assert response.status_code == expected_status
     if expected_status == 202:
-        from fastapi.responses import JSONResponse
-
-        payload = await endpoint("run-1")
-        assert isinstance(payload, JSONResponse)
-        assert payload.status_code == 202
-        body = json.loads(payload.body)
+        body = response.json()
         assert body["status"] == "analyzing"
         assert body["run_id"] == "run-1"
         return
-
-    with pytest.raises(HTTPException) as exc_info:
-        await endpoint("run-1")
-    assert exc_info.value.status_code == expected_status
-    assert exc_info.value.detail == expected_detail
+    assert response.json()["detail"] == expected_detail
 
 
-@pytest.mark.asyncio
-async def test_delete_run_returns_404_for_not_found_reason() -> None:
-    router, _ = make_router_and_state(language="en")
-    delete_endpoint = route_endpoint_with_method(router, "/api/history/{run_id}", "DELETE")
+def test_delete_run_returns_404_for_not_found_reason() -> None:
+    app, _ = make_app_and_state(language="en")
 
-    with pytest.raises(HTTPException) as exc_info:
-        await delete_endpoint("missing-run")
-    assert exc_info.value.status_code == 404
+    with TestClient(app) as client:
+        response = client.delete("/api/history/missing-run")
+
+    assert response.status_code == 404
 
 
-@pytest.mark.asyncio
-async def test_delete_run_returns_generic_409_for_unknown_reason() -> None:
+def test_delete_run_returns_generic_409_for_unknown_reason() -> None:
     @dataclass
     class LockedDB(FakeHistoryDB):
         async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]:
@@ -131,88 +120,91 @@ async def test_delete_run_returns_generic_409_for_unknown_reason() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(LockedDB(metadata, samples, analysis), FakeWsHub()))
-    delete_endpoint = route_endpoint_with_method(router, "/api/history/{run_id}", "DELETE")
+    app = _app_from_state(FakeState(LockedDB(metadata, samples, analysis), FakeWsHub()))
 
-    with pytest.raises(HTTPException) as exc_info:
-        await delete_endpoint("run-1")
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == "Cannot delete run at this time"
+    with TestClient(app) as client:
+        response = client.delete("/api/history/run-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Cannot delete run at this time"
 
 
-@pytest.mark.asyncio
-async def test_history_insights_does_not_mutate_db_analysis() -> None:
-    router, state = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
+def test_history_insights_does_not_mutate_db_analysis() -> None:
+    app, state = make_app_and_state(language="en")
     original_analysis = state.history_db.analysis
     original_keys = set(original_analysis.keys())
 
-    await endpoint("run-1")
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
 
+    assert response.status_code == 200
     assert set(state.history_db.analysis.keys()) == original_keys
 
 
-@pytest.mark.asyncio
-async def test_history_insights_complete_response_includes_status_and_run_id() -> None:
+def test_history_insights_complete_response_includes_status_and_run_id() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
     analysis.pop("status", None)
     analysis.pop("run_id", None)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    payload = response_payload(await endpoint("run-1"))
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1/insights")
 
+    payload = response.json()
     assert payload["status"] == "complete"
     assert payload["run_id"] == "run-1"
 
 
-@pytest.mark.asyncio
-async def test_history_endpoints_preserve_analysis_case_id() -> None:
+def test_history_endpoints_preserve_analysis_case_id() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
     analysis["case_id"] = "case-123"
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    history_payload = response_payload(
-        await route_endpoint(router, "/api/history/{run_id}")("run-1")
-    )
-    insights_payload = response_payload(
-        await route_endpoint(router, "/api/history/{run_id}/insights")("run-1")
-    )
+    with TestClient(app) as client:
+        history_payload = client.get("/api/history/run-1").json()
+        insights_payload = client.get("/api/history/run-1/insights").json()
 
     assert history_payload["analysis"]["case_id"] == "case-123"
     assert insights_payload["case_id"] == "case-123"
 
 
-@pytest.mark.asyncio
-async def test_history_run_includes_sample_count() -> None:
+def test_history_run_includes_sample_count() -> None:
     metadata = make_metadata()
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    payload = response_payload(await route_endpoint(router, "/api/history/{run_id}")("run-1"))
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1")
 
-    assert payload["sample_count"] == 3
+    assert response.json()["sample_count"] == 3
 
 
-@pytest.mark.asyncio
-async def test_history_list_includes_recorded_car_name() -> None:
+def test_history_list_includes_recorded_car_name() -> None:
     metadata = make_metadata(active_car_snapshot={"name": "Track Car"})
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    payload = response_payload(await route_endpoint(router, "/api/history")())
+    with TestClient(app) as client:
+        response = client.get("/api/history")
 
-    assert payload["runs"][0]["car_name"] == "Track Car"
+    assert response.json()["runs"][0]["car_name"] == "Track Car"
 
 
-@pytest.mark.asyncio
-async def test_history_endpoints_include_degraded_raw_capture_finalize_state() -> None:
+def test_history_endpoints_include_degraded_raw_capture_finalize_state() -> None:
     metadata = make_metadata(
         raw_capture_finalize={
             "status": "timeout",
@@ -222,10 +214,13 @@ async def test_history_endpoints_include_degraded_raw_capture_finalize_state() -
     )
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    list_payload = response_payload(await route_endpoint(router, "/api/history")())
-    run_payload = response_payload(await route_endpoint(router, "/api/history/{run_id}")("run-1"))
+    with TestClient(app) as client:
+        list_payload = client.get("/api/history").json()
+        run_payload = client.get("/api/history/run-1").json()
 
     assert list_payload["runs"][0]["lifecycle"] == {
         "stage": "post_analysis_ready",
@@ -255,8 +250,7 @@ async def test_history_endpoints_include_degraded_raw_capture_finalize_state() -
     }
 
 
-@pytest.mark.asyncio
-async def test_history_list_uses_nested_active_car_snapshot_name() -> None:
+def test_history_list_uses_nested_active_car_snapshot_name() -> None:
     metadata = make_metadata(
         active_car_snapshot={
             "id": "car-1",
@@ -266,15 +260,17 @@ async def test_history_list_uses_nested_active_car_snapshot_name() -> None:
     )
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    payload = response_payload(await route_endpoint(router, "/api/history")())
+    with TestClient(app) as client:
+        payload = client.get("/api/history").json()
 
     assert payload["runs"][0]["car_name"] == "Nested Track Car"
 
 
-@pytest.mark.asyncio
-async def test_history_run_projects_canonical_nested_run_context() -> None:
+def test_history_run_projects_canonical_nested_run_context() -> None:
     metadata = make_metadata(
         analysis_settings_snapshot={
             "tire_width_mm": 275.0,
@@ -291,11 +287,14 @@ async def test_history_run_projects_canonical_nested_run_context() -> None:
     )
     samples = [sample(i) for i in range(3)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-    router = create_router(FakeState(FakeHistoryDB(metadata, samples, analysis), FakeWsHub()))
+    app, _ = make_app_and_state(
+        language="en", metadata=metadata, samples=samples, analysis=analysis
+    )
 
-    payload = response_payload(await route_endpoint(router, "/api/history/{run_id}")("run-1"))
+    with TestClient(app) as client:
+        payload = client.get("/api/history/run-1").json()
+
     projected_metadata = payload["metadata"]
-
     assert projected_metadata["active_car_snapshot"]["name"] == "Nested Track Car"
     assert projected_metadata["active_car_snapshot"]["type"] == "hatchback"
     assert projected_metadata["active_car_snapshot"]["id"] == "car-1"
@@ -311,21 +310,20 @@ async def test_history_run_projects_canonical_nested_run_context() -> None:
     assert "tire_circumference_m" not in projected_metadata
 
 
-@pytest.mark.asyncio
-async def test_history_run_includes_error_message_for_error_status() -> None:
-    router = make_status_router(
+def test_history_run_includes_error_message_for_error_status() -> None:
+    app = make_status_app(
         status="error",
         analysis={"status": "error"},
         include_error_message=True,
     )
 
-    payload = response_payload(await route_endpoint(router, "/api/history/{run_id}")("run-1"))
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1")
 
-    assert payload["error_message"] == "Analysis failed"
+    assert response.json()["error_message"] == "Analysis failed"
 
 
-@pytest.mark.asyncio
-async def test_history_insights_localizes_and_adds_run_context_warnings() -> None:
+def test_history_insights_localizes_and_adds_run_context_warnings() -> None:
     metadata = make_metadata(
         analysis_settings_snapshot={
             "tire_width_mm": 245.0,
@@ -350,7 +348,7 @@ async def test_history_insights_localizes_and_adds_run_context_warnings() -> Non
     samples = [sample(i) for i in range(5)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
 
-    router, state = make_router_and_state(
+    app, state = make_app_and_state(
         language="en",
         metadata=metadata,
         analysis=analysis,
@@ -368,9 +366,10 @@ async def test_history_insights_localizes_and_adds_run_context_warnings() -> Non
             "current_gear_ratio": 0.72,
         },
     )
-    endpoint = route_endpoint(router, "/api/history/{run_id}/insights")
 
-    payload = response_payload(await endpoint("run-1", "nl"))
+    with TestClient(app) as client:
+        payload = client.get("/api/history/run-1/insights", params={"lang": "nl"}).json()
+
     warnings = payload.get("warnings")
     assert isinstance(warnings, list)
     assert len(warnings) == 2
@@ -379,8 +378,7 @@ async def test_history_insights_localizes_and_adds_run_context_warnings() -> Non
     assert "Voertuigprofielinstellingen zijn na deze run gewijzigd" in titles
 
 
-@pytest.mark.asyncio
-async def test_history_run_strips_internal_analysis_fields() -> None:
+def test_history_run_strips_internal_analysis_fields() -> None:
     @dataclass
     class InternalFieldDB(FakeHistoryDB):
         async def aget_run(self, run_id: str) -> StoredHistoryRun | None:
@@ -395,11 +393,12 @@ async def test_history_run_strips_internal_analysis_fields() -> None:
 
     metadata = make_metadata()
     samples = [sample(0)]
-    db = InternalFieldDB(metadata, samples, {})
-    router = create_router(FakeState(db, FakeWsHub()))
-    endpoint = route_endpoint(router, "/api/history/{run_id}")
+    app = _app_from_state(FakeState(InternalFieldDB(metadata, samples, {}), FakeWsHub()))
 
-    result = response_payload(await endpoint("run-1"))
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1")
+
+    result = response.json()
     assert {"run_id", "status", "sample_count", "metadata", "analysis"}.issubset(result.keys())
     assert result.get("error_message") is None
     analysis = result.get("analysis", {})
@@ -407,25 +406,25 @@ async def test_history_run_strips_internal_analysis_fields() -> None:
     assert "_report_template_data" not in analysis
 
 
-@pytest.mark.asyncio
-async def test_history_run_preserves_missing_optional_analysis_fields() -> None:
+def test_history_run_preserves_missing_optional_analysis_fields() -> None:
     metadata = make_metadata()
     samples = [sample(0)]
     analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
     analysis.pop("plots", None)
     analysis.pop("analysis_metadata", None)
     db = FakeHistoryDB(metadata, samples, analysis)
-    router = create_router(FakeState(db, FakeWsHub()))
-    endpoint = route_endpoint(router, "/api/history/{run_id}")
+    app = _app_from_state(FakeState(db, FakeWsHub()))
     route = next(
         route
-        for route in router.routes
+        for route in app.router.routes
         if getattr(route, "path", "") == "/api/history/{run_id}"
         and "GET" in getattr(route, "methods", set())
     )
 
-    result = await endpoint("run-1")
-    payload = response_payload(result)["analysis"]
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1")
+
+    payload = response.json()["analysis"]
     assert getattr(route, "response_model_exclude_unset", False) is True
     assert "findings" in payload
     assert "samples" not in payload

--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -6,37 +6,35 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from _history_endpoint_helpers import (
-    FakeWs,
-    make_router_and_state,
-    response_payload,
-    route_endpoint,
-    route_endpoint_with_method,
-)
-from fastapi import HTTPException
+from _history_endpoint_helpers import make_app_and_state
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 async def _close_history_db(db) -> None:
     await db.aclose()
 
 
-@pytest.mark.asyncio
-async def test_ws_selected_client_id_validation() -> None:
-    router, state = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/ws")
-    ws = FakeWs(
-        messages=[
-            json.dumps({"client_id": "not-a-mac"}),
-            json.dumps({"client_id": "aa:bb:cc:dd:ee:ff"}),
-        ],
-        selected_query="ZZZZZZZZZZZZ",
-    )
-    await endpoint(ws)
+def _client_routes_app(registry, control_plane, settings_store, processor) -> FastAPI:
+    from vibesensor.adapters.http.clients import create_client_routes
+
+    app = FastAPI()
+    app.include_router(create_client_routes(registry, control_plane, settings_store, processor))
+    return app
+
+
+def test_ws_selected_client_id_validation() -> None:
+    app, state = make_app_and_state(language="en")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws?client_id=ZZZZZZZZZZZZ") as ws:
+            ws.send_text(json.dumps({"client_id": "not-a-mac"}))
+            ws.send_text(json.dumps({"client_id": "aa:bb:cc:dd:ee:ff"}))
+
     assert None in state.ws_hub.selected_updates
     assert "aabbccddeeff" in state.ws_hub.selected_updates
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "messages",
     [
@@ -46,98 +44,76 @@ async def test_ws_selected_client_id_validation() -> None:
         ['{"client_id":"not-a-mac"}'],
     ],
 )
-async def test_ws_ignores_invalid_client_selection_messages(messages: list[str]) -> None:
-    router, state = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/ws")
-    ws = FakeWs(messages=messages)
-    await endpoint(ws)
+def test_ws_ignores_invalid_client_selection_messages(messages: list[str]) -> None:
+    app, state = make_app_and_state(language="en")
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws") as ws:
+            for message in messages:
+                ws.send_text(message)
+
     assert state.ws_hub.selected_updates == [None]
 
 
-@pytest.mark.asyncio
-async def test_ws_unexpected_update_error_propagates() -> None:
-    router, state = make_router_and_state(language="en")
-    endpoint = route_endpoint(router, "/ws")
+def test_ws_unexpected_update_error_propagates() -> None:
+    app, state = make_app_and_state(language="en")
     state.ws_hub.update_selected_client = AsyncMock(side_effect=RuntimeError("boom"))
-    ws = FakeWs(messages=[json.dumps({"client_id": "aa:bb:cc:dd:ee:ff"})])
 
-    with pytest.raises(RuntimeError, match="boom"):
-        await endpoint(ws)
-
-
-@pytest.mark.asyncio
-async def test_health_ok_status_when_no_failures() -> None:
-    router, _ = make_router_and_state()
-    endpoint = route_endpoint(router, "/api/health")
-    resp = response_payload(await endpoint())
-    assert resp["status"] == "ok"
-    assert resp["startup_state"] == "ready"
+    with TestClient(app) as client, pytest.raises(RuntimeError, match="boom"):
+        with client.websocket_connect("/ws") as ws:
+            ws.send_text(json.dumps({"client_id": "aa:bb:cc:dd:ee:ff"}))
 
 
-@pytest.mark.asyncio
-async def test_health_warn_status_when_processing_failures() -> None:
-    router, state = make_router_and_state()
-    state.health_state.mark_ready()
-    state.processing_loop_state.processing_failure_count = 3
-    endpoint = route_endpoint(router, "/api/health")
-    resp = response_payload(await endpoint())
-    assert resp["status"] == "warn"
-    assert resp["processing_failures"] == 3
-
-
-@pytest.mark.asyncio
-async def test_identify_client_404_when_sensor_not_in_registry() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_identify_client_404_when_sensor_not_in_registry() -> None:
     registry = type("R", (), {"get": lambda self, cid: None})()
     control_plane = MagicMock()
     settings_store = MagicMock()
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/identify", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    with pytest.raises(HTTPException) as exc_info:
-        await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})())
-    assert exc_info.value.status_code == 404
-    assert "not found" in exc_info.value.detail.lower()
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/identify",
+            json={"duration_ms": 1000},
+        )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
 
 
-@pytest.mark.asyncio
-async def test_identify_client_503_when_sensor_known_but_unreachable() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_identify_client_503_when_sensor_known_but_unreachable() -> None:
     sentinel = object()
     registry = type("R", (), {"get": lambda self, cid: sentinel})()
     control_plane = type("C", (), {"send_identify": lambda self, _id, _dur: (False, None)})()
     settings_store = MagicMock()
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/identify", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    with pytest.raises(HTTPException) as exc_info:
-        await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})())
-    assert exc_info.value.status_code == 503
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/identify",
+            json={"duration_ms": 1000},
+        )
+
+    assert response.status_code == 503
 
 
-@pytest.mark.asyncio
-async def test_identify_client_200_when_sensor_reachable() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_identify_client_200_when_sensor_reachable() -> None:
     sentinel = object()
     registry = type("R", (), {"get": lambda self, cid: sentinel})()
     control_plane = type("C", (), {"send_identify": lambda self, _id, _dur: (True, 7)})()
     settings_store = MagicMock()
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/identify", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    resp = response_payload(
-        await endpoint("aa:bb:cc:dd:ee:ff", type("Req", (), {"duration_ms": 1000})()),
-    )
-    assert resp == {"status": "sent", "cmd_seq": 7}
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/identify",
+            json={"duration_ms": 1000},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "sent", "cmd_seq": 7}
 
 
-@pytest.mark.asyncio
-async def test_identify_client_normalizes_client_id_before_registry_and_control_plane() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_identify_client_normalizes_client_id_before_registry_and_control_plane() -> None:
     class RecordingRegistry:
         def __init__(self) -> None:
             self.requested_ids: list[str] = []
@@ -157,22 +133,21 @@ async def test_identify_client_normalizes_client_id_before_registry_and_control_
     registry = RecordingRegistry()
     control_plane = RecordingControlPlane()
     settings_store = MagicMock()
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/identify", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    resp = response_payload(
-        await endpoint(" AA:BB:CC:DD:EE:FF ", type("Req", (), {"duration_ms": 1000})()),
-    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/ AA:BB:CC:DD:EE:FF /identify",
+            json={"duration_ms": 1000},
+        )
 
+    assert response.status_code == 200
     assert registry.requested_ids == ["aabbccddeeff"]
     assert control_plane.calls == [("aabbccddeeff", 1000)]
-    assert resp == {"status": "sent", "cmd_seq": 7}
+    assert response.json() == {"status": "sent", "cmd_seq": 7}
 
 
-@pytest.mark.asyncio
-async def test_set_client_location_maps_canonical_location_conflict_to_409() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_set_client_location_maps_canonical_location_conflict_to_409() -> None:
     class KnownRegistry:
         def get(self, _client_id: str) -> object:
             return object()
@@ -183,20 +158,19 @@ async def test_set_client_location_maps_canonical_location_conflict_to_409() -> 
     settings_store.assign_sensor_location.side_effect = ValueError(
         "Location 'front_left_wheel' already assigned to other sensor",
     )
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    with pytest.raises(HTTPException) as exc_info:
-        request = type("Req", (), {"location_code": "front_left_wheel"})()
-        await endpoint("aa:bb:cc:dd:ee:ff", request)
-    assert exc_info.value.status_code == 409
-    assert "already assigned" in exc_info.value.detail
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/location",
+            json={"location_code": "front_left_wheel"},
+        )
+
+    assert response.status_code == 409
+    assert "already assigned" in response.json()["detail"]
 
 
-@pytest.mark.asyncio
-async def test_set_client_location_maps_unknown_location_to_400() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_set_client_location_maps_unknown_location_to_400() -> None:
     class KnownRegistry:
         def get(self, _client_id: str) -> object:
             return object()
@@ -205,20 +179,19 @@ async def test_set_client_location_maps_unknown_location_to_400() -> None:
     control_plane = MagicMock()
     settings_store = MagicMock()
     settings_store.assign_sensor_location.side_effect = ValueError("Unknown location_code")
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    with pytest.raises(HTTPException) as exc_info:
-        request = type("Req", (), {"location_code": "not_a_real_location"})()
-        await endpoint("aa:bb:cc:dd:ee:ff", request)
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == "Unknown location_code"
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/location",
+            json={"location_code": "not_a_real_location"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unknown location_code"
 
 
-@pytest.mark.asyncio
-async def test_set_client_location_persists_canonical_name_and_location() -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
-
+def test_set_client_location_persists_canonical_name_and_location() -> None:
     class KnownRegistry:
         def __init__(self) -> None:
             self.cleared: list[str] = []
@@ -249,12 +222,15 @@ async def test_set_client_location_persists_canonical_name_and_location() -> Non
             "location_code": "front_left_wheel",
         }
     }
-    router = create_client_routes(registry, control_plane, settings_store, MagicMock())
-    endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+    app = _client_routes_app(registry, control_plane, settings_store, MagicMock())
 
-    request = type("Req", (), {"location_code": "front_left_wheel"})()
-    resp = response_payload(await endpoint("aa:bb:cc:dd:ee:ff", request))
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/clients/aa:bb:cc:dd:ee:ff/location",
+            json={"location_code": "front_left_wheel"},
+        )
 
+    assert response.status_code == 200
     settings_store.assign_sensor_location.assert_called_once_with(
         "aabbccddeeff",
         "front_left_wheel",
@@ -262,32 +238,24 @@ async def test_set_client_location_persists_canonical_name_and_location() -> Non
     assert registry.locations == [("aabbccddeeff", "front_left_wheel")]
     assert registry.names == [("aabbccddeeff", "Front Left Wheel")]
     assert registry.cleared == []
-    assert resp["name"] == "Front Left Wheel"
-    assert resp["location_code"] == "front_left_wheel"
+    assert response.json()["name"] == "Front Left Wheel"
+    assert response.json()["location_code"] == "front_left_wheel"
 
 
-@pytest.mark.asyncio
-async def test_set_client_location_works_with_real_persistence_in_async_route(
+def test_set_client_location_works_with_real_persistence_in_async_route(
     tmp_path: Path,
 ) -> None:
     from test_support.settings_services import build_settings_services
 
-    from vibesensor.adapters.http.clients import create_client_routes
     from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        settings_store = (
-            await asyncio.to_thread(
-                build_settings_services,
-                db=db.settings_snapshot_repository,
-            )
-        ).sensor_settings
-        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
-        await asyncio.to_thread(
-            registry.update_from_hello,
+        settings_store = build_settings_services(db=db.settings_snapshot_repository).sensor_settings
+        registry = ClientRegistry(db=db.client_name_repository)
+        registry.update_from_hello(
             HelloMessage(
                 client_id=bytes.fromhex("001122334455"),
                 control_port=9010,
@@ -300,40 +268,36 @@ async def test_set_client_location_works_with_real_persistence_in_async_route(
             now_mono=1.0,
         )
 
-        router = create_client_routes(registry, MagicMock(), settings_store, MagicMock())
-        endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+        app = _client_routes_app(registry, MagicMock(), settings_store, MagicMock())
 
-        resp = response_payload(
-            await endpoint(
-                "00:11:22:33:44:55",
-                type("Req", (), {"location_code": "front_left_wheel"})(),
-            ),
-        )
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/clients/00:11:22:33:44:55/location",
+                json={"location_code": "front_left_wheel"},
+            )
 
-        assert resp["name"] == "Front Left Wheel"
-        assert resp["location_code"] == "front_left_wheel"
-        assert await asyncio.to_thread(settings_store.get_sensors) == {
+        assert response.status_code == 200
+        assert response.json()["name"] == "Front Left Wheel"
+        assert response.json()["location_code"] == "front_left_wheel"
+        assert settings_store.get_sensors() == {
             "001122334455": {
                 "name": "Front Left Wheel",
                 "location_code": "front_left_wheel",
             }
         }
     finally:
-        await _close_history_db(db)
+        asyncio.run(_close_history_db(db))
 
 
-@pytest.mark.asyncio
-async def test_remove_client_clears_persisted_name_from_async_route(tmp_path: Path) -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
+def test_remove_client_clears_persisted_name_from_async_route(tmp_path: Path) -> None:
     from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
-        await asyncio.to_thread(
-            registry.update_from_hello,
+        registry = ClientRegistry(db=db.client_name_repository)
+        registry.update_from_hello(
             HelloMessage(
                 client_id=bytes.fromhex("001122334455"),
                 control_port=9010,
@@ -345,33 +309,31 @@ async def test_remove_client_clears_persisted_name_from_async_route(tmp_path: Pa
             1.0,
             now_mono=1.0,
         )
-        await asyncio.to_thread(registry.set_name, "001122334455", "Front Left Wheel")
+        registry.set_name("001122334455", "Front Left Wheel")
 
-        router = create_client_routes(registry, MagicMock(), MagicMock(), MagicMock())
-        endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}", "DELETE")
+        app = _client_routes_app(registry, MagicMock(), MagicMock(), MagicMock())
 
-        resp = response_payload(await endpoint("00:11:22:33:44:55"))
+        with TestClient(app) as client:
+            response = client.delete("/api/clients/00:11:22:33:44:55")
 
-        assert resp == {"id": "001122334455", "status": "removed"}
-        assert await asyncio.to_thread(db.client_name_repository.list_client_names) == {}
+        assert response.status_code == 200
+        assert response.json() == {"id": "001122334455", "status": "removed"}
+        assert db.client_name_repository.list_client_names() == {}
     finally:
-        await _close_history_db(db)
+        asyncio.run(_close_history_db(db))
 
 
-@pytest.mark.asyncio
-async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected(
+def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    from vibesensor.adapters.http.clients import create_client_routes
     from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        registry = await asyncio.to_thread(
-            ClientRegistry,
+        registry = ClientRegistry(
             db=db.client_name_repository,
             live_ttl_seconds=5.0,
             retention_ttl_seconds=30.0,
@@ -394,12 +356,14 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
         settings_store.get_sensors.return_value = {}
         processor = MagicMock()
         processor.all_latest_metrics.return_value = {}
-        router = create_client_routes(registry, control_plane, settings_store, processor)
-        endpoint = route_endpoint(router, "/api/clients")
+        app = _client_routes_app(registry, control_plane, settings_store, processor)
 
-        resp = response_payload(await endpoint())
+        with TestClient(app) as client:
+            response = client.get("/api/clients")
+
+        assert response.status_code == 200
         assert processor.all_latest_metrics.call_args.args == ([],)
-        assert resp["clients"] == [
+        assert response.json()["clients"] == [
             {
                 "id": "001122334455",
                 "mac_address": "00:11:22:33:44:55",
@@ -418,40 +382,29 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
             },
         ]
     finally:
-        await _close_history_db(db)
+        asyncio.run(_close_history_db(db))
 
 
-@pytest.mark.asyncio
-async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
+def test_get_clients_overlays_canonical_settings_metadata_after_restart(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     from test_support.settings_services import build_settings_services
 
-    from vibesensor.adapters.http.clients import create_client_routes
     from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        initial_settings = await asyncio.to_thread(
-            build_settings_services,
-            db=db.settings_snapshot_repository,
-        )
-        await asyncio.to_thread(
-            initial_settings.sensor_settings.assign_sensor_location,
+        initial_settings = build_settings_services(db=db.settings_snapshot_repository)
+        initial_settings.sensor_settings.assign_sensor_location(
             "00:11:22:33:44:55",
             "rear_left_wheel",
         )
 
-        settings_store = (
-            await asyncio.to_thread(
-                build_settings_services,
-                db=db.settings_snapshot_repository,
-            )
-        ).sensor_settings
-        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
+        settings_store = build_settings_services(db=db.settings_snapshot_repository).sensor_settings
+        registry = ClientRegistry(db=db.client_name_repository)
         registry.update_from_hello(
             HelloMessage(
                 client_id=bytes.fromhex("001122334455"),
@@ -470,16 +423,17 @@ async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
         control_plane = MagicMock()
         processor = MagicMock()
         processor.all_latest_metrics.return_value = {}
-        router = create_client_routes(registry, control_plane, settings_store, processor)
-        endpoint = route_endpoint(router, "/api/clients")
+        app = _client_routes_app(registry, control_plane, settings_store, processor)
 
-        resp = response_payload(await endpoint())
+        with TestClient(app) as client:
+            response = client.get("/api/clients")
 
+        assert response.status_code == 200
         assert settings_store.get_sensors()["001122334455"] == {
             "name": "Rear Left Wheel",
             "location_code": "rear_left_wheel",
         }
-        assert resp["clients"] == [
+        assert response.json()["clients"] == [
             {
                 "id": "001122334455",
                 "mac_address": "00:11:22:33:44:55",
@@ -498,4 +452,4 @@ async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
             },
         ]
     finally:
-        await _close_history_db(db)
+        asyncio.run(_close_history_db(db))

--- a/apps/server/tests/adapters/http/test_health_endpoint.py
+++ b/apps/server/tests/adapters/http/test_health_endpoint.py
@@ -3,35 +3,42 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint
-from test_support import response_payload
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def _health_router(fake_state):
-    """Return ``(router, state)`` for health-endpoint tests."""
+def _health_client(fake_state):
+    """Return ``(client, state, app)`` for health-endpoint tests."""
+
     from vibesensor.adapters.http import create_router
 
     fake_state.processing_loop_state.processing_state = "ok"
     fake_state.processing_loop_state.processing_failure_count = 0
-    return create_router(fake_state), fake_state
+    app = FastAPI()
+    app.include_router(create_router(fake_state))
+    with TestClient(app) as client:
+        yield client, fake_state, app
 
 
-def test_health_route_registered(_health_router):
+def test_health_route_registered(_health_client):
     """Verify /api/health is registered as a GET route in the API router."""
-    router, _ = _health_router
-    routes = {r.path: r.methods for r in router.routes if hasattr(r, "methods")}
+
+    _client, _state, app = _health_client
+    routes = {r.path: r.methods for r in app.router.routes if hasattr(r, "methods")}
     assert "/api/health" in routes
     assert "GET" in routes["/api/health"]
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_response_shape(_health_router):
+def test_health_endpoint_response_shape(_health_client):
     """Verify GET /api/health returns typed degradation, data-loss, and persistence state."""
-    router, _ = _health_router
-    endpoint = route_endpoint(router, "/api/health")
 
-    result = response_payload(await endpoint())
+    client, _state, _app = _health_client
+
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    result = response.json()
     assert result["status"] == "ok"
     assert result["startup_state"] == "ready"
     assert result["startup_phase"] == "ready"
@@ -59,10 +66,8 @@ async def test_health_endpoint_response_shape(_health_router):
     assert result["ingest"]["clients"] == []
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_degrades_for_data_loss_and_persistence_error(_health_router):
-    router, state = _health_router
-    endpoint = route_endpoint(router, "/api/health")
+def test_health_endpoint_degrades_for_data_loss_and_persistence_error(_health_client):
+    client, state, _app = _health_client
 
     state.registry.data_loss_snapshot.return_value = {
         "tracked_clients": 2,
@@ -96,8 +101,10 @@ async def test_health_endpoint_degrades_for_data_loss_and_persistence_error(_hea
     state.health_state.mark_failed("gps-speed", "gpsd unavailable")
     state.health_state.record_task_failure("metrics-log", "disk write failed")
 
-    result = response_payload(await endpoint())
+    response = client.get("/api/health")
 
+    assert response.status_code == 200
+    result = response.json()
     assert result["status"] == "degraded"
     assert result["degradation_reasons"] == [
         "startup_state:failed",
@@ -125,58 +132,55 @@ async def test_health_endpoint_degrades_for_data_loss_and_persistence_error(_hea
     assert result["persistence"]["analysis_active_run_id"] == "run-42"
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_degrades_for_db_corruption(_health_router):
-    router, state = _health_router
-    endpoint = route_endpoint(router, "/api/health")
-
+def test_health_endpoint_degrades_for_db_corruption(_health_client):
+    client, state, _app = _health_client
     state.health_state.mark_db_corrupted("row 7 missing from index")
 
-    result = response_payload(await endpoint())
+    response = client.get("/api/health")
 
+    assert response.status_code == 200
+    result = response.json()
     assert result["status"] == "degraded"
     assert result["db_corruption_detected"] is True
     assert "db_corruption_detected" in result["degradation_reasons"]
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_warns_for_buffer_overflow_drops(_health_router):
-    router, state = _health_router
-    endpoint = route_endpoint(router, "/api/health")
-
+def test_health_endpoint_warns_for_buffer_overflow_drops(_health_client):
+    client, state, _app = _health_client
     state.processor.buffer_overflow_drops.return_value = 4
 
-    result = response_payload(await endpoint())
+    response = client.get("/api/health")
 
+    assert response.status_code == 200
+    result = response.json()
     assert result["status"] == "warn"
     assert result["data_loss"]["buffer_overflow_drops"] == 4
     assert "buffer_overflow_drops" in result["degradation_reasons"]
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_validates_through_fastapi_response_field(_health_router):
+def test_health_endpoint_validates_through_fastapi_response_field(_health_client):
     """Verify FastAPI can validate the declared /api/health response model."""
-    router, _ = _health_router
-    route = next(r for r in router.routes if getattr(r, "path", "") == "/api/health")
-    payload = await route.endpoint()
-    validated, errors = route.response_field.validate(payload, {}, loc=("response",))
-    payload_dict = response_payload(payload)
 
+    client, _state, app = _health_client
+    route = next(r for r in app.router.routes if getattr(r, "path", "") == "/api/health")
+
+    response = client.get("/api/health")
+    payload = response.json()
+    validated, errors = route.response_field.validate(payload, {}, loc=("response",))
+
+    assert response.status_code == 200
     assert errors == []
-    assert payload_dict["status"] == "ok"
-    assert payload_dict["startup_state"] == "ready"
-    assert payload_dict["data_loss"]["tracked_clients"] == 0
-    assert payload_dict["persistence"]["analysis_in_progress"] is False
+    assert payload["status"] == "ok"
+    assert payload["startup_state"] == "ready"
+    assert payload["data_loss"]["tracked_clients"] == 0
+    assert payload["persistence"]["analysis_in_progress"] is False
     assert validated.status == "ok"
 
 
-@pytest.mark.asyncio
-async def test_health_endpoint_keeps_public_intake_stats_shape_when_worker_pool_is_present(
-    _health_router,
+def test_health_endpoint_keeps_public_intake_stats_shape_when_worker_pool_is_present(
+    _health_client,
 ):
-    router, state = _health_router
-    endpoint = route_endpoint(router, "/api/health")
-
+    client, state, _app = _health_client
     state.processor.intake_stats.return_value = {
         "total_ingested_samples": 10,
         "total_compute_calls": 2,
@@ -201,8 +205,10 @@ async def test_health_endpoint_keeps_public_intake_stats_shape_when_worker_pool_
         },
     }
 
-    result = response_payload(await endpoint())
+    response = client.get("/api/health")
 
+    assert response.status_code == 200
+    result = response.json()
     assert result["intake_stats"] == {
         "total_ingested_samples": 10,
         "total_compute_calls": 2,

--- a/apps/server/tests/adapters/http/test_recording_endpoints.py
+++ b/apps/server/tests/adapters/http/test_recording_endpoints.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint
-from test_support import response_payload
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from vibesensor.domain import CaptureReadiness, CaptureReadinessCheck
 from vibesensor.use_cases.run.status_reporting import RunRecorderStatusSnapshot
@@ -38,7 +38,7 @@ def _make_recording_status_snapshot(
 
 
 @pytest.fixture
-def _recording_router(fake_state):
+def _recording_client(fake_state):
     from vibesensor.adapters.http.recording import create_recording_routes
 
     fake_state.run_recorder.status.return_value = _make_recording_status_snapshot(
@@ -56,17 +56,20 @@ def _recording_router(fake_state):
         run_id=None,
         samples_written=0,
     )
-    return create_recording_routes(fake_state.run_recorder), fake_state
+    app = FastAPI()
+    app.include_router(create_recording_routes(fake_state.run_recorder))
+    with TestClient(app) as client:
+        yield client, fake_state
 
 
 class TestRecordingStatusEndpoint:
-    @pytest.mark.asyncio
-    async def test_status_response_shape(self, _recording_router) -> None:
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/status")
+    def test_status_response_shape(self, _recording_client) -> None:
+        client, _state = _recording_client
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/recording/status")
 
+        assert response.status_code == 200
+        result = response.json()
         assert "enabled" in result
         assert "run_id" in result
         assert "write_error" in result
@@ -78,22 +81,20 @@ class TestRecordingStatusEndpoint:
         assert "capture_readiness" in result
         assert "current_file" not in result
 
-    @pytest.mark.asyncio
-    async def test_status_idle_enabled_false(self, _recording_router) -> None:
-        router, _ = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/status")
+    def test_status_idle_enabled_false(self, _recording_client) -> None:
+        client, _ = _recording_client
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/recording/status")
 
+        assert response.status_code == 200
+        result = response.json()
         assert result["enabled"] is False
         assert result["run_id"] is None
         assert result["start_time_utc"] is None
         assert result["samples_written"] == 0
 
-    @pytest.mark.asyncio
-    async def test_status_serializes_capture_readiness(self, _recording_router) -> None:
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/status")
+    def test_status_serializes_capture_readiness(self, _recording_client) -> None:
+        client, state = _recording_client
         state.run_recorder.status.return_value = _make_recording_status_snapshot(
             enabled=False,
             run_id=None,
@@ -116,9 +117,10 @@ class TestRecordingStatusEndpoint:
             ),
         )
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/recording/status")
 
-        assert result["capture_readiness"] == {
+        assert response.status_code == 200
+        assert response.json()["capture_readiness"] == {
             "is_ready": False,
             "checks": [
                 {
@@ -138,22 +140,20 @@ class TestRecordingStatusEndpoint:
 
 
 class TestRecordingStartEndpoint:
-    @pytest.mark.asyncio
-    async def test_start_calls_run_recorder(self, _recording_router) -> None:
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/start")
+    def test_start_calls_run_recorder(self, _recording_client) -> None:
+        client, state = _recording_client
 
-        result = response_payload(await endpoint())
+        response = client.post("/api/recording/start")
 
+        assert response.status_code == 200
         state.run_recorder.start_recording.assert_called_once()
-        assert result["enabled"] is True
-        assert result["run_id"] == "run-abc"
+        assert response.json()["enabled"] is True
+        assert response.json()["run_id"] == "run-abc"
 
-    @pytest.mark.asyncio
-    async def test_start_when_already_recording_returns_status(self, _recording_router) -> None:
+    def test_start_when_already_recording_returns_status(self, _recording_client) -> None:
         """start_recording is idempotent — called again it still returns a valid status."""
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/start")
+
+        client, state = _recording_client
         state.run_recorder.start_recording.return_value = _make_recording_status_snapshot(
             enabled=True,
             run_id="run-abc",
@@ -161,36 +161,36 @@ class TestRecordingStartEndpoint:
             samples_written=42,
         )
 
-        result = response_payload(await endpoint())
+        response = client.post("/api/recording/start")
 
-        assert result["enabled"] is True
-        assert "run_id" in result
-        assert result["start_time_utc"] == "2026-03-27T12:01:00Z"
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+        assert "run_id" in response.json()
+        assert response.json()["start_time_utc"] == "2026-03-27T12:01:00Z"
 
 
 class TestRecordingStopEndpoint:
-    @pytest.mark.asyncio
-    async def test_stop_calls_run_recorder(self, _recording_router) -> None:
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/stop")
+    def test_stop_calls_run_recorder(self, _recording_client) -> None:
+        client, state = _recording_client
 
-        result = response_payload(await endpoint())
+        response = client.post("/api/recording/stop")
 
+        assert response.status_code == 200
         state.run_recorder.stop_recording.assert_called_once()
-        assert result["enabled"] is False
+        assert response.json()["enabled"] is False
 
-    @pytest.mark.asyncio
-    async def test_stop_when_not_recording_returns_idle_status(self, _recording_router) -> None:
+    def test_stop_when_not_recording_returns_idle_status(self, _recording_client) -> None:
         """stop_recording when not recording is safe — returns idle status."""
-        router, state = _recording_router
-        endpoint = route_endpoint(router, "/api/recording/stop")
+
+        client, state = _recording_client
         state.run_recorder.stop_recording.return_value = _make_recording_status_snapshot(
             enabled=False,
             run_id=None,
             samples_written=0,
         )
 
-        result = response_payload(await endpoint())
+        response = client.post("/api/recording/stop")
 
-        assert result["enabled"] is False
-        assert result["run_id"] is None
+        assert response.status_code == 200
+        assert response.json()["enabled"] is False
+        assert response.json()["run_id"] is None

--- a/apps/server/tests/adapters/http/test_settings_analysis_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_analysis_endpoints.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint, route_endpoint_with_method
-from test_support import response_payload
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from vibesensor.domain import AnalysisSettingsSnapshot
 
@@ -13,61 +13,51 @@ def _make_default_snapshot() -> AnalysisSettingsSnapshot:
     return AnalysisSettingsSnapshot(**AnalysisSettingsSnapshot.DEFAULTS)
 
 
-def _find_endpoint(router, path: str, method: str = "GET"):
-    if method.upper() == "GET":
-        return route_endpoint(router, path)
-    return route_endpoint_with_method(router, path, method)
-
-
 @pytest.fixture
-def _analysis_router(fake_state):
+def _analysis_client(fake_state):
     from vibesensor.adapters.http.settings.analysis import create_analysis_settings_routes
     from vibesensor.adapters.http.settings.dependencies import AnalysisSettingsRouteDeps
 
     fake_state.settings_store.analysis_settings_snapshot.return_value = _make_default_snapshot()
-    return (
+    app = FastAPI()
+    app.include_router(
         create_analysis_settings_routes(
             AnalysisSettingsRouteDeps(analysis_settings=fake_state.settings_store),
-        ),
-        fake_state,
+        )
     )
+    with TestClient(app) as client:
+        yield client, fake_state
 
 
 class TestSetAnalysisSettingsEndpoint:
-    @pytest.mark.asyncio
-    async def test_empty_changes_is_noop(self, _analysis_router) -> None:
+    def test_empty_changes_is_noop(self, _analysis_client) -> None:
         """PUT /api/settings/analysis with all-None body skips update_active_car_aspects."""
 
-        router, state = _analysis_router
-        endpoint = _find_endpoint(router, "/api/settings/analysis", "PUT")
+        client, state = _analysis_client
 
-        from vibesensor.adapters.http.models import AnalysisSettingsRequest
+        response = client.put("/api/settings/analysis", json={})
 
-        result = response_payload(await endpoint(req=AnalysisSettingsRequest()))
-
+        assert response.status_code == 200
         state.settings_store.update_active_car_aspects.assert_not_called()
-        assert "tire_width_mm" in result
+        assert "tire_width_mm" in response.json()
 
-    @pytest.mark.asyncio
-    async def test_valid_changes_calls_update(self, _analysis_router) -> None:
-        router, state = _analysis_router
-        endpoint = _find_endpoint(router, "/api/settings/analysis", "PUT")
+    def test_valid_changes_calls_update(self, _analysis_client) -> None:
+        client, state = _analysis_client
 
-        from vibesensor.adapters.http.models import AnalysisSettingsRequest
+        response = client.put("/api/settings/analysis", json={"tire_width_mm": 265.0})
 
-        await endpoint(req=AnalysisSettingsRequest(tire_width_mm=265.0))
-
+        assert response.status_code == 200
         state.settings_store.update_active_car_aspects.assert_called_once_with(
             {"tire_width_mm": 265.0}
         )
 
-    @pytest.mark.asyncio
-    async def test_get_analysis_settings_response_shape(self, _analysis_router) -> None:
-        router, _ = _analysis_router
-        endpoint = _find_endpoint(router, "/api/settings/analysis", "GET")
+    def test_get_analysis_settings_response_shape(self, _analysis_client) -> None:
+        client, _ = _analysis_client
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/analysis")
 
+        assert response.status_code == 200
+        result = response.json()
         for key in (
             "tire_width_mm",
             "tire_aspect_pct",

--- a/apps/server/tests/adapters/http/test_settings_car_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_car_endpoints.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint, route_endpoint_with_method
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from test_support import response_payload
 
 from vibesensor.shared.types.car_config import CarConfigPayload, CarsSnapshot
 
@@ -33,95 +31,74 @@ def _make_cars_snapshot(
     )
 
 
-def _find_endpoint(router, path: str, method: str = "GET"):
-    if method.upper() == "GET":
-        return route_endpoint(router, path)
-    return route_endpoint_with_method(router, path, method)
-
-
 @pytest.fixture
-def _car_router(fake_state):
+def _car_client(fake_state):
     from vibesensor.adapters.http.settings.cars import create_car_settings_routes
     from vibesensor.adapters.http.settings.dependencies import CarSettingsRouteDeps
 
     fake_state.settings_store.get_cars.return_value = _make_cars_snapshot()
-    return (
+    app = FastAPI()
+    app.include_router(
         create_car_settings_routes(
             CarSettingsRouteDeps(car_settings=fake_state.settings_store),
-        ),
-        fake_state,
+        )
     )
+    with TestClient(app) as client:
+        yield client, fake_state
 
 
 class TestDeleteCarEndpoint:
-    @pytest.mark.asyncio
-    async def test_delete_unknown_car_returns_404(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
-
+    def test_delete_unknown_car_returns_404(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.get_cars.return_value = _make_cars_snapshot(
             cars=[],
             active_car_id=None,
         )
 
-        with pytest.raises(HTTPException) as exc_info:
-            await endpoint(car_id="no-such-car")
-        assert exc_info.value.status_code == 404
+        response = client.delete("/api/settings/cars/no-such-car")
 
-    @pytest.mark.asyncio
-    async def test_delete_known_car_calls_store(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
+        assert response.status_code == 404
 
+    def test_delete_known_car_calls_store(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.get_cars.return_value = _make_cars_snapshot()
         state.settings_store.delete_car.return_value = _make_cars_snapshot(
             cars=[],
             active_car_id=None,
         )
 
-        result = response_payload(await endpoint(car_id="car-1"))
+        response = client.delete("/api/settings/cars/car-1")
 
+        assert response.status_code == 200
         state.settings_store.delete_car.assert_called_once_with("car-1")
-        assert "cars" in result
+        assert "cars" in response.json()
 
-    @pytest.mark.asyncio
-    async def test_delete_car_business_logic_error_returns_400(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "DELETE")
-
+    def test_delete_car_business_logic_error_returns_400(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.get_cars.return_value = _make_cars_snapshot()
         state.settings_store.delete_car.side_effect = ValueError("cannot delete last car")
 
-        with pytest.raises(HTTPException) as exc_info:
-            await endpoint(car_id="car-1")
-        assert exc_info.value.status_code == 400
+        response = client.delete("/api/settings/cars/car-1")
+
+        assert response.status_code == 400
 
 
 class TestSetActiveCarEndpoint:
-    @pytest.mark.asyncio
-    async def test_unknown_car_id_raises_404(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars/active", "PUT")
-
+    def test_unknown_car_id_raises_404(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.set_active_car.side_effect = ValueError("Car not found")
 
-        from vibesensor.adapters.http.models import ActiveCarRequest
+        response = client.put("/api/settings/cars/active", json={"car_id": "no-such-car"})
 
-        with pytest.raises(HTTPException) as exc_info:
-            await endpoint(req=ActiveCarRequest(car_id="no-such-car"))
-        assert exc_info.value.status_code == 404
+        assert response.status_code == 404
 
-    def test_static_put_route_wins_over_dynamic_car_id_route(self, _car_router) -> None:
-        router, state = _car_router
-        app = FastAPI()
-        app.include_router(router)
-
+    def test_static_put_route_wins_over_dynamic_car_id_route(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.set_active_car.return_value = _make_cars_snapshot(
             active_car_id="car-1"
         )
 
-        with TestClient(app) as client:
-            response = client.put("/api/settings/cars/active", json={"car_id": "car-1"})
+        response = client.put("/api/settings/cars/active", json={"car_id": "car-1"})
 
         assert response.status_code == 200
         state.settings_store.set_active_car.assert_called_once_with("car-1")
@@ -129,43 +106,38 @@ class TestSetActiveCarEndpoint:
 
 
 class TestCarsEndpoint:
-    @pytest.mark.asyncio
-    async def test_get_cars_response_shape(self, _car_router) -> None:
-        router, _ = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars", "GET")
+    def test_get_cars_response_shape(self, _car_client) -> None:
+        client, _ = _car_client
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/cars")
 
+        assert response.status_code == 200
+        result = response.json()
         assert result["active_car_id"] == "car-1"
         assert result["cars"][0]["type"] == "sedan"
         assert result["cars"][0]["aspects"]["tire_width_mm"] == 225.0
 
-    @pytest.mark.asyncio
-    async def test_add_car_passes_only_non_null_fields(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars", "POST")
-
-        from vibesensor.adapters.http.models import CarUpsertRequest
-
+    def test_add_car_passes_only_non_null_fields(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.add_car.return_value = _make_cars_snapshot(
             cars=[_make_car_payload(), _make_car_payload(car_id="car-2", name="Second")],
         )
 
-        await endpoint(req=CarUpsertRequest(name="Second", variant="Sport"))
+        response = client.post("/api/settings/cars", json={"name": "Second", "variant": "Sport"})
 
+        assert response.status_code == 200
         state.settings_store.add_car.assert_called_once_with({"name": "Second", "variant": "Sport"})
 
-    @pytest.mark.asyncio
-    async def test_update_car_passes_only_non_null_fields(self, _car_router) -> None:
-        router, state = _car_router
-        endpoint = _find_endpoint(router, "/api/settings/cars/{car_id}", "PUT")
-
-        from vibesensor.adapters.http.models import CarUpsertRequest
-
+    def test_update_car_passes_only_non_null_fields(self, _car_client) -> None:
+        client, state = _car_client
         state.settings_store.update_car.return_value = _make_cars_snapshot()
 
-        await endpoint(car_id="car-1", req=CarUpsertRequest(name="Updated", variant="GT"))
+        response = client.put(
+            "/api/settings/cars/car-1",
+            json={"name": "Updated", "variant": "GT"},
+        )
 
+        assert response.status_code == 200
         state.settings_store.update_car.assert_called_once_with(
             "car-1",
             {"name": "Updated", "variant": "GT"},

--- a/apps/server/tests/adapters/http/test_settings_preferences_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_preferences_endpoints.py
@@ -3,77 +3,58 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint, route_endpoint_with_method
-from fastapi import HTTPException
-from test_support import response_payload
-
-
-def _find_endpoint(router, path: str, method: str = "GET"):
-    if method.upper() == "GET":
-        return route_endpoint(router, path)
-    return route_endpoint_with_method(router, path, method)
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def _preferences_router(fake_state):
+def _preferences_client(fake_state):
     from vibesensor.adapters.http.settings.dependencies import UiPreferencesRouteDeps
     from vibesensor.adapters.http.settings.preferences import create_ui_preferences_routes
 
-    return (
+    app = FastAPI()
+    app.include_router(
         create_ui_preferences_routes(
             UiPreferencesRouteDeps(ui_preferences=fake_state.settings_store),
-        ),
-        fake_state,
+        )
     )
+    with TestClient(app) as client:
+        yield client, fake_state
 
 
 class TestPreferencesEndpoint:
-    @pytest.mark.asyncio
-    async def test_get_language_returns_current_language(self, _preferences_router) -> None:
-        router, state = _preferences_router
-        endpoint = _find_endpoint(router, "/api/settings/language", "GET")
-
+    def test_get_language_returns_current_language(self, _preferences_client) -> None:
+        client, state = _preferences_client
         state.settings_store.language = "lt"
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/language")
 
-        assert result == {"language": "lt"}
+        assert response.status_code == 200
+        assert response.json() == {"language": "lt"}
 
-    @pytest.mark.asyncio
-    async def test_set_language_maps_invalid_language_to_400(self, _preferences_router) -> None:
-        router, state = _preferences_router
-        endpoint = _find_endpoint(router, "/api/settings/language", "PUT")
-
-        from vibesensor.adapters.http.models import LanguageRequest
-
+    def test_set_language_maps_invalid_language_to_400(self, _preferences_client) -> None:
+        client, state = _preferences_client
         state.settings_store.set_language.side_effect = ValueError("Unsupported language code")
 
-        with pytest.raises(HTTPException) as exc_info:
-            await endpoint(req=LanguageRequest(language="en"))
+        response = client.put("/api/settings/language", json={"language": "en"})
 
-        assert exc_info.value.status_code == 400
+        assert response.status_code == 400
 
-    @pytest.mark.asyncio
-    async def test_get_speed_unit_returns_current_speed_unit(self, _preferences_router) -> None:
-        router, state = _preferences_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-unit", "GET")
-
+    def test_get_speed_unit_returns_current_speed_unit(self, _preferences_client) -> None:
+        client, state = _preferences_client
         state.settings_store.speed_unit = "mps"
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/speed-unit")
 
-        assert result == {"speed_unit": "mps"}
+        assert response.status_code == 200
+        assert response.json() == {"speed_unit": "mps"}
 
-    @pytest.mark.asyncio
-    async def test_set_speed_unit_returns_updated_unit(self, _preferences_router) -> None:
-        router, state = _preferences_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-unit", "PUT")
-
-        from vibesensor.adapters.http.models import SpeedUnitRequest
-
+    def test_set_speed_unit_returns_updated_unit(self, _preferences_client) -> None:
+        client, state = _preferences_client
         state.settings_store.set_speed_unit.return_value = "mps"
 
-        result = response_payload(await endpoint(req=SpeedUnitRequest(speed_unit="mps")))
+        response = client.put("/api/settings/speed-unit", json={"speed_unit": "mps"})
 
+        assert response.status_code == 200
         state.settings_store.set_speed_unit.assert_called_once_with("mps")
-        assert result == {"speed_unit": "mps"}
+        assert response.json() == {"speed_unit": "mps"}

--- a/apps/server/tests/adapters/http/test_settings_speed_source_endpoints.py
+++ b/apps/server/tests/adapters/http/test_settings_speed_source_endpoints.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from _history_endpoint_helpers import route_endpoint, route_endpoint_with_method
-from fastapi import HTTPException
-from test_support import response_payload
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
 
@@ -32,34 +31,27 @@ def _make_speed_source_status_snapshot() -> SpeedSourceStatusSnapshot:
     )
 
 
-def _find_endpoint(router, path: str, method: str = "GET"):
-    if method.upper() == "GET":
-        return route_endpoint(router, path)
-    return route_endpoint_with_method(router, path, method)
-
-
 @pytest.fixture
-def _speed_source_router(fake_state):
+def _speed_source_client(fake_state):
     from vibesensor.adapters.http.settings.dependencies import SpeedSourceRouteDeps
     from vibesensor.adapters.http.settings.speed_source import create_speed_source_routes
 
-    return (
+    app = FastAPI()
+    app.include_router(
         create_speed_source_routes(
             SpeedSourceRouteDeps(
                 speed_source_service=fake_state.speed_source_service,
                 speed_status_service=fake_state.gps_monitor,
             ),
-        ),
-        fake_state,
+        )
     )
+    with TestClient(app) as client:
+        yield client, fake_state
 
 
 class TestSpeedSourceEndpoint:
-    @pytest.mark.asyncio
-    async def test_get_speed_source_response_shape(self, _speed_source_router) -> None:
-        router, state = _speed_source_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-source", "GET")
-
+    def test_get_speed_source_response_shape(self, _speed_source_client) -> None:
+        client, state = _speed_source_client
         state.speed_source_service.get_speed_source.return_value = {
             "speedSource": "manual",
             "manualSpeedKph": 42.0,
@@ -68,9 +60,10 @@ class TestSpeedSourceEndpoint:
             "obdDeviceName": "OBDLink MX+",
         }
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/speed-source")
 
-        assert result == {
+        assert response.status_code == 200
+        assert response.json() == {
             "speed_source": "manual",
             "manual_speed_kph": 42.0,
             "stale_timeout_s": 15.0,
@@ -78,55 +71,47 @@ class TestSpeedSourceEndpoint:
             "obd_device_name": "OBDLink MX+",
         }
 
-    @pytest.mark.asyncio
-    async def test_update_speed_source_passes_only_non_null_fields(
+    def test_update_speed_source_passes_only_non_null_fields(
         self,
-        _speed_source_router,
+        _speed_source_client,
     ) -> None:
-        router, state = _speed_source_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-source", "PUT")
-
-        from vibesensor.adapters.http.models import SpeedSourceRequest
-
+        client, state = _speed_source_client
         state.speed_source_service.update_speed_source.return_value = {
             "speedSource": "manual",
             "manualSpeedKph": 42.0,
             "staleTimeoutS": 15.0,
         }
 
-        await endpoint(req=SpeedSourceRequest(speed_source="manual", manual_speed_kph=42.0))
+        response = client.put(
+            "/api/settings/speed-source",
+            json={"speed_source": "manual", "manual_speed_kph": 42.0},
+        )
 
+        assert response.status_code == 200
         state.speed_source_service.update_speed_source.assert_called_once_with(
             {"speedSource": "manual", "manualSpeedKph": 42.0}
         )
 
-    @pytest.mark.asyncio
-    async def test_update_speed_source_maps_invalid_config_to_400(
+    def test_update_speed_source_maps_invalid_config_to_400(
         self,
-        _speed_source_router,
+        _speed_source_client,
     ) -> None:
-        router, state = _speed_source_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-source", "PUT")
-
-        from vibesensor.adapters.http.models import SpeedSourceRequest
-
+        client, state = _speed_source_client
         state.speed_source_service.update_speed_source.side_effect = ValueError(
             "SpeedSourceConfig with speed_source=MANUAL requires manual_speed_kph"
         )
 
-        with pytest.raises(HTTPException) as exc_info:
-            await endpoint(req=SpeedSourceRequest(speed_source="manual"))
+        response = client.put("/api/settings/speed-source", json={"speed_source": "manual"})
 
-        assert exc_info.value.status_code == 400
+        assert response.status_code == 400
 
-    @pytest.mark.asyncio
-    async def test_speed_source_status_response_shape(self, _speed_source_router) -> None:
-        router, state = _speed_source_router
-        endpoint = _find_endpoint(router, "/api/settings/speed-source/status", "GET")
-
+    def test_speed_source_status_response_shape(self, _speed_source_client) -> None:
+        client, state = _speed_source_client
         state.gps_monitor.status_snapshot.return_value = _make_speed_source_status_snapshot()
 
-        result = response_payload(await endpoint())
+        response = client.get("/api/settings/speed-source/status")
 
+        assert response.status_code == 200
+        result = response.json()
         assert result["speed_source"] == "gps"
         assert result["fix_dimension"] == "3d"


### PR DESCRIPTION
## What changed
- rewrote the helper-backed HTTP adapter test cluster to use `TestClient` and `websocket_connect()` instead of extracted route endpoint functions and ad hoc request objects
- removed the fake websocket and `route_endpoint*` helpers from `_history_endpoint_helpers.py`
- converted the history, health, recording, settings, and websocket/client adapter tests to assert real status codes, JSON payloads, and websocket behavior

## Why
- issue #3396 is about testing the real HTTP boundary instead of fragile route signatures and call graphs
- the old helper path broke on harmless endpoint refactors because tests bypassed FastAPI routing, validation, and websocket handling

## Validation
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/http`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs / edge cases
- this test slice is a little more integration-like because it now exercises the real ASGI boundary, but that is the behavior the issue is asking to pin
- one health test still inspects the registered route metadata because it is specifically checking the declared response-model contract, while the payload itself now comes from a real request

Fixes #3396
