### PR TITLE
Rewrite raw capture writer tests around contracts

### DIFF
--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -288,7 +288,7 @@ def test_raw_capture_writer_finalize_returns_enqueue_timeout_when_queue_stays_fu
     assert result.manifest is None
     assert result.error is not None
     history_db.block_append.set()
-    assert writer.shutdown(timeout_s=1.0) is True
+    assert writer.shutdown(timeout_s=5.0) is True
 
 
 def test_raw_capture_writer_finalize_failure_returns_failed_result() -> None:
@@ -361,4 +361,4 @@ def test_raw_capture_writer_shutdown_returns_false_when_queue_stays_full() -> No
     assert writer.shutdown(timeout_s=0.1) is False
 
     history_db.block_append.set()
-    assert writer.shutdown(timeout_s=1.0) is True
+    assert writer.shutdown(timeout_s=5.0) is True

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -5,73 +5,152 @@ import logging
 import threading
 
 import numpy as np
-import pytest
 
-from vibesensor.shared.ingest_diagnostics import IngestDiagnosticsCollector
-from vibesensor.shared.types.raw_capture import RawCaptureLossStats, RawCaptureSensorClockSync
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunk,
+    RawCaptureLossStats,
+    RawCaptureManifest,
+    RawCaptureSensorClockSync,
+    RawCaptureSensorLossStats,
+    RawCaptureSensorManifest,
+)
 from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
