### PR TITLE
Remove UI FindingPayload API alias

### DIFF
--- a/apps/ui/src/api/types.ts
+++ b/apps/ui/src/api/types.ts
@@ -25,7 +25,6 @@ export type EspFlashPortsPayload = Schema<"EspFlashPortsResponse">;
 export type EspFlashStartPayload = Schema<"EspFlashStartResponse">;
 export type EspFlashStatusPayload = Schema<"EspFlashStatusResponse">;
 export type EspSerialPortPayload = Schema<"EspSerialPortResponse">;
-export type FindingPayload = Schema<"FindingPayload">;
 export type HealthStatusPayload = Schema<"HealthResponse">;
 export type HistoryEntry = Schema<"HistoryListEntryResponse">;
 export type HistoryInsightWarningPayload = Schema<"HistoryInsightWarningResponse">;

--- a/apps/ui/src/app/views/history_detail_presenter.ts
+++ b/apps/ui/src/app/views/history_detail_presenter.ts
@@ -1,8 +1,4 @@
-import type {
-  FindingPayload,
-  HistoryEntry,
-  HistoryInsightsPayload,
-} from "../../api/types";
+import type { HistoryEntry, HistoryInsightsPayload } from "../../api/types";
 import type { RunDetail } from "../ui_app_state";
 import { buildHistoryHeatmapViewModel } from "./history_heatmap_presenter";
 import {
@@ -17,6 +13,7 @@ import {
   isInconclusiveFinding,
   summarizeFindings,
   summarizeWarnings,
+  type HistoryFindingPayload,
   type PresenterParams,
 } from "./history_presenter_shared";
 import type {
@@ -27,7 +24,7 @@ import type {
   HistoryWarningBannerViewModel,
 } from "./history_table_models";
 
-function shouldShowNextStep(finding: FindingPayload | null): boolean {
+function shouldShowNextStep(finding: HistoryFindingPayload | null): boolean {
   if (!finding) {
     return false;
   }
@@ -95,7 +92,7 @@ function buildPrimaryFinding(
 }
 
 function buildSecondaryFinding(
-  finding: FindingPayload,
+  finding: HistoryFindingPayload,
   summary: HistoryInsightsPayload,
   params: Pick<PresenterParams, "fmt" | "t">,
 ): HistorySecondaryFindingViewModel {

--- a/apps/ui/src/app/views/history_presenter_shared.ts
+++ b/apps/ui/src/app/views/history_presenter_shared.ts
@@ -1,5 +1,4 @@
 import type {
-  FindingPayload,
   HistoryEntry,
   HistoryInsightWarningPayload,
   HistoryInsightsPayload,
@@ -21,6 +20,8 @@ export type PresenterParams = Pick<
   | "runs"
   | "t"
 >;
+
+export type HistoryFindingPayload = HistoryInsightsPayload["findings"][number];
 
 export type HistoryRowStatusBadge = {
   label: string;
@@ -56,7 +57,7 @@ export const EMPTY_RUN_DETAIL: RunDetail = {
 
 export function summarizeFindings(
   summary: HistoryInsightsPayload | null,
-): FindingPayload[] {
+): HistoryFindingPayload[] {
   return summary?.findings?.slice(0, VISIBLE_FINDING_LIMIT) ?? [];
 }
 
@@ -101,12 +102,14 @@ function isInconclusiveSource(source: unknown): boolean {
   return key === "" || key === "unknown_resonance" || key === "baseline_noise";
 }
 
-export function isInconclusiveFinding(finding: FindingPayload | null): boolean {
+export function isInconclusiveFinding(
+  finding: HistoryFindingPayload | null,
+): boolean {
   return finding !== null && isInconclusiveSource(finding.suspected_source);
 }
 
 export function confidenceText(
-  finding: FindingPayload,
+  finding: HistoryFindingPayload,
   params: Pick<PresenterParams, "fmt" | "t">,
 ): string {
   const { fmt, t } = params;
@@ -121,7 +124,7 @@ export function confidenceText(
 }
 
 export function findingTone(
-  finding: FindingPayload | null,
+  finding: HistoryFindingPayload | null,
 ): HistoryFindingTone {
   const tone = String(finding?.confidence_tone ?? "").toLowerCase();
   if (tone === "success" || tone === "warn") {
@@ -131,7 +134,7 @@ export function findingTone(
 }
 
 export function findingSignatureText(
-  finding: FindingPayload,
+  finding: HistoryFindingPayload,
   params: Pick<PresenterParams, "fmt">,
 ): string {
   const raw = finding.frequency_hz_or_order;
@@ -143,7 +146,7 @@ export function findingSignatureText(
 }
 
 export function findingLocationText(
-  finding: FindingPayload,
+  finding: HistoryFindingPayload,
   summary: HistoryInsightsPayload | null,
   t: PresenterParams["t"],
 ): string {
@@ -155,7 +158,7 @@ export function findingLocationText(
 }
 
 export function findingSpeedBandText(
-  finding: FindingPayload,
+  finding: HistoryFindingPayload,
   summary: HistoryInsightsPayload | null,
   t: PresenterParams["t"],
 ): string {


### PR DESCRIPTION
Closes #3464

## What changed
- Removed the exported `FindingPayload` alias from `apps/ui/src/api/types.ts`.
- Replaced UI presenter imports with a local `HistoryFindingPayload` type derived from `HistoryInsightsPayload["findings"]`.

## Why
- The API type barrel no longer needs to export the raw schema alias.
- History presenters still keep a precise finding type without widening the public API type surface.

## Validation
- `make ui-typecheck`

## Risks / tradeoffs / edge cases
- The issue text was stale: UI presenters were still importing `FindingPayload`.
- The replacement keeps the presenter type tied to the actual insights payload shape.

## Follow-ups
- None.
