### PR TITLE
Rewrite Wi-Fi update tests around outcomes

### DIFF
--- a/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
+++ b/apps/server/tests/use_cases/updates/_update_manager_test_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+from collections import deque
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -32,10 +33,18 @@ class FakeRunner(CommandRunner):
     def __init__(self) -> None:
         self.calls: list[tuple[list[str], dict]] = []
         self.responses: list[tuple[str, tuple[int, str, str]]] = []
+        self.response_sequences: list[tuple[str, deque[tuple[int, str, str]]]] = []
         self.default_response: tuple[int, str, str] = (0, "", "")
 
     def set_response(self, match_substr: str, rc: int, stdout: str = "", stderr: str = "") -> None:
         self.responses.append((match_substr, (rc, stdout, stderr)))
+
+    def set_response_sequence(
+        self,
+        match_substr: str,
+        *responses: tuple[int, str, str],
+    ) -> None:
+        self.response_sequences.append((match_substr, deque(responses)))
 
     async def run(
         self,
@@ -46,6 +55,9 @@ class FakeRunner(CommandRunner):
     ) -> tuple[int, str, str]:
         self.calls.append((list(args), {"timeout": timeout, "env": env}))
         joined = " ".join(args)
+        for match_substr, response_queue in self.response_sequences:
+            if match_substr in joined and response_queue:
+                return response_queue.popleft()
         for match_substr, response in self.responses:
             if match_substr in joined:
                 return response
@@ -116,15 +128,6 @@ async def cancel_task(mgr: UpdateManager) -> None:
         mgr.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await task
-
-
-def assert_hotspot_restored(runner: FakeRunner) -> None:
-    restore_calls = [
-        call
-        for call in runner.calls
-        if "VibeSensor-AP" in " ".join(call[0]) and "up" in " ".join(call[0])
-    ]
-    assert len(restore_calls) > 0
 
 
 async def run_update(

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from _update_manager_test_helpers import (
-    assert_hotspot_restored,
     make_mock_release,
     patch_release_fetcher,
     patch_validation_environment,
@@ -54,6 +53,10 @@ def _build_fake_wheel(path, *, version: str) -> bytes:
         )
         wheel_zip.writestr(f"{dist_info}/WHEEL", "Wheel-Version: 1.0\nTag: py3-none-any\n")
     return path.read_bytes()
+
+
+def _assert_hotspot_restore_logged(manager: UpdateManager) -> None:
+    assert any("Hotspot restored on attempt" in line for line in manager.status.log_tail)
 
 
 def _build_manager_with_cancellation_cleanup(
@@ -125,7 +128,7 @@ class TestUpdateManagerAsync:
             for call in runner.calls
             if "pip" in " ".join(call[0]) and "install" in " ".join(call[0])
         ]
-        assert_hotspot_restored(runner)
+        _assert_hotspot_restore_logged(manager)
         fw_mod = "vibesensor.use_cases.updates.firmware.firmware_cache"
         firmware_refresh_calls = [call[0] for call in runner.calls if fw_mod in " ".join(call[0])]
         assert firmware_refresh_calls
@@ -178,33 +181,23 @@ class TestUpdateManagerAsync:
         )
         await run_update(manager, "BadNet", "wrong")
         assert manager.status.state == UpdateState.failed
-        assert_hotspot_restored(runner)
+        _assert_hotspot_restore_logged(manager)
 
     async def test_wifi_ssid_not_found_retries_then_succeeds(self, tmp_path) -> None:
         with (
             patch_release_fetcher() as fetcher,
-            patch(
-                "vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep",
-                new=AsyncMock(return_value=None),
-            ),
+            patch("vibesensor.use_cases.updates.wifi.wifi_config.UPLINK_RESCAN_DELAY_S", 0.0),
         ):
             manager, runner, _ = setup_update_env(
                 tmp_path,
                 seed_artifacts=True,
                 server_release_fetcher=fetcher,
             )
