### PR TITLE
Rewrite simulator tests around emitted behavior

### DIFF
--- a/apps/server/tests/adapters/simulator/test_sim_runtime.py
+++ b/apps/server/tests/adapters/simulator/test_sim_runtime.py
@@ -1,61 +1,60 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 
 import pytest
 
 from vibesensor.adapters.simulator.sim_runtime import command_loop
 
 
+@dataclass
+class _SummaryFailingClient:
+    name: str = "front-left"
+    client_id: bytes = b"\x01\x02\x03\x04\x05\x06"
+    profile_name: str = "engine_idle"
+    scene_mode: str = "road"
+    scene_gain: float = 1.0
+    scene_noise_gain: float = 1.0
+    amp_scale: float = 1.0
+    noise_scale: float = 1.0
+    common_event_gain: float = 0.0
+    paused: bool = False
+
+    @property
+    def mac_address(self) -> str:
+        return "01:02:03:04:05:06"
+
+    def pulse(self, _strength: float) -> None:
+        return None
+
+    def summary(self) -> str:
+        raise RuntimeError("boom")
+
+
 @pytest.mark.asyncio
-async def test_command_loop_handles_value_error_and_continues(monkeypatch, capsys) -> None:
+async def test_command_loop_handles_command_parse_error_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     stop_event = asyncio.Event()
-    prompts = iter(["bad", "quit"])
-    calls: list[str] = []
-
-    async def fake_to_thread(_func, _prompt: str) -> str:
-        return next(prompts)
-
-    def fake_apply_command(_clients, line: str, stop: asyncio.Event, _profiles):
-        calls.append(line)
-        if line == "bad":
-            raise ValueError("bad value")
-        stop.set()
-        return "Stopping simulator..."
-
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.sim_runtime.asyncio.to_thread",
-        fake_to_thread,
-    )
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.sim_runtime.apply_command",
-        fake_apply_command,
-    )
+    prompts = iter(['bad "quote', "quit"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(prompts))
 
     await command_loop([], stop_event)
 
-    assert calls == ["bad", "quit"]
-    assert "Command error: bad value" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert stop_event.is_set()
+    assert "Command error:" in output
+    assert "Stopping simulator..." in output
 
 
 @pytest.mark.asyncio
-async def test_command_loop_propagates_unexpected_command_errors(monkeypatch) -> None:
+async def test_command_loop_propagates_unexpected_command_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     stop_event = asyncio.Event()
-
-    async def fake_to_thread(_func, _prompt: str) -> str:
-        return "boom"
-
-    def fake_apply_command(_clients, _line: str, _stop: asyncio.Event, _profiles):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.sim_runtime.asyncio.to_thread",
-        fake_to_thread,
-    )
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.sim_runtime.apply_command",
-        fake_apply_command,
-    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "list")
 
     with pytest.raises(RuntimeError, match="boom"):
-        await command_loop([], stop_event)
+        await command_loop([_SummaryFailingClient()], stop_event)

--- a/apps/server/tests/integration/test_ingest_backpressure_metrics.py
+++ b/apps/server/tests/integration/test_ingest_backpressure_metrics.py
@@ -140,21 +140,17 @@ def _ready_health_state() -> RuntimeHealthState:
 
 
 def _backpressure_wait_state(
-    proto: DataDatagramProtocol,
     ingest_diagnostics: IngestDiagnosticsCollector,
-    websocket: AsyncMock,
 ) -> dict[str, object]:
     udp = ingest_diagnostics.udp_snapshot()
     raw_capture = ingest_diagnostics.raw_capture_snapshot()
     ws_publish = ingest_diagnostics.ws_publish_snapshot()
     return {
-        "udp_queue_size": proto._queue.qsize(),
         "udp_processed_datagrams": udp.processed_datagrams,
         "udp_queue_depth": udp.queue_depth,
         "raw_capture_queue_depth": raw_capture.queue_depth,
         "ws_publish_ticks": ws_publish.total_publish_ticks,
         "ws_active_connections": ws_publish.active_connections,
-        "ws_send_count": websocket.send_text.await_count,
     }
 
 
@@ -241,11 +237,13 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
         )
     )
     try:
