### PR TITLE
Remove redundant updater cancellation handler

### DIFF
--- a/apps/server/vibesensor/use_cases/updates/finalization.py
+++ b/apps/server/vibesensor/use_cases/updates/finalization.py
@@ -35,8 +35,6 @@ class UpdateWorkflowFinalizer:
         try:
             await self._transport_coordinator.cleanup_after_update(prepared_transport)
             await self._runtime_details_refresher.refresh()
-        except asyncio.CancelledError:
-            raise
         except UpdateCleanupError as exc:
             if prior_error is None:
                 raise


### PR DESCRIPTION
Closes #3458

## What changed
- Removed the redundant `except asyncio.CancelledError: raise` branch from update workflow finalization.

## Why
- `CancelledError` is not caught by the remaining `except UpdateCleanupError` handler.
- The branch only re-raised unchanged and added no behavior.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/use_cases/updates/test_update_finalization.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/use_cases/updates/finalization.py tests/use_cases/updates/test_update_finalization.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/use_cases/updates/finalization.py tests/use_cases/updates/test_update_finalization.py`
- `uv run --python 3.13 --extra dev mypy --config-file pyproject.toml vibesensor/use_cases/updates/finalization.py`

## Risks / tradeoffs / edge cases
- Tiny cleanup only. Cancellation still propagates because it is not handled by the cleanup-error branch.
- `asyncio` import remains needed for `prior_error` cancellation handling.

## Follow-ups
- None.
