### PR TITLE
Rewrite OBD and speed tests around outcomes

### DIFF
--- a/apps/server/tests/adapters/obd/test_connection_executor.py
+++ b/apps/server/tests/adapters/obd/test_connection_executor.py
@@ -72,6 +72,84 @@ async def test_executor_marks_disconnected_and_backs_off_after_connect_failure()
 
 
 @pytest.mark.asyncio
+async def test_executor_connect_step_marks_connected_without_closing_initialized_session() -> None:
+    clock = FakeClock()
+    parts = build_obd_runtime_parts(clock=clock)
+
+    next_state = await parts.executor.execute(
+        state=ObdConnectionLoopState(),
+        step=ObdConnectionStep(
+            kind=ObdConnectionStepKind.CONNECT,
+            mac_address="00043e5a4a4d",
+            configured_name="OBDLink MX+",
+        ),
+    )
+
+    status = parts.projection.status_snapshot()
+    assert next_state.session is parts.session
+    assert next_state.session_device_mac == "00043e5a4a4d"
+    assert next_state.reconnect_delay_s == pytest.approx(1.0)
+    parts.session.initialize.assert_called_once_with()
+    parts.session.close.assert_not_called()
+    assert status.connection_state == "connected"
+    assert status.device_mac == "00043e5a4a4d"
+    assert status.connected is True
+
+
+@pytest.mark.asyncio
+async def test_executor_connect_step_backs_off_after_initialize_transport_error() -> None:
+    clock = FakeClock()
+    session = MagicMock()
+    session.initialize.side_effect = ObdTransportError("no prompt from adapter")
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    parts = build_obd_runtime_parts(clock=clock, session=session, sleep=record_sleep)
+
+    next_state = await parts.executor.execute(
+        state=ObdConnectionLoopState(reconnect_delay_s=2.0),
+        step=ObdConnectionStep(
+            kind=ObdConnectionStepKind.CONNECT,
+            mac_address="00043e5a4a4d",
+            configured_name="OBDLink MX+",
+        ),
+    )
+
+    status = parts.projection.status_snapshot()
+    session.close.assert_called_once_with()
+    assert sleeps == [2.0]
+    assert status.connection_state == "disconnected"
+    assert status.last_error == "no prompt from adapter"
+    assert next_state.session is None
+    assert next_state.session_device_mac is None
+    assert next_state.reconnect_delay_s == pytest.approx(4.0)
+
+
+@pytest.mark.asyncio
+async def test_executor_connect_step_closes_session_and_propagates_unexpected_runtime_error() -> (
+    None
+):
+    clock = FakeClock()
+    session = MagicMock()
+    session.initialize.side_effect = RuntimeError("session bug")
+    parts = build_obd_runtime_parts(clock=clock, session=session)
+
+    with pytest.raises(RuntimeError, match="session bug"):
+        await parts.executor.execute(
+            state=ObdConnectionLoopState(),
+            step=ObdConnectionStep(
+                kind=ObdConnectionStepKind.CONNECT,
+                mac_address="00043e5a4a4d",
+                configured_name="OBDLink MX+",
+            ),
+        )
+
+    session.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_executor_closes_session_and_backs_off_after_poll_connection_loss() -> None:
     clock = FakeClock()
     sleeps: list[float] = []

--- a/apps/server/tests/adapters/obd/test_runtime_services.py
+++ b/apps/server/tests/adapters/obd/test_runtime_services.py
@@ -15,13 +15,16 @@ from test_support.obd_runtime import (
 )
 
 from vibesensor.adapters.http.obd_status_presentation import obd_debug_hint
+from vibesensor.adapters.obd.connection_executor import ObdConnectionLoopState
+from vibesensor.adapters.obd.connection_plan import ObdConnectionStep, ObdConnectionStepKind
 from vibesensor.adapters.obd.elm327 import ObdTransportError
 from vibesensor.adapters.obd.models import ObdDeviceSnapshot
 from vibesensor.adapters.obd.polling import ObdPidFailureKind, ObdPidPollResult, ObdPollResult
 from vibesensor.shared.operational_errors import ExternalCommandError
 
 
