### PR TITLE
Consolidate legacy context caveat key

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_confidence_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_confidence_facts.py
@@ -4,6 +4,7 @@ from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_document import build_report_document
 
@@ -417,7 +418,7 @@ def test_prepare_persisted_report_input_marks_legacy_raw_backed_context_fallback
     data = build_report_document(prepared)
 
     assert prepared.report_facts.context.source == "legacy"
-    assert "legacy_context" in confidence.caveat_keys
+    assert LEGACY_CONTEXT_CAVEAT_KEY in confidence.caveat_keys
     assert "summary_only" not in confidence.caveat_keys
     assert [warning.code for warning in prepared.report_facts.decision.warnings] == [
         "whole_run_context_legacy_fallback"

--- a/apps/server/tests/use_cases/history/test_report_confidence_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_confidence_facts.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_document import build_report_document
 

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
@@ -4,6 +4,7 @@ from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 
 
@@ -141,7 +142,7 @@ def test_prepare_persisted_report_input_builds_raw_backed_legacy_fallback_diagno
     assert "summary_only" not in {
         factor.factor_key for factor in diagnosis[0].counterevidence_factors
     }
-    assert "legacy_context" in {
+    assert LEGACY_CONTEXT_CAVEAT_KEY in {
         factor.factor_key for factor in diagnosis[0].counterevidence_factors
     }
 

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from test_support.findings import make_finding_payload
 from test_support.report_helpers import minimal_summary
 
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 
 

--- a/apps/server/vibesensor/domain/diagnosis_assessment.py
+++ b/apps/server/vibesensor/domain/diagnosis_assessment.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field, replace
-
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
+from typing import Final, Literal
 
 from .finding import Finding
 
@@ -16,6 +15,7 @@ __all__ = [
     "DiagnosisAssessmentFactor",
     "DiagnosisAssessmentFactorDetails",
     "DiagnosisAssessmentInputs",
+    "LEGACY_CONTEXT_CAVEAT_KEY",
     "apply_diagnosis_assessment_fallback",
     "diagnosis_assessment_from_components",
     "score_diagnosis_assessment_inputs",
@@ -23,6 +23,9 @@ __all__ = [
 
 DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP = 0.10
 DIAGNOSIS_AMBIGUOUS_SCORE_GAP = 0.05
+LEGACY_CONTEXT_CAVEAT_KEY: Final[Literal["legacy_context"]] = "legacy_context"
+"""Shared caveat/factor key for legacy whole-run context fallbacks."""
+
 _DIAGNOSIS_SUSPICIOUS_CAVEAT_KEYS = frozenset(
     {
         "drifting_frequency",

--- a/apps/server/vibesensor/domain/diagnosis_assessment.py
+++ b/apps/server/vibesensor/domain/diagnosis_assessment.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field, replace
 
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
+
 from .finding import Finding
 
 __all__ = [
@@ -156,7 +158,7 @@ def score_diagnosis_assessment_inputs(inputs: DiagnosisAssessmentInputs) -> Diag
     if inputs.context_traceable:
         if inputs.context_source == "legacy":
             score -= 0.05
-            caveat_keys.append("legacy_context")
+            caveat_keys.append(LEGACY_CONTEXT_CAVEAT_KEY)
         else:
             if inputs.speed_gap_window_count > 0:
                 score -= 0.04
@@ -557,7 +559,7 @@ def _support_factor_weight(factor_key: str, assessment: DiagnosisAssessment) -> 
 
 
 def _counter_factor_weight(factor_key: str) -> float:
-    if factor_key in {"summary_only", "legacy_context", "raw_replay_incomplete"}:
+    if factor_key in {"summary_only", LEGACY_CONTEXT_CAVEAT_KEY, "raw_replay_incomplete"}:
         return 0.05
     if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
         return 0.04
@@ -666,7 +668,7 @@ def _tier_for_score(*, label_key: str, score_0_to_1: float, caveat_keys: tuple[s
             "weak_spatial",
             "close_alternative",
             "incomplete_reference",
-            "legacy_context",
+            LEGACY_CONTEXT_CAVEAT_KEY,
             "speed_context_gaps",
             "rpm_context_gaps",
             "noisy_signal",

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from vibesensor.domain import LocationIntensitySummary
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.codecs.scalars import (
     coerce_count,
     optional_float,
@@ -16,7 +17,6 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.summary_fields.hotspot import (
     location_intensity_summaries_from_rows,
 )
-from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarKind,

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -16,6 +16,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.summary_fields.hotspot import (
     location_intensity_summaries_from_rows,
 )
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarKind,
@@ -460,7 +461,7 @@ _DIAGNOSIS_FACTOR_KEY_VALUES: frozenset[DiagnosisFactorKey] = frozenset(
         "clean_signal",
         "summary_only",
         "raw_replay_incomplete",
-        "legacy_context",
+        LEGACY_CONTEXT_CAVEAT_KEY,
         "speed_context_gaps",
         "rpm_context_gaps",
         "sparse_support",

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -16,7 +16,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.summary_fields.hotspot import (
     location_intensity_summaries_from_rows,
 )
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarKind,

--- a/apps/server/vibesensor/shared/constants/analysis.py
+++ b/apps/server/vibesensor/shared/constants/analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Final, Literal
+from typing import Final
 
 SILENCE_DB: Final[float] = -120.0
 """dB value representing silence / no meaningful vibration signal."""
@@ -46,9 +46,6 @@ shown as perfectly certain."""
 
 SNR_LOG_DIVISOR: Final[float] = 2.5
 """Divisor for log1p(SNR) normalisation to [0, 1]."""
-
-LEGACY_CONTEXT_CAVEAT_KEY: Final[Literal["legacy_context"]] = "legacy_context"
-"""Shared caveat/factor key for legacy whole-run context fallbacks."""
 
 ORDER_SUPPRESS_PERSISTENT_MIN_CONF: Final[float] = 0.40
 """Minimum order-finding confidence to suppress a matching persistent peak."""

--- a/apps/server/vibesensor/shared/constants/analysis.py
+++ b/apps/server/vibesensor/shared/constants/analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, Literal
 
 SILENCE_DB: Final[float] = -120.0
 """dB value representing silence / no meaningful vibration signal."""
@@ -46,6 +46,9 @@ shown as perfectly certain."""
 
 SNR_LOG_DIVISOR: Final[float] = 2.5
 """Divisor for log1p(SNR) normalisation to [0, 1]."""
+
+LEGACY_CONTEXT_CAVEAT_KEY: Final[Literal["legacy_context"]] = "legacy_context"
+"""Shared caveat/factor key for legacy whole-run context fallbacks."""
 
 ORDER_SUPPRESS_PERSISTENT_MIN_CONF: Final[float] = 0.40
 """Minimum order-finding confidence to suppress a matching persistent peak."""

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -7,10 +7,10 @@ import math
 from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationSource
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.report_i18n import human_location, location_candidates
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.strength_bands import BANDS
 
 __all__ = [

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -10,6 +10,7 @@ from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, Vibrat
 from vibesensor.report_i18n import human_location, location_candidates
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.strength_bands import BANDS
 
 __all__ = [
@@ -451,7 +452,7 @@ def _confidence_caveat_texts(
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
         elif key == "raw_replay_incomplete":
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RAW_REPLAY_INCOMPLETE"))
-        elif key == "legacy_context":
+        elif key == LEGACY_CONTEXT_CAVEAT_KEY:
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
         elif key == "sparse_support":
             parts.append(

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, Required, TypedDict
 
 from pydantic import ConfigDict
 
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.analysis_views import (
     PhaseSpeedBreakdownRow,
     PlotDataResult,
@@ -145,7 +146,7 @@ DIAGNOSIS_FACTOR_KEY_VALUES: frozenset[DiagnosisFactorKey] = frozenset(
         "user_confirmed_vehicle_data",
         "summary_only",
         "raw_replay_incomplete",
-        "legacy_context",
+        LEGACY_CONTEXT_CAVEAT_KEY,
         "speed_context_gaps",
         "rpm_context_gaps",
         "sparse_support",

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -18,7 +18,7 @@ from typing import Any, Literal, Required, TypedDict
 
 from pydantic import ConfigDict
 
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.types.analysis_views import (
     PhaseSpeedBreakdownRow,
     PlotDataResult,

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
+from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.report_presentation import (
     confidence_snapshot_text,
     display_location,
@@ -215,7 +216,7 @@ def _diagnosis_counterevidence_texts(
         notes.append(tr("REPORT_COUNTEREVIDENCE_REFERENCE_GAP"))
     if "summary_only" in counter_keys:
         notes.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
-    if "legacy_context" in counter_keys:
+    if LEGACY_CONTEXT_CAVEAT_KEY in counter_keys:
         notes.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
     if "speed_context_gaps" in counter_keys:
         notes.append(tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS"))

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
-from vibesensor.shared.constants.analysis import LEGACY_CONTEXT_CAVEAT_KEY
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.report_presentation import (
     confidence_snapshot_text,
     display_location,

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
-from vibesensor.domain.diagnosis_assessment import LEGACY_CONTEXT_CAVEAT_KEY
 from vibesensor.shared.report_presentation import (
     confidence_snapshot_text,
     display_location,


### PR DESCRIPTION
## What changed
- Add `LEGACY_CONTEXT_CAVEAT_KEY` as the shared legacy-context caveat/factor key in the domain layer.
- Replace runtime comparisons and emitted caveat/factor values with the shared constant.
- Update focused assertions to use the shared key.

## Why
The sentinel string was repeated across scoring, reporting, and tests. One constant removes typo-driven drift without changing payload values. Keeping it in the domain layer preserves import-direction guardrails.

## Validation
- `uv run --python 3.13 --extra dev python -m ruff check vibesensor/domain/diagnosis_assessment.py vibesensor/shared/types/history_analysis_contracts.py vibesensor/shared/boundaries/reporting/summary.py vibesensor/use_cases/history/report_document/evidence_snapshot.py vibesensor/shared/report_presentation.py tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py tests/use_cases/history/test_report_confidence_facts.py`
- `uv run --python 3.13 --extra dev pytest tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py tests/use_cases/history/test_report_confidence_facts.py`
- `uv run --python 3.13 --extra dev python -m mypy --config-file pyproject.toml vibesensor/domain/diagnosis_assessment.py vibesensor/shared/types/history_analysis_contracts.py vibesensor/shared/boundaries/reporting/summary.py vibesensor/use_cases/history/report_document/evidence_snapshot.py vibesensor/shared/report_presentation.py`
- `uv run --python 3.13 --extra dev python ../../tools/dev/verify_backend_static_guards.py`

## Risks, tradeoffs, edge cases
Low risk. The serialized key remains `legacy_context`; the `Literal` contract keeps that wire value explicit.

## Follow-ups
None.