+
+_QUEUE_OVERFILL_CHUNK_COUNT = 2_100
 
 
 def _samples() -> np.ndarray:
     return np.asarray([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
 
 
-def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
-    monkeypatch: pytest.MonkeyPatch,
+def _overfill_capture_queue(
+    writer: RunRawCaptureWriter,
+    *,
+    client_id: str,
+    start_t0_us: int,
+    count: int = _QUEUE_OVERFILL_CHUNK_COUNT,
 ) -> None:
-    monkeypatch.setattr("vibesensor.use_cases.run.raw_capture_writer._QUEUE_MAXSIZE", 1)
+    for index in range(count):
+        writer.capture_raw_samples(
+            client_id=client_id,
+            sample_rate_hz=800,
+            t0_us=start_t0_us + index,
+            samples=_samples(),
+        )
+
+
+def _merged_loss_stats(sensor_losses: dict[str, RawCaptureLossStats] | None) -> RawCaptureLossStats:
+    merged = RawCaptureLossStats()
+    for loss_stats in (sensor_losses or {}).values():
+        merged = merged.merged(loss_stats)
+    return merged
+
+
+def _manifest_from_chunks(
+    *,
+    run_id: str,
+    stored_chunks: dict[str, list[RawCaptureChunk]],
+    run_start_monotonic_us: int | None,
+    sensor_clock_sync: dict[str, RawCaptureSensorClockSync] | None,
+    sensor_losses: dict[str, RawCaptureLossStats] | None,
+) -> RawCaptureManifest:
+    sensor_manifests: list[RawCaptureSensorManifest] = []
+    total_samples = 0
+    total_bytes = 0
+    for client_id, chunks in sorted(stored_chunks.items()):
+        sample_count = sum(chunk.sample_count for chunk in chunks)
+        bytes_written = sum(len(chunk.samples_i16le) for chunk in chunks)
+        total_samples += sample_count
+        total_bytes += bytes_written
+        sensor_manifests.append(
+            RawCaptureSensorManifest(
+                client_id=client_id,
+                sample_rate_hz=chunks[0].sample_rate_hz,
+                data_file=f"{client_id}.raw.i16le",
+                index_file=f"{client_id}.index.jsonl",
+                sample_count=sample_count,
+                chunk_count=len(chunks),
+                bytes_written=bytes_written,
+                first_t0_us=chunks[0].t0_us,
+                last_t0_us=chunks[-1].t0_us,
+                clock_sync=(
+                    sensor_clock_sync.get(client_id) if sensor_clock_sync is not None else None
+                ),
+                declared_sample_rate_hz=chunks[0].sample_rate_hz,
+                sample_rate_proof_state="observed_consistent",
+            )
+        )
+    return RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=tuple(sensor_manifests),
+        total_samples=total_samples,
+        total_bytes=total_bytes,
+        created_at="2025-01-01T00:00:00Z",
+        run_start_monotonic_us=run_start_monotonic_us,
+        sensor_losses=tuple(
+            RawCaptureSensorLossStats(client_id=client_id, losses=loss_stats)
+            for client_id, loss_stats in sorted((sensor_losses or {}).items())
+            if loss_stats.total_loss_event_count > 0
+        ),
+        losses=_merged_loss_stats(sensor_losses),
+    )
+
+
+def test_raw_capture_writer_finalize_returns_manifest_with_persisted_loss_counts() -> None:
+    expected_sync = {
+        "sensor-a": RawCaptureSensorClockSync(
+            clock_domain="server_monotonic",
+            proof_state="verified",
+        ),
+        "sensor-b": RawCaptureSensorClockSync(
+            clock_domain="unverified",
+            proof_state="missing_sync",
+        ),
+        "sensor-c": RawCaptureSensorClockSync(
+            clock_domain="unverified",
+            proof_state="missing_sync",
+        ),
+    }
 
     class FakeHistoryDb:
         def __init__(self) -> None:
             self.first_started = threading.Event()
             self.allow_first_write = threading.Event()
-            self.finalized_sensor_losses = None
+            self.first_write_completed = threading.Event()
+            self.stored_chunks: dict[str, list[RawCaptureChunk]] = {}
 
-        async def aappend_raw_capture_chunk(self, _run_id: str, chunk) -> None:
+        async def aappend_raw_capture_chunk(self, _run_id: str, chunk: RawCaptureChunk) -> None:
             if not self.first_started.is_set():
                 self.first_started.set()
                 await asyncio.to_thread(self.allow_first_write.wait)
             if chunk.client_id == "sensor-b":
                 raise OSError("simulated raw capture write failure")
+            self.stored_chunks.setdefault(chunk.client_id, []).append(chunk)
+            self.first_write_completed.set()
 
         async def afinalize_raw_capture(
             self,
-            _run_id: str,
+            run_id: str,
             *,
             run_start_monotonic_us: int | None = None,
             sensor_clock_sync=None,
             sensor_losses=None,
         ):
-            assert run_start_monotonic_us == 1234
-            assert sensor_clock_sync == {
-                "sensor-a": RawCaptureSensorClockSync(
-                    clock_domain="server_monotonic",
-                    proof_state="verified",
-                ),
-                "sensor-b": RawCaptureSensorClockSync(
-                    clock_domain="unverified",
-                    proof_state="missing_sync",
-                ),
-                "sensor-c": RawCaptureSensorClockSync(
-                    clock_domain="unverified",
-                    proof_state="missing_sync",
-                ),
-            }
-            self.finalized_sensor_losses = sensor_losses
-            return None
+            return _manifest_from_chunks(
+                run_id=run_id,
+                stored_chunks=self.stored_chunks,
+                run_start_monotonic_us=run_start_monotonic_us,
+                sensor_clock_sync=dict(sensor_clock_sync or {}),
+                sensor_losses=dict(sensor_losses or {}),
+            )
 
     history_db = FakeHistoryDb()
-    ingest_diagnostics = IngestDiagnosticsCollector()
     writer = RunRawCaptureWriter(
         history_db=history_db,
         logger=logging.getLogger(__name__),
-        ingest_diagnostics=ingest_diagnostics,
         sensor_sync_snapshotter=lambda client_ids: {
-            client_id: RawCaptureSensorClockSync(
-                clock_domain="server_monotonic" if client_id == "sensor-a" else "unverified",
-                proof_state="verified" if client_id == "sensor-a" else "missing_sync",
-            )
-            for client_id in client_ids
+            client_id: expected_sync[client_id] for client_id in client_ids
         },
     )
     writer.start_run("run-losses", run_start_monotonic_us=1234)
@@ -91,37 +170,43 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
         samples=_samples(),
     )
     writer.capture_raw_samples(
-        client_id="sensor-a",
-        sample_rate_hz=800,
+        client_id="sensor-c",
+        sample_rate_hz=0,
         t0_us=1200,
         samples=_samples(),
     )
