### PR TITLE
Reconcile UI API barrel exports

### DIFF
--- a/apps/ui/src/api.ts
+++ b/apps/ui/src/api.ts
@@ -1,12 +1,11 @@
-export type {
-  CarLibraryModel,
-  CarLibraryGearbox,
-  CarLibraryTireOption,
-  CarLibraryVariant,
-} from "./api/types";
+export type * from "./api/types";
 export {
   getAnalysisSettings,
   setAnalysisSettings,
+  getSettingsLanguage,
+  setSettingsLanguage,
+  getSettingsSpeedUnit,
+  setSettingsSpeedUnit,
   getSettingsCars,
   addSettingsCar,
   deleteSettingsCar,
@@ -22,17 +21,3 @@ export {
   deleteHistoryRun,
   getHistoryInsights,
 } from "./api/history";
-export type {
-  HealthStatusPayload,
-  ObdDevicePayload,
-  ObdPairPayload,
-  ObdScanPayload,
-  ObdStatusPayload,
-  UpdateStartRequestPayload,
-  UpdateStatusPayload,
-  UpdateIssue,
-  SpeedSourceStatusPayload,
-  EspFlashStatusPayload,
-  EspSerialPortPayload,
-  UsbInternetStatusPayload,
-} from "./api/types";

--- a/apps/ui/src/app/features/car_confidence_summary.ts
+++ b/apps/ui/src/app/features/car_confidence_summary.ts
@@ -1,4 +1,4 @@
-import type { CarLibraryGearbox, CarOrderReferenceStatus } from "../../api/types";
+import type { CarLibraryGearbox, CarOrderReferenceStatus } from "../../api";
 
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
 

--- a/apps/ui/src/app/features/cars_feature_transport.ts
+++ b/apps/ui/src/app/features/cars_feature_transport.ts
@@ -3,7 +3,7 @@ import {
   getCarLibraryModels,
   getCarLibraryTypes,
 } from "../../api";
-import type { CarLibraryModel } from "../../api/types";
+import type { CarLibraryModel } from "../../api";
 
 export interface CarsFeatureTransport {
   loadBrands(): Promise<string[]>;

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -6,7 +6,7 @@ import type {
   CarOrderReferenceStatus,
   CarLibraryTireOption,
   CarLibraryVariant,
-} from "../../api/types";
+} from "../../api";
 import {
   createCarsManualInputStore,
   firstMissingManualInputField,

--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -1,4 +1,4 @@
-import type { CarLibraryTireOption } from "../../api/types";
+import type { CarLibraryTireOption } from "../../api";
 import { tireOptionFront } from "./cars_tire_setup";
 import {
   DEFAULT_CARS_WIZARD_MANUAL_INPUTS,

--- a/apps/ui/src/app/features/cars_tire_setup.ts
+++ b/apps/ui/src/app/features/cars_tire_setup.ts
@@ -1,4 +1,4 @@
-import type { CarLibraryTireOption } from "../../api/types";
+import type { CarLibraryTireOption } from "../../api";
 
 type FormatNumber = (value: number, digits?: number) => string;
 

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from "@tanstack/query-core";
 
-import type { CarOrderReferenceStatus, CarsPayload } from "../../api/types";
+import type { CarOrderReferenceStatus, CarsPayload } from "../../api";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarSelectionDerivedState } from "../car_selection_state";
 import type { SettingsState, ShellState } from "../ui_app_state";

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -5,7 +5,7 @@ import {
   getSettingsSpeedUnit,
   setSettingsLanguage,
   setSettingsSpeedUnit,
-} from "../../api/settings";
+} from "../../api";
 import { uiLogger } from "../../ui_logger";
 import { serverStateQueryKeys } from "../features/server_state_query_keys";
 import type { SettingsFeedbackMessage } from "../views/settings_feedback";

--- a/apps/ui/src/app/views/car_wizard_view.ts
+++ b/apps/ui/src/app/views/car_wizard_view.ts
@@ -2,7 +2,7 @@ import type {
   CarLibraryGearbox,
   CarLibraryTireOption,
   CarLibraryVariant,
-} from "../../api/types";
+} from "../../api";
 import type {
   CarsFeatureRenderState,
 } from "../features/cars_feature_workflow";


### PR DESCRIPTION
Closes #3471.

What changed:
- Made `apps/ui/src/api.ts` the complete app-facing API barrel for UI contract types.
- Added missing preference settings functions to the barrel:
  - `getSettingsLanguage`
  - `setSettingsLanguage`
  - `getSettingsSpeedUnit`
  - `setSettingsSpeedUnit`
- Updated related app-layer imports to use `../../api` for the barrel surface.

Why:
- The barrel was partial: some related symbols were available through it and others required direct module imports.
- Completing the barrel removes the drift while keeping implementation modules (`api/settings`, `api/types`) unchanged.

Validation:
- `make ui-typecheck`

Risks / tradeoffs:
- Small type/import-surface cleanup. No runtime behavior change.
- Existing direct imports in lower-level API modules stay direct to avoid circular imports.

Follow-ups:
- None.
