### PR TITLE
Rewrite UI transport test around state

### DIFF
--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -33,10 +33,6 @@ function makeClient(id: string): LiveWsPayload["clients"][number] {
   };
 }
 
-function applyPayload(controller: UiLiveTransportController, payload: LiveWsPayload): void {
-  (controller as unknown as { applyPayload(nextPayload: LiveWsPayload): void }).applyPayload(payload);
-}
-
 function installRafHarness() {
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
   const callbacks: FrameRequestCallback[] = [];
@@ -269,18 +265,6 @@ describe("UiLiveTransportController", () => {
     wsUiState.value = "connected";
     await flushAsyncWork();
     expect(state.transport.wsState.value).toBe("connected");
-  });
-
-  test("applies payloads without requiring feature-port attachment", async () => {
-    const state = createAppState();
-    const controller = new UiLiveTransportController({
-      state,
-      payloadErrorMessage: () => "payload error",
-    });
-
-    expect(() => applyPayload(controller, makeLivePayload())).not.toThrow();
-    await flushAsyncWork(30);
-    expect(state.realtime.speedMps.value).toBe(10);
   });
 
   test("routes demo mode through the shared queued transport pipeline", async () => {


### PR DESCRIPTION
## What changed
- delete the `UiLiveTransportController` spec helper that cast into the private `applyPayload()` method
- remove the redundant direct-call test and keep the queued-payload and websocket-ingress tests as the public owner for the same state update behavior

## Why
- fixes #3410
- the audit showed the frontend runtime/transport issue was narrower than the file list: the surrounding live payload, ws client, and shell status tests were already public-state-first
- the remaining bad seam was one redundant controller test reaching into a private method even though adjacent tests already proved the same behavior through public state signals

## Validation
- `make ui-typecheck`
- `cd apps/ui && npx vitest run tests/ui_live_transport_controller.spec.ts tests/ui_live_payload_application.spec.ts tests/ws_contract.spec.ts tests/ui_shell_runtime_modules.spec.ts tests/ws.spec.ts`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- direct coverage for the private `applyPayload()` entrypoint is intentionally gone; the queued-payload and websocket-ingress tests remain as the public owner for live transport state application
- the rest of the candidate files stayed unchanged after audit because they were already proving public state or contract behavior

## Follow-ups
- none