### PR TITLE
Remove infra ci placeholder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,6 @@ HTTP/WebSocket error semantics. Pair it with `apps/ui/README.md` §
 | `firmware/esp/README.md` | ESP32 firmware setup and flashing. |
 | `firmware/esp/HARDENING.md` | Firmware security hardening notes. |
 | `hardware/README.md` | Hardware components and wiring. |
-| `infra/ci/README.md` | CI pipeline overview. |
 | `infra/pi-image/pi-gen/README.md` | Raspberry Pi image build flow. |
 
 ## Data & reference

--- a/infra/ci/README.md
+++ b/infra/ci/README.md
@@ -1,5 +1,0 @@
-# CI helpers
-
-This directory is reserved for CI helper scripts and reusable pipeline snippets.
-
-Current CI workflow remains in `.github/workflows/ci.yml` (required at repo root).


### PR DESCRIPTION
## What changed
- Deleted the placeholder-only `infra/ci/README.md`.
- Removed the stale docs index entry for that placeholder.

## Why
CI helpers live in `tools/tests/` and `.github/actions/`; `infra/ci/` had no active content and contradicted the actual layout.

## Validation
- Confirmed no `infra/ci` or placeholder wording references remain.
- Confirmed the `infra/ci/` directory is gone locally.

## Risks / tradeoffs / edge cases
- No CI behavior changes.
- Future CI helper docs should be added near the actual implementation path.

## Follow-ups
- None.
