### PR TITLE
Rewrite tooling tests around CLI behavior

### DIFF
--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -1,4 +1,4 @@
-"""Guards for the local CI-parallel runner bootstrap behavior."""
+"""Guards for local CI runner bootstrap behavior through the public entrypoint."""
 
 from __future__ import annotations
 
@@ -21,11 +21,7 @@ def _load_ci_parallel_module():
     return module
 
 
-def test_bootstrap_uses_shared_ui_bootstrap_helper_when_npm_ci_is_needed(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    module = _load_ci_parallel_module()
+def _configure_ui_paths(module, monkeypatch, tmp_path: Path) -> Path:
     ui_dir = tmp_path / "apps" / "ui"
     ui_dir.mkdir(parents=True)
     helper_path = tmp_path / "tools" / "ui" / "ensure_ui_bootstrap.mjs"
@@ -33,12 +29,83 @@ def test_bootstrap_uses_shared_ui_bootstrap_helper_when_npm_ci_is_needed(
     helper_path.write_text("// helper\n", encoding="utf-8")
 
     monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "LOG_DIR", tmp_path / "logs")
     monkeypatch.setattr(module, "UI_DIR", ui_dir)
     monkeypatch.setattr(module, "UI_BOOTSTRAP_HELPER", helper_path)
+    return ui_dir
 
-    steps = module._bootstrap_steps("python3", True, include_platformio=False)
 
-    assert steps[-1] == module.Step(
+def _stub_ui_bootstrap_check(
+    monkeypatch,
+    module,
+    *,
+    needs_npm_ci: bool,
+    current_lock_hash: str = "",
+    node_modules_exists: bool = True,
+) -> None:
+    monkeypatch.setattr(
+        module.subprocess,
+        "check_output",
+        lambda command, cwd, text: json.dumps(
+            {
+                "needs_npm_ci": needs_npm_ci,
+                "lock_hash": "lock",
+                "current_lock_hash": current_lock_hash,
+                "node_modules_exists": node_modules_exists,
+            }
+        ),
+    )
+
+
+def _install_main_harness(module, monkeypatch, tmp_path: Path, jobs):
+    captured: dict[str, object] = {}
+    outputs: list[str] = []
+
+    monkeypatch.setattr(module, "_job_steps", lambda _python_cmd: jobs)
+
+    def _fake_run_bootstrap(steps):
+        captured["bootstrap_steps"] = steps
+        return 0
+
+    def _fake_run_job(name, steps, results):
+        results[name] = module.JobResult(
+            name=name,
+            ok=True,
+            failed_step=None,
+            return_code=0,
+            duration_s=0.0,
+            log_path=tmp_path / f"{name}.log",
+        )
+
+    monkeypatch.setattr(module, "_run_bootstrap", _fake_run_bootstrap)
+    monkeypatch.setattr(module, "_run_job", _fake_run_job)
+    monkeypatch.setattr(module, "_emit", outputs.append)
+    return captured, outputs
+
+
+def test_main_uses_shared_ui_bootstrap_helper_when_npm_ci_is_needed(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    ui_dir = _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(
+        monkeypatch,
+        module,
+        needs_npm_ci=True,
+        node_modules_exists=False,
+    )
+    ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=ui_dir)
+    captured, _outputs = _install_main_harness(
+        module,
+        monkeypatch,
+        tmp_path,
+        {"frontend-typecheck": [ui_step]},
+    )
+
+    assert module.main(["--job", "frontend-typecheck"]) == 0
+
+    assert captured["bootstrap_steps"][-1] == module.Step(
         "ui deps: ensure bootstrap",
         ["node", "../../tools/ui/ensure_ui_bootstrap.mjs"],
         cwd=ui_dir,
@@ -46,51 +113,30 @@ def test_bootstrap_uses_shared_ui_bootstrap_helper_when_npm_ci_is_needed(
 
 
 def test_main_refuses_skip_bootstrap_when_release_smoke_would_race_ui_jobs(
-    monkeypatch, capsys, tmp_path: Path
+    monkeypatch,
+    tmp_path: Path,
 ) -> None:
     module = _load_ci_parallel_module()
-    ui_dir = tmp_path / "apps" / "ui"
-    ui_dir.mkdir(parents=True)
-    (ui_dir / "package-lock.json").write_text('{"lockfileVersion": 3}\n', encoding="utf-8")
-    (ui_dir / "node_modules").mkdir()
-
-    monkeypatch.setattr(module, "ROOT", tmp_path)
-    monkeypatch.setattr(module, "LOG_DIR", tmp_path / "logs")
-    monkeypatch.setattr(module, "UI_DIR", ui_dir)
+    ui_dir = _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=True)
     release_smoke_step = module.Step(
         "Release smoke validation",
         ["python3", "tools/tests/run_release_smoke.py"],
     )
     ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=ui_dir)
-    monkeypatch.setattr(
+    captured, outputs = _install_main_harness(
         module,
-        "_job_steps",
-        lambda python_cmd: {
+        monkeypatch,
+        tmp_path,
+        {
             "frontend-typecheck": [ui_step],
             "ui-smoke": [ui_step],
             "release-smoke": [release_smoke_step],
         },
     )
 
-    def _unexpected_bootstrap(_steps):
-        raise AssertionError("bootstrap should not run when the race guard exits early")
-
-    monkeypatch.setattr(module, "_run_bootstrap", _unexpected_bootstrap)
-    monkeypatch.setattr(
-        module,
-        "_ui_bootstrap_status",
-        lambda skip_npm_ci: module.UiBootstrapStatus(
-            needs_npm_ci=not skip_npm_ci,
-            lock_hash="lock",
-            current_lock_hash="",
-            node_modules_exists=True,
-        ),
-    )
-    monkeypatch.setattr(
-        module.sys,
-        "argv",
+    result = module.main(
         [
-            "run_ci_parallel.py",
             "--skip-bootstrap",
             "--job",
             "frontend-typecheck",
@@ -98,76 +144,73 @@ def test_main_refuses_skip_bootstrap_when_release_smoke_would_race_ui_jobs(
             "ui-smoke",
             "--job",
             "release-smoke",
-        ],
+        ]
     )
 
-    result = module.main()
-    output = capsys.readouterr().out
-
     assert result == 2
-    assert "release-smoke would trigger npm ci inside apps/ui" in output
+    assert "release-smoke would trigger npm ci inside apps/ui" in "\n".join(outputs)
+    assert "bootstrap_steps" not in captured
 
 
-def test_release_smoke_skip_ui_build_does_not_trigger_ui_race(monkeypatch) -> None:
+def test_main_allows_release_smoke_with_skip_ui_build_under_skip_bootstrap(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     module = _load_ci_parallel_module()
+    ui_dir = _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=True)
     release_smoke_step = module.Step(
         "Release smoke validation",
         ["python3", "tools/tests/run_release_smoke.py", "--skip-ui-build"],
     )
-    ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=module.UI_DIR)
-    jobs = {
-        "frontend-typecheck": [ui_step],
-        "release-smoke": [release_smoke_step],
-    }
-
-    monkeypatch.setattr(
+    ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=ui_dir)
+    captured, outputs = _install_main_harness(
         module,
-        "_ui_bootstrap_status",
-        lambda skip_npm_ci: module.UiBootstrapStatus(
-            needs_npm_ci=not skip_npm_ci,
-            lock_hash="lock",
-            current_lock_hash="",
-            node_modules_exists=True,
-        ),
+        monkeypatch,
+        tmp_path,
+        {
+            "frontend-typecheck": [ui_step],
+            "release-smoke": [release_smoke_step],
+        },
     )
 
-    assert not module._job_runs_release_smoke_ui_build([release_smoke_step])
-    assert not module._shared_ui_workspace_would_race(
-        ["frontend-typecheck", "release-smoke"],
-        jobs,
-        skip_bootstrap=True,
-        skip_npm_ci=False,
+    assert (
+        module.main(
+            [
+                "--skip-bootstrap",
+                "--job",
+                "frontend-typecheck",
+                "--job",
+                "release-smoke",
+            ]
+        )
+        == 0
     )
+    assert "refusing to run shared UI jobs" not in "\n".join(outputs)
+    assert captured["bootstrap_steps"] == []
 
 
-def test_ui_bootstrap_status_reads_shared_helper_json(monkeypatch, tmp_path: Path) -> None:
+def test_main_skips_ui_bootstrap_step_when_helper_reports_clean_workspace(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     module = _load_ci_parallel_module()
-    ui_dir = tmp_path / "apps" / "ui"
-    ui_dir.mkdir(parents=True)
-    helper_path = tmp_path / "tools" / "ui" / "ensure_ui_bootstrap.mjs"
-    helper_path.parent.mkdir(parents=True, exist_ok=True)
-    helper_path.write_text("// helper\n", encoding="utf-8")
-
-    monkeypatch.setattr(module, "UI_DIR", ui_dir)
-    monkeypatch.setattr(module, "UI_BOOTSTRAP_HELPER", helper_path)
-    monkeypatch.setattr(
-        module.subprocess,
-        "check_output",
-        lambda command, cwd, text: json.dumps(
-            {
-                "needs_npm_ci": True,
-                "lock_hash": "abc",
-                "current_lock_hash": "",
-                "node_modules_exists": False,
-            }
-        ),
+    ui_dir = _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(
+        monkeypatch,
+        module,
+        needs_npm_ci=False,
+        current_lock_hash="lock",
+        node_modules_exists=True,
+    )
+    ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=ui_dir)
+    captured, _outputs = _install_main_harness(
+        module,
+        monkeypatch,
+        tmp_path,
+        {"frontend-typecheck": [ui_step]},
     )
 
-    status = module._ui_bootstrap_status(False)
+    assert module.main(["--job", "frontend-typecheck"]) == 0
 
-    assert status == module.UiBootstrapStatus(
-        needs_npm_ci=True,
-        lock_hash="abc",
-        current_lock_hash="",
-        node_modules_exists=False,
-    )
+    assert all(step.label != "ui deps: ensure bootstrap" for step in captured["bootstrap_steps"])

--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -77,7 +77,7 @@ def test_main_falls_back_to_repo_walk_outside_git_checkout(
 
     monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
 
-    assert module.main() == 0
+    assert module.main([]) == 0
 
     stdout = capsys.readouterr().out
     assert "src/main.py" in stdout

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -1,10 +1,11 @@
-"""Guard backend test shard planning and cache observations."""
+"""Guard backend test shard planning and CLI-visible runner behavior."""
 
 from __future__ import annotations
 
 import importlib.util
 import sys
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 from tests._paths import REPO_ROOT
 
@@ -20,6 +21,30 @@ def _load_run_backend_parallel_module():
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _install_main_fakes(module, monkeypatch, tmp_path: Path) -> tuple[dict[str, object], list[str]]:
+    captured: dict[str, object] = {}
+    emitted: list[str] = []
+
+    monkeypatch.setattr(module, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(
+        module,
+        "collect_test_ids",
+        lambda _pytest_args: ["apps/server/tests/app/test_app_main.py::test_fast"],
+    )
+    monkeypatch.setattr(module, "_load_duration_cache", lambda _path: {})
+    monkeypatch.setattr(module, "_observed_durations_from_junit", lambda _path, _selected: {})
+    monkeypatch.setattr(module, "_emit", emitted.append)
+
+    def _fake_run(cmd: list[str], *, log_path: Path) -> int:
+        captured["cmd"] = list(cmd)
+        captured["log_path"] = log_path
+        log_path.write_text("$ fake pytest\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+    return captured, emitted
 
 
 def test_assign_shards_uses_cached_durations_by_file() -> None:
@@ -42,7 +67,7 @@ def test_assign_shards_uses_cached_durations_by_file() -> None:
     assert shards[1] == ["apps/server/tests/app/test_app_main.py"]
 
 
-def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path) -> None:
+def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path: Path) -> None:
     module = _load_run_backend_parallel_module()
     junit_path = tmp_path / "backend-shard.xml"
     root = ET.Element("testsuite")
@@ -76,38 +101,43 @@ def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path) -> No
     }
 
 
-def test_parse_args_defaults_to_single_shard(monkeypatch) -> None:
+def test_main_uses_default_single_shard_and_default_workers(monkeypatch, tmp_path: Path) -> None:
     module = _load_run_backend_parallel_module()
     monkeypatch.delenv(module._XDIST_WORKERS_ENV, raising=False)
-    monkeypatch.setattr(module.sys, "argv", ["run_backend_parallel.py"])
+    captured, emitted = _install_main_fakes(module, monkeypatch, tmp_path)
 
-    args = module._parse_args()
+    assert module.main([]) == 0
 
-    assert args.shards == 1
-    assert args.shard_index == 1
-    assert args.junitxml is None
-    assert args.xdist_workers == 3
+    assert captured["cmd"] == [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-n",
+        "3",
+        "--tb=short",
+        "--junitxml",
+        str(tmp_path / "backend-tests-1.xml"),
+        "apps/server/tests/app/test_app_main.py",
+    ]
+    assert any("running shard 1/1" in line for line in emitted)
 
 
-def test_parse_args_reads_xdist_workers_from_env(monkeypatch) -> None:
+def test_main_reads_xdist_workers_from_env(monkeypatch, tmp_path: Path) -> None:
     module = _load_run_backend_parallel_module()
-    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "3")
-    monkeypatch.setattr(module.sys, "argv", ["run_backend_parallel.py"])
+    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "5")
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
 
-    args = module._parse_args()
+    assert module.main([]) == 0
 
-    assert args.xdist_workers == 3
+    assert captured["cmd"][4:6] == ["-n", "5"]
 
 
-def test_parse_args_cli_overrides_env_xdist_workers(monkeypatch) -> None:
+def test_main_cli_overrides_env_xdist_workers(monkeypatch, tmp_path: Path) -> None:
     module = _load_run_backend_parallel_module()
-    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "3")
-    monkeypatch.setattr(
-        module.sys,
-        "argv",
-        ["run_backend_parallel.py", "--xdist-workers", "2"],
-    )
+    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "5")
+    captured, _emitted = _install_main_fakes(module, monkeypatch, tmp_path)
 
-    args = module._parse_args()
+    assert module.main(["--xdist-workers", "2"]) == 0
 
-    assert args.xdist_workers == 2
+    assert captured["cmd"][4:6] == ["-n", "2"]

--- a/apps/server/tests/hygiene/test_run_changed.py
+++ b/apps/server/tests/hygiene/test_run_changed.py
@@ -1,4 +1,4 @@
-"""Guard the heuristic changed-file test runner."""
+"""Guard the heuristic changed-file runner through CLI-visible behavior."""
 
 from __future__ import annotations
 
@@ -22,134 +22,225 @@ def _load_run_changed_module():
     return module
 
 
-def test_plan_commands_maps_backend_source_to_mirrored_test_dir() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(
-        ("apps/server/vibesensor/shared/boundaries/summary_fields/finding.py",)
-    )
-
-    assert commands == (
-        module.PlannedCommand(
-            "pytest",
-            (sys.executable, "-m", "pytest", "-q", "apps/server/tests/shared"),
-        ),
-    )
-
-
-def test_plan_commands_uses_changed_test_file_directly() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(
-        ("apps/server/tests/shared/boundaries/test_finding_roundtrip.py",)
-    )
-
-    assert commands == (
-        module.PlannedCommand(
-            "pytest",
-            (
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "apps/server/tests/shared/boundaries/test_finding_roundtrip.py",
-            ),
-        ),
-    )
-
-
-def test_plan_commands_uses_parent_dir_for_deleted_changed_test_file() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(
-        ("apps/server/tests/adapters/http/test_deleted_settings_endpoints.py",)
-    )
-
-    assert commands == (
-        module.PlannedCommand(
-            "pytest",
-            (
-                sys.executable,
-                "-m",
-                "pytest",
-                "-q",
-                "apps/server/tests/adapters/http",
-            ),
-        ),
-    )
-
-
-def test_plan_commands_combines_docs_ui_and_hygiene_checks() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(("README.md", "apps/ui/package.json", "Makefile"))
-
-    assert commands == (
-        module.PlannedCommand("docs-lint", ("make", "docs-lint")),
-        module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),
-        module.PlannedCommand(
-            "pytest",
-            (sys.executable, "-m", "pytest", "-q", "apps/server/tests/hygiene"),
-        ),
-    )
-
-
-def test_plan_commands_runs_ui_unit_tests_for_changed_ui_source_files() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(("apps/ui/src/ws_payload_validator.ts",))
-
-    assert commands == (
-        module.PlannedCommand("ui-test", ("make", "ui-test")),
-        module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),
-    )
-
-
-def test_plan_commands_keeps_non_source_ui_changes_on_typecheck_only() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(("apps/ui/package.json",))
-
-    assert commands == (module.PlannedCommand("ui-typecheck", ("make", "ui-typecheck")),)
-
-
-def test_plan_commands_falls_back_to_make_test_for_unmapped_backend_changes() -> None:
-    module = _load_run_changed_module()
-
-    commands = module._plan_commands(("apps/server/vibesensor/_version.py",))
-
-    assert commands == (module.PlannedCommand("backend-tests", ("make", "test")),)
-
-
-def test_changed_files_includes_committed_and_worktree_changes(monkeypatch) -> None:
-    module = _load_run_changed_module()
-    outputs = {
+def _git_outputs(
+    *,
+    committed: tuple[str, ...] = (),
+    staged: tuple[str, ...] = (),
+    unstaged: tuple[str, ...] = (),
+    untracked: tuple[str, ...] = (),
+) -> dict[tuple[str, ...], object]:
+    return {
         ("merge-base", "origin/main", "HEAD"): "abc123",
-        ("diff", "--name-only", "abc123..HEAD"): "docs/testing.md\n",
-        ("diff", "--name-only", "--cached"): "Makefile\n",
-        ("diff", "--name-only"): "CONTRIBUTING.md\n",
-        ("ls-files", "--others", "--exclude-standard"): "tools/tests/run_changed.py\n",
+        ("diff", "--name-only", "abc123..HEAD"): "\n".join(committed),
+        ("diff", "--name-only", "--cached"): "\n".join(staged),
+        ("diff", "--name-only"): "\n".join(unstaged),
+        ("ls-files", "--others", "--exclude-standard"): "\n".join(untracked),
     }
 
-    monkeypatch.setattr(module, "_git_output", lambda *args: outputs.get(args, ""))
 
-    assert module._changed_files("origin/main") == (
-        "CONTRIBUTING.md",
-        "Makefile",
-        "docs/testing.md",
-        "tools/tests/run_changed.py",
+def _install_git_state(
+    monkeypatch: pytest.MonkeyPatch,
+    module,
+    *,
+    outputs: dict[tuple[str, ...], object],
+    valid_refs: tuple[str, ...] = ("origin/main",),
+) -> None:
+    def _fake_run(command, **_kwargs):
+        assert command[:3] == ["git", "rev-parse", "--verify"]
+        ref = command[3]
+        return subprocess.CompletedProcess(command, 0 if ref in valid_refs else 1)
+
+    def _fake_check_output(command, **_kwargs):
+        assert command[0] == "git"
+        payload = outputs.get(tuple(command[1:]), "")
+        if isinstance(payload, BaseException):
+            raise payload
+        return payload
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(module.subprocess, "check_output", _fake_check_output)
+
+
+def _run_dry_run(
+    module,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    committed: tuple[str, ...] = (),
+    staged: tuple[str, ...] = (),
+    unstaged: tuple[str, ...] = (),
+    untracked: tuple[str, ...] = (),
+) -> str:
+    _install_git_state(
+        monkeypatch,
+        module,
+        outputs=_git_outputs(
+            committed=committed,
+            staged=staged,
+            unstaged=unstaged,
+            untracked=untracked,
+        ),
+    )
+    assert module.main(["--dry-run"]) == 0
+    return capsys.readouterr().out
+
+
+def test_main_dry_run_maps_backend_source_to_mirrored_test_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/server/vibesensor/shared/boundaries/summary_fields/finding.py",),
+    )
+
+    assert (
+        f"[test-changed] pytest: {sys.executable} -m pytest -q apps/server/tests/shared" in output
     )
 
 
-def test_changed_files_exits_cleanly_when_merge_base_is_missing(monkeypatch) -> None:
+def test_main_dry_run_uses_changed_test_file_directly(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     module = _load_run_changed_module()
 
-    def _raise_on_merge_base(*args: str) -> str:
-        if args == ("merge-base", "origin/main", "HEAD"):
-            raise subprocess.CalledProcessError(128, ("git", *args))
-        return ""
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/server/tests/shared/boundaries/test_finding_roundtrip.py",),
+    )
 
-    monkeypatch.setattr(module, "_git_output", _raise_on_merge_base)
+    assert (
+        f"{sys.executable} -m pytest -q apps/server/tests/shared/boundaries/"
+        "test_finding_roundtrip.py"
+    ) in output
+
+
+def test_main_dry_run_uses_parent_dir_for_deleted_changed_test_file(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/server/tests/adapters/http/test_deleted_settings_endpoints.py",),
+    )
+
+    assert f"{sys.executable} -m pytest -q apps/server/tests/adapters/http" in output
+
+
+def test_main_dry_run_combines_docs_ui_and_hygiene_checks(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("README.md", "apps/ui/package.json", "Makefile"),
+    )
+
+    assert "[test-changed] docs-lint: make docs-lint" in output
+    assert "[test-changed] ui-typecheck: make ui-typecheck" in output
+    assert (
+        f"[test-changed] pytest: {sys.executable} -m pytest -q apps/server/tests/hygiene" in output
+    )
+
+
+def test_main_dry_run_runs_ui_unit_tests_for_changed_ui_source_files(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/ui/src/ws_payload_validator.ts",),
+    )
+
+    assert "[test-changed] ui-test: make ui-test" in output
+    assert "[test-changed] ui-typecheck: make ui-typecheck" in output
+
+
+def test_main_dry_run_keeps_non_source_ui_changes_on_typecheck_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/ui/package.json",),
+    )
+
+    assert "[test-changed] ui-typecheck: make ui-typecheck" in output
+    assert "[test-changed] ui-test: make ui-test" not in output
+
+
+def test_main_dry_run_falls_back_to_make_test_for_unmapped_backend_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+
+    output = _run_dry_run(
+        module,
+        monkeypatch,
+        capsys,
+        committed=("apps/server/vibesensor/_version.py",),
+    )
+
+    assert "[test-changed] backend-tests: make test" in output
+
+
+def test_main_lists_committed_and_worktree_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_run_changed_module()
+    _install_git_state(
+        monkeypatch,
+        module,
+        outputs=_git_outputs(
+            committed=("docs/testing.md",),
+            staged=("Makefile",),
+            unstaged=("CONTRIBUTING.md",),
+            untracked=("tools/tests/run_changed.py",),
+        ),
+    )
+
+    assert module.main(["--dry-run"]) == 0
+    output = capsys.readouterr().out
+
+    assert "  - CONTRIBUTING.md" in output
+    assert "  - Makefile" in output
+    assert "  - docs/testing.md" in output
+    assert "  - tools/tests/run_changed.py" in output
+
+
+def test_main_exits_cleanly_when_merge_base_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_run_changed_module()
+    outputs = _git_outputs()
+    outputs[("merge-base", "origin/main", "HEAD")] = subprocess.CalledProcessError(
+        128,
+        ("git", "merge-base", "origin/main", "HEAD"),
+    )
+    _install_git_state(monkeypatch, module, outputs=outputs)
 
     with pytest.raises(SystemExit, match="Unable to find a common ancestor"):
