### PR TITLE
Keep dev rollback data local

### DIFF
--- a/apps/server/config.dev.yaml
+++ b/apps/server/config.dev.yaml
@@ -6,3 +6,6 @@ server:
 
 gps:
   gps_enabled: false  # Developer machines do not run a gpsd daemon
+
+update:
+  rollback_dir: data/rollback

--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -105,6 +105,7 @@ def test_base_dev_and_docker_configs_capture_intended_runtime_invariants(tmp_pat
     base_cfg = _write_and_load(tmp_path / "config.yaml", {})
     dev_cfg = load_config(SERVER_DIR / "config.dev.yaml")
     docker_cfg = load_config(SERVER_DIR / "config.docker.yaml")
+    pi_cfg = load_config(SERVER_DIR / "config.pi.yaml")
 
     assert base_cfg.server.host == dev_cfg.server.host == docker_cfg.server.host
     assert base_cfg.server.port == 80
@@ -120,6 +121,9 @@ def test_base_dev_and_docker_configs_capture_intended_runtime_invariants(tmp_pat
     assert base_cfg.ap.self_heal.enabled is True
     assert dev_cfg.ap.self_heal.enabled is True
     assert docker_cfg.ap.self_heal.enabled is False
+    assert base_cfg.update.rollback_dir == Path("/var/lib/vibesensor/rollback")
+    assert pi_cfg.update.rollback_dir == Path("/var/lib/vibesensor/rollback")
+    assert dev_cfg.update.rollback_dir == SERVER_DIR / "data/rollback"
     assert docker_cfg.update.rollback_dir != base_cfg.update.rollback_dir
 
 

--- a/apps/server/tests/app/test_config_extended.py
+++ b/apps/server/tests/app/test_config_extended.py
@@ -38,6 +38,9 @@ def test_load_config_preserves_absolute_paths(tmp_path: Path) -> None:
                     "state_file": "/tmp/hotspot-state.json",
                 }
             },
+            "update": {
+                "rollback_dir": "/tmp/rollback",
+            },
         },
     )
 
@@ -47,6 +50,7 @@ def test_load_config_preserves_absolute_paths(tmp_path: Path) -> None:
     assert result.logging.app_log_path == Path("/tmp/app.log")
     assert result.tracing.output_path == Path("/tmp/traces.jsonl")
     assert result.ap.self_heal.state_file == Path("/tmp/hotspot-state.json")
+    assert result.update.rollback_dir == Path("/tmp/rollback")
 
 
 def test_load_config_resolves_relative_paths_from_config_parent(tmp_path: Path) -> None:
@@ -67,6 +71,9 @@ def test_load_config_resolves_relative_paths_from_config_parent(tmp_path: Path) 
                     "state_file": "data/hotspot-state.json",
                 }
             },
+            "update": {
+                "rollback_dir": "data/rollback",
+            },
         },
     )
 
@@ -76,6 +83,7 @@ def test_load_config_resolves_relative_paths_from_config_parent(tmp_path: Path) 
     assert result.logging.app_log_path == config_path.parent / "logs/app.log"
     assert result.tracing.output_path == config_path.parent / "logs/traces.jsonl"
     assert result.ap.self_heal.state_file == config_path.parent / "data/hotspot-state.json"
+    assert result.update.rollback_dir == config_path.parent / "data/rollback"
 
 
 def test_load_config_preserves_parent_traversal_relative_to_config(tmp_path: Path) -> None:

--- a/apps/server/vibesensor/app/config_loader.py
+++ b/apps/server/vibesensor/app/config_loader.py
@@ -223,7 +223,10 @@ def load_config(config_path: Path | None = None) -> AppConfig:
             ),
         ),
         update=UpdateConfig(
-            rollback_dir=Path(str(update_cfg["rollback_dir"])),
+            rollback_dir=_resolve_config_path(
+                str(update_cfg["rollback_dir"]),
+                path,
+            ),
         ),
         tracing=TracingConfig(
             enabled=bool(tracing_cfg["enabled"]),


### PR DESCRIPTION
## What changed
- Add `update.rollback_dir: data/rollback` to `config.dev.yaml`.
- Resolve relative `update.rollback_dir` values against the config file directory.
- Extend config tests for absolute rollback paths, relative rollback paths, dev-local rollback storage, and unchanged Pi default rollback storage.

## Why
Native development should not inherit the Pi `/var/lib/vibesensor/rollback` path. Dev rollback state now stays under `apps/server/data/rollback`, matching the repo-local pattern used by other dev data.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/app/test_config.py tests/app/test_config_extended.py -q`

## Risks, tradeoffs, edge cases
Low risk. Absolute rollback paths are preserved, so Docker and Pi behavior remain unchanged. Relative rollback paths now resolve from the config file directory, matching other config path fields.

## Follow-ups
None.