### PR TITLE
Use ellipsis for history DB protocol stubs

### DIFF
--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
-from typing import TypeVar, cast
+from typing import Protocol, TypeVar, cast
 
 import aiosqlite
 
@@ -49,15 +49,13 @@ LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-class _HistoryDBQueryMixin:
+class _HistoryDBQueryMixin(Protocol):
     _raw_capture_store: HistoryRawCaptureStore
     _whole_run_artifact_store: HistoryWholeRunArtifactStore
 
-    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
-        raise NotImplementedError
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]: ...
 
-    def _run_sync(self, coro: Awaitable[_T]) -> _T:
-        raise NotImplementedError
+    def _run_sync(self, coro: Awaitable[_T]) -> _T: ...
 
     @staticmethod
     def _artifact_availability_state(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable, Mapping
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime, timedelta
-from typing import TypeVar, cast
+from typing import Protocol, TypeVar, cast
 
 import aiosqlite
 
@@ -44,18 +44,15 @@ _EXPECTED_ANALYSIS_KEYS: frozenset[str] = frozenset({"findings", "top_causes", "
 _T = TypeVar("_T")
 
 
-class _HistoryDBRunLifecycleMixin:
+class _HistoryDBRunLifecycleMixin(Protocol):
     _raw_capture_store: HistoryRawCaptureStore
     _whole_run_artifact_store: HistoryWholeRunArtifactStore
 
-    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
-        raise NotImplementedError
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]: ...
 
-    def write_transaction_cursor(self) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
-        raise NotImplementedError
+    def write_transaction_cursor(self) -> AbstractAsyncContextManager[aiosqlite.Cursor]: ...
 
-    def _run_sync(self, coro: Awaitable[_T]) -> _T:
-        raise NotImplementedError
+    def _run_sync(self, coro: Awaitable[_T]) -> _T: ...
 
     @staticmethod
     async def _run_status(cur: aiosqlite.Cursor, run_id: str) -> str | None:

--- a/apps/server/vibesensor/adapters/persistence/history_db/_sample_io.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_sample_io.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator, Awaitable, Iterator
 from contextlib import AbstractAsyncContextManager
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 import aiosqlite
 
@@ -22,12 +22,10 @@ LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-class _HistoryDBSampleIOMixin:
-    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
-        raise NotImplementedError
+class _HistoryDBSampleIOMixin(Protocol):
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]: ...
 
-    def _run_sync(self, coro: Awaitable[_T]) -> _T:
-        raise NotImplementedError
+    def _run_sync(self, coro: Awaitable[_T]) -> _T: ...
 
     def get_run_samples(self, run_id: str) -> list[SensorFrame]:
         return self._run_sync(self.aget_run_samples(run_id))


### PR DESCRIPTION
Closes #3467.

What changed:
- Replaced `raise NotImplementedError` stub bodies in the history DB repository mixins with `...`.
- Made those mixin contracts explicit `Protocol`s so ellipsis bodies are valid under mypy.

Why:
- These methods are structural requirements implemented by `RunHistoryRepository`.
- Protocol ellipsis stubs match the convention used elsewhere and avoid unreachable runtime paths.

Validation:
- `uv run --python 3.13 --extra dev pytest tests/adapters/persistence/history_db -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/adapters/persistence/history_db/_run_lifecycle.py vibesensor/adapters/persistence/history_db/_queries.py vibesensor/adapters/persistence/history_db/_sample_io.py vibesensor/adapters/persistence/history_db/_run_repository.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/adapters/persistence/history_db/_run_lifecycle.py vibesensor/adapters/persistence/history_db/_queries.py vibesensor/adapters/persistence/history_db/_sample_io.py vibesensor/adapters/persistence/history_db/_run_repository.py`
- `uv run --python 3.13 --extra dev mypy vibesensor/adapters/persistence/history_db/_run_lifecycle.py vibesensor/adapters/persistence/history_db/_queries.py vibesensor/adapters/persistence/history_db/_sample_io.py vibesensor/adapters/persistence/history_db/_run_repository.py`

Risks / tradeoffs:
- Small typing-shape change: the mixins now state their structural contract explicitly.
- Runtime repository behavior stays covered by the existing history DB tests.

Follow-ups:
- None.