-        module._changed_files("origin/main")
+        module.main(["--dry-run"])

--- a/apps/server/tests/hygiene/test_run_e2e_parallel.py
+++ b/apps/server/tests/hygiene/test_run_e2e_parallel.py
@@ -1,4 +1,4 @@
-"""Guard process-backed e2e shard runner behavior."""
+"""Guard process-backed e2e shard runner behavior without pinning helper names."""
 
 from __future__ import annotations
 
@@ -23,27 +23,39 @@ def _load_run_e2e_parallel_module():
     return module
 
 
-def test_build_shard_config_creates_isolated_runtime(monkeypatch, tmp_path: Path) -> None:
-    module = _load_run_e2e_parallel_module()
+def _install_main_fakes(
+    module,
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    collected: list[str] | None = None,
+    assigned: list[list[str]] | None = None,
+) -> tuple[dict[str, object], list[str]]:
     recorded: dict[str, object] = {}
-    shard_root = tmp_path / "shard-root"
-    runtime = module.IsolatedRuntimePaths(
-        root=shard_root,
-        data_dir=shard_root / "data",
-        rollback_dir=shard_root / "rollback",
-        config_path=shard_root / "shard-2.yaml",
-    )
+    emitted: list[str] = []
+    runtime_root = tmp_path / "runtime-root"
 
