### PR TITLE
Replace app lazy facade with direct reexports

### DIFF
--- a/apps/server/tests/app/test_import_purity.py
+++ b/apps/server/tests/app/test_import_purity.py
@@ -53,15 +53,17 @@ def _run_import_probe(import_code: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_importing_app_package_stays_lightweight() -> None:
+def test_importing_app_package_exposes_startup_entrypoints() -> None:
     result = _run_import_probe(
         """
 import importlib
-import sys
 
 module = importlib.import_module("vibesensor.app")
 assert module.__name__ == "vibesensor.app"
-assert "vibesensor.app.bootstrap" not in sys.modules
+assert callable(module.create_app)
+assert callable(module.create_app_from_env)
+assert callable(module.main)
+assert not hasattr(module, "app")
         """
     )
     assert result.stdout.strip() == "ok"

--- a/apps/server/vibesensor/app/__init__.py
+++ b/apps/server/vibesensor/app/__init__.py
@@ -1,14 +1,5 @@
 """Lightweight application package facade for explicit startup entrypoints."""
 
+from .bootstrap import create_app, create_app_from_env, main
+
 __all__ = ["create_app", "create_app_from_env", "main"]
-
-
-def __getattr__(name: str) -> object:
-    from importlib import import_module
-
-    bootstrap = import_module(".bootstrap", __name__)
-
-    try:
-        return getattr(bootstrap, name)
-    except AttributeError as exc:
-        raise AttributeError(name) from exc


### PR DESCRIPTION
Closes #3459

## What changed
- Replaced the lazy `vibesensor.app.__getattr__` facade with direct re-exports from `vibesensor.app.bootstrap`.
- Updated the app import-purity test to assert the package exposes the startup entrypoints directly and still does not construct an app.

## Why
- The public API stays the same: `create_app`, `create_app_from_env`, and `main` remain exported from `vibesensor.app`.
- Direct re-exports remove runtime `import_module` indirection and improve static analysis.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/app/test_import_purity.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/app/__init__.py tests/app/test_import_purity.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/app/__init__.py tests/app/test_import_purity.py`
- `uv run --python 3.13 --extra dev mypy --config-file pyproject.toml vibesensor/app/__init__.py`

## Risks / tradeoffs / edge cases
- `import vibesensor.app` now imports `vibesensor.app.bootstrap` immediately. The test keeps coverage that this import path does not build runtime state or create an app object.
- No external API rename.

## Follow-ups
- None.
