### PR TITLE
Use Object.hasOwn in i18n

### DIFF
--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -13,7 +13,6 @@ const supported = ["en", "nl"] as const;
 type SupportedLanguage = (typeof supported)[number];
 
 const _PLACEHOLDER_RE = /\{([a-zA-Z0-9_]+)\}/g;
-const _HAS_OWN = Object.prototype.hasOwnProperty;
 const _catalogs: Partial<Record<SupportedLanguage, Catalog>> = {
   en: enCatalog,
 };
@@ -80,7 +79,7 @@ export function get(lang: string, key: string, vars?: Record<string, unknown>): 
   const template = getLoadedCatalog(normalized)?.[key] || fallback;
   if (!vars || typeof vars !== "object") return template;
   return String(template).replace(_PLACEHOLDER_RE, (_m, placeholder) => {
-    if (_HAS_OWN.call(vars, placeholder)) {
+    if (Object.hasOwn(vars, placeholder)) {
       return formatVar(normalized, vars[placeholder]);
     }
     return `{${placeholder}}`;

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": [
-      "ES2020",
+      "ES2022",
       "DOM",
       "DOM.Iterable"
     ],

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -63,9 +63,9 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: buildPlugins(mode),
     build: {
-      // Align with tsconfig.json "target": "ES2020" so vite and tsc target the
+      // Align with tsconfig.json "target": "ES2022" so vite and tsc target the
       // same language level and avoid duplicate down-transpilation.
-      target: "es2020",
+      target: "es2022",
       rollupOptions: {
         output: {
           manualChunks: resolveManualChunk,


### PR DESCRIPTION
## What changed
- Replaced the `hasOwnProperty.call` placeholder guard in `i18n.ts` with `Object.hasOwn`.
- Removed the cached `_HAS_OWN` helper.
- Aligned UI TypeScript and Vite targets to ES2022 so the API is part of the project type/runtime target.

## Why
The app already targets modern UI tooling. `Object.hasOwn` keeps the same own-property semantics with less indirection.

## Validation
- `make ui-typecheck`

## Risks / tradeoffs / edge cases
- Requires ES2022-capable browsers for the UI bundle target.
- Placeholder lookup behavior stays own-property-only; prototype properties still do not substitute.

## Follow-ups
- None.
