### PR TITLE
Add CodeQL TypeScript analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,9 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Current CodeQL coverage targets the Python backend.
+        # Analyze both backend Python and UI JavaScript/TypeScript.
         language:
           - python
+          - javascript-typescript
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## What changed
- Add `javascript-typescript` to the CodeQL language matrix.
- Update the matrix comment to state that CodeQL analyzes backend Python and UI JavaScript/TypeScript.

## Why
The workflow comment and matrix disagreed about coverage. The UI is TypeScript, so the workflow now analyzes it instead of only documenting backend coverage.

## Validation
- Parsed `.github/workflows/codeql.yml` and asserted the matrix languages are `python` and `javascript-typescript`.
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_workflow_python_runtime_usage.py tests/hygiene/test_ci_workflow_manifest.py`

## Risks, tradeoffs, edge cases
Low risk. This intentionally adds a second CodeQL matrix job for JS/TS, so CodeQL runtime will increase.

## Follow-ups
None.