### PR TITLE
Deduplicate setup-backend retry helper

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -42,12 +42,13 @@ runs:
       shell: bash
       run: 'echo "Backend virtualenv cache miss: rebuilding .venv."'
 
-    - name: Install dependencies
-      if: ${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}
+    - name: Prepare retry helper
       shell: bash
       run: |
         set -euo pipefail
 
+        retry_helper="${RUNNER_TEMP}/setup-backend-retry.sh"
+        cat > "${retry_helper}" <<'EOF'
         retry_command() {
           local max_attempts=$1
           shift
@@ -69,6 +70,14 @@ runs:
             attempt=$(( attempt + 1 ))
           done
         }
+        EOF
+
+    - name: Install dependencies
+      if: ${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        source "${RUNNER_TEMP}/setup-backend-retry.sh"
 
         rm -rf .venv
         retry_command 3 "${{ steps.setup-python.outputs.python-path }}" -m venv .venv
@@ -99,27 +108,6 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-
-        retry_command() {
-          local max_attempts=$1
-          shift
-          local attempt=1
-
-          while true; do
-            if "$@"; then
-              return 0
-            fi
-
-            if [[ "$attempt" -ge "$max_attempts" ]]; then
-              return 1
-            fi
-
-            local delay=$(( attempt * 5 ))
-            echo "Command failed on attempt ${attempt}/${max_attempts}: $*" >&2
-            echo "Retrying in ${delay}s..." >&2
-            sleep "$delay"
-            attempt=$(( attempt + 1 ))
-          done
-        }
+        source "${RUNNER_TEMP}/setup-backend-retry.sh"
 
         retry_command 3 "${{ steps.backend-python.outputs.python-path }}" -m pip install "platformio>=6,<7"

--- a/apps/server/tests/hygiene/test_workflow_backend_env_cache.py
+++ b/apps/server/tests/hygiene/test_workflow_backend_env_cache.py
@@ -59,6 +59,16 @@ def test_setup_backend_caches_repo_virtualenv_with_explicit_invalidation_inputs(
     )
     assert miss_step["if"] == "${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}"
 
+    prepare_retry_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Prepare retry helper"
+    )
+    prepare_retry_run = prepare_retry_step["run"]
+    assert isinstance(prepare_retry_run, str)
+    assert prepare_retry_run.count("retry_command()") == 1
+    assert 'cat > "${retry_helper}"' in prepare_retry_run
+
     install_step = next(
         step
         for step in steps
@@ -67,6 +77,8 @@ def test_setup_backend_caches_repo_virtualenv_with_explicit_invalidation_inputs(
     assert install_step["if"] == "${{ steps.backend-venv-cache.outputs.cache-hit != 'true' }}"
     install_run = install_step["run"]
     assert isinstance(install_run, str)
+    assert 'source "${RUNNER_TEMP}/setup-backend-retry.sh"' in install_run
+    assert "retry_command()" not in install_run
     assert "rm -rf .venv" in install_run
     assert '"${{ steps.setup-python.outputs.python-path }}" -m venv .venv' in install_run
     assert ".venv/bin/python -m pip install --upgrade pip" in install_run
@@ -88,6 +100,8 @@ def test_setup_backend_caches_repo_virtualenv_with_explicit_invalidation_inputs(
     )
     platformio_run = platformio_step["run"]
     assert isinstance(platformio_run, str)
+    assert 'source "${RUNNER_TEMP}/setup-backend-retry.sh"' in platformio_run
+    assert "retry_command()" not in platformio_run
     assert (
         'retry_command 3 "${{ steps.backend-python.outputs.python-path }}"'
         ' -m pip install "platformio>=6,<7"' in platformio_run


### PR DESCRIPTION
## What changed
- Add one setup-backend retry helper generation step.
- Source that helper from backend dependency install and PlatformIO install steps.
- Add hygiene coverage that rejects reintroducing duplicate inline retry helpers.

## Why
The same bash retry function was duplicated in the composite action. One helper keeps behavior in one place.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_workflow_backend_env_cache.py`
- Generated helper syntax check and source smoke test with repo Python environment.

## Risks, tradeoffs, edge cases
Low risk. Runtime behavior stays the same. The helper now depends on `RUNNER_TEMP`, which GitHub-hosted and action runners provide.

## Follow-ups
None.