### PR TITLE
Fix RAF animation indentation

### DIFF
--- a/apps/ui/src/app/dom/raf_animation.ts
+++ b/apps/ui/src/app/dom/raf_animation.ts
@@ -37,9 +37,9 @@ export function createRafAnimation(
       callbacks.onFrame(alpha);
       if (alpha >= 1) {
         handle = null;
-      callbacks.onComplete();
-      return;
-    }
+        callbacks.onComplete();
+        return;
+      }
       handle = api.requestAnimationFrame(animate);
     };
     handle = api.requestAnimationFrame(animate);


### PR DESCRIPTION
Closes #3472.

What changed:
- Fixed the indentation in the `createRafAnimation` completion early-return block.

Why:
- The logic was correct, but the block had inconsistent indentation.

Validation:
- `make ui-typecheck`

Risks / tradeoffs:
- Formatting-only change. No runtime behavior change.

Follow-ups:
- None.