-        recorder.start_recording()
+        started = recorder.start_recording()
+        run_id = started.run_id
+        start_utc = started.start_time_utc
+        assert run_id is not None
+        assert start_utc is not None
         snapshot = recorder._session_snapshot()
         assert snapshot is not None
-        run_id = snapshot.run_id
-        start_utc = snapshot.start_time_utc
         start_mono = snapshot.start_mono_s
         seq_by_sensor = {sensor.client_id.hex(): 1 for sensor in sensors}
         deferred_late_seq_by_sensor: dict[str, int] = {}
@@ -292,11 +290,7 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
                     lambda expected=expected_processed_datagrams: (
                         ingest_diagnostics.udp_snapshot().processed_datagrams >= expected
                     ),
-                    state=lambda: _backpressure_wait_state(
-                        proto,
-                        ingest_diagnostics,
-                        websocket,
-                    ),
+                    state=lambda: _backpressure_wait_state(ingest_diagnostics),
                 )
                 processor.compute_all(
                     registry.active_client_ids(),
@@ -311,15 +305,19 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
             if step % 6 == 5:
                 await _assert_async_wait_until(
                     "udp queue drain after the current burst",
-                    lambda: proto._queue.qsize() == 0,
-                    state=lambda: _backpressure_wait_state(
-                        proto,
-                        ingest_diagnostics,
-                        websocket,
-                    ),
+                    lambda: ingest_diagnostics.udp_snapshot().queue_depth == 0,
+                    state=lambda: _backpressure_wait_state(ingest_diagnostics),
                 )
 
-        await asyncio.wait_for(proto._queue.join(), timeout=10.0)
+        await _assert_async_wait_until(
+            "udp queue drain after simulator load completes",
+            lambda expected=expected_processed_datagrams: (
+                ingest_diagnostics.udp_snapshot().queue_depth == 0
+                and ingest_diagnostics.udp_snapshot().processed_datagrams >= expected
+            ),
+            timeout_s=10.0,
+            state=lambda: _backpressure_wait_state(ingest_diagnostics),
+        )
         processor.compute_all(
             registry.active_client_ids(),
             sample_rates_hz=_sample_rates(registry),
@@ -335,14 +333,9 @@ async def test_ingest_metrics_hold_ci_budget_under_sensor_load(
             lambda: (
                 ingest_diagnostics.raw_capture_snapshot().queue_depth == 0
                 and ingest_diagnostics.ws_publish_snapshot().total_publish_ticks > 0
-                and websocket.send_text.await_count > 0
             ),
             timeout_s=5.0,
-            state=lambda: _backpressure_wait_state(
-                proto,
-                ingest_diagnostics,
-                websocket,
-            ),
+            state=lambda: _backpressure_wait_state(ingest_diagnostics),
         )
 
         health = await asyncio.to_thread(


### PR DESCRIPTION
## What changed
- rewrote `apps/server/tests/adapters/simulator/test_sim_runtime.py` around real `command_loop()` input and real command parsing instead of patched `asyncio.to_thread` / `apply_command()`
- rewrote `apps/server/tests/integration/test_ingest_backpressure_metrics.py` waits around public ingest diagnostics and health metrics instead of `proto._queue` and mock websocket send call counts
- left `apps/server/tests/integration/test_sim_ingestion.py` unchanged because it already owns the public simulator -> history/report contract

## Why
- simulator tests should follow emitted behavior and public metrics, not runtime helper structure
- private queue objects and command-loop call graphs are brittle under safe refactors

## Validation
- `make format`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/simulator/test_sim_runtime.py apps/server/tests/integration/test_ingest_backpressure_metrics.py apps/server/tests/integration/test_sim_ingestion.py`
- `./.venv/bin/python -m pytest -q -n 0 apps/server/tests/adapters/simulator apps/server/tests/integration/test_ingest_backpressure_metrics.py apps/server/tests/integration/test_sim_ingestion.py`
- `make typecheck-backend`
- `PATH="$PWD/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- `test_ingest_backpressure_metrics.py` still uses `recorder._session_snapshot()` / `_sample_flush.append_records(...)` because the current public recorder API does not expose `start_mono_s` or a flush hook; this change removes the issue's targeted queue/runtime coupling without inventing new production seams
- `test_sim_ingestion.py` stays unchanged by design because it already covers the public subprocess/API path

Closes #3412
