### PR TITLE
Avoid unused runtime boundary parse output

### DIFF
--- a/apps/ui/src/runtime_boundary_validation.ts
+++ b/apps/ui/src/runtime_boundary_validation.ts
@@ -22,13 +22,16 @@ export function parseRuntimeBoundary<T>(options: {
   payload: unknown;
   schema: v.GenericSchema<T>;
 }): T {
-  const result = v.safeParse(options.schema, options.payload);
-  if (!result.success) {
-    const issue = result.issues[0];
-    throw new Error(
-      `Invalid ${options.boundary}: ${formatIssuePath(issue?.path)} ${issue?.message ?? "is invalid"}`,
-    );
+  if (v.is(options.schema, options.payload)) {
+    // These boundary schemas assert shape only; keep original object identity for hot paths.
+    return options.payload as T;
   }
-  // These boundary schemas assert shape only; keep original object identity for hot paths.
-  return options.payload as T;
+  const result = v.safeParse(options.schema, options.payload);
+  if (result.success) {
+    return options.payload as T;
+  }
+  const issue = result.issues[0];
+  throw new Error(
+    `Invalid ${options.boundary}: ${formatIssuePath(issue?.path)} ${issue?.message ?? "is invalid"}`,
+  );
 }


### PR DESCRIPTION
Closes #3474.

What changed:
- `parseRuntimeBoundary` now validates the common success path with `v.is(...)`.
- It only calls `v.safeParse(...)` after `v.is(...)` fails, preserving detailed error messages for invalid payloads.
- The helper still returns the original payload object for accepted boundary data.

Why:
- Callers only need validation and keep original object identity.
- Avoids building and discarding transformed output objects on valid hot-path payloads.

Validation:
- `make ui-typecheck`

Risks / tradeoffs:
- Tiny validation-path change. Failure diagnostics still come from `safeParse`.

Follow-ups:
- None.
