### PR TITLE
Remove dead UI integer formatter

### DIFF
--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -22,13 +22,7 @@ export function formatEpochTimestamp(epoch: number | null | undefined): string {
   return formatDateTime(new Date(epoch * 1000), "—");
 }
 
-const _defaultNumberFormat = new Intl.NumberFormat();
 const _localeFormatCache = new Map<string, Intl.NumberFormat>();
-
-function formatInt(value: number): string {
-  if (typeof value !== "number" || !Number.isFinite(value)) return "--";
-  return _defaultNumberFormat.format(Math.round(value));
-}
 
 /** Like formatInt but respects the given BCP 47 locale tag (e.g. "nl", "en"). */
 export function formatIntLocale(value: number, lang: string): string {


### PR DESCRIPTION
Closes #3465

## What changed
- Removed the dead local `formatInt` helper from `apps/ui/src/format.ts`.
- Removed its unused `_defaultNumberFormat` constant.

## Why
- UI callers use injected `formatInt` formatter properties or `formatIntLocale`.
- The removed helper had no importers or call sites.

## Validation
- `make ui-typecheck`
- Search confirmed no `_defaultNumberFormat` or local `function formatInt(` references remain.

## Risks / tradeoffs / edge cases
- Pure dead-code removal. `formatIntLocale` and runtime formatter wiring are unchanged.

## Follow-ups
- None.
