### PR TITLE
Inline raw timeline legacy helper

### DIFF
--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -252,7 +252,9 @@ def build_raw_backed_samples(
     sample_rate_unverified_sensor_count = sum(
         1 for sensor in raw_capture.sensors if sensor.manifest.sample_rate_unverified
     )
-    legacy_sensor_count = sum(1 for timeline in timelines.values() if _timeline_is_legacy(timeline))
+    legacy_sensor_count = sum(
+        1 for timeline in timelines.values() if raw_timeline_is_legacy(timeline)
+    )
     sync_unverified_sensor_count = sum(
         1 for timeline in timelines.values() if _timeline_has_unverified_sync(timeline)
     )
@@ -740,10 +742,6 @@ def _build_replay_warnings(
         )
     )
     return tuple(warnings)
-
-
-def _timeline_is_legacy(timeline: RawSensorTimeline) -> bool:
-    return raw_timeline_is_legacy(timeline)
 
 
 def _timeline_has_unverified_sync(timeline: RawSensorTimeline) -> bool:


### PR DESCRIPTION
Closes #3463

## What changed
- Replaced the single `_timeline_is_legacy(...)` call with `raw_timeline_is_legacy(...)`.
- Deleted the private one-line wrapper.

## Why
- The canonical helper was already imported in `raw_capture_replay.py`.
- The private wrapper added no behavior or abstraction.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/use_cases/run/test_raw_capture_replay.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/use_cases/run/raw_capture_replay.py tests/use_cases/run/test_raw_capture_replay.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/use_cases/run/raw_capture_replay.py tests/use_cases/run/test_raw_capture_replay.py`
- `uv run --python 3.13 --extra dev mypy --config-file pyproject.toml vibesensor/use_cases/run/raw_capture_replay.py`

## Risks / tradeoffs / edge cases
- Identifier-only cleanup. Legacy timeline detection still uses the same canonical helper.

## Follow-ups
- None.
