### PR TITLE
Rewrite payload tests around emitted contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,9 +579,10 @@ jobs:
           path: ~/.cache/vibesensor/backend-duration-cache.json
           # Keep each run's write key distinct while still restoring from the stable test-history prefix.
           key: ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-${{ matrix.cache_suffix }}-${{ github.run_id }}
+          # Avoid restoring duration caches from older test-suite hashes: stale timings can
+          # rebalance whole-file shards badly enough to trip the 15-minute backend-test timeout.
           restore-keys: |
             ${{ runner.os }}-backend-test-durations-${{ hashFiles('tools/tests/run_backend_parallel.py', 'apps/server/tests/**/*.py') }}-
-            ${{ runner.os }}-backend-test-durations-
 
       - name: Prepare backend test artifacts
         run: mkdir -p artifacts/ai/logs/ci

--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -4,58 +4,59 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import MagicMock, patch
+import time
 
-import orjson
 import pytest
 
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
 
 
+class _PayloadBuilder:
+    def __init__(self, *, delay_s: float = 0.0, payload_factory=None) -> None:
+        self._delay_s = delay_s
+        self._payload_factory = payload_factory or (lambda selected: {"selected": selected})
+
+    def __call__(self, selected: str | None) -> dict[str, object]:
+        if self._delay_s:
+            time.sleep(self._delay_s)
+        return self._payload_factory(selected)
+
+
 @pytest.mark.asyncio
-async def test_prepare_builds_payload_once_per_unique_selection() -> None:
-    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
-    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+async def test_prepare_caches_payload_text_for_selected_clients() -> None:
+    orchestrator = PayloadBuildOrchestrator(_PayloadBuilder(), capture_debug=False)
 
     await orchestrator.prepare(["same", "same", None])
 
-    assert payload_builder.call_count == 2
+    assert set(orchestrator.payload_cache) == {"same", None}
     assert json.loads(orchestrator.payload_cache["same"]) == {"selected": "same"}
     assert json.loads(orchestrator.payload_cache[None]) == {"selected": None}
 
 
 @pytest.mark.asyncio
-async def test_get_or_build_payload_text_reuses_pending_task() -> None:
-    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
-    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
-
-    async def fake_to_thread(func, /, *args, **kwargs):
-        await asyncio.sleep(0)
-        return func(*args, **kwargs)
-
-    with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
-        side_effect=fake_to_thread,
-    ):
-        first, second = await asyncio.gather(
-            orchestrator.get_or_build_payload_text("same"),
-            orchestrator.get_or_build_payload_text("same"),
-        )
+async def test_get_or_build_payload_text_returns_same_payload_for_concurrent_calls() -> None:
+    orchestrator = PayloadBuildOrchestrator(
+        _PayloadBuilder(delay_s=0.05),
+        capture_debug=False,
+    )
+    first, second = await asyncio.gather(
+        orchestrator.get_or_build_payload_text("same"),
+        orchestrator.get_or_build_payload_text("same"),
+    )
 
     assert first == second
-    assert payload_builder.call_count == 1
+    assert first == orchestrator.payload_cache["same"]
+    assert json.loads(first) == {"selected": "same"}
 
 
 @pytest.mark.asyncio
 async def test_prepare_falls_back_to_error_payload_on_serialization_failure() -> None:
-    payload_builder = MagicMock(return_value={"bad": object()})
-    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+    orchestrator = PayloadBuildOrchestrator(
+        _PayloadBuilder(payload_factory=lambda selected: {"selected": selected, "bad": object()}),
+        capture_debug=False,
+    )
 
