### PR TITLE
Make WebSocket client options internal

### DIFF
--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -7,7 +7,7 @@ import { batch, signal, type ReadonlySignal } from "./app/ui_signals";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
 
-export interface WsClientOptions {
+interface WsClientOptions {
   url: string;
   staleAfterMs?: number;
   reconnectDelayMs?: number;


### PR DESCRIPTION
Closes #3470.

What changed:
- Dropped `export` from the `WsClientOptions` interface in `apps/ui/src/ws.ts`.

Why:
- The interface is only used inside `ws.ts`.
- Keeping it internal reduces the public UI API surface without changing behavior.

Validation:
- `make ui-typecheck`
- Search confirmed `WsClientOptions` is referenced only in `ws.ts`.

Risks / tradeoffs:
- Tiny type-only cleanup. No runtime behavior change.

Follow-ups:
- None.
