### PR TITLE
Make spectrum CSS refresh internal

### DIFF
--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -55,7 +55,7 @@ export function getSpectrumCssVars(): Readonly<SpectrumCssVars> {
   return spectrumCssVars.value;
 }
 
-export function refreshSpectrumCssVars(): Readonly<SpectrumCssVars> {
+function refreshSpectrumCssVars(): Readonly<SpectrumCssVars> {
   ensureSpectrumCssVarsThemeTracking();
   spectrumCssVarsVersion.value += 1;
   return spectrumCssVars.value;
@@ -71,7 +71,7 @@ function ensureSpectrumCssVarsThemeTracking(): void {
   stopSpectrumCssVarsThemeTracking = effect(() => {
     const mediaQuery = globalThis.matchMedia(THEME_MEDIA_QUERY);
     const refresh = () => {
-      spectrumCssVarsVersion.value += 1;
+      refreshSpectrumCssVars();
     };
     mediaQuery.addEventListener("change", refresh);
     return () => {

--- a/apps/ui/tests/spectrum_css_vars.spec.ts
+++ b/apps/ui/tests/spectrum_css_vars.spec.ts
@@ -37,11 +37,9 @@ describe("spectrum_css_vars", () => {
     })) as typeof matchMedia;
 
     try {
-      const { getSpectrumCssVars, refreshSpectrumCssVars } = await import(
-        "../src/spectrum_css_vars"
-      );
+      const { getSpectrumCssVars } = await import("../src/spectrum_css_vars");
 
-      const first = refreshSpectrumCssVars();
+      const first = getSpectrumCssVars();
       expect(first).toEqual({
         surface: "#101820",
         muted: "#556677",
@@ -51,7 +49,11 @@ describe("spectrum_css_vars", () => {
       });
       expect(readCount).toBe(1);
 
-      const unchangedRefresh = refreshSpectrumCssVars();
+      themeChangeHandler?.({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+      } as MediaQueryListEvent);
+      const unchangedRefresh = getSpectrumCssVars();
       expect(unchangedRefresh).toBe(first);
       expect(readCount).toBe(2);
 
@@ -60,7 +62,11 @@ describe("spectrum_css_vars", () => {
       expect(getSpectrumCssVars().surface).toBe("#101820");
       expect(readCount).toBe(2);
 
-      const refreshed = refreshSpectrumCssVars();
+      themeChangeHandler?.({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+      } as MediaQueryListEvent);
+      const refreshed = getSpectrumCssVars();
       expect(refreshed.surface).toBe("#222222");
       expect(refreshed).not.toBe(first);
       expect(getSpectrumCssVars()).toBe(refreshed);


### PR DESCRIPTION
Closes #3475.

What changed:
- Removed the public export from `refreshSpectrumCssVars`.
- Kept refresh behavior internal for theme-change handling.
- Updated `spectrum_css_vars` tests to drive refresh through the `matchMedia` change seam instead of importing the hook directly.

Why:
- Production code only needs `getSpectrumCssVars`.
- The old export exposed a test helper as part of the module’s public surface.

Validation:
- `npm run test:unit -- spectrum_css_vars.spec.ts`
- `make ui-typecheck`

Risks / tradeoffs:
- Small test seam change. Runtime behavior is unchanged: theme changes still invalidate the cached CSS variable snapshot.

Follow-ups:
- None.