-    with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
-        return_value=({"still_bad": object()}, False),
-    ):
-        await orchestrator.prepare(["broken"])
+    await orchestrator.prepare(["broken"])
 
     assert orchestrator.failed_client_ids == {"broken"}
     assert json.loads(orchestrator.payload_cache["broken"]) == {
@@ -64,64 +65,20 @@ async def test_prepare_falls_back_to_error_payload_on_serialization_failure() ->
 
 
 @pytest.mark.asyncio
-async def test_prepare_serializes_plain_non_finite_payload_without_sanitizer() -> None:
-    payload_builder = MagicMock(
-        side_effect=lambda selected: {
-            "selected_client_id": selected,
-            "value": float("nan"),
-        }
+async def test_prepare_replaces_non_finite_values_with_null() -> None:
+    orchestrator = PayloadBuildOrchestrator(
+        _PayloadBuilder(
+            payload_factory=lambda selected: {
+                "selected_client_id": selected,
+                "value": float("nan"),
+            }
+        ),
+        capture_debug=False,
     )
-    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
 
-    with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
-        side_effect=AssertionError("plain Python NaN should stay on the direct dump path"),
-    ):
-        await orchestrator.prepare(["sensor-a"])
+    await orchestrator.prepare(["sensor-a"])
 
     assert json.loads(orchestrator.payload_cache["sensor-a"]) == {
         "selected_client_id": "sensor-a",
         "value": None,
     }
-
-
-@pytest.mark.asyncio
-async def test_prepare_reuses_serialized_template_across_selected_clients() -> None:
-    shared_clients = [{"id": "sensor-a", "connected": True}]
-    shared_rotational_speeds = {
-        "basis_speed_source": None,
-        "wheel": {"rpm": None, "mode": None, "reason": None},
-        "driveshaft": {"rpm": None, "mode": None, "reason": None},
-        "engine": {"rpm": None, "mode": None, "reason": None},
-        "order_bands": None,
-    }
-
-    def payload_builder(selected: str | None) -> dict[str, object]:
-        return {
-            "schema_version": "1",
-            "server_time": "2026-04-18T00:00:00Z",
-            "speed_mps": None,
-            "clients": shared_clients,
-            "selected_client_id": selected,
-            "rotational_speeds": shared_rotational_speeds,
-        }
-
-    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
-    dict_dump_calls = 0
-    real_dumps = orjson.dumps
-
-    def counting_dumps(value: object) -> str:
-        nonlocal dict_dump_calls
-        if isinstance(value, dict):
-            dict_dump_calls += 1
-        return real_dumps(value).decode()
-
-    with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator._dump_json_text",
-        side_effect=counting_dumps,
-    ):
-        await orchestrator.prepare(["sensor-a", "sensor-b"])
-
-    assert dict_dump_calls == 1
-    assert json.loads(orchestrator.payload_cache["sensor-a"])["selected_client_id"] == "sensor-a"
-    assert json.loads(orchestrator.payload_cache["sensor-b"])["selected_client_id"] == "sensor-b"

--- a/apps/server/tests/infra/runtime/test_ws_payload_projection.py
+++ b/apps/server/tests/infra/runtime/test_ws_payload_projection.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from vibesensor.domain import AnalysisSettingsSnapshot
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
 from vibesensor.infra.runtime.processing_tick import STALE_DATA_AGE_S
@@ -15,6 +13,51 @@ class _SpeedResolution:
         self.source = source
 
 
+class _FakeRegistry:
+    def __init__(self, snapshots: list[ClientSnapshot]) -> None:
+        self._snapshots = snapshots
+
+    def client_snapshots(self, **_kwargs: object) -> list[ClientSnapshot]:
+        return list(self._snapshots)
+
+
+class _FakeProcessor:
+    def __init__(
+        self,
+        *,
+        fresh_ids: list[str],
+        spectra_payload: dict[str, object],
+    ) -> None:
+        self._fresh_ids = fresh_ids
+        self._spectra_payload = spectra_payload
+
+    def clients_with_recent_data(self, _client_ids: list[str], *, max_age_s: float) -> list[str]:
+        assert max_age_s == STALE_DATA_AGE_S
+        return list(self._fresh_ids)
+
+    def multi_spectrum_payload(self, _fresh_ids: list[str]) -> dict[str, object]:
+        return dict(self._spectra_payload)
+
+
+class _FakeGpsMonitor:
+    def __init__(self, resolution: _SpeedResolution) -> None:
+        self._resolution = resolution
+        self.engine_rpm = None
+
+    def resolve_speed(self) -> _SpeedResolution:
+        return self._resolution
+
+
+class _FakeSettingsReader:
+    def analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
+        return _analysis_settings()
+
+
+class _FakeSpeedSourceReader:
+    def speed_source_config(self) -> SpeedSourceConfig:
+        return SpeedSourceConfig.default()
+
+
 def _analysis_settings() -> AnalysisSettingsSnapshot:
     return AnalysisSettingsSnapshot(
         tire_width_mm=285.0,
@@ -25,45 +68,45 @@ def _analysis_settings() -> AnalysisSettingsSnapshot:
     )
 
 
