### PR TITLE
Normalize rapidocr dependency pin

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
   "pytest-randomly>=3.16,<5",
   "pytest-timeout>=2.4.0,<3",
   "pytest-xdist>=3.8.0,<4",
-  "rapidocr-onnxruntime>=1.4,<2",
+  "rapidocr-onnxruntime>=1.2.3,<1.3",
   "ruff>=0.15.10,<0.16",
 ]
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -54,8 +54,7 @@ dev = [
   "pytest-randomly>=3.16,<5",
   "pytest-timeout>=2.4.0,<3",
   "pytest-xdist>=3.8.0,<4",
-  "rapidocr-onnxruntime>=1.4,<2; python_version < '3.13'",
-  "rapidocr-onnxruntime>=1.2.3,<1.3; python_version >= '3.13'",
+  "rapidocr-onnxruntime>=1.4,<2",
   "ruff>=0.15.10,<0.16",
 ]
 


### PR DESCRIPTION
## What changed
- Collapsed the two `rapidocr-onnxruntime` dev dependency markers into one unmarked `>=1.2.3,<1.3` pin.
- Removed the unreachable Python `<3.13` branch.

## Why
The server requires Python `>=3.13`, so the lower-version marker was dead. CI/pip also rejects `rapidocr-onnxruntime` 1.4.x on Python 3.13 because those releases declare `Requires-Python <3.13`; the supported single pin is the existing Python 3.13-compatible range.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_pi_image_python_runtime_policy.py tests/hygiene/test_install_pi_runtime_policy.py`
- Fresh Python 3.13 pip venv: `pip install -e './apps/server[dev]'`, confirmed `rapidocr-onnxruntime==1.2.3`

## Risks / tradeoffs / edge cases
- Keeps the supported Python 3.13 install path on the 1.2 series because newer RapidOCR releases are not installable with pip on Python 3.13.
- Removes the dead branch without changing the effective CI-compatible dependency range.

## Follow-ups
- Revisit the range if RapidOCR publishes a newer release with Python 3.13 metadata support.