### PR TITLE
Stop writing heuristics audit artifact

### DIFF
--- a/tools/tests/heuristics_audit.py
+++ b/tools/tests/heuristics_audit.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import json
 import re
 from pathlib import Path
 
@@ -169,14 +168,6 @@ def main() -> int:
         for msg in msgs:
             print(f"  - {msg}")
         all_ok &= ok
-    (ROOT / "artifacts" / "ai").mkdir(parents=True, exist_ok=True)
-    (ROOT / "artifacts" / "ai" / "heuristics_audit.json").write_text(
-        json.dumps(
-            {k: {"ok": v[0], "messages": v[1]} for k, v in checks.items()}, indent=2
-        ),
-        encoding="utf-8",
-    )
-    print("wrote artifacts/ai/heuristics_audit.json")
     return 0 if all_ok else 1
 
 


### PR DESCRIPTION
## What changed
- Removed the unused `artifacts/ai/heuristics_audit.json` write from `tools/tests/heuristics_audit.py`.
- Removed the now-unused `json` import.

## Why
No repo path consumes that JSON output. The script already prints the audit result to stdout.

## Validation
- Ran `python3 tools/tests/heuristics_audit.py` and confirmed `artifacts/ai/heuristics_audit.json` is not created.
- Confirmed the script no longer references `heuristics_audit.json`.

## Risks / tradeoffs / edge cases
- Existing stdout audit behavior is unchanged.
- The historical JSON side artifact is no longer available.

## Follow-ups
- Existing audit findings are out of scope for this cleanup.