-def _build_projector() -> tuple[LiveWsPayloadProjector, MagicMock, MagicMock, MagicMock]:
-    registry = MagicMock()
-    registry.client_snapshots.return_value = [
-        ClientSnapshot(
-            client_id="aaaaaaaaaaaa",
-            name="front-left",
-            connected=True,
-            sample_rate_hz=800,
-            frame_samples=256,
-            frames_total=12,
-        )
-    ]
-    processor = MagicMock()
-    processor.clients_with_recent_data.return_value = ["aaaaaaaaaaaa"]
-    processor.multi_spectrum_payload.return_value = {
-        "frame_fingerprint": "aaaaaaaaaaaa:0:0:0",
-        "freq": [],
-        "clients": {"aaaaaaaaaaaa": {}},
-    }
-    gps_monitor = MagicMock()
-    gps_monitor.resolve_speed.return_value = _SpeedResolution(12.5)
-    gps_monitor.engine_rpm = None
-    settings_reader = MagicMock()
-    settings_reader.analysis_settings_snapshot.return_value = _analysis_settings()
-    speed_source_reader = MagicMock()
-    speed_source_reader.speed_source_config.return_value = SpeedSourceConfig.default()
+def _build_projector(
+    *,
+    speed_mps: float | None = 12.5,
+    speed_source: str = "gps",
+) -> tuple[LiveWsPayloadProjector, _FakeProcessor, _FakeGpsMonitor]:
+    registry = _FakeRegistry(
+        [
+            ClientSnapshot(
+                client_id="aaaaaaaaaaaa",
+                name="front-left",
+                connected=True,
+                sample_rate_hz=800,
+                frame_samples=256,
+                frames_total=12,
+            )
+        ]
+    )
+    processor = _FakeProcessor(
+        fresh_ids=["aaaaaaaaaaaa"],
+        spectra_payload={
+            "frame_fingerprint": "aaaaaaaaaaaa:0:0:0",
+            "freq": [],
+            "clients": {"aaaaaaaaaaaa": {}},
+        },
+    )
+    gps_monitor = _FakeGpsMonitor(_SpeedResolution(speed_mps, speed_source))
     projector = LiveWsPayloadProjector(
         registry=registry,
         processor=processor,
         gps_monitor=gps_monitor,
         gps_enabled=True,
-        settings_reader=settings_reader,
-        speed_source_reader=speed_source_reader,
+        settings_reader=_FakeSettingsReader(),
+        speed_source_reader=_FakeSpeedSourceReader(),
     )
-    return projector, processor, registry, gps_monitor
+    return projector, processor, gps_monitor
 
 
 def test_build_shared_payload_projects_live_rows_without_broadcaster() -> None:
-    projector, processor, registry, _gps_monitor = _build_projector()
+    projector, _processor, _gps_monitor = _build_projector()
 
     payload = projector.build_shared_payload(include_heavy=True)
 
@@ -74,32 +117,22 @@ def test_build_shared_payload_projects_live_rows_without_broadcaster() -> None:
     assert payload["rotational_speeds"]["basis_speed_source"] == "gps"
     assert "spectra" in payload
     assert payload["spectra"]["frame_fingerprint"] == "aaaaaaaaaaaa:0:0:0"
-    registry.client_snapshots.assert_called_once_with(
-        now=None,
-        now_mono=None,
-        metrics_by_client=None,
-    )
-    processor.clients_with_recent_data.assert_called_once_with(
-        ["aaaaaaaaaaaa"],
-        max_age_s=STALE_DATA_AGE_S,
-    )
 
 
 def test_build_shared_payload_light_tick_omits_spectra() -> None:
-    projector, processor, _registry, _gps_monitor = _build_projector()
+    projector, _processor, _gps_monitor = _build_projector()
 
     payload = projector.build_shared_payload(include_heavy=False)
 
     assert "spectra" not in payload
-    processor.multi_spectrum_payload.assert_not_called()
 
 
 def test_build_shared_payload_carries_speed_unavailable_reason() -> None:
-    projector, _processor, _registry, gps_monitor = _build_projector()
-    gps_monitor.resolve_speed.return_value = _SpeedResolution(None)
+    projector, _processor, _gps_monitor = _build_projector(speed_mps=None)
 
     payload = projector.build_shared_payload(include_heavy=False)
 
+    assert payload["speed_mps"] is None
     assert payload["rotational_speeds"]["wheel"]["reason"] == "speed_unavailable"
 
 
