### PR TITLE
Rewrite release/update tests around outcomes

### DIFF
--- a/apps/server/tests/use_cases/updates/test_release_deployment.py
+++ b/apps/server/tests/use_cases/updates/test_release_deployment.py
@@ -2,125 +2,144 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from test_support.update_status import build_update_status_harness
 
-from vibesensor.shared.exceptions import UpdateReleaseError
-from vibesensor.use_cases.updates.models import UpdatePhase
+from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
 from vibesensor.use_cases.updates.release_deployment import (
     UpdateReleaseDeploymentCoordinator,
+    UpdateReleaseError,
 )
 from vibesensor.use_cases.updates.wheel_installation import WheelInstallResult
 
 
-def _staged_release(version: str = "2025.6.15") -> SimpleNamespace:
-    return SimpleNamespace(
-        wheel_path=Path("/tmp/vibesensor.whl"),
-        release=SimpleNamespace(version=version, tag=f"server-v{version}"),
-    )
-
-
-def _make_coordinator() -> tuple[
-    UpdateReleaseDeploymentCoordinator,
-    MagicMock,
-    MagicMock,
-]:
-    installer = MagicMock()
-    installer.snapshot_for_rollback = AsyncMock()
-    installer.install_release = AsyncMock()
-    installer.rollback = AsyncMock()
-    status = MagicMock()
-    return (
-        UpdateReleaseDeploymentCoordinator(
-            installer=installer,
-            status=status,
+def _build_status_tracker(state_path: Path):
+    tracker = build_update_status_harness(state_path)
+    tracker.start_job(
+        UpdateRequest(
+            transport=UpdateTransport.wifi,
+            ssid="TestNet",
+            password="secret-passphrase",
         ),
-        installer,
-        status,
+    )
+    tracker.transition(UpdatePhase.stopping_hotspot)
+    tracker.transition(UpdatePhase.connecting_wifi)
+    tracker.transition(UpdatePhase.checking)
+    tracker.transition(UpdatePhase.downloading)
+    return tracker
+
+
+class _FakeInstaller:
+    def __init__(
+        self,
+        *,
+        snapshot_ok: bool = True,
+        install_result: WheelInstallResult | None = None,
+        rollback_result: bool = False,
+    ) -> None:
+        self.snapshot_ok = snapshot_ok
+        self.install_result = install_result or WheelInstallResult(
+            succeeded=True,
+            rollback_required=False,
+        )
+        self.rollback_result = rollback_result
+        self.snapshot_attempted = False
+        self.install_args: tuple[Path, str] | None = None
+        self.rollback_attempted = False
+
+    async def snapshot_for_rollback(self) -> bool:
+        self.snapshot_attempted = True
+        return self.snapshot_ok
+
+    async def install_release(self, wheel_path: Path, expected_version: str) -> WheelInstallResult:
+        assert self.snapshot_attempted
+        self.install_args = (wheel_path, expected_version)
+        return self.install_result
+
+    async def rollback(self) -> bool:
+        self.rollback_attempted = True
+        return self.rollback_result
+
+
+def _staged_release(version: str, wheel_path: Path) -> object:
+    return SimpleNamespace(
+        release=SimpleNamespace(version=version),
+        wheel_path=wheel_path,
     )
 
 
 @pytest.mark.asyncio
-async def test_deploy_aborts_before_live_mutation_when_snapshot_fails() -> None:
-    coordinator, installer, status = _make_coordinator()
-    installer.snapshot_for_rollback.return_value = False
+async def test_deploy_aborts_before_live_mutation_when_snapshot_fails(tmp_path: Path) -> None:
+    installer = _FakeInstaller(snapshot_ok=False)
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    coordinator = UpdateReleaseDeploymentCoordinator(installer=installer, status=status)
 
     with pytest.raises(
-        UpdateReleaseError,
-        match="Rollback snapshot could not be created",
+        UpdateReleaseError, match="Rollback snapshot could not be created"
     ) as excinfo:
-        await coordinator.deploy(_staged_release())
+        await coordinator.deploy(_staged_release("2025.6.15", tmp_path / "release.whl"))
 
-    status.transition.assert_called_once_with(UpdatePhase.installing)
     assert excinfo.value.phase == UpdatePhase.installing.value
     assert excinfo.value.detail == "Install aborted before mutating the live environment"
-    status.fail.assert_not_called()
-    status.log.assert_called_once_with("Installing update...")
-    installer.install_release.assert_not_awaited()
-    installer.rollback.assert_not_awaited()
+    assert status.status.phase == UpdatePhase.installing
+    assert any("Installing update..." in line for line in status.status.log_tail)
+    assert not any("Attempting rollback..." in line for line in status.status.log_tail)
+    assert installer.install_args is None
 
 
 @pytest.mark.asyncio
-async def test_deploy_snapshots_before_install(tmp_path: Path) -> None:
-    coordinator, installer, _status = _make_coordinator()
-    events: list[str] = []
-    staged_release = SimpleNamespace(
-        wheel_path=tmp_path / "vibesensor.whl",
-        release=SimpleNamespace(version="2025.6.15", tag="server-v2025.6.15"),
-    )
-
-    async def snapshot_for_rollback() -> bool:
-        events.append("snapshot")
-        return True
-
-    async def install_release(wheel_path: Path, expected_version: str) -> WheelInstallResult:
-        events.append(f"install:{wheel_path.name}:{expected_version}")
-        return WheelInstallResult(succeeded=True, rollback_required=False)
-
-    installer.snapshot_for_rollback.side_effect = snapshot_for_rollback
-    installer.install_release.side_effect = install_release
+async def test_deploy_installs_staged_release_after_snapshot(tmp_path: Path) -> None:
+    installer = _FakeInstaller()
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    coordinator = UpdateReleaseDeploymentCoordinator(installer=installer, status=status)
+    staged_release = _staged_release("2025.6.15", tmp_path / "release.whl")
 
     await coordinator.deploy(staged_release)
 
-    assert events == [
-        "snapshot",
-        "install:vibesensor.whl:2025.6.15",
-    ]
+    assert installer.install_args == (staged_release.wheel_path, "2025.6.15")
+    assert installer.rollback_attempted is False
+    assert status.status.phase == UpdatePhase.installing
+    assert status.status.issues == []
 
 
 @pytest.mark.asyncio
-async def test_deploy_raises_plain_failure_without_rollback_for_non_mutating_rejection() -> None:
-    coordinator, installer, status = _make_coordinator()
-    installer.snapshot_for_rollback.return_value = True
-    installer.install_release.return_value = WheelInstallResult(
-        succeeded=False,
-        rollback_required=False,
+async def test_deploy_raises_plain_failure_without_rollback_for_non_mutating_rejection(
+    tmp_path: Path,
+) -> None:
+    installer = _FakeInstaller(
+        install_result=WheelInstallResult(
+            succeeded=False,
+            rollback_required=False,
+        ),
     )
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    coordinator = UpdateReleaseDeploymentCoordinator(installer=installer, status=status)
 
     with pytest.raises(UpdateReleaseError, match="Update install failed"):
-        await coordinator.deploy(_staged_release())
+        await coordinator.deploy(_staged_release("2025.6.15", tmp_path / "release.whl"))
 
-    installer.rollback.assert_not_awaited()
-    status.fail.assert_not_called()
-    status.log.assert_any_call("Installing update...")
+    assert not any("Attempting rollback..." in line for line in status.status.log_tail)
+    assert installer.rollback_attempted is False
 
 
 @pytest.mark.asyncio
-async def test_deploy_attempts_rollback_after_mutating_failure() -> None:
-    coordinator, installer, status = _make_coordinator()
-    installer.snapshot_for_rollback.return_value = True
-    installer.install_release.return_value = WheelInstallResult(
-        succeeded=False,
-        rollback_required=True,
+async def test_deploy_logs_rollback_attempt_after_mutating_failure(tmp_path: Path) -> None:
+    installer = _FakeInstaller(
+        install_result=WheelInstallResult(
+            succeeded=False,
+            rollback_required=True,
+        ),
+        rollback_result=True,
     )
-    installer.rollback.return_value = True
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    coordinator = UpdateReleaseDeploymentCoordinator(installer=installer, status=status)
 
     with pytest.raises(
         UpdateReleaseError,
         match="Update install failed; rollback restored the previous version",
     ):
-        await coordinator.deploy(_staged_release())
+        await coordinator.deploy(_staged_release("2025.6.15", tmp_path / "release.whl"))
 
-    installer.rollback.assert_awaited_once_with()
-    status.log.assert_any_call("Attempting rollback...")
+    assert installer.rollback_attempted is True
+    assert any("Attempting rollback..." in line for line in status.status.log_tail)

--- a/apps/server/tests/use_cases/updates/test_release_resolution.py
+++ b/apps/server/tests/use_cases/updates/test_release_resolution.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,12 +8,23 @@ from vibesensor.shared.exceptions import UpdateReleaseError
 from vibesensor.use_cases.updates.release_resolution import ServerReleaseResolver
 
 
+class _StaticFetcher:
+    def __init__(self, release: object) -> None:
+        self._release = release
+
+    def find_latest_release(self) -> object:
+        return self._release
+
+
+class _FailingFetcher:
+    def find_latest_release(self) -> object:
+        raise OSError("rate limited")
+
+
 @pytest.mark.asyncio
 async def test_resolve_returns_release_when_latest_version_is_newer() -> None:
     release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4")
-    fetcher = MagicMock()
-    fetcher.find_latest_release.return_value = release
-    resolver = ServerReleaseResolver(release_fetcher=fetcher)
+    resolver = ServerReleaseResolver(release_fetcher=_StaticFetcher(release))
 
     resolution = await resolver.resolve("2026.4.3")
 
@@ -22,17 +32,18 @@ async def test_resolve_returns_release_when_latest_version_is_newer() -> None:
     assert resolution.release is release
     assert resolution.latest_tag == ""
     assert resolution.update_available is True
-    fetcher.find_latest_release.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_resolve_uses_latest_tag_when_no_update_is_available() -> None:
-    fetcher = MagicMock()
-    fetcher.find_latest_release.return_value = SimpleNamespace(
-        tag="server-v2026.4.4",
-        version="2026.4.3",
+    resolver = ServerReleaseResolver(
+        release_fetcher=_StaticFetcher(
+            SimpleNamespace(
+                tag="server-v2026.4.4",
+                version="2026.4.3",
+            ),
+        ),
     )
-    resolver = ServerReleaseResolver(release_fetcher=fetcher)
 
     resolution = await resolver.resolve("2026.4.3")
 
@@ -44,9 +55,7 @@ async def test_resolve_uses_latest_tag_when_no_update_is_available() -> None:
 
 @pytest.mark.asyncio
 async def test_resolve_propagates_release_check_failure() -> None:
-    fetcher = MagicMock()
-    fetcher.find_latest_release.side_effect = OSError("rate limited")
-    resolver = ServerReleaseResolver(release_fetcher=fetcher)
+    resolver = ServerReleaseResolver(release_fetcher=_FailingFetcher())
 
     with pytest.raises(UpdateReleaseError, match="rate limited"):
         await resolver.resolve("2026.4.3")

--- a/apps/server/tests/use_cases/updates/test_run_release_smoke.py
+++ b/apps/server/tests/use_cases/updates/test_run_release_smoke.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 def _load_release_smoke_runner():
@@ -15,113 +18,97 @@ def _load_release_smoke_runner():
     return module, repo_root
 
 
-def test_run_release_smoke_builds_ui_and_wheel_then_runs_smoke(monkeypatch, tmp_path: Path) -> None:
-    module, repo_root = _load_release_smoke_runner()
-    commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
-    built_wheel = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
-    built_wheel.write_text("wheel", encoding="utf-8")
-
-    monkeypatch.setattr(module, "_build_server_wheel", lambda root: built_wheel)
-    monkeypatch.setattr(
-        module,
-        "_run",
-        lambda cmd, *, cwd, env=None: commands.append((list(cmd), cwd, env)),
-    )
-    monkeypatch.setattr(module.venv.EnvBuilder, "create", lambda self, path: None)
-    monkeypatch.setattr(module, "_venv_python", lambda path: path / "bin" / "python")
-
-    exit_code = module.main(["--skip-npm-ci"])
-
-    assert exit_code == 0
-    assert commands[0][0] == [
-        module.sys.executable,
-        "tools/build_ui_static.py",
-        "--skip-typecheck",
-        "--assume-prevalidated-contracts",
-        "--skip-npm-ci",
-    ]
-    assert commands[0][1] == repo_root
-    assert any(command[0][-1] == str(built_wheel) for command in commands)
-    smoke_command = commands[-1]
-    assert smoke_command[0][1:4] == [
-        "-m",
-        "vibesensor.use_cases.updates.releases.release_validation",
-        "smoke-server",
-    ]
-    assert smoke_command[2] is None
+def _set_repo_root(module: object, repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_script = repo_root / "tools" / "tests" / "run_release_smoke.py"
+    fake_script.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(module, "__file__", str(fake_script))
 
 
-def test_run_release_smoke_can_reuse_existing_wheel_and_skip_ui_build(
-    monkeypatch,
+def test_run_release_smoke_main_builds_artifacts_and_runs_smoke(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    module, repo_root = _load_release_smoke_runner()
-    commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
-    existing_wheel = repo_root / "apps" / "server" / "dist" / "prebuilt.whl"
-    existing_wheel.parent.mkdir(parents=True, exist_ok=True)
-    existing_wheel.write_text("wheel", encoding="utf-8")
-
-    def _unexpected_build(root: Path) -> Path:
-        raise AssertionError("wheel build should be skipped when --wheel-path is provided")
-
-    monkeypatch.setattr(module, "_build_server_wheel", _unexpected_build)
-    monkeypatch.setattr(
-        module,
-        "_run",
-        lambda cmd, *, cwd, env=None: commands.append((list(cmd), cwd, env)),
-    )
-    monkeypatch.setattr(module.venv.EnvBuilder, "create", lambda self, path: None)
-    monkeypatch.setattr(module, "_venv_python", lambda path: path / "bin" / "python")
-
-    exit_code = module.main(["--skip-ui-build", "--wheel-path", "apps/server/dist/prebuilt.whl"])
-
-    assert exit_code == 0
-    assert all(command[0][1] != "tools/build_ui_static.py" for command in commands)
-    pip_install_command = next(
-        command for command in commands if command[0][-1] == str(existing_wheel.resolve())
-    )
-    assert pip_install_command[0][-1] == str(existing_wheel.resolve())
-
-
-def test_build_server_wheel_uses_builder_venv(monkeypatch, tmp_path: Path) -> None:
     module, _repo_root = _load_release_smoke_runner()
     repo_root = tmp_path / "repo"
     dist_dir = repo_root / "apps" / "server" / "dist"
-    dist_dir.mkdir(parents=True)
+    dist_dir.mkdir(parents=True, exist_ok=True)
     built_wheel = dist_dir / "vibesensor-2025.6.15-py3-none-any.whl"
     commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
-    builder_venv = tmp_path / "builder-venv"
 
-    class _FakeTempDir:
-        def __init__(self, *_args, **_kwargs) -> None:
-            pass
-
-        def __enter__(self) -> str:
-            return str(builder_venv)
-
-        def __exit__(self, exc_type, exc, tb) -> bool:
-            return False
-
-    def _fake_run(cmd: list[str], *, cwd: Path, env=None) -> None:
-        commands.append((list(cmd), cwd, env))
-        if cmd[1:4] == ["-m", "build", "--wheel"]:
+    def fake_run(
+        cmd: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        assert check is True
+        commands.append((list(cmd), Path(cwd), env))
+        if "-m build --wheel apps/server/" in " ".join(cmd):
             built_wheel.parent.mkdir(parents=True, exist_ok=True)
             built_wheel.write_text("wheel", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
 
-    monkeypatch.setattr(module.tempfile, "TemporaryDirectory", _FakeTempDir)
+    _set_repo_root(module, repo_root, monkeypatch)
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
     monkeypatch.setattr(module.venv.EnvBuilder, "create", lambda self, path: None)
-    monkeypatch.setattr(module, "_venv_python", lambda path: Path(path) / "bin" / "python")
-    monkeypatch.setattr(module, "_run", _fake_run)
 
-    wheel_path = module._build_server_wheel(repo_root)
+    exit_code = module.main(["--skip-npm-ci", "--port", "18081"])
 
-    assert wheel_path == built_wheel
-    expected_python = str(builder_venv / "bin" / "python")
-    assert commands == [
-        (
-            [expected_python, "-m", "pip", "install", "--upgrade", "pip", "build"],
-            repo_root,
-            None,
-        ),
-        ([expected_python, "-m", "build", "--wheel", "apps/server/"], repo_root, None),
-    ]
+    command_lines = [" ".join(cmd) for cmd, _cwd, _env in commands]
+    assert exit_code == 0
+    assert built_wheel.is_file()
+    assert any("tools/build_ui_static.py" in line for line in command_lines)
+    assert any("-m build --wheel apps/server/" in line for line in command_lines)
+    assert any("-m pip install" in line and str(built_wheel) in line for line in command_lines)
+    assert any("smoke-server" in line and "--port 18081" in line for line in command_lines)
+
+
+def test_run_release_smoke_main_reuses_existing_wheel_and_skips_ui_build(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module, _repo_root = _load_release_smoke_runner()
+    repo_root = tmp_path / "repo"
+    dist_dir = repo_root / "apps" / "server" / "dist"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
+    existing_wheel = dist_dir / "prebuilt.whl"
+    existing_wheel.write_text("wheel", encoding="utf-8")
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        cwd: str,
+        check: bool,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        assert check is True
+        commands.append((list(cmd), Path(cwd), env))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    _set_repo_root(module, repo_root, monkeypatch)
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.venv.EnvBuilder, "create", lambda self, path: None)
+
+    exit_code = module.main(["--skip-ui-build", "--wheel-path", "apps/server/dist/prebuilt.whl"])
+
+    command_lines = [" ".join(cmd) for cmd, _cwd, _env in commands]
+    assert exit_code == 0
+    assert not any("tools/build_ui_static.py" in line for line in command_lines)
+    assert not any("-m build --wheel apps/server/" in line for line in command_lines)
+    assert any(
+        "-m pip install" in line and str(existing_wheel.resolve()) in line for line in command_lines
+    )
+
+
+def test_run_release_smoke_main_rejects_missing_wheel_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module, _repo_root = _load_release_smoke_runner()
+    repo_root = tmp_path / "repo"
+    _set_repo_root(module, repo_root, monkeypatch)
+
+    with pytest.raises(RuntimeError, match="Wheel path does not exist or is not a .whl file"):
+        module.main(["--skip-ui-build", "--wheel-path", "apps/server/dist/missing.whl"])

--- a/apps/server/tests/use_cases/updates/test_server_release_execution.py
+++ b/apps/server/tests/use_cases/updates/test_server_release_execution.py
@@ -3,100 +3,105 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from test_support.update_status import build_update_status_harness
 
 from vibesensor.use_cases.updates.firmware import FirmwareRefreshResult
-from vibesensor.use_cases.updates.models import UpdatePhase
+from vibesensor.use_cases.updates.models import UpdatePhase, UpdateRequest, UpdateTransport
 from vibesensor.use_cases.updates.server_release_execution import (
     ServerReleaseExecutionCoordinator,
 )
 
 
-def _coordinator() -> tuple[
-    ServerReleaseExecutionCoordinator,
-    MagicMock,
-    MagicMock,
-    MagicMock,
-    MagicMock,
-]:
-    stager = MagicMock()
-    firmware_refresher = MagicMock()
-    firmware_refresher.refresh_esp_firmware = AsyncMock(
-        return_value=FirmwareRefreshResult.success(),
-    )
-    deployment = MagicMock()
-    deployment.deploy = AsyncMock(return_value=None)
-    status = MagicMock()
-    return (
-        ServerReleaseExecutionCoordinator(
-            stager=stager,
-            firmware_refresher=firmware_refresher,
-            deployment=deployment,
-            status=status,
+def _build_status_tracker(state_path: Path):
+    tracker = build_update_status_harness(state_path)
+    tracker.start_job(
+        UpdateRequest(
+            transport=UpdateTransport.wifi,
+            ssid="TestNet",
+            password="secret-passphrase",
         ),
-        stager,
-        firmware_refresher,
-        deployment,
-        status,
     )
+    tracker.transition(UpdatePhase.stopping_hotspot)
+    tracker.transition(UpdatePhase.connecting_wifi)
+    tracker.transition(UpdatePhase.checking)
+    tracker.transition(UpdatePhase.downloading)
+    return tracker
+
+
+class _StaticStager:
+    def __init__(self, staged_release: object) -> None:
+        self._staged_release = staged_release
+
+    @asynccontextmanager
+    async def stage(self, release: object):
+        assert release is self._staged_release.release
+        yield self._staged_release
+
+
+class _StaticFirmwareRefresher:
+    def __init__(self, result: FirmwareRefreshResult) -> None:
+        self._result = result
+        self.pinned_tags: list[str] = []
+
+    async def refresh_esp_firmware(self, pinned_tag: str = "") -> FirmwareRefreshResult:
+        self.pinned_tags.append(pinned_tag)
+        return self._result
+
+
+class _RecordingDeployment:
+    def __init__(self) -> None:
+        self.deployed_release: object | None = None
+
+    async def deploy(self, staged_release: object) -> None:
+        self.deployed_release = staged_release
 
 
 @pytest.mark.asyncio
-async def test_execute_stages_refreshes_then_deploys(tmp_path: Path) -> None:
-    coordinator, stager, firmware_refresher, deployment, _status = _coordinator()
-    events: list[str] = []
-    release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="a" * 64)
+async def test_execute_deploys_staged_release_after_successful_refresh(tmp_path: Path) -> None:
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4")
     staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
-
-    @asynccontextmanager
-    async def stage(_release: object):
-        events.append("stage")
-        yield staged_release
-
-    async def refresh_esp_firmware(*, pinned_tag: str) -> FirmwareRefreshResult:
-        events.append(f"firmware:{pinned_tag}")
-        return FirmwareRefreshResult.success()
-
-    async def deploy(arg: object) -> None:
-        events.append(f"deploy:{Path(arg.wheel_path).name}")
-
-    stager.stage.side_effect = stage
-    firmware_refresher.refresh_esp_firmware.side_effect = refresh_esp_firmware
-    deployment.deploy.side_effect = deploy
-
-    await coordinator.execute(release)
-
-    assert events == [
-        "stage",
-        "firmware:server-v2026.4.4",
-        "deploy:release.whl",
-    ]
-
-
-@pytest.mark.asyncio
-async def test_execute_continues_when_firmware_refresh_fails(tmp_path: Path) -> None:
-    coordinator, stager, firmware_refresher, deployment, status = _coordinator()
-    release = SimpleNamespace(version="2026.4.4", tag="server-v2026.4.4", sha256="a" * 64)
-    staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
-
-    @asynccontextmanager
-    async def stage(_release: object):
-        yield staged_release
-
-    stager.stage.side_effect = stage
-    firmware_refresher.refresh_esp_firmware.return_value = FirmwareRefreshResult.failure(
-        message="ESP firmware cache refresh failed (exit 1)",
-        detail="cache unavailable",
+    firmware_refresher = _StaticFirmwareRefresher(FirmwareRefreshResult.success())
+    deployment = _RecordingDeployment()
+    coordinator = ServerReleaseExecutionCoordinator(
+        stager=_StaticStager(staged_release),
+        firmware_refresher=firmware_refresher,
+        deployment=deployment,
+        status=status,
     )
 
     await coordinator.execute(release)
 
-    status.add_issue.assert_called_once_with(
-        UpdatePhase.downloading,
-        "ESP firmware cache refresh failed (exit 1)",
-        "cache unavailable",
+    assert firmware_refresher.pinned_tags == ["server-v2026.4.4"]
+    assert deployment.deployed_release is staged_release
+    assert status.status.issues == []
+
+
+@pytest.mark.asyncio
+async def test_execute_records_firmware_refresh_failure_and_still_deploys(tmp_path: Path) -> None:
+    status = _build_status_tracker(tmp_path / "update-state.json")
+    release = SimpleNamespace(tag="server-v2026.4.4", version="2026.4.4")
+    staged_release = SimpleNamespace(release=release, wheel_path=tmp_path / "release.whl")
+    firmware_refresher = _StaticFirmwareRefresher(
+        FirmwareRefreshResult.failure(
+            message="ESP firmware cache refresh failed (exit 4)",
+            detail="download timed out",
+        ),
     )
-    status.log.assert_any_call("ESP firmware refresh failed; continuing with existing cache")
-    deployment.deploy.assert_awaited_once_with(staged_release)
+    deployment = _RecordingDeployment()
+    coordinator = ServerReleaseExecutionCoordinator(
+        stager=_StaticStager(staged_release),
+        firmware_refresher=firmware_refresher,
+        deployment=deployment,
+        status=status,
+    )
+
+    await coordinator.execute(release)
+
+    assert deployment.deployed_release is staged_release
+    assert firmware_refresher.pinned_tags == ["server-v2026.4.4"]
+    assert status.status.issues[-1].message == "ESP firmware cache refresh failed (exit 4)"
+    assert status.status.issues[-1].detail == "download timed out"
+    assert "ESP firmware refresh failed; continuing with existing cache" in status.status.log_tail

--- a/apps/server/tests/use_cases/updates/test_update_tool_cli_fault_boundaries.py
+++ b/apps/server/tests/use_cases/updates/test_update_tool_cli_fault_boundaries.py
@@ -1,11 +1,65 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from vibesensor.use_cases.updates.firmware.firmware_cache import refresh_cache_cli
 from vibesensor.use_cases.updates.releases.cli import fetch_latest_wheel_cli
+
+
+def test_fetch_latest_wheel_cli_prints_release_and_downloaded_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    dest_dir = tmp_path / "downloads"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vibesensor-release-fetch",
+            "--repo",
+            "Skamba/VibeSensor",
+            "--dest",
+            str(dest_dir),
+        ],
+    )
+
+    class _Fetcher:
+        def __init__(self, config) -> None:
+            assert config.server_repo == "Skamba/VibeSensor"
+
+        def find_latest_release(self) -> object:
+            return SimpleNamespace(
+                tag="server-v2026.4.4",
+                version="2026.4.4",
+                sha256="a" * 64,
+                asset_name="vibesensor-2026.4.4-py3-none-any.whl",
+            )
+
+        def download_wheel(self, release: object, dest_dir: str) -> Path:
+            dest_path = Path(dest_dir)
+            dest_path.mkdir(parents=True, exist_ok=True)
+            wheel_path = dest_path / release.asset_name
+            wheel_path.write_text("wheel", encoding="utf-8")
+            return wheel_path
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.releases.cli.ServerReleaseFetcher",
+        _Fetcher,
+    )
+
+    fetch_latest_wheel_cli()
+
+    captured = capsys.readouterr()
+    wheel_path = dest_dir / "vibesensor-2026.4.4-py3-none-any.whl"
+    assert "Latest release: server-v2026.4.4 (2026.4.4)" in captured.out
+    assert f"Downloaded: {wheel_path}" in captured.out
+    assert f"SHA256: {'a' * 64}" in captured.out
+    assert wheel_path.is_file()
 
 
 def test_fetch_latest_wheel_cli_exits_for_operational_value_error(
@@ -52,6 +106,57 @@ def test_fetch_latest_wheel_cli_allows_programmer_errors_to_surface(
 
     with pytest.raises(AssertionError, match="programmer bug"):
         fetch_latest_wheel_cli()
+
+
+def test_refresh_cache_cli_prints_refreshed_cache_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "firmware-cache"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vibesensor-fw-refresh",
+            "--cache-dir",
+            str(cache_dir),
+            "--repo",
+            "Skamba/VibeSensor",
+            "--channel",
+            "stable",
+            "--tag",
+            "server-v2026.4.4",
+        ],
+    )
+
+    class _Cache:
+        def __init__(self, config) -> None:
+            assert config.cache_dir == str(cache_dir)
+            assert config.firmware_repo == "Skamba/VibeSensor"
+            assert config.channel == "stable"
+            assert config.pinned_tag == "server-v2026.4.4"
+
+        def refresh(self) -> object:
+            return SimpleNamespace(
+                tag="server-v2026.4.4",
+                asset="server-v2026.4.4.zip",
+                source="downloaded",
+                sha256="b" * 64,
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.firmware.firmware_cache.FirmwareCache",
+        _Cache,
+    )
+
+    refresh_cache_cli()
+
+    captured = capsys.readouterr()
+    assert (
+        "Firmware cache refreshed: tag=server-v2026.4.4, asset=server-v2026.4.4.zip" in captured.out
+    )
+    assert f"Source: downloaded, SHA256: {'b' * 64}" in captured.out
 
 
 def test_refresh_cache_cli_exits_for_operational_os_error(


### PR DESCRIPTION
## What changed
- rewrote the release execution and deployment coordinator tests around real status-tracker issues, logs, and release errors instead of `MagicMock` call graphs
- rewrote `test_run_release_smoke.py` around `main(...)`, temp repo artifacts, and the `subprocess.run` process boundary instead of `_run` / `_build_server_wheel`
- replaced release-resolution fetcher call assertions with stub fetchers and added successful fetch/cache CLI stdout plus downloaded-wheel-path coverage

## Why
- the old tests were coupled to helper decomposition and exact command arrays instead of protecting CLI-visible behavior and artifact state
- this keeps the lower-layer fetch/validation/install/cache owners intact while making the higher-level tests resilient to internal refactors

## Validation
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/updates/test_server_release_execution.py apps/server/tests/use_cases/updates/test_release_deployment.py apps/server/tests/use_cases/updates/test_release_resolution.py apps/server/tests/use_cases/updates/test_run_release_smoke.py apps/server/tests/use_cases/updates/test_update_tool_cli_fault_boundaries.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/use_cases/updates`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- the coordinator tests still use small boundary fakes because staging, install, and deploy remain the external seams of the units under test
- `test_run_release_smoke.py` still patches `subprocess.run`, but now only at the process boundary while asserting built/reused wheel artifacts and smoke-invocation outcomes

Closes #3406