### PR TITLE
Remove redundant vibration db aliases

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_units_db_only.py
@@ -97,18 +97,16 @@ def test_post_analysis_summary_has_no_g_unit_strings(_summary: dict[str, Any]) -
 
 
 def test_analysis_modules_use_canonical_db_helper() -> None:
-    """Analysis modules must import vibration_strength_db_scalar as canonical_vibration_db
-    and call it via the alias, not directly as vibration_strength_db_scalar().
-    """
+    """Analysis modules must use the canonical vibration_strength_db_scalar helper."""
     analysis_root = SERVER_ROOT / "vibesensor" / "use_cases" / "diagnostics"
 
-    direct_users = [
+    alias_users = [
         str(py_file.relative_to(analysis_root))
         for py_file in sorted(analysis_root.rglob("*.py"))
-        if "vibration_strength_db_scalar(" in py_file.read_text(encoding="utf-8")
+        if "as canonical_vibration_db" in py_file.read_text(encoding="utf-8")
     ]
 
-    assert not direct_users, (
-        "Analysis modules must use canonical_vibration_db() (aliased import); "
-        "direct vibration_strength_db_scalar() calls found in: " + ", ".join(direct_users)
+    assert not alias_users, (
+        "Analysis modules must import vibration_strength_db_scalar directly; "
+        "aliased imports found in: " + ", ".join(alias_users)
     )

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py
@@ -22,9 +22,7 @@ from vibesensor.use_cases.diagnostics.orders.scoring import (
 from vibesensor.use_cases.diagnostics.orders.statistics import (
     compute_matched_speed_phase_evidence,
 )
-from vibesensor.vibration_strength import (
-    vibration_strength_db_scalar as canonical_vibration_db,
-)
+from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 
 def assemble_order_finding(
@@ -78,7 +76,7 @@ def assemble_order_finding(
             global_match_rate=context.match_rate,
             focused_speed_band=context.focused_speed_band,
             mean_relative_error=score.mean_relative_error,
-            mean_noise_floor_db=canonical_vibration_db(
+            mean_noise_floor_db=vibration_strength_db_scalar(
                 peak_band_rms_amp_g=max(MEMS_NOISE_FLOOR_G, score.mean_floor),
                 floor_amp_g=MEMS_NOISE_FLOOR_G,
             ),

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py
@@ -22,9 +22,7 @@ from vibesensor.use_cases.diagnostics.orders.statistics import (
     compute_order_confidence,
     compute_phase_stats,
 )
-from vibesensor.vibration_strength import (
-    vibration_strength_db_scalar as canonical_vibration_db,
-)
+from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 
 @dataclass(frozen=True)
@@ -148,7 +146,7 @@ def score_order_finding(
     snr_score = min(1.0, log1p(mean_amp / max(MEMS_NOISE_FLOOR_G, mean_floor)) / SNR_LOG_DIVISOR)
     if mean_amp <= 2 * MEMS_NOISE_FLOOR_G:
         snr_score = min(snr_score, 0.40)
-    absolute_strength_db = canonical_vibration_db(
+    absolute_strength_db = vibration_strength_db_scalar(
         peak_band_rms_amp_g=mean_amp,
         floor_amp_g=max(MEMS_NOISE_FLOOR_G, mean_floor),
     )

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
@@ -6,9 +6,7 @@ from collections.abc import Mapping, Sequence
 from math import log1p
 
 from vibesensor.shared.constants.analysis import NEGLIGIBLE_STRENGTH_MAX_DB, SNR_LOG_DIVISOR
-from vibesensor.vibration_strength import (
-    vibration_strength_db_scalar as canonical_vibration_db,
-)
+from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 from .._sample_metrics import _effective_baseline_floor
 from .classification import classify_peak_type
@@ -169,7 +167,7 @@ class PeakBin:
             spatial_uniformity=spatial_uniformity,
             speed_uniformity=speed_uniformity,
         )
-        peak_strength_db = canonical_vibration_db(
+        peak_strength_db = vibration_strength_db_scalar(
             peak_band_rms_amp_g=stats.p95_amp,
             floor_amp_g=effective_floor,
         )


### PR DESCRIPTION
Closes #3462

## What changed
- Removed `as canonical_vibration_db` import aliases in diagnostics scoring/building modules.
- Updated call sites to use `vibration_strength_db_scalar` directly.
- Updated the diagnostics unit guard to reject the old alias form.

## Why
- `vibration_strength_db_scalar` is already the canonical entrypoint.
- Direct usage improves grep-ability and avoids a second local name for the same function.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/use_cases/diagnostics/test_analysis_units_db_only.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/use_cases/diagnostics/peaks/scoring.py vibesensor/use_cases/diagnostics/orders/scoring.py vibesensor/use_cases/diagnostics/orders/finding_builder.py tests/use_cases/diagnostics/test_analysis_units_db_only.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/use_cases/diagnostics/peaks/scoring.py vibesensor/use_cases/diagnostics/orders/scoring.py vibesensor/use_cases/diagnostics/orders/finding_builder.py tests/use_cases/diagnostics/test_analysis_units_db_only.py`
- `uv run --python 3.13 --extra dev mypy --config-file pyproject.toml vibesensor/use_cases/diagnostics/peaks/scoring.py vibesensor/use_cases/diagnostics/orders/scoring.py vibesensor/use_cases/diagnostics/orders/finding_builder.py`

## Risks / tradeoffs / edge cases
- Identifier rename only. Function and arguments are unchanged.
- Test guard now protects the direct canonical import style.

## Follow-ups
- None.
