### PR TITLE
Move report source presentation helper

### DIFF
--- a/apps/server/vibesensor/report_i18n.py
+++ b/apps/server/vibesensor/report_i18n.py
@@ -6,27 +6,14 @@ Translation data is loaded from ``apps/server/vibesensor/data/report_i18n.json``
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import Callable
 from functools import lru_cache
 
-from vibesensor.domain import VibrationSource
 from vibesensor.shared._data_files import resolve_static_data_file
 from vibesensor.shared.constants.phases import PHASE_I18N_KEYS
 from vibesensor.shared.types.json_types import JsonValue
 
 _DATA_FILE = resolve_static_data_file("report_i18n.json")
-_SOURCE_I18N_KEYS: dict[VibrationSource, str] = {
-    VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
-    VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
-    VibrationSource.ENGINE: "SOURCE_ENGINE",
-    VibrationSource.BODY_RESONANCE: "SOURCE_BODY_RESONANCE",
-    VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
-    VibrationSource.BASELINE_NOISE: "SOURCE_BASELINE_NOISE",
-    VibrationSource.UNKNOWN_RESONANCE: "SOURCE_UNKNOWN_RESONANCE",
-    VibrationSource.UNKNOWN: "UNKNOWN",
-}
-
 _SHORT_LOCATION_LABELS: dict[str, str] = {
     "front left": "Front-Left",
     "front left wheel": "Front-Left",
@@ -91,26 +78,9 @@ def tr(lang: object, key: str, **kwargs: JsonValue) -> str:
         return template
 
 
-_logger = logging.getLogger(__name__)
-
-
 def is_i18n_ref(value: object) -> bool:
     """Check whether *value* is a language-neutral i18n reference dict."""
     return isinstance(value, dict) and "_i18n_key" in value
-
-
-def human_source(source: object, *, tr: Callable[[str], str]) -> str:
-    """Resolve a source code to its user-facing label."""
-    raw = str(source or "").strip().lower()
-    try:
-        key = VibrationSource(raw)
-    except ValueError:
-        _logger.warning(
-            "Unrecognized vibration source %r; falling back to titlecase",
-            raw,
-        )
-        return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
-    return tr(_SOURCE_I18N_KEYS.get(key, "UNKNOWN"))
 
 
 def human_location(location: object, *, short: bool = True) -> str:
@@ -176,6 +146,8 @@ def resolve_i18n(
         if is_i18n_ref(param_value):
             resolved_params[param_key] = resolve_i18n(lang, param_value, tr=tr)
         elif param_key == "source" and isinstance(param_value, str):
+            from vibesensor.shared.report_presentation import human_source
+
             resolved_params[param_key] = human_source(param_value, tr=tr)
         elif param_key == "phase" and isinstance(param_value, str):
             i18n_key = PHASE_I18N_KEYS.get(param_value)

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationSource
-from vibesensor.report_i18n import human_location, human_source, location_candidates
+from vibesensor.report_i18n import human_location, location_candidates
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.strength_bands import BANDS
@@ -24,6 +25,7 @@ __all__ = [
     "display_location",
     "first_confidence_reason_clause",
     "has_source_overlap",
+    "human_source",
     "is_transient_primary",
     "location_confidence_text",
     "order_label_human",
@@ -38,6 +40,18 @@ __all__ = [
 ]
 
 _isfinite = math.isfinite
+_logger = logging.getLogger(__name__)
+
+_SOURCE_I18N_KEYS: dict[VibrationSource, str] = {
+    VibrationSource.WHEEL_TIRE: "SOURCE_WHEEL_TIRE",
+    VibrationSource.DRIVELINE: "SOURCE_DRIVELINE",
+    VibrationSource.ENGINE: "SOURCE_ENGINE",
+    VibrationSource.BODY_RESONANCE: "SOURCE_BODY_RESONANCE",
+    VibrationSource.TRANSIENT_IMPACT: "SOURCE_TRANSIENT_IMPACT",
+    VibrationSource.BASELINE_NOISE: "SOURCE_BASELINE_NOISE",
+    VibrationSource.UNKNOWN_RESONANCE: "SOURCE_UNKNOWN_RESONANCE",
+    VibrationSource.UNKNOWN: "UNKNOWN",
+}
 
 _STRENGTH_LABELS_BY_BUCKET: dict[str, tuple[str, str, str]] = {
     "l0": ("negligible", "Negligible", "Verwaarloosbaar"),
@@ -292,6 +306,20 @@ def confidence_caveat_text(
     if not caveats:
         return None
     return "; ".join(caveats[:2])
+
+
+def human_source(source: object, *, tr: Callable[[str], str]) -> str:
+    """Resolve a source code to its user-facing label."""
+    raw = str(source or "").strip().lower()
+    try:
+        key = VibrationSource(raw)
+    except ValueError:
+        _logger.warning(
+            "Unrecognized vibration source %r; falling back to titlecase",
+            raw,
+        )
+        return raw.replace("_", " ").title() if raw else tr("UNKNOWN")
+    return tr(_SOURCE_I18N_KEYS.get(key, "UNKNOWN"))
 
 
 def source_with_confidence(finding: Finding, *, tr: Callable[..., str]) -> str:

--- a/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import Finding, TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.report_presentation import (
     confidence_reason_text,
+    human_source,
     strength_label,
     strength_text,
 )

--- a/apps/server/vibesensor/use_cases/history/report_document/_card_builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/_card_builder.py
@@ -6,12 +6,11 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.document import (
     PartSuggestion,
     SystemFindingCard,
 )
-from vibesensor.shared.report_presentation import order_label_human
+from vibesensor.shared.report_presentation import human_source, order_label_human
 from vibesensor.use_cases.history.report_document.pattern_parts import parts_for_pattern
 
 if TYPE_CHECKING:

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
 from vibesensor.shared.report_presentation import (
     confidence_snapshot_text,
     display_location,
+    human_source,
 )
 
 __all__ = ["build_evidence_snapshot_rows"]

--- a/apps/server/vibesensor/use_cases/history/report_document/measurements.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/measurements.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from vibesensor.domain import Finding, TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.document import (
     EvidenceChainRow,
     MeasurementRow,
@@ -14,6 +13,7 @@ from vibesensor.shared.boundaries.reporting.facts import ReportRunFacts
 from vibesensor.shared.report_presentation import (
     candidate_signal_text,
     display_location,
+    human_source,
     source_with_confidence,
 )
 

--- a/apps/server/vibesensor/use_cases/history/report_document/narrative_summaries.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/narrative_summaries.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from vibesensor.domain import TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.report_presentation import (
     candidate_signal_text,
     display_location,
+    human_source,
     uses_shared_overlap_wording,
 )
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext

--- a/apps/server/vibesensor/use_cases/history/report_document/pattern_evidence.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/pattern_evidence.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, TestRun, VibrationOrigin
-from vibesensor.report_i18n import human_source, resolve_i18n
+from vibesensor.report_i18n import resolve_i18n
 from vibesensor.shared.boundaries.reporting.document import PatternEvidence
 from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
 from vibesensor.shared.boundaries.summary_fields.origin import build_origin_explanation
-from vibesensor.shared.report_presentation import display_location, order_label_human
+from vibesensor.shared.report_presentation import display_location, human_source, order_label_human
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
 from vibesensor.use_cases.history.report_document.pattern_parts import why_parts_listed
 

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -7,13 +7,13 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import SuitabilityCheck, TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.document import PatternEvidence, VerdictPageData
 from vibesensor.shared.report_diagnostics import first_nonpass_detail
 from vibesensor.shared.report_presentation import (
     action_status_text,
     display_location,
+    human_source,
     location_confidence_text,
     presented_location_confidence_key,
     proof_caveat_text,

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import Finding, SuitabilityCheck, TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.document import AppendixAData, RankedCandidateRow
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
@@ -17,6 +16,7 @@ from vibesensor.shared.report_presentation import (
     confidence_pct_text,
     display_location,
     has_source_overlap,
+    human_source,
     is_transient_primary,
     proof_caveat_text,
     uses_shared_overlap_wording,

--- a/apps/server/vibesensor/use_cases/history/report_observation_matrix.py
+++ b/apps/server/vibesensor/use_cases/history/report_observation_matrix.py
@@ -6,12 +6,15 @@ from collections.abc import Callable
 from math import isfinite
 
 from vibesensor.domain import Finding, TestRun
-from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting.document import (
     SensorObservationCell,
     SensorObservationMatrixRow,
 )
-from vibesensor.shared.report_presentation import candidate_signal_text, display_location
+from vibesensor.shared.report_presentation import (
+    candidate_signal_text,
+    display_location,
+    human_source,
+)
 from vibesensor.vibration_strength import percentile, relative_level_db_scalar
 
 __all__ = ["build_sensor_observation_matrix_rows"]


### PR DESCRIPTION
Closes #3468.

What changed:
- Moved `human_source` from `report_i18n.py` into `shared.report_presentation`.
- Moved the source translation-key map with it.
- Updated report-document and observation-matrix callers to import from the presentation module.
- Preserved `resolve_i18n(..., source=...)` behavior with a local lazy import to avoid a module import cycle.

Why:
- Source label formatting is report presentation logic, not translation-file lookup logic.
- `source_with_confidence` now composes with a local presentation helper in the same module.

Validation:
- Import probe for `human_source` and `resolve_i18n` source translation.
- `uv run --python 3.13 --extra dev pytest tests/adapters/pdf/test_i18n_separation.py tests/use_cases/history/test_report_document_sections.py tests/use_cases/history/test_report_document_context.py tests/use_cases/history/test_report_document_assembly_context.py tests/shared/test_report_presentation_vehicle_data_confidence.py -q`
- `uv run --python 3.13 --extra dev ruff check vibesensor/report_i18n.py vibesensor/shared/report_presentation.py vibesensor/use_cases/history/report_document vibesensor/use_cases/history/report_observation_matrix.py`
- `uv run --python 3.13 --extra dev ruff format --check vibesensor/report_i18n.py vibesensor/shared/report_presentation.py vibesensor/use_cases/history/report_document vibesensor/use_cases/history/report_observation_matrix.py`
- `uv run --python 3.13 --extra dev mypy vibesensor/report_i18n.py vibesensor/shared/report_presentation.py vibesensor/use_cases/history/report_document vibesensor/use_cases/history/report_observation_matrix.py`

Risks / tradeoffs:
- Medium fan-out import cleanup across report document modules.
- `resolve_i18n` still supports source-param formatting; it imports lazily to keep existing layering cycle-free at import time.

Follow-ups:
- None.