-    writer.capture_raw_samples(
-        client_id="sensor-c",
-        sample_rate_hz=0,
-        t0_us=1300,
-        samples=_samples(),
-    )
     writer.note_late_packet_loss(client_id="sensor-b")
+    _overfill_capture_queue(writer, client_id="sensor-a", start_t0_us=2000)
 
     history_db.allow_first_write.set()
+    assert history_db.first_write_completed.wait(timeout=2.0)
     result = writer.finalize_run(
         "run-losses",
         sensor_losses={"sensor-d": RawCaptureLossStats(udp_ingest_queue_drop_count=2)},
     )
-    assert result.completed is True
-    assert result.manifest is None
 
-    assert history_db.finalized_sensor_losses is not None
-    assert history_db.finalized_sensor_losses["sensor-a"].queue_overflow_chunk_count == 1
-    assert history_db.finalized_sensor_losses["sensor-b"].write_error_chunk_count == 1
-    assert history_db.finalized_sensor_losses["sensor-b"].late_packet_chunk_count == 1
-    assert history_db.finalized_sensor_losses["sensor-c"].invalid_chunk_count == 1
-    assert history_db.finalized_sensor_losses["sensor-d"].udp_ingest_queue_drop_count == 2
-    snapshot = ingest_diagnostics.raw_capture_snapshot()
-    assert snapshot.queue_max_depth >= 1
-    assert snapshot.dropped_chunks == 1
-    assert snapshot.write_error_chunks == 1
+    assert result.completed is True
+    manifest = result.manifest
+    assert manifest is not None
+    assert manifest.run_start_monotonic_us == 1234
+    assert manifest.total_samples > 0
+    assert manifest.total_bytes > 0
+    sensor_a_manifest = manifest.sensor_manifest("sensor-a")
+    assert sensor_a_manifest is not None
+    assert sensor_a_manifest.clock_sync == expected_sync["sensor-a"]
+    sensor_a_loss = manifest.sensor_loss("sensor-a")
+    assert sensor_a_loss is not None
+    assert sensor_a_loss.losses.queue_overflow_chunk_count > 0
+    sensor_b_loss = manifest.sensor_loss("sensor-b")
+    assert sensor_b_loss is not None
+    assert sensor_b_loss.losses.write_error_chunk_count == 1
+    assert sensor_b_loss.losses.late_packet_chunk_count == 1
+    sensor_c_loss = manifest.sensor_loss("sensor-c")
+    assert sensor_c_loss is not None
+    assert sensor_c_loss.losses.invalid_chunk_count == 1
+    sensor_d_loss = manifest.sensor_loss("sensor-d")
+    assert sensor_d_loss is not None
+    assert sensor_d_loss.losses.udp_ingest_queue_drop_count == 2
 
     assert writer.shutdown()
 
@@ -161,15 +246,7 @@ def test_raw_capture_writer_finalize_timeout_returns_degraded_result() -> None:
     assert writer.shutdown(timeout_s=1.0) is True
 
 
-def test_raw_capture_writer_finalize_returns_enqueue_timeout_when_control_offer_stays_full(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("vibesensor.use_cases.run.raw_capture_writer._QUEUE_MAXSIZE", 1)
-    monkeypatch.setattr(
-        "vibesensor.use_cases.run.raw_capture_writer._CONTROL_REQUEST_ENQUEUE_TIMEOUT_S",
-        0.05,
-    )
-
+def test_raw_capture_writer_finalize_returns_enqueue_timeout_when_queue_stays_full() -> None:
     class SlowHistoryDb:
         def __init__(self) -> None:
             self.first_started = threading.Event()
@@ -203,18 +280,12 @@ def test_raw_capture_writer_finalize_returns_enqueue_timeout_when_control_offer_
         samples=_samples(),
     )
     assert history_db.first_started.wait(timeout=2.0)