@@ -112,45 +145,40 @@ def test_build_shared_payload_marks_retained_stale_clients_disconnected(
     from vibesensor.infra.runtime.registry import ClientRegistry
 
     db = create_history_persistence_adapters(tmp_path / "history.db")
-    registry = ClientRegistry(
-        db=db.client_name_repository,
-        live_ttl_seconds=5.0,
-        retention_ttl_seconds=30.0,
-    )
-    hello = HelloMessage(
-        client_id=bytes.fromhex("001122334455"),
-        control_port=9010,
-        sample_rate_hz=800,
-        name="sensor",
-        firmware_version="fw",
-    )
-    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
+    try:
+        registry = ClientRegistry(
+            db=db.client_name_repository,
+            live_ttl_seconds=5.0,
+            retention_ttl_seconds=30.0,
+        )
+        hello = HelloMessage(
+            client_id=bytes.fromhex("001122334455"),
+            control_port=9010,
+            sample_rate_hz=800,
+            name="sensor",
+            firmware_version="fw",
+        )
+        registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
 
-    now = {"wall": 9.0, "mono": 9.0}
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
+        now = {"wall": 9.0, "mono": 9.0}
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
 
-    processor = MagicMock()
-    processor.clients_with_recent_data.return_value = []
-    processor.multi_spectrum_payload.return_value = {"freq": [], "clients": {}}
-    gps_monitor = MagicMock()
-    gps_monitor.resolve_speed.return_value = _SpeedResolution(12.5)
-    gps_monitor.engine_rpm = None
-    settings_reader = MagicMock()
-    settings_reader.analysis_settings_snapshot.return_value = _analysis_settings()
-    speed_source_reader = MagicMock()
-    speed_source_reader.speed_source_config.return_value = SpeedSourceConfig.default()
-    projector = LiveWsPayloadProjector(
-        registry=registry,
-        processor=processor,
-        gps_monitor=gps_monitor,
-        gps_enabled=True,
-        settings_reader=settings_reader,
-        speed_source_reader=speed_source_reader,
-    )
+        processor = _FakeProcessor(fresh_ids=[], spectra_payload={"freq": [], "clients": {}})
+        gps_monitor = _FakeGpsMonitor(_SpeedResolution(12.5))
+        projector = LiveWsPayloadProjector(
+            registry=registry,
+            processor=processor,
+            gps_monitor=gps_monitor,
+            gps_enabled=True,
+            settings_reader=_FakeSettingsReader(),
+            speed_source_reader=_FakeSpeedSourceReader(),
+        )
 
-    payload = projector.build_shared_payload(include_heavy=False)
+        payload = projector.build_shared_payload(include_heavy=False)
 
-    assert len(payload["clients"]) == 1
-    assert payload["clients"][0]["connected"] is False
-    assert payload["clients"][0]["last_seen_age_ms"] == 8000
+        assert len(payload["clients"]) == 1
+        assert payload["clients"][0]["connected"] is False
+        assert payload["clients"][0]["last_seen_age_ms"] == 8000
+    finally:
+        db.lifecycle.close()

--- a/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
+++ b/apps/server/tests/shared/boundaries/test_analysis_summary_projection.py
@@ -150,11 +150,7 @@ def test_project_analysis_summary_uses_list_sensor_locations_for_fallback_confid
     )
 
 
-def test_project_persisted_analysis_uses_persisted_reconstruction_path(
-    monkeypatch,
-) -> None:
-    import vibesensor.shared.boundaries.analysis_payloads.projection as projection
-
+def test_project_persisted_analysis_projects_persisted_payload_contract() -> None:
     analysis = PersistedAnalysis.from_json_object(
         {
             "case_id": "case-001",
@@ -167,11 +163,6 @@ def test_project_persisted_analysis_uses_persisted_reconstruction_path(
             "warnings": [],
         }
     )
-
-    def _explode(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("project_persisted_analysis should not use test_run_from_summary")
-
-    monkeypatch.setattr(projection, "test_run_from_summary", _explode)
 
     projected, test_run = project_persisted_analysis(analysis)
 


### PR DESCRIPTION
## What changed
- rewrite the live payload projector tests around emitted payload rows and stale-client payload output instead of registry/processor call shapes
- rewrite the payload orchestrator tests around cached/emitted payload text, concurrent result stability, fallback error payloads, and NaN-to-null normalization instead of serializer and cache internals
- keep the persisted-analysis projection test on the public projection contract, leave the lower-level websocket payload-shape owners unchanged, and stop backend test shards from restoring stale cross-hash duration caches after test edits

## Why
- fixes #3408
- the old tests were proving helper selection, call graphs, and optimization details instead of the payload contracts clients actually consume
- the first PR run timed out because shard 2 restored duration data from an older backend-test hash, shifted from the usual ~1438/~1616 selected tests to 1684, and hit the 15-minute timeout

## Validation
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/infra/runtime/test_ws_payload_projection.py apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/shared/boundaries/test_analysis_summary_projection.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/infra/runtime apps/server/tests/adapters/websocket apps/server/tests/shared/boundaries`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- direct assertions about payload-builder dedupe and template-cache internals are gone; emitted payload results and the lower-level websocket payload owners now carry the durable contract coverage
- backend shard timing reuse now stays within the current backend-test hash; the first run for a changed test hash may cold-start instead of borrowing timings from older suite layouts
- the broader runtime/websocket/shared-boundary slice still shows one unrelated pre-existing `aiosqlite` worker-thread warning in `tests/shared/boundaries/test_run_metadata_codec.py`

## Follow-ups
- none