-def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -> None:
+@pytest.mark.asyncio
+async def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -> None:
     clock = _FakeClock(now=time.monotonic())
     started_at = clock.now
     calls: list[tuple[str, float | None]] = []
@@ -43,9 +46,16 @@ def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -
 
     parts.session.request.side_effect = request
 
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    state = ObdConnectionLoopState(session=parts.session, session_device_mac="00043e5a4a4d")
+    state = await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
     clock.now = started_at + 0.05
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.2)]
     assert parts.projection.resolve_speed().source == "obd2"
@@ -60,7 +70,8 @@ def test_obd_observation_prioritizes_rpm_and_keeps_speed_as_a_companion_poll() -
     assert status.connection_state == "connected"
 
 
-def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() -> None:
+@pytest.mark.asyncio
+async def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() -> None:
     clock = _FakeClock()
     rpm_responses = [("410C1AF8", 0.01)]
     speed_responses = [("410D28", 0.01)]
@@ -82,9 +93,16 @@ def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() ->
 
     parts.session.request.side_effect = request
 
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    state = ObdConnectionLoopState(session=parts.session, session_device_mac="00043e5a4a4d")
+    state = await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
     clock.now = 0.05
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
 
     assert parts.facts.engine_rpm == pytest.approx(0x1AF8 / 4.0)
     clock.now = 1.99
@@ -97,7 +115,10 @@ def test_obd_observation_keeps_last_good_rpm_until_the_reference_goes_stale() ->
     assert status.backoff_active is True
 
 
-def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_times_out() -> None:
+@pytest.mark.asyncio
+async def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_times_out() -> (
+    None
+):
     clock = _FakeClock()
     calls: list[tuple[str, float | None]] = []
     rpm_responses = [("410C1AF8", 0.12), ("410C1AF8", 0.06)]
@@ -116,8 +137,15 @@ def test_obd_connection_state_backs_off_and_stays_in_rpm_only_mode_when_speed_ti
 
     parts.session.request.side_effect = request
 
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
-    parts.connection_control.apply_poll_cycle(parts.executor._poll_cycle_blocking(parts.session))
+    state = ObdConnectionLoopState(session=parts.session, session_device_mac="00043e5a4a4d")
+    state = await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
+    await parts.executor.execute(
+        state=state,
+        step=ObdConnectionStep(kind=ObdConnectionStepKind.POLL),
+    )
 
     assert calls == [("010C", 0.2), ("010D", 0.2), ("010C", 0.3)]
     status = parts.projection.status_snapshot()
@@ -151,6 +179,14 @@ def test_obd_runtime_projection_resolves_stale_speed_to_manual_fallback() -> Non
 
 def test_obd_status_snapshot_does_not_refresh_admin_state_implicitly() -> None:
     admin_client = MagicMock()