-    monkeypatch.setattr(module.tempfile, "mkdtemp", lambda prefix: str(shard_root))
+    monkeypatch.setattr(module, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(module, "_register_cleanup_hooks", lambda: None)
     monkeypatch.setattr(
         module,
-        "_track_active_runtime_root",
-        lambda path: recorded.setdefault("tracked", path),
+        "collect_test_ids",
+        lambda _pytest_args: collected or ["apps/server/tests_e2e/test_sample.py::test_alpha"],
     )
+    monkeypatch.setattr(module, "_load_duration_cache", lambda _path: {})
+    monkeypatch.setattr(module, "_observed_durations_from_junit", lambda _path, _selected: {})
+    monkeypatch.setattr(module, "_emit", emitted.append)
+    monkeypatch.setattr(module.tempfile, "mkdtemp", lambda prefix: str(runtime_root))
+    if assigned is not None:
+        monkeypatch.setattr(
+            module,
+            "_assign_shards_by_duration",
+            lambda _collected, _min_shards, _durations: assigned,
+        )
 
-    def fake_build_isolated_server_config(
+    def _fake_build_isolated_server_config(
         source_config: Path,
-        runtime_root: Path,
+        runtime_root_arg: Path,
         *,
         host: str,
         port: int,
@@ -52,9 +64,10 @@ def test_build_shard_config_creates_isolated_runtime(monkeypatch, tmp_path: Path
         config_name: str,
         data_seed_dir: Path | None,
     ):
+        runtime_root_arg.mkdir(parents=True, exist_ok=True)
         recorded["config_call"] = {
             "source_config": source_config,
-            "runtime_root": runtime_root,
+            "runtime_root": runtime_root_arg,
             "host": host,
             "port": port,
             "udp_data_port": udp_data_port,
@@ -62,36 +75,61 @@ def test_build_shard_config_creates_isolated_runtime(monkeypatch, tmp_path: Path
             "config_name": config_name,
             "data_seed_dir": data_seed_dir,
         }
-        return runtime
+        return module.IsolatedRuntimePaths(
+            root=runtime_root_arg,
+            data_dir=runtime_root_arg / "data",
+            rollback_dir=runtime_root_arg / "rollback",
+            config_path=runtime_root_arg / config_name,
+        )
 
-    monkeypatch.setattr(module, "build_isolated_server_config", fake_build_isolated_server_config)
+    monkeypatch.setattr(module, "build_isolated_server_config", _fake_build_isolated_server_config)
+    monkeypatch.setattr(module, "_run_shard_e2e", lambda *, config, marker: 0)
+    return recorded, emitted
 
-    config = module._build_shard_config(
-        source_config=Path("/tmp/base-config.yaml"),
-        shard_index=2,
-        shard_count=6,
-        tests=["apps/server/tests_e2e/test_sample.py::test_alpha"],
-        http_port_base=18020,
-        sim_data_port_base=19020,
-        sim_control_port_base=19120,
+
+def test_main_builds_isolated_runtime_for_selected_shard(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_run_e2e_parallel_module()
+    base_config = tmp_path / "base-config.yaml"
+    base_config.write_text("server:\n  port: 8000\n", encoding="utf-8")
+    recorded, emitted = _install_main_fakes(
+        module,
+        monkeypatch,
+        tmp_path,
+        assigned=[["apps/server/tests_e2e/test_sample.py::test_alpha"]],
     )
 
-    assert recorded["tracked"] == shard_root
+    assert (
+        module.main(
+            [
+                "--config",
+                str(base_config),
+                "--shards",
+                "1",
+                "--http-port-base",
+                "18020",
+                "--sim-data-port-base",
+                "19020",
+                "--sim-control-port-base",
+                "19120",
+            ]
+        )
+        == 0
+    )
+
     assert recorded["config_call"] == {
-        "source_config": Path("/tmp/base-config.yaml"),
-        "runtime_root": shard_root,
+        "source_config": base_config.resolve(),
+        "runtime_root": tmp_path / "runtime-root",
         "host": "127.0.0.1",
-        "port": 18021,
-        "udp_data_port": 19021,
-        "udp_control_port": 19121,
-        "config_name": "shard-2.yaml",
+        "port": 18020,
+        "udp_data_port": 19020,
+        "udp_control_port": 19120,
+        "config_name": "shard-1.yaml",
         "data_seed_dir": module._DEFAULT_DATA_SEED_DIR,
     }
-    assert config.http_port == 18021
-    assert config.sim_data_port == 19021
-    assert config.sim_control_port == 19121
-    assert config.sim_client_control_base == 9200
-    assert config.runtime == runtime
+    assert any("min requested: 1" in line for line in emitted)
 
 
 def test_assign_shards_uses_cached_durations() -> None:
@@ -174,25 +212,27 @@ def test_cleanup_active_processes_terminates_tracked_processes(monkeypatch) -> N
     process_a = object()
     process_b = object()
     module._ACTIVE_PROCESSES.clear()
-    module._track_active_process("shard-a-server", process_a)
-    module._track_active_process("shard-b-pytest", process_b)
-    monkeypatch.setattr(
-        module,
-        "terminate_subprocess",
-        lambda process: terminated.append(process),
-    )
+    try:
+        module._track_active_process("shard-a-server", process_a)
+        module._track_active_process("shard-b-pytest", process_b)
+        monkeypatch.setattr(
+            module,
+            "terminate_subprocess",
+            lambda process: terminated.append(process),
+        )
 
-    module._cleanup_active_processes()
+        module._cleanup_active_processes()
+    finally:
+        module._ACTIVE_PROCESSES.clear()
 
     assert terminated == [process_a, process_b]
-    assert module._ACTIVE_PROCESSES == {}
 
 
-def test_parse_args_defaults_to_six_shards(monkeypatch) -> None:
+def test_main_reports_default_min_shards_and_base_config(monkeypatch, tmp_path: Path) -> None:
     module = _load_run_e2e_parallel_module()
-    monkeypatch.setattr(module.sys, "argv", ["run_e2e_parallel.py"])
+    recorded, emitted = _install_main_fakes(module, monkeypatch, tmp_path)
 
-    args = module._parse_args()
+    assert module.main([]) == 0
 
-    assert args.shards == 6
-    assert args.config == module._DEFAULT_BASE_CONFIG
+    assert recorded["config_call"]["source_config"] == module._DEFAULT_BASE_CONFIG.resolve()
+    assert any("min requested: 6" in line for line in emitted)

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -233,7 +233,7 @@ def _write_empty_junit(path: Path) -> None:
     ET.ElementTree(testsuite).write(path, encoding="utf-8", xml_declaration=True)
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run a duration-balanced shard of apps/server/tests."
     )
@@ -263,7 +263,7 @@ def _parse_args() -> argparse.Namespace:
             f"{_XDIST_WORKERS_ENV} or {_DEFAULT_XDIST_WORKERS}."
         ),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
     if not 1 <= args.shard_index <= args.shards:
@@ -273,8 +273,8 @@ def _parse_args() -> argparse.Namespace:
     return args
 
 
-def main() -> int:
-    args = _parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     collected = collect_test_ids(["apps/server/tests"])

--- a/tools/tests/run_changed.py
+++ b/tools/tests/run_changed.py
@@ -192,7 +192,7 @@ def _run_planned_commands(commands: tuple[PlannedCommand, ...]) -> int:
     return 0
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--base-ref",
@@ -203,7 +203,7 @@ def main() -> int:
         action="store_true",
         help="Print the selected commands without running them.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     base_ref = _resolve_base_ref(args.base_ref)
     changed_files = _changed_files(base_ref)

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -286,7 +286,7 @@ def _run_bootstrap(steps: list[Step]) -> int:
     return 0
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Run local CI-equivalent checks with the same command groups as .github/workflows/ci.yml, "
@@ -314,7 +314,7 @@ def main() -> int:
         action="store_true",
         help="Skip npm ci bootstrap even when node_modules is missing.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.job and args.ci_lite:
         parser.error("--ci-lite cannot be combined with --job")
 

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -608,7 +608,7 @@ def _shard_worker(
             )
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run process-backed e2e tests in isolated parallel shards."
     )
@@ -652,14 +652,14 @@ def _parse_args() -> argparse.Namespace:
         default=19120,
         help="Base host simulator UDP control port; shard N uses base + (N-1).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
     return args
 
 
-def main() -> int:
-    args = _parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     _register_cleanup_hooks()
 


### PR DESCRIPTION
Closes #3400

## What changed
- added optional `argv` parameters to the local tooling runners so tests can drive their real `main(...)` entrypoints directly
- rewrote the hot-spot hygiene tests for `run_changed`, `run_backend_parallel`, `run_e2e_parallel`, and `run_ci_parallel` around CLI-visible behavior instead of direct `_plan_commands()` / `_changed_files()` / `_parse_args()` / `_build_shard_config()` / `_bootstrap_steps()` / `_ui_bootstrap_status()` calls
- kept the stable shard-balancing and JUnit-duration parsing seams as direct unit tests, and tightened the adjacent `loc_check` test to call `main([])` so the broader hygiene suite stays deterministic under pytest

## Why
- these tooling tests were pinned to helper names and internal wiring, so harmless runner refactors caused churn
- the issue asks for black-box or near-black-box coverage around exit codes, stdout, selected commands, bootstrap decisions, and artifact/config outputs

## Validation
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py`
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/hygiene`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- these tests now pin less helper decomposition, so the intentionally retained direct coverage is limited to the stable duration/path-selection and parser seams that still carry real value
