### PR TITLE
Inline local format int wrapper

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -1,7 +1,6 @@
 import type { QueryClient } from "@tanstack/query-core";
 
 import * as I18N from "../../i18n";
-import { formatIntLocale } from "../../format";
 import { setUiLanguage, translateUiText } from "../ui_i18n";
 import type { AppState } from "../ui_app_state";
 import {
@@ -155,10 +154,6 @@ export class UiShellController {
 
   t(key: string, vars?: Record<string, unknown>): string {
     return translateUiText(key, vars);
-  }
-
-  localFormatInt(value: number): string {
-    return formatIntLocale(value, this.state.shell.lang.value);
   }
 
   showError(message: string): void {

--- a/apps/ui/src/app/ui_app_boot_runtime.ts
+++ b/apps/ui/src/app/ui_app_boot_runtime.ts
@@ -1,4 +1,4 @@
-import { fmt, fmtTs } from "../format";
+import { fmt, fmtTs, formatIntLocale } from "../format";
 import {
   createAppFeatureBundle,
   type AppFeatureBundle,
@@ -27,6 +27,7 @@ import type {
 
 function createUiAppSharedDeps(
   shell: UiShellController,
+  state: AppState,
 ): Pick<AppFeatureBundleSharedDeps, "formatting" | "services"> {
   return {
     services: {
@@ -37,7 +38,7 @@ function createUiAppSharedDeps(
     formatting: {
       fmt,
       fmtTs,
-      formatInt: (value) => shell.localFormatInt(value),
+      formatInt: (value) => formatIntLocale(value, state.shell.lang.value),
     },
   };
 }
@@ -104,7 +105,7 @@ export function createUiAppBootRuntime(deps: {
   featurePorts = createAppFeatureBundle({
     state: deps.state,
     shared: {
-      ...createUiAppSharedDeps(shell),
+      ...createUiAppSharedDeps(shell, deps.state),
       serverState: {
         queryClient,
       },


### PR DESCRIPTION
## What changed
- Removed `UiShellController.localFormatInt`.
- Inlined its only caller to use `formatIntLocale` with the app language signal.

## Why
The method was a single-caller wrapper around one formatting call.

## Validation
- `make ui-typecheck`

## Risks / tradeoffs / edge cases
- Formatting behavior stays tied to the current shell language signal.
- No UI state or service wiring changes beyond removing the wrapper.

## Follow-ups
- None.