-            original_run = runner.run
-            connect_calls = {"count": 0}
-
-            async def run_with_retry(args, *, timeout=30, env=None):
-                joined = " ".join(args)
-                if "connection up VibeSensor-Uplink" in joined:
-                    connect_calls["count"] += 1
-                    if connect_calls["count"] == 1:
-                        return (10, "", "Error: No network with SSID 'TestNet' found.\n")
-                return await original_run(args, timeout=timeout, env=env)
-
-            runner.run = run_with_retry
+            runner.set_response_sequence(
+                "connection up VibeSensor-Uplink",
+                (10, "", "Error: No network with SSID 'TestNet' found.\n"),
+                (0, "", ""),
+            )
             fetcher.find_latest_release.return_value = make_mock_release()
             manager.start("TestNet", "pass123")
             task = manager.job_task
@@ -212,7 +205,7 @@ class TestUpdateManagerAsync:
             await asyncio.wait_for(task, timeout=10)
 
         assert manager.status.state == UpdateState.success
-        assert connect_calls["count"] >= 2
+        assert any("rescanning and retrying" in line for line in manager.status.log_tail)
 
     async def test_dns_not_ready_fails_with_clear_issue(self, tmp_path) -> None:
         with (
@@ -230,31 +223,26 @@ class TestUpdateManagerAsync:
         assert manager.status.state == UpdateState.failed
 
     async def test_dns_probe_retries_then_update_continues(self, tmp_path) -> None:
-        probe_attempts = {"count": 0}
         with (
             patch_release_fetcher() as fetcher,
-            patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_READY_MIN_WAIT_S", 0.2),
-            patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_RETRY_INTERVAL_S", 0.01),
+            patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_READY_MIN_WAIT_S", 1.0),
+            patch("vibesensor.use_cases.updates.wifi.wifi_config.DNS_RETRY_INTERVAL_S", 0.0),
         ):
             manager, runner, _ = setup_update_env(
                 tmp_path,
                 seed_artifacts=True,
                 server_release_fetcher=fetcher,
             )
-            original_run = runner.run
-
-            async def run_with_dns_retry(args, *, timeout=30, env=None):
-                if "socket.getaddrinfo" in " ".join(args):
-                    probe_attempts["count"] += 1
-                    if probe_attempts["count"] < 3:
-                        return (1, "", "Temporary failure in name resolution")
-                return await original_run(args, timeout=timeout, env=env)
-
-            runner.run = run_with_dns_retry
+            runner.set_response_sequence(
+                "socket.getaddrinfo",
+                (1, "", "Temporary failure in name resolution"),
+                (1, "", "Temporary failure in name resolution"),
+                (0, "", ""),
+            )
             await run_update(manager)
 
         assert manager.status.state == UpdateState.success
-        assert probe_attempts["count"] >= 3
+        assert any("DNS probe succeeded on attempt 3" in line for line in manager.status.log_tail)
 
     async def test_secure_ssid_requires_password(self, tmp_path) -> None:
         manager, runner, _ = setup_update_env(tmp_path)
@@ -262,18 +250,18 @@ class TestUpdateManagerAsync:
         await run_update(manager, "Pim", "")
         assert manager.status.state == UpdateState.failed
 
-    async def test_password_is_applied_via_connection_modify(self, tmp_path) -> None:
+    async def test_password_configuration_failure_fails_update(self, tmp_path) -> None:
         with patch_release_fetcher() as fetcher:
             manager, runner, _ = setup_update_env(
                 tmp_path,
                 seed_artifacts=True,
                 server_release_fetcher=fetcher,
             )
+            runner.set_response("wifi-sec.psk", 10, "", "failed to set Wi-Fi credentials")
             await run_update(manager, "Pim", "tomaat123")
+        assert manager.status.state == UpdateState.failed
         assert any(
-            "connection modify VibeSensor-Uplink "
-            "wifi-sec.key-mgmt wpa-psk wifi-sec.psk" in " ".join(call[0])
-            for call in runner.calls
+            issue.message == "Failed to set Wi-Fi credentials" for issue in manager.status.issues
         )
 
     async def test_download_failure_still_restores_hotspot(self, tmp_path) -> None:
@@ -287,7 +275,7 @@ class TestUpdateManagerAsync:
             fetcher.download_wheel.side_effect = OSError("Network error")
             await run_update(manager, "TestNet", "pass")
         assert manager.status.state == UpdateState.failed
-        assert_hotspot_restored(runner)
+        _assert_hotspot_restore_logged(manager)
 
     async def test_install_failure_triggers_rollback(self, tmp_path) -> None:
         with patch_release_fetcher(current_version="2025.6.14") as fetcher:
@@ -365,7 +353,7 @@ class TestUpdateManagerAsync:
             if "pip" in " ".join(call[0]) and "install" in " ".join(call[0])
         ]
         assert not pip_calls
