### PR TITLE
Drop regen-contracts Makefile alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -96,9 +96,6 @@ benchmark-compare-backend: ## Compare saved backend benchmark runs from apps/ser
 sync-contracts: ## Regenerate or check the authoritative contract sync pipeline
 	@$(RESOLVE_PYTHON) \
 	cd $(UI_DIR) && PYTHON="$$PYTHON" npm run sync:contracts $(if $(CHECK),-- --check,)
-
-regen-contracts: ## Backward-compatible alias for the authoritative contract sync
-regen-contracts: sync-contracts
 
 coverage: ## Run backend coverage with optional COV_OPTS overrides
 	@$(RESOLVE_PYTHON) \

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1858,10 +1858,6 @@ def check_contract_sync_entrypoint() -> list[str]:
         errors.append(
             "Makefile sync-contracts target must route through apps/ui npm run sync:contracts and forward CHECK=1 to --check."
         )
-    if "regen-contracts: sync-contracts" not in makefile_text:
-        errors.append(
-            "Makefile regen-contracts target must stay a thin alias to sync-contracts."
-        )
     for rel_path in _UI_DERIVATIVE_GENERATED_ARTIFACTS:
         if rel_path in tracked_paths and (ROOT / rel_path).exists():
             errors.append(


### PR DESCRIPTION
## What changed
- Remove the unused `regen-contracts` Makefile alias.
- Remove the hygiene check that required keeping that alias.

## Why
The repo uses `make sync-contracts` as the authoritative contract sync entrypoint. The compatibility alias had no callers and contradicted the no-unused-alias policy.

## Validation
- No remaining `regen-contracts` references.
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_check_hygiene_entrypoints.py tests/hygiene/test_dev_workflow.py`
- `make -n sync-contracts`
- `make help | grep -E 'sync-contracts|regen-contracts'`\n\n## Risks, tradeoffs, edge cases\nLow risk. External users of the undocumented alias must switch to `make sync-contracts`. The issue explicitly says no real consumer is known.\n\n## Follow-ups\nNone.