### PR TITLE
Consolidate UI number format cache

### DIFF
--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -1,3 +1,5 @@
+import { getDefaultNumberFormat } from "./number_format";
+
 export function fmt(n: number, digits = 2): string {
   if (typeof n !== "number" || !Number.isFinite(n)) return "--";
   return n.toFixed(digits);
@@ -22,15 +24,8 @@ export function formatEpochTimestamp(epoch: number | null | undefined): string {
   return formatDateTime(new Date(epoch * 1000), "—");
 }
 
-const _localeFormatCache = new Map<string, Intl.NumberFormat>();
-
 /** Like formatInt but respects the given BCP 47 locale tag (e.g. "nl", "en"). */
 export function formatIntLocale(value: number, lang: string): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "--";
-  let fmt = _localeFormatCache.get(lang);
-  if (!fmt) {
-    fmt = new Intl.NumberFormat(lang);
-    _localeFormatCache.set(lang, fmt);
-  }
-  return fmt.format(Math.round(value));
+  return getDefaultNumberFormat(lang).format(Math.round(value));
 }

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -1,4 +1,5 @@
 import enCatalog from "./i18n/catalogs/en.json" with { type: "json" };
+import { getDefaultNumberFormat } from "./number_format";
 
 type Catalog = Record<string, string>;
 type CatalogModule = { default: Catalog };
@@ -12,7 +13,6 @@ const supported = ["en", "nl"] as const;
 type SupportedLanguage = (typeof supported)[number];
 
 const _PLACEHOLDER_RE = /\{([a-zA-Z0-9_]+)\}/g;
-const _numberFormatCache = new Map<string, Intl.NumberFormat>();
 const _HAS_OWN = Object.prototype.hasOwnProperty;
 const _catalogs: Partial<Record<SupportedLanguage, Catalog>> = {
   en: enCatalog,
@@ -22,15 +22,6 @@ const _catalogLoaders: Record<SupportedLanguage, () => Promise<CatalogModule>> =
   nl: () => import("./i18n/catalogs/nl"),
   en: async () => ({ default: enCatalog }),
 };
-
-function _getDefaultNumberFormat(lang: string): Intl.NumberFormat {
-  let fmt = _numberFormatCache.get(lang);
-  if (!fmt) {
-    fmt = new Intl.NumberFormat(lang);
-    _numberFormatCache.set(lang, fmt);
-  }
-  return fmt;
-}
 
 export function normalizeLang(value: string): string {
   const raw = String(value || "").trim().toLowerCase();
@@ -78,7 +69,7 @@ function formatVar(lang: string, value: unknown): string {
   }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return "--";
-    return _getDefaultNumberFormat(lang).format(value);
+    return getDefaultNumberFormat(lang).format(value);
   }
   return String(value);
 }

--- a/apps/ui/src/number_format.ts
+++ b/apps/ui/src/number_format.ts
@@ -1,0 +1,10 @@
+const defaultNumberFormatCache = new Map<string, Intl.NumberFormat>();
+
+export function getDefaultNumberFormat(lang: string): Intl.NumberFormat {
+  let fmt = defaultNumberFormatCache.get(lang);
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(lang);
+    defaultNumberFormatCache.set(lang, fmt);
+  }
+  return fmt;
+}


### PR DESCRIPTION
Closes #3473.

What changed:
- Added a shared `getDefaultNumberFormat` helper in `apps/ui/src/number_format.ts`.
- Updated `formatIntLocale` to use the shared cache.
- Updated `i18n` number interpolation to use the same shared cache.
- Removed the duplicate per-module caches.

Why:
- `format.ts` and `i18n.ts` were maintaining equivalent `Intl.NumberFormat` caches.
- One shared helper keeps locale formatter state in one place.

Validation:
- `make ui-typecheck`
- Search confirmed `_localeFormatCache`, `_numberFormatCache`, and `_getDefaultNumberFormat` are gone.

Risks / tradeoffs:
- Small shared helper extraction. Formatting behavior is unchanged because both paths still use `new Intl.NumberFormat(lang)` defaults.

Follow-ups:
- None.
