### PR TITLE
Consolidate capture readiness finite helper

### DIFF
--- a/apps/server/vibesensor/use_cases/run/capture_readiness_evaluator.py
+++ b/apps/server/vibesensor/use_cases/run/capture_readiness_evaluator.py
@@ -6,7 +6,6 @@ import math
 
 from vibesensor.domain import CaptureReadiness, CaptureReadinessCheck, CaptureReadinessPolicy
 from vibesensor.shared.constants.analysis import STEADY_SPEED_RANGE_KMH, STEADY_SPEED_STDDEV_KMH
-from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.shared.order_reference_settings import order_reference_spec_from_snapshot
 from vibesensor.use_cases.run.capture_readiness_observation import (
     CaptureReadinessObservation,
@@ -16,6 +15,7 @@ from vibesensor.use_cases.run.capture_readiness_state import (
     CaptureReadinessStateSnapshot,
     IntegrityState,
     SpeedObservation,
+    _is_finite_number,
 )
 
 __all__ = ["evaluate_capture_readiness"]
@@ -401,7 +401,3 @@ def _stddev(values: tuple[float, ...]) -> float:
     mean_value = sum(values) / len(values)
     variance = sum((value - mean_value) ** 2 for value in values) / len(values)
     return math.sqrt(variance)
-
-
-def _is_finite_number(value: object) -> bool:
-    return isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool) and math.isfinite(value)

--- a/apps/server/vibesensor/use_cases/run/capture_readiness_state.py
+++ b/apps/server/vibesensor/use_cases/run/capture_readiness_state.py
@@ -7,6 +7,7 @@ from collections import deque
 from dataclasses import dataclass
 
 from vibesensor.domain import CaptureReadinessPolicy
+from vibesensor.shared.constants.type_checks import NUMERIC_TYPES
 from vibesensor.use_cases.run.capture_readiness_observation import (
     CaptureReadinessObservation,
     CaptureReadinessSensorObservation,
@@ -220,4 +221,4 @@ class CaptureReadinessState:
 
 
 def _is_finite_number(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+    return isinstance(value, NUMERIC_TYPES) and not isinstance(value, bool) and math.isfinite(value)


### PR DESCRIPTION
Closes #3461

## What changed
- Kept one `_is_finite_number` helper for capture-readiness code.
- Moved the `NUMERIC_TYPES`-based implementation into `capture_readiness_state`.
- Reused that helper from `capture_readiness_evaluator` and removed the duplicate evaluator copy.

## Why
- The two helpers did the same finite-number check.
- `capture_readiness_state` is the safe owner because evaluator already imports state types. Importing evaluator from state would create a cycle.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/use_cases/run/test_capture_readiness*.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/use_cases/run/capture_readiness_evaluator.py vibesensor/use_cases/run/capture_readiness_state.py tests/use_cases/run/test_capture_readiness*.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/use_cases/run/capture_readiness_evaluator.py vibesensor/use_cases/run/capture_readiness_state.py tests/use_cases/run/test_capture_readiness*.py`
- `uv run --python 3.13 --extra dev mypy --config-file pyproject.toml vibesensor/use_cases/run/capture_readiness_evaluator.py vibesensor/use_cases/run/capture_readiness_state.py`

## Risks / tradeoffs / edge cases
- The helper remains private to the run package modules.
- Behavior stays the same: booleans are still excluded and values must be finite numeric types.

## Follow-ups
- None.