+    admin_client.device_info.return_value = ObdDeviceSnapshot(
+        mac_address="00043e5a4a4d",
+        name="OBDLink MX+",
+        paired=True,
+        trusted=True,
+        connected=True,
+        rfcomm_channel=1,
+    )
     parts = _build_runtime_parts(clock=lambda: 100.0, admin_client=admin_client)
     parts.settings.apply_speed_source_settings(
         effective_speed_kmh=None,
@@ -162,9 +198,9 @@ def test_obd_status_snapshot_does_not_refresh_admin_state_implicitly() -> None:
 
     status = parts.projection.status_snapshot()
 
-    admin_client.device_info.assert_not_called()
     assert status.device_mac == "00043e5a4a4d"
     assert status.paired is False
+    assert status.trusted is False
 
 
 def test_obd_status_reports_sudo_helper_hint_when_admin_refresh_fails() -> None:
@@ -210,56 +246,3 @@ def test_obd_connection_state_marks_disconnected_after_fatal_poll_cycle() -> Non
     assert status.connection_state == "disconnected"
     assert status.last_error == "PID 010C request failed: Session is not connected"
     assert status.reconnect_delay_s == 4.0
-
-
-def test_connect_blocking_closes_session_and_propagates_transport_error() -> None:
-    clock = _FakeClock()
-    admin_client = MagicMock()
-    admin_client.device_info.return_value = ObdDeviceSnapshot(
-        mac_address="00043e5a4a4d",
-        name="OBDLink MX+",
-        paired=True,
-        trusted=True,
-        connected=False,
-        rfcomm_channel=1,
-    )
-    session = MagicMock()
-    session.initialize.side_effect = ObdTransportError("no prompt from adapter")
-    parts = _build_runtime_parts(clock=clock, admin_client=admin_client, session=session)
-
-    with pytest.raises(ObdTransportError, match="no prompt from adapter"):
-        parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-
-    session.close.assert_called_once_with()
-
-
-def test_connect_blocking_keeps_initialized_session_open() -> None:
-    clock = _FakeClock()
-    parts = _connected_runtime_parts(clock=clock)
-
-    assert parts.runner is not None
-    assert parts.facts is not None
-    assert parts.projection is not None
-    parts.session.initialize.assert_called_once_with()
-    assert parts.session.close.call_count == 0
-
-
-def test_connect_blocking_closes_session_and_propagates_unexpected_runtime_error() -> None:
-    clock = _FakeClock()
-    admin_client = MagicMock()
-    admin_client.device_info.return_value = ObdDeviceSnapshot(
-        mac_address="00043e5a4a4d",
-        name="OBDLink MX+",
-        paired=True,
-        trusted=True,
-        connected=False,
-        rfcomm_channel=1,
-    )
-    session = MagicMock()
-    session.initialize.side_effect = RuntimeError("session bug")
-    parts = _build_runtime_parts(clock=clock, admin_client=admin_client, session=session)
-
-    with pytest.raises(RuntimeError, match="session bug"):
-        parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-
-    session.close.assert_called_once_with()

--- a/apps/server/tests/adapters/speed/test_speed_services.py
+++ b/apps/server/tests/adapters/speed/test_speed_services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from test_support.obd_runtime import build_obd_runtime_parts
 
 from vibesensor.adapters.gps.speed_resolution import SpeedResolution
 from vibesensor.adapters.gps.speed_status import SpeedSourceStatusSnapshot
@@ -100,23 +101,19 @@ def test_observation_service_switches_to_obd_status_and_resolution() -> None:
     assert status.device == "OBDLink MX+ (00043e5a4a4d)"
     assert status.raw_speed_kmh == pytest.approx(43.2)
     assert status.speed_source == "obd2"
-    obd_status_refresher.refresh_configured_device.assert_not_called()
-    obd_projection.status_snapshot.assert_called_once_with()
 
 
 def test_observation_service_obd_status_is_side_effect_free() -> None:
     gps_monitor = MagicMock()
-    obd_facts = MagicMock()
-    obd_projection = MagicMock()
-    expected_status = _obd_status_snapshot()
-    obd_projection.status_snapshot.return_value = expected_status
+    gps_monitor.apply_speed_source_settings.return_value = None
+    parts = build_obd_runtime_parts(clock=lambda: 100.0)
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_facts=obd_facts,
-        obd_projection=obd_projection,
+        obd_facts=parts.facts,
+        obd_projection=parts.projection,
         obd_device_admin=MagicMock(),
-        obd_status_refresher=MagicMock(),
-        obd_control=MagicMock(),
+        obd_status_refresher=parts.admin,
+        obd_control=parts.settings,
     )
 
     services.control.apply_speed_source_settings(
@@ -130,25 +127,43 @@ def test_observation_service_obd_status_is_side_effect_free() -> None:
 
     status = services.observation.obd_status()
 
-    assert status == expected_status
-    obd_projection.status_snapshot.assert_called_once_with()
+    assert status.device_mac == "00043e5a4a4d"
+    assert status.paired is False
+    assert status.trusted is False
 
 
 def test_admin_service_refreshes_obd_status_explicitly() -> None:
     gps_monitor = MagicMock()
-    obd_status_refresher = MagicMock()
+    gps_monitor.apply_speed_source_settings.return_value = None
+    parts = build_obd_runtime_parts(clock=lambda: 100.0)
     services = build_speed_source_services(
         gps_monitor=gps_monitor,
-        obd_facts=MagicMock(),
-        obd_projection=MagicMock(),
+        obd_facts=parts.facts,
+        obd_projection=parts.projection,
         obd_device_admin=MagicMock(),
-        obd_status_refresher=obd_status_refresher,
-        obd_control=MagicMock(),
+        obd_status_refresher=parts.admin,
+        obd_control=parts.settings,
     )
 
+    services.control.apply_speed_source_settings(
+        effective_speed_kmh=None,
+        manual_source_selected=False,
+        stale_timeout_s=8.0,
+        selected_source="obd2",
+        obd_device_mac="00043e5a4a4d",
+        obd_device_name="OBDLink MX+",
+    )
+
+    before = services.observation.obd_status()
     services.admin.refresh_obd_status()
 
-    obd_status_refresher.refresh_configured_device.assert_called_once_with()
+    after = services.observation.obd_status()
+
+    assert before.paired is False
+    assert before.trusted is False
+    assert after.paired is True
+    assert after.trusted is True
+    assert after.device_mac == "00043e5a4a4d"
 
 
 def test_admin_service_delegates_scan_and_pair_to_obd_device_admin() -> None:
@@ -178,5 +193,3 @@ def test_admin_service_delegates_scan_and_pair_to_obd_device_admin() -> None:
 
     assert scanned == [device]
     assert paired == device
-    obd_device_admin.scan_devices.assert_called_once_with(timeout_s=8)
-    obd_device_admin.pair_device.assert_called_once_with("00043e5a4a4d")

--- a/apps/server/tests/test_support/obd_runtime.py
+++ b/apps/server/tests/test_support/obd_runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from unittest.mock import MagicMock
 
 from vibesensor.adapters.obd.admin_runtime import ObdAdminRuntime
@@ -122,6 +122,10 @@ def build_connected_obd_runtime_parts(
         obd_device_mac="00043e5a4a4d",
         obd_device_name="OBDLink MX+",
     )
-    _, device = parts.executor._connect_blocking("00043e5a4a4d", "OBDLink MX+")
-    parts.connection_control.mark_connected(device)
+    configured_device = replace(
+        parts.admin_client.device_info.return_value,
+        name=parts.admin_client.device_info.return_value.name or "OBDLink MX+",
+        connected=True,
+    )
+    parts.connection_control.mark_connected(configured_device)
     return parts


### PR DESCRIPTION
Closes #3398

## What changed
- rewrote OBD runtime service tests to drive poll behavior through `await executor.execute(... step=POLL)` instead of `_poll_cycle_blocking(...)`
- moved public connect-step outcome coverage into `test_connection_executor.py`
- changed shared OBD runtime test support to mark connected state through `mark_connected(...)` instead of `_connect_blocking()`
- rewrote speed service tests around visible OBD status refresh, scan, and pair outcomes instead of collaborator call-count assertions
- left `test_vibesensor_obd_admin.py` unchanged because it already owns the repo-venv re-exec wrapper and `test_admin_helper.py` already owns CLI-visible admin output behavior

## Why
- private executor calls and collaborator call assertions were making the tests fail on harmless internal refactors
- the public contracts here are status, connect, poll, scan, pair, and CLI behavior, so the tests should pin those outcomes directly

## Validation
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/obd/test_connection_executor.py apps/server/tests/adapters/obd/test_runtime_services.py apps/server/tests/adapters/speed/test_speed_services.py apps/server/tests/scripts/test_vibesensor_obd_admin.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/obd apps/server/tests/adapters/speed apps/server/tests/scripts/test_vibesensor_obd_admin.py`
- `make format`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- executor tests still mock the transport/admin boundaries because those are the real external seams for connect/poll failure behavior
- the script wrapper still does not duplicate helper output assertions; those stay with the helper's direct tests so the wrapper only owns re-exec behavior
