### PR TITLE
Add workspace excludes and clean target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,9 @@ artifacts/fuzz/*
 
 # IDE / editor files
 .idea/
-.vscode/
+.vscode/*
+!.vscode/
+!.vscode/settings.json
 *.swp
 *.swo
 .DS_Store

--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,4 @@
+**/.cache/
+apps/server/build/
+apps/server/dist/
+apps/server/vibesensor.egg-info/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "search.exclude": {
+    "**/.cache/**": true,
+    "apps/server/build/**": true,
+    "apps/server/dist/**": true,
+    "apps/server/vibesensor.egg-info/**": true,
+    "infra/pi-image/pi-gen/.cache/**": true
+  },
+  "files.watcherExclude": {
+    "**/.cache/**": true,
+    "apps/server/build/**": true,
+    "apps/server/dist/**": true,
+    "apps/server/vibesensor.egg-info/**": true,
+    "infra/pi-image/pi-gen/.cache/**": true
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -40,6 +40,9 @@ setup: ## Install backend dev dependencies and UI node_modules
 
 dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
+clean: ## Remove local build, package, and Pi image cache artifacts
+	rm -rf $(SERVER_DIR)/build $(SERVER_DIR)/dist $(SERVER_DIR)/vibesensor.egg-info infra/pi-image/pi-gen/.cache
 
 format: ## Run Ruff formatter over backend and tooling files
 	@$(RESOLVE_PYTHON) \


### PR DESCRIPTION
## What changed
- Track VS Code workspace search/watcher excludes for shadow build and cache trees.
- Add `.rgignore` entries for `.cache`, backend build, dist, and egg-info trees.
- Add `make clean` to remove backend build/dist/egg-info and Pi image cache artifacts.
- Allow the repo to track `.vscode/settings.json` while keeping other local VS Code files ignored.

## Why
Ignored shadow trees were duplicating source paths in local search/static analysis. The repo now hides them from common search tools and has a single cleanup command.

## Validation
- `python3 -m json.tool .vscode/settings.json`
- `make -n clean`
- `make clean` removed disposable test artifacts under each target tree.
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_check_hygiene_entrypoints.py tests/hygiene/test_dev_workflow.py`

## Risks, tradeoffs, edge cases
Low risk. `make clean` only removes ignored local build/cache outputs. `.vscode/settings.json` is now shared; other `.vscode` files remain ignored.

## Follow-ups
None.