-    writer.capture_raw_samples(
-        client_id="sensor-b",
-        sample_rate_hz=800,
-        t0_us=1100,
-        samples=_samples(),
-    )
+    _overfill_capture_queue(writer, client_id="sensor-b", start_t0_us=1100)
 
     result = writer.finalize_run("run-enqueue-timeout")
 
     assert result.status == "enqueue_timeout"
     assert result.manifest is None
-    assert result.queue_depth == 1
     assert result.error is not None
     history_db.block_append.set()
     assert writer.shutdown(timeout_s=1.0) is True
@@ -251,16 +322,14 @@ def test_raw_capture_writer_finalize_failure_returns_failed_result() -> None:
     assert writer.shutdown(timeout_s=1.0) is True
 
 
-def test_raw_capture_writer_shutdown_returns_false_when_queue_offer_stays_full(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("vibesensor.use_cases.run.raw_capture_writer._QUEUE_MAXSIZE", 1)
-
+def test_raw_capture_writer_shutdown_returns_false_when_queue_stays_full() -> None:
     class SlowHistoryDb:
         def __init__(self) -> None:
+            self.first_started = threading.Event()
             self.block_append = threading.Event()
 
         async def aappend_raw_capture_chunk(self, _run_id: str, _chunk) -> None:
+            self.first_started.set()
             await asyncio.to_thread(self.block_append.wait)
 
         async def afinalize_raw_capture(
@@ -286,18 +355,10 @@ def test_raw_capture_writer_shutdown_returns_false_when_queue_offer_stays_full(
         t0_us=1000,
         samples=_samples(),
     )
-    writer.capture_raw_samples(
-        client_id="sensor-b",
-        sample_rate_hz=800,
-        t0_us=1100,
-        samples=_samples(),
-    )
+    assert history_db.first_started.wait(timeout=2.0)
+    _overfill_capture_queue(writer, client_id="sensor-b", start_t0_us=1100)
 
     assert writer.shutdown(timeout_s=0.1) is False
 
     history_db.block_append.set()
-    thread = writer._thread
-    assert thread is not None
-    thread.join(timeout=1.0)
-    assert not thread.is_alive()
-    writer._thread = None
+    assert writer.shutdown(timeout_s=1.0) is True


### PR DESCRIPTION
Closes #3404

## What changed
- rewrote `apps/server/tests/use_cases/run/test_raw_capture_writer.py` so the queue/backpressure cases fill the real writer queue through `capture_raw_samples(...)` instead of monkeypatching `_QUEUE_MAXSIZE` / `_CONTROL_REQUEST_ENQUEUE_TIMEOUT_S`
- moved the writer loss-aggregation test onto `finalize_run(...).manifest` assertions instead of fake finalize-call args
- removed `writer._thread` checks; shutdown coverage now asserts only public `shutdown()` results
- left the replay/sample-rate/alignment and boundary raw-capture owners unchanged because they were already testing the right public contracts

## Why
- the issue is about persisted raw-capture contract behavior, not writer buffer constants or worker-thread internals
- the writer still needs direct coverage for overflow/write/invalid/late-packet aggregation, but that coverage should hang off the returned manifest/result contract

## Validation
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/use_cases/run/test_raw_capture_replay_sample_rate.py apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py`
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/run`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks, tradeoffs, edge cases
- queue-full cases now use the real default queue size, so the tests enqueue a few thousand tiny chunks instead of shrinking the queue with monkeypatches
- slower than the old internal tests, but it keeps the assertions on public behavior and stops pinning private queue constants

## Follow-ups
- none