-        assert_hotspot_restored(runner)
+        _assert_hotspot_restore_logged(manager)
 
     async def test_password_never_in_logs(self, tmp_path) -> None:
         secret = "SuperSecret!Password#2024"

--- a/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
@@ -10,22 +9,21 @@ from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
-from vibesensor.use_cases.updates.wifi.wifi_config import (
-    HOTSPOT_RESTORE_RETRIES,
-    build_default_wifi_config,
-)
+from vibesensor.use_cases.updates.wifi.wifi_config import build_default_wifi_config
 from vibesensor.use_cases.updates.wifi.wifi_hotspot_recovery import UpdateHotspotRecovery
 
 
 def _build_recovery(
     tmp_path: Path,
     *,
-    delay_s: float = 0.01,
+    restore_retries: int = 3,
+    delay_s: float = 0.0,
 ) -> tuple[UpdateHotspotRecovery, FakeRunner, UpdateStatusTracker]:
     runner = FakeRunner()
     status = build_update_status_harness(tmp_path / "state.json")
     config = replace(
         build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
+        hotspot_restore_retries=restore_retries,
         hotspot_restore_delay_s=delay_s,
     )
     commands = UpdateCommandExecutor(runner=runner)
@@ -50,71 +48,31 @@ async def test_stop_hotspot_returns_true_when_nmcli_reports_inactive(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_cleanup_uplink_downs_then_deletes_connection(tmp_path: Path) -> None:
-    recovery, runner, _tracker = _build_recovery(tmp_path)
-
-    await recovery.cleanup_uplink()
-
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert "connection down VibeSensor-Uplink" in commands[0]
-    assert "connection delete VibeSensor-Uplink" in commands[1]
-
-
-@pytest.mark.asyncio
-async def test_restore_hotspot_retries_then_succeeds(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_restore_hotspot_retries_then_succeeds(tmp_path: Path) -> None:
     recovery, runner, tracker = _build_recovery(tmp_path)
-    original_run = runner.run
-    restore_attempts = {"count": 0}
-
-    async def flaky_restore(args, *, timeout=30, env=None):
-        joined = " ".join(args)
-        if "connection up VibeSensor-AP" in joined:
-            restore_attempts["count"] += 1
-            if restore_attempts["count"] < 3:
-                return (10, "", "failed")
-        return await original_run(args, timeout=timeout, env=env)
-
-    runner.run = flaky_restore
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr(
-        "vibesensor.use_cases.updates.wifi.wifi_hotspot_recovery.asyncio.sleep",
-        sleep,
+    runner.set_response_sequence(
+        "connection up VibeSensor-AP",
+        (10, "", "failed"),
+        (10, "", "failed"),
+        (0, "", ""),
     )
 
     assert await recovery.restore_hotspot() is True
-    assert restore_attempts["count"] == 3
-    assert sleep.await_count == 2
     assert any("Hotspot restored on attempt 3" in line for line in tracker.status.log_tail)
-
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert "connection down VibeSensor-Uplink" in commands[0]
-    assert "connection delete VibeSensor-Uplink" in commands[1]
-    assert "connection up VibeSensor-AP" in commands[2]
 
 
 @pytest.mark.asyncio
-async def test_restore_hotspot_exhausts_retries_and_records_issue(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    recovery, runner, tracker = _build_recovery(tmp_path)
+async def test_restore_hotspot_exhausts_retries_and_records_issue(tmp_path: Path) -> None:
+    recovery, runner, tracker = _build_recovery(tmp_path, restore_retries=2)
     runner.set_response("connection up VibeSensor-AP", 10, "", "failed")
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr(
-        "vibesensor.use_cases.updates.wifi.wifi_hotspot_recovery.asyncio.sleep",
-        sleep,
-    )
 
     assert await recovery.restore_hotspot() is False
-    assert sleep.await_count == HOTSPOT_RESTORE_RETRIES - 1
     assert any(
         issue.phase == "restoring_hotspot"
         and issue.message == "Failed to restore hotspot after retries"
         for issue in tracker.status.issues
     )
+    assert any("Hotspot restore attempt" in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio
@@ -131,8 +89,4 @@ async def test_restore_hotspot_still_attempts_ap_recovery_after_cleanup_failure(
         for line in tracker.status.log_tail
     )
     assert any("down failed" in line for line in tracker.status.log_tail)
-
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert "connection down VibeSensor-Uplink" in commands[0]
-    assert "connection delete VibeSensor-Uplink" in commands[1]
-    assert "connection up VibeSensor-AP" in commands[2]
+    assert any("Hotspot restored on attempt 1" in line for line in tracker.status.log_tail)

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport.failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.transport.uplink_readiness import UpdateUplinkReadiness
 from vibesensor.use_cases.updates.wifi.wifi_config import build_default_wifi_config
@@ -19,7 +19,7 @@ def _build_readiness(
     *,
     dns_ready_min_wait_s: float = 0.05,
     dns_retry_interval_s: float = 0.01,
-) -> tuple[UpdateUplinkReadiness, FakeRunner]:
+) -> tuple[UpdateUplinkReadiness, FakeRunner, UpdateStatusTracker]:
     runner = FakeRunner()
     status = build_update_status_harness(tmp_path / "state.json")
     config = replace(
@@ -33,42 +33,31 @@ def _build_readiness(
         status=status,
         config=config,
     )
-    return readiness, runner
+    return readiness, runner, status
 
 
 @pytest.mark.asyncio
-async def test_wait_for_dns_ready_retries_then_succeeds(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    readiness, runner = _build_readiness(tmp_path, dns_ready_min_wait_s=1.0)
-    original_run = runner.run
-    probe_attempts = {"count": 0}
-
-    async def flaky_probe(args, *, timeout=30, env=None):
-        joined = " ".join(args)
-        if "socket.getaddrinfo" in joined:
-            probe_attempts["count"] += 1
-            if probe_attempts["count"] < 3:
-                return (1, "", "Temporary failure in name resolution")
-        return await original_run(args, timeout=timeout, env=env)
-
-    runner.run = flaky_probe
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr(
-        "vibesensor.use_cases.updates.transport.uplink_readiness.asyncio.sleep",
-        sleep,
+async def test_wait_for_dns_ready_retries_then_succeeds(tmp_path: Path) -> None:
+    readiness, runner, tracker = _build_readiness(
+        tmp_path,
+        dns_ready_min_wait_s=1.0,
+        dns_retry_interval_s=0.0,
+    )
+    runner.set_response_sequence(
+        "socket.getaddrinfo",
+        (1, "", "Temporary failure in name resolution"),
+        (1, "", "Temporary failure in name resolution"),
+        (0, "", ""),
     )
 
     await readiness.wait_for_dns_ready()
 
-    assert probe_attempts["count"] == 3
-    assert sleep.await_count == 2
+    assert any("DNS probe succeeded on attempt 3" in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio
 async def test_wait_for_dns_ready_raises_clear_failure(tmp_path: Path) -> None:
-    readiness, runner = _build_readiness(tmp_path)
+    readiness, runner, _status = _build_readiness(tmp_path)
     runner.set_response("socket.getaddrinfo", 1, "", "Temporary failure in name resolution")
 
     with pytest.raises(UpdateTransportStepError) as exc_info:

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_session.py
@@ -65,17 +65,14 @@ def _seed_installing_phase(tracker: UpdateStatusTracker) -> None:
 
 
 @pytest.mark.asyncio
-async def test_recover_interrupted_update_cleans_uplink_and_restores_hotspot(
+async def test_recover_interrupted_update_restores_hotspot_successfully(
     tmp_path: Path,
 ) -> None:
-    session, runner, tracker = _build_session(tmp_path)
+    session, _runner, tracker = _build_session(tmp_path)
 
     await session.recover_interrupted_update(tracker.status)
 
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert any("connection down VibeSensor-Uplink" in command for command in commands)
-    assert any("connection delete VibeSensor-Uplink" in command for command in commands)
-    assert any("connection up VibeSensor-AP" in command for command in commands)
+    assert any("startup_recover: restoring hotspot" in line for line in tracker.status.log_tail)
     assert any(
         "startup_recover: hotspot restored successfully" in line for line in tracker.status.log_tail
     )
@@ -83,16 +80,15 @@ async def test_recover_interrupted_update_cleans_uplink_and_restores_hotspot(
 
 @pytest.mark.asyncio
 async def test_prepare_stops_hotspot_and_connects_uplink(tmp_path: Path) -> None:
-    session, runner, tracker = _build_session(tmp_path)
+    session, _runner, tracker = _build_session(tmp_path)
     tracker.start_job(_wifi_request(password="pass123"))
 
     prepared_transport = await session.prepare(_wifi_request(password="pass123"))
 
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert any("connection down VibeSensor-AP" in command for command in commands)
-    assert any("connection add type wifi" in command for command in commands)
     assert tracker.status.phase == UpdatePhase.connecting_wifi
     assert prepared_transport is session
+    assert any("Stopping hotspot..." in line for line in tracker.status.log_tail)
+    assert any("Wi-Fi connected successfully" in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio
@@ -205,14 +201,15 @@ async def test_cleanup_restore_orchestration_restores_hotspot_when_needed(tmp_pa
 async def test_cleanup_restore_orchestration_skips_restore_when_no_longer_needed(
     tmp_path: Path,
 ) -> None:
-    session, runner, tracker = _build_session(tmp_path)
+    session, _runner, tracker = _build_session(tmp_path)
     _seed_checked_phase(tracker)
     tracker.mark_success("done")
 
     await session.cleanup_after_update()
 
-    commands = [" ".join(call[0]) for call in runner.calls]
-    assert not any("connection up VibeSensor-AP" in command for command in commands)
+    assert tracker.status.state == UpdateState.success
+    assert tracker.status.phase == UpdatePhase.done
+    assert not any("Restoring hotspot..." in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
 from use_cases.updates._update_manager_test_helpers import FakeRunner
 
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.transport.failures import UpdateTransportStepError
 from vibesensor.use_cases.updates.wifi.wifi_config import build_default_wifi_config
 from vibesensor.use_cases.updates.wifi.wifi_uplink_setup import (
@@ -16,15 +17,25 @@ from vibesensor.use_cases.updates.wifi.wifi_uplink_setup import (
 )
 
 
-def _build_uplink_provisioner(tmp_path: Path) -> tuple[UpdateUplinkProvisioner, FakeRunner]:
+def _build_uplink_provisioner(
+    tmp_path: Path,
+    *,
+    uplink_connect_retries: int = 3,
+    uplink_rescan_delay_s: float = 0.0,
+) -> tuple[UpdateUplinkProvisioner, FakeRunner, UpdateStatusTracker]:
     runner = FakeRunner()
+    status = build_update_status_harness(tmp_path / "state.json")
     commands = UpdateCommandExecutor(runner=runner)
     provisioner = UpdateUplinkProvisioner(
         commands=commands,
-        status=build_update_status_harness(tmp_path / "state.json"),
-        config=build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
+        status=status,
+        config=replace(
+            build_default_wifi_config(ap_con_name="VibeSensor-AP", wifi_ifname="wlan0"),
+            uplink_connect_retries=uplink_connect_retries,
+            uplink_rescan_delay_s=uplink_rescan_delay_s,
+        ),
     )
-    return provisioner, runner
+    return provisioner, runner, status
 
 
 def test_ssid_security_modes_handles_escaped_ssids() -> None:
@@ -38,7 +49,7 @@ def test_ssid_security_modes_handles_escaped_ssids() -> None:
 async def test_prepare_uplink_connection_requires_password_for_secured_network(
     tmp_path: Path,
 ) -> None:
-    provisioner, runner = _build_uplink_provisioner(tmp_path)
+    provisioner, runner, _status = _build_uplink_provisioner(tmp_path)
     runner.set_response("dev wifi list", 0, "Pim:WPA2 WPA3\n")
 
     with pytest.raises(
@@ -49,59 +60,48 @@ async def test_prepare_uplink_connection_requires_password_for_secured_network(
 
 
 @pytest.mark.asyncio
-async def test_prepare_uplink_connection_applies_password(tmp_path: Path) -> None:
-    provisioner, runner = _build_uplink_provisioner(tmp_path)
+async def test_prepare_uplink_connection_reports_password_configuration_failure(
+    tmp_path: Path,
+) -> None:
+    provisioner, runner, _status = _build_uplink_provisioner(tmp_path)
+    runner.set_response("wifi-sec.psk", 10, "", "failed to set Wi-Fi credentials")
 
-    await provisioner.prepare_uplink_connection("Pim", "tomaat123")
-    assert any(
-        "connection modify VibeSensor-Uplink wifi-sec.key-mgmt wpa-psk wifi-sec.psk tomaat123"
-        in " ".join(call[0])
-        for call in runner.calls
-    )
+    with pytest.raises(
+        UpdateTransportStepError,
+        match="Failed to set Wi-Fi credentials",
+    ) as exc_info:
+        await provisioner.prepare_uplink_connection("Pim", "tomaat123")
+
+    assert exc_info.value.detail == "failed to set Wi-Fi credentials"
 
 
 @pytest.mark.asyncio
 async def test_bring_uplink_up_retries_ssid_not_found_then_succeeds(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    provisioner, runner = _build_uplink_provisioner(tmp_path)
-    original_run = runner.run
-    connect_calls = {"count": 0}
-
-    async def run_with_retry(args, *, timeout=30, env=None):
-        joined = " ".join(args)
-        if "connection up VibeSensor-Uplink" in joined:
-            connect_calls["count"] += 1
-            if connect_calls["count"] == 1:
-                return (10, "", "Error: No network with SSID 'TestNet' found.\n")
-        return await original_run(args, timeout=timeout, env=env)
-
-    runner.run = run_with_retry
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep", sleep)
+    provisioner, runner, tracker = _build_uplink_provisioner(tmp_path)
+    runner.set_response_sequence(
+        "connection up VibeSensor-Uplink",
+        (10, "", "Error: No network with SSID 'TestNet' found.\n"),
+        (0, "", ""),
+    )
 
     await provisioner.bring_uplink_up("TestNet")
 
-    assert connect_calls["count"] == 2
-    assert sleep.await_count == 1
-    assert any("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls)
+    assert any("rescanning and retrying" in line for line in tracker.status.log_tail)
 
 
 @pytest.mark.asyncio
 async def test_bring_uplink_up_fails_immediately_for_non_retryable_error(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    provisioner, runner = _build_uplink_provisioner(tmp_path)
+    provisioner, runner, _status = _build_uplink_provisioner(tmp_path)
     runner.set_response(
         "connection up VibeSensor-Uplink",
         10,
         "",
         "Error: Connection activation failed",
     )
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep", sleep)
 
     with pytest.raises(
         UpdateTransportStepError,
@@ -110,24 +110,19 @@ async def test_bring_uplink_up_fails_immediately_for_non_retryable_error(
         await provisioner.bring_uplink_up("TestNet")
 
     assert exc_info.value.detail == "Error: Connection activation failed"
-    assert sleep.await_count == 0
-    assert not any("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls)
 
 
 @pytest.mark.asyncio
 async def test_bring_uplink_up_exhausts_retryable_ssid_not_found_error(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    provisioner, runner = _build_uplink_provisioner(tmp_path)
+    provisioner, runner, tracker = _build_uplink_provisioner(tmp_path, uplink_connect_retries=2)
     runner.set_response(
         "connection up VibeSensor-Uplink",
         10,
         "",
         "Error: No network with SSID 'TestNet' found.\n",
     )
-    sleep = AsyncMock(return_value=None)
-    monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep", sleep)
 
     with pytest.raises(
         UpdateTransportStepError,
@@ -136,6 +131,4 @@ async def test_bring_uplink_up_exhausts_retryable_ssid_not_found_error(
         await provisioner.bring_uplink_up("TestNet")
 
     assert exc_info.value.detail == "Error: No network with SSID 'TestNet' found.\n"
-    assert sleep.await_count == 2
-    assert sum("connection up VibeSensor-Uplink" in " ".join(call[0]) for call in runner.calls) == 3
-    assert sum("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls) == 2
+    assert any("rescanning and retrying" in line for line in tracker.status.log_tail)

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_config.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 UPLINK_CONNECTION_NAME = "VibeSensor-Uplink"
 UPLINK_CONNECT_WAIT_S = 30
 UPLINK_CONNECT_RETRIES = 3
+UPLINK_RESCAN_DELAY_S = 2.0
 UPLINK_FALLBACK_DNS = "1.1.1.1,1.0.0.1"
 DNS_READY_MIN_WAIT_S = 10.0
 DNS_RETRY_INTERVAL_S = 1.0
@@ -23,6 +24,7 @@ class UpdateWifiConfig:
     uplink_connection_name: str
     uplink_connect_wait_s: int
     uplink_connect_retries: int
+    uplink_rescan_delay_s: float
     uplink_fallback_dns: str
     dns_ready_min_wait_s: float
     dns_retry_interval_s: float
@@ -41,6 +43,7 @@ def build_default_wifi_config(*, ap_con_name: str, wifi_ifname: str) -> UpdateWi
         uplink_connection_name=UPLINK_CONNECTION_NAME,
         uplink_connect_wait_s=UPLINK_CONNECT_WAIT_S,
         uplink_connect_retries=UPLINK_CONNECT_RETRIES,
+        uplink_rescan_delay_s=UPLINK_RESCAN_DELAY_S,
         uplink_fallback_dns=UPLINK_FALLBACK_DNS,
         dns_ready_min_wait_s=DNS_READY_MIN_WAIT_S,
         dns_retry_interval_s=DNS_RETRY_INTERVAL_S,

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
@@ -12,7 +12,6 @@ from vibesensor.use_cases.updates.transport.failures import UpdateTransportStepE
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 _UNESCAPED_COLON_RE = re.compile(r"(?<!\\):")
-_UPLINK_RESCAN_DELAY_S = 2.0
 
 
 class _RetryableSsidNotFoundError(Exception):
@@ -88,7 +87,7 @@ class UpdateUplinkProvisioner:
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(self._config.uplink_connect_retries),
-                wait=wait_fixed(_UPLINK_RESCAN_DELAY_S),
+                wait=wait_fixed(self._config.uplink_rescan_delay_s),
                 retry=retry_if_exception_type(_RetryableSsidNotFoundError),
                 sleep=asyncio.sleep,
                 reraise=True,


### PR DESCRIPTION
Closes #3405

## What changed
- moved the uplink rescan retry delay into `UpdateWifiConfig` so Wi-Fi retry tests can use deterministic timing without monkeypatching sleep internals
- added sequenced responses to the shared updater `FakeRunner` so Wi-Fi tests can model transient network state directly
- rewrote the Wi-Fi unit and workflow tests around tracker logs, issues, phases, and failure outcomes instead of command order, retry counters, and exact `nmcli` command strings

## Why
- the old tests broke on command-runner and retry-loop refactors even when the observable Wi-Fi transition behavior stayed correct
- the hardcoded uplink rescan delay forced the retry tests to patch `asyncio.sleep` instead of driving public outcomes

## Validation
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py apps/server/tests/use_cases/updates/wifi/test_hotspot_recovery.py apps/server/tests/use_cases/updates/wifi/test_wifi_session.py apps/server/tests/use_cases/updates/test_update_manager_async.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/updates`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- this adds one small production seam: Wi-Fi config now owns the uplink rescan delay instead of a module constant
- some tests now pin public status-log text for retry/recovery outcomes; if those user-visible diagnostics intentionally change later, the tests should change with them

## Follow-ups
- none