### PR TITLE
Deduplicate benchmark target documentation

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -178,14 +178,13 @@ settings snapshots now follow the same pattern in
 For repeatable codec comparisons, run the explicit benchmark suite:
 
 ```bash
-make benchmark-backend \
-  BACKEND_BENCHMARK_TARGETS=tests/use_cases/updates/benchmark_update_status_codec.py \
-  BENCHMARK_OPTS="--benchmark-save=update-status-codec"
+make benchmark-backend BENCHMARK_OPTS="--benchmark-save=update-status-codec"
 make benchmark-compare-backend
 ```
 
-The benchmark uses a representative updater-status payload. Saved runs land in
-`apps/server/.benchmarks/` so later runs can be compared with the same target.
+The default benchmark target list is defined in the repository `Makefile` and
+includes the updater-status codec benchmark. Saved runs land in
+`apps/server/.benchmarks/` so later runs can be compared with the same targets.
 
 ## Configuration
 

--- a/docs/multithreading_performance.md
+++ b/docs/multithreading_performance.md
@@ -70,11 +70,13 @@ larger FFT sizes, the adaptive parallel path still carries the benefit.
 ## How to run the benchmark
 
 ```bash
-make benchmark-backend \
-  BACKEND_BENCHMARK_TARGETS=tests/infra/workers/benchmark_compute_all.py \
-  BENCHMARK_OPTS="--benchmark-save=worker-pool"
+make benchmark-backend BENCHMARK_OPTS="--benchmark-save=worker-pool"
 make benchmark-compare-backend
 ```
+
+`make benchmark-backend` uses the default backend benchmark target list defined in
+the repository `Makefile`. Override `BACKEND_BENCHMARK_TARGETS` only for ad hoc
+single-file runs so the documented default cannot drift from the Makefile.
 
 ## Design decisions for a 4-core Pi
 


### PR DESCRIPTION
## What changed
- Remove duplicated `BACKEND_BENCHMARK_TARGETS` path overrides from benchmark docs examples.
- Point docs at the Makefile-owned default benchmark target list.
- Keep `BACKEND_BENCHMARK_TARGETS` documented only as an ad hoc override.

## Why
The default benchmark list should have one source of truth. Repeating benchmark file paths in docs created drift risk.

## Validation
- `uv run --python 3.13 --extra dev python ../../tools/dev/docs_lint.py`
- `make -n benchmark-backend`

## Risks, tradeoffs, edge cases
Low risk. Docs-only change. Users still can override `BACKEND_BENCHMARK_TARGETS` for focused runs.

## Follow-ups
None.