### PR TITLE
Rewrite config/preflight tests around outcomes

### DIFF
--- a/apps/server/tests/app/test_config_extended.py
+++ b/apps/server/tests/app/test_config_extended.py
@@ -1,4 +1,4 @@
-"""Additional config coverage for logging defaults and network validation edges."""
+"""Additional config coverage for public loader path and validation behavior."""
 
 from __future__ import annotations
 
@@ -7,106 +7,136 @@ from pathlib import Path
 import pytest
 import yaml
 
-from vibesensor.app.config_loader import _read_config_file, _resolve_config_path, load_config
-from vibesensor.shared.json_utils import deep_merge as _deep_merge
-
-# -- _deep_merge ---------------------------------------------------------------
+from vibesensor.app.config_loader import load_config
 
 
-@pytest.mark.parametrize(
-    ("base", "override", "expected"),
-    [
-        ({"a": 1, "b": 2}, {"a": 10}, {"a": 10, "b": 2}),
-        ({"top": {"a": 1, "b": 2}}, {"top": {"b": 3}}, {"top": {"a": 1, "b": 3}}),
-        ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
-        ({"items": [1, 2]}, {"items": [3]}, {"items": [3]}),
-    ],
-)
-def test_deep_merge_contract(
-    base: dict[str, object],
-    override: dict[str, object],
-    expected: dict[str, object],
-) -> None:
-    assert _deep_merge(base, override) == expected
+def _write_config(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
 
 
-def test_deep_merge_null_dict_section_keeps_defaults_and_logs_warning(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    result = _deep_merge({"ap": {"self_heal": {"enabled": True}}}, {"ap": None})
-
-    assert result == {"ap": {"self_heal": {"enabled": True}}}
-    assert "keeping default section" in caplog.text
+def _write_config_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
 
 
-# -- _resolve_config_path ------------------------------------------------------
-
-
-def test_resolve_config_path_absolute(tmp_path: Path) -> None:
-    result = _resolve_config_path("/tmp/foo.txt", tmp_path / "config.yaml")
-    assert result == Path("/tmp/foo.txt")
-
-
-def test_resolve_config_path_relative(tmp_path: Path) -> None:
+def test_load_config_preserves_absolute_paths(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
-    result = _resolve_config_path("data/foo.txt", config_path)
-    assert result == (tmp_path / "data/foo.txt")
+    _write_config(
+        config_path,
+        {
+            "logging": {
+                "history_db_path": "/tmp/history.db",
+                "app_log_path": "/tmp/app.log",
+            },
+            "tracing": {
+                "enabled": True,
+                "output_path": "/tmp/traces.jsonl",
+            },
+            "ap": {
+                "self_heal": {
+                    "state_file": "/tmp/hotspot-state.json",
+                }
+            },
+        },
+    )
+
+    result = load_config(config_path)
+
+    assert result.logging.history_db_path == Path("/tmp/history.db")
+    assert result.logging.app_log_path == Path("/tmp/app.log")
+    assert result.tracing.output_path == Path("/tmp/traces.jsonl")
+    assert result.ap.self_heal.state_file == Path("/tmp/hotspot-state.json")
 
 
-def test_resolve_config_path_preserves_parent_traversal_relative_to_config(tmp_path: Path) -> None:
-    config_dir = tmp_path / "configs" / "dev"
-    config_dir.mkdir(parents=True)
-    config_path = config_dir / "config.yaml"
+def test_load_config_resolves_relative_paths_from_config_parent(tmp_path: Path) -> None:
+    config_path = tmp_path / "configs" / "config.yaml"
+    _write_config(
+        config_path,
+        {
+            "logging": {
+                "history_db_path": "data/history.db",
+                "app_log_path": "logs/app.log",
+            },
+            "tracing": {
+                "enabled": True,
+                "output_path": "logs/traces.jsonl",
+            },
+            "ap": {
+                "self_heal": {
+                    "state_file": "data/hotspot-state.json",
+                }
+            },
+        },
+    )
 
-    result = _resolve_config_path("../shared/state.json", config_path)
+    result = load_config(config_path)
 
-    assert result.resolve() == (config_dir.parent / "shared/state.json").resolve()
+    assert result.logging.history_db_path == config_path.parent / "data/history.db"
+    assert result.logging.app_log_path == config_path.parent / "logs/app.log"
+    assert result.tracing.output_path == config_path.parent / "logs/traces.jsonl"
+    assert result.ap.self_heal.state_file == config_path.parent / "data/hotspot-state.json"
 
 
-def test_resolve_config_path_uses_real_config_parent_for_symlinks(tmp_path: Path) -> None:
+def test_load_config_preserves_parent_traversal_relative_to_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "configs" / "dev" / "config.yaml"
+    _write_config(config_path, {"logging": {"history_db_path": "../shared/history.db"}})
+
+    result = load_config(config_path)
+
+    assert (
+        result.logging.history_db_path.resolve()
+        == (tmp_path / "configs" / "shared" / "history.db").resolve()
+    )
+
+
+def test_load_config_uses_real_config_parent_for_symlinks(tmp_path: Path) -> None:
     real_dir = tmp_path / "real"
-    real_dir.mkdir()
     real_config = real_dir / "config.yaml"
-    real_config.write_text("{}", encoding="utf-8")
+    _write_config(real_config, {"logging": {"history_db_path": "data/history.db"}})
     link_dir = tmp_path / "linked"
     link_dir.mkdir()
     symlink_path = link_dir / "config.yaml"
     symlink_path.symlink_to(real_config)
 
-    result = _resolve_config_path("data/file.txt", symlink_path)
+    result = load_config(symlink_path)
 
-    assert result.resolve() == (real_dir / "data/file.txt").resolve()
-
-
-# -- _read_config_file ---------------------------------------------------------
+    assert result.logging.history_db_path.resolve() == (real_dir / "data/history.db").resolve()
 
 
-def test_read_config_file_missing_returns_empty(tmp_path: Path) -> None:
-    result = _read_config_file(tmp_path / "nonexistent.yaml")
-    assert result == {}
+def test_load_config_missing_explicit_file_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Explicitly specified config file does not exist"):
+        load_config(tmp_path / "missing.yaml")
 
 
-def test_read_config_file_valid(tmp_path: Path) -> None:
-    cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text("ap:\n  ssid: TestNet\n")
-    result = _read_config_file(cfg_path)
-    assert result["ap"]["ssid"] == "TestNet"
+def test_load_config_invalid_yaml_raises(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config_text(config_path, "server: [\n")
+
+    with pytest.raises(ValueError, match="contains invalid YAML"):
+        load_config(config_path)
 
 
-def test_read_config_file_non_dict_raises(tmp_path: Path) -> None:
-    cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text("- item1\n- item2\n")
+def test_load_config_non_dict_top_level_raises(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config_text(config_path, "- item1\n- item2\n")
+
     with pytest.raises(ValueError, match="must contain a YAML object"):
-        _read_config_file(cfg_path)
+        load_config(config_path)
 
 
-# -- load_config: AP self-heal -------------------------------------------------
-# NOTE: accel_scale_g_per_lsb zero/negative tests live in
-# test_config_validation.py::TestAccelScaleValidation.
+def test_load_config_null_section_keeps_defaults_and_logs_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, {"ap": None})
 
+    with caplog.at_level("WARNING", logger="vibesensor.shared.json_utils"):
+        result = load_config(config_path)
 
-def _write_config(path: Path, payload: dict[str, object]) -> None:
-    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    assert result.ap.self_heal.enabled is True
+    assert "keeping default section" in caplog.text
 
 
 def test_load_config_ap_self_heal_defaults(tmp_path: Path) -> None:

--- a/apps/server/tests/app/test_granian_runtime.py
+++ b/apps/server/tests/app/test_granian_runtime.py
@@ -1,31 +1,60 @@
-"""Granian runtime wiring coverage for backend startup."""
+"""Granian main-entry coverage for platform loop selection."""
 
 from __future__ import annotations
+
+import logging
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
 
 from granian.constants import Interfaces, Loops
 from granian.log import LogLevels
 
 
-def test_granian_loop_uses_uvloop_on_linux(monkeypatch) -> None:
-    from vibesensor.app import bootstrap as app_module
-
-    monkeypatch.setattr(app_module.sys, "platform", "linux")
-
-    assert app_module._granian_loop() is Loops.uvloop
-
-
-def test_granian_loop_uses_asyncio_off_linux(monkeypatch) -> None:
-    from vibesensor.app import bootstrap as app_module
-
-    monkeypatch.setattr(app_module.sys, "platform", "darwin")
-
-    assert app_module._granian_loop() is Loops.asyncio
+def _loaded_config(*, host: str, port: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        server=SimpleNamespace(host=host, port=port),
+        logging=SimpleNamespace(app_log_path=None),
+        tracing=SimpleNamespace(enabled=False, output_path=Path("/tmp/traces.jsonl")),
+    )
 
 
-def test_run_server_uses_granian_with_expected_options(monkeypatch) -> None:
+def _run_with_restored_root_logging(callable_obj) -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    try:
+        callable_obj()
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            if handler not in original_handlers:
+                handler.close()
+        for handler in original_handlers:
+            if handler not in root_logger.handlers:
+                root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)
+
+
+def _run_main_for_platform(monkeypatch, *, platform: str) -> dict[str, object]:
     from vibesensor.app import bootstrap as app_module
 
     recorded: dict[str, object] = {}
+    monkeypatch.setattr(
+        app_module.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: Namespace(config=None, reload=False),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "load_config",
+        lambda config_path=None: _loaded_config(host="127.0.0.1", port=8000),
+    )
+    monkeypatch.setattr(app_module, "export_config_path_env", lambda config_path: None)
+    monkeypatch.setattr(app_module.sys, "platform", platform)
+    if platform.startswith("linux"):
+        monkeypatch.setitem(sys.modules, "uvloop", SimpleNamespace(new_event_loop=lambda: None))
 
     class FakeGranian:
         def __init__(self, *args, **kwargs):
@@ -36,15 +65,12 @@ def test_run_server_uses_granian_with_expected_options(monkeypatch) -> None:
             recorded["served"] = True
 
     monkeypatch.setattr(app_module, "Granian", FakeGranian)
-    monkeypatch.setattr(app_module, "_granian_loop", lambda: Loops.uvloop)
+    _run_with_restored_root_logging(app_module.main)
+    return recorded
 
-    app_module._run_server(
-        "vibesensor.app.bootstrap:create_app_from_env",
-        host="127.0.0.1",
-        port=8000,
-        reload=True,
-        factory=True,
-    )
+
+def test_main_uses_uvloop_on_linux(monkeypatch) -> None:
+    recorded = _run_main_for_platform(monkeypatch, platform="linux")
 
     assert recorded == {
         "args": ("vibesensor.app.bootstrap:create_app_from_env",),
@@ -55,7 +81,26 @@ def test_run_server_uses_granian_with_expected_options(monkeypatch) -> None:
             "log_enabled": True,
             "log_level": LogLevels.info,
             "loop": Loops.uvloop,
-            "reload": True,
+            "reload": False,
+            "factory": True,
+        },
+        "served": True,
+    }
+
+
+def test_main_uses_asyncio_off_linux(monkeypatch) -> None:
+    recorded = _run_main_for_platform(monkeypatch, platform="darwin")
+
+    assert recorded == {
+        "args": ("vibesensor.app.bootstrap:create_app_from_env",),
+        "kwargs": {
+            "address": "127.0.0.1",
+            "port": 8000,
+            "interface": Interfaces.ASGI,
+            "log_enabled": True,
+            "log_level": LogLevels.info,
+            "loop": Loops.asyncio,
+            "reload": False,
             "factory": True,
         },
         "served": True,

--- a/apps/server/tests/app/test_preflight_cli.py
+++ b/apps/server/tests/app/test_preflight_cli.py
@@ -1,4 +1,4 @@
-"""CLI coverage for config preflight defaults, argument errors, and JSON output."""
+"""CLI coverage for config preflight defaults, argument errors, and validation outcomes."""
 
 from __future__ import annotations
 
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-from vibesensor.app.config_loader import load_config
 from vibesensor.cli import preflight
 
 
@@ -25,22 +24,28 @@ def test_preflight_cli_dump_defaults(monkeypatch, capsys) -> None:
     assert payload["processing"]["sample_rate_hz"] == 800
 
 
-def test_preflight_cli_requires_config_without_dump_defaults(monkeypatch) -> None:
+def test_preflight_cli_requires_config_without_dump_defaults(monkeypatch, capsys) -> None:
     monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight"])
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as excinfo:
         preflight.main()
 
+    assert excinfo.value.code == 2
+    assert "config is required unless --dump-defaults is set" in capsys.readouterr().err
 
-def test_preflight_cli_rejects_dump_defaults_with_config(monkeypatch) -> None:
+
+def test_preflight_cli_rejects_dump_defaults_with_config(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
         ["vibesensor-config-preflight", "--dump-defaults", "apps/server/config.dev.yaml"],
     )
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as excinfo:
         preflight.main()
+
+    assert excinfo.value.code == 2
+    assert "--dump-defaults and config are mutually exclusive" in capsys.readouterr().err
 
 
 def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Path) -> None:
@@ -65,40 +70,7 @@ def test_preflight_cli_prints_resolved_config(monkeypatch, capsys, tmp_path: Pat
     assert payload["process_settings"]["github_token_configured"] is True
 
 
-def test_writable_path_checks_include_active_runtime_targets(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        "\n".join(
-            (
-                "tracing:",
-                "  enabled: true",
-                "  output_path: traces/export.jsonl",
-                "update:",
-                f"  rollback_dir: {tmp_path / 'rollback'}",
-            )
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("VIBESENSOR_UPDATE_STATE_PATH", str(tmp_path / "update" / "state.json"))
-    monkeypatch.setenv("VIBESENSOR_FIRMWARE_CACHE_DIR", str(tmp_path / "firmware"))
-
-    cfg = load_config(config_path)
-
-    assert [check.label for check in preflight._writable_path_checks(cfg)] == [
-        "logging.history_db_path",
-        "logging.app_log_path",
-        "ap.self_heal.state_file",
-        "tracing.output_path",
-        "update.rollback_dir",
-        "process_settings.update_state_path",
-        "process_settings.firmware_cache_dir",
-    ]
-
-
-def test_preflight_cli_reports_unwritable_runtime_path(
+def test_preflight_cli_reports_unwritable_history_db_path(
     monkeypatch,
     capsys,
     tmp_path: Path,
@@ -138,22 +110,31 @@ def test_preflight_cli_reports_unwritable_runtime_path(
     assert str(blocked_dir) in captured.err
 
 
-def test_missing_parent_path_does_not_probe_higher_ancestors(
+def test_preflight_cli_reports_unwritable_update_state_path(
     monkeypatch,
+    capsys,
     tmp_path: Path,
 ) -> None:
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("server:\n  port: 8000\n", encoding="utf-8")
+    monkeypatch.setenv("VIBESENSOR_UPDATE_STATE_PATH", str(blocked_dir / "state.json"))
+    monkeypatch.setenv("VIBESENSOR_FIRMWARE_CACHE_DIR", str(tmp_path / "firmware"))
+
     real_access = os.access
 
     def _mock_access(path: str | os.PathLike[str], mode: int) -> bool:
-        if Path(path) == tmp_path:
+        if Path(path) == blocked_dir:
             return False
         return real_access(path, mode)
 
     monkeypatch.setattr(preflight.os, "access", _mock_access)
+    monkeypatch.setattr(sys, "argv", ["vibesensor-config-preflight", str(config_path)])
 
-    preflight._validate_writable_path(
-        preflight._WritablePathCheck(
-            "logging.history_db_path",
-            tmp_path / "missing" / "history.db",
-        )
-    )
+    assert preflight.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "process_settings.update_state_path is not writable" in captured.err
+    assert str(blocked_dir) in captured.err

--- a/apps/server/tests/shared/utils/test_json_utils.py
+++ b/apps/server/tests/shared/utils/test_json_utils.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from vibesensor.shared.json_utils import (
+    deep_merge,
     json_text_dumps,
     payload_object_from_json,
     payload_objects_from_json,
@@ -18,6 +19,42 @@ from vibesensor.shared.json_utils import (
     sanitize_for_json,
     sanitize_value,
 )
+
+
+class TestDeepMerge:
+    """Tests for the shared ``deep_merge`` helper."""
+
+    @pytest.mark.parametrize(
+        ("base", "override", "expected"),
+        [
+            pytest.param({"a": 1, "b": 2}, {"a": 10}, {"a": 10, "b": 2}, id="scalar"),
+            pytest.param(
+                {"top": {"a": 1, "b": 2}},
+                {"top": {"b": 3}},
+                {"top": {"a": 1, "b": 3}},
+                id="nested-object",
+            ),
+            pytest.param({"a": 1}, {"b": 2}, {"a": 1, "b": 2}, id="new-key"),
+            pytest.param({"items": [1, 2]}, {"items": [3]}, {"items": [3]}, id="list-replace"),
+        ],
+    )
+    def test_merges_nested_objects_and_replaces_scalars(
+        self,
+        base: dict[str, object],
+        override: dict[str, object],
+        expected: dict[str, object],
+    ) -> None:
+        assert deep_merge(base, override) == expected
+
+    def test_null_dict_section_keeps_existing_section_and_logs_warning(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        result = deep_merge({"ap": {"self_heal": {"enabled": True}}}, {"ap": None})
+
+        assert result == {"ap": {"self_heal": {"enabled": True}}}
+        assert "keeping default section" in caplog.text
+
 
 # ── sanitize_for_json ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed
- rewrote `test_preflight_cli.py` around parser exit codes and CLI stderr for resolved config and unwritable runtime-path failures instead of `_writable_path_checks` / `_validate_writable_path`
- rewrote `test_config_extended.py` around `load_config(...)` outcomes for path resolution, symlink handling, invalid YAML, non-dict top-level config, missing explicit config, and null-section fallback instead of `_resolve_config_path` / `_read_config_file`
- moved generic `deep_merge(...)` contract coverage to `apps/server/tests/shared/utils/test_json_utils.py`
- rewrote `test_granian_runtime.py` to drive `bootstrap.main()` on Linux and Darwin and assert Granian launch kwargs/loop selection instead of calling `_granian_loop` / `_run_server` directly

## Why
- the old tests were coupled to private config/preflight/runtime helpers instead of the public loader and CLI behavior that callers actually rely on
- this keeps the lower-level history-db startup owner intact while making config/preflight coverage resilient to helper refactors

## Validation
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/app/test_preflight_cli.py apps/server/tests/app/test_config_extended.py apps/server/tests/app/test_granian_runtime.py apps/server/tests/app/test_history_db_container_startup.py apps/server/tests/shared/utils/test_json_utils.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/app apps/server/tests/shared/utils/test_json_utils.py`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- `test_history_db_container_startup.py` stays mock-based at the fake persistence-adapter boundary because `create_history_db(...)` is itself the public startup seam under test
- the preflight/runtime tests still fake OS writability and the Granian process boundary, but only at those true external boundaries rather than mirroring helper internals

Closes #3407