### PR TITLE
Align UI Playwright tooling inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ apps/server/build/
 apps/server/dist/
 
 # Playwright test artifacts
-apps/ui/tests/test-results/
+apps/ui/test-results/
 apps/ui/playwright-report/
 
 # Generic artifacts/caches
@@ -111,7 +111,6 @@ artifacts/fuzz/*
 *.swo
 .DS_Store
 .coverage
-apps/ui/test-results/
 apps/ui/src/constants.ts
 apps/ui/src/generated/http_api_contracts.ts
 apps/ui/src/contracts/ws_payload_schema.generated.ts

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -12,7 +12,9 @@ import yaml
 from tests._paths import REPO_ROOT
 
 _UI_PACKAGE_JSON = REPO_ROOT / "apps" / "ui" / "package.json"
+_UI_BIOME_JSON = REPO_ROOT / "apps" / "ui" / "biome.json"
 _SMOKE_CONFIG = REPO_ROOT / "apps" / "ui" / "playwright.smoke.config.ts"
+_UI_ROOT = REPO_ROOT / "apps" / "ui"
 _UI_TESTS_DIR = REPO_ROOT / "apps" / "ui" / "tests"
 _CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _EXPECTED_CORE_SMOKE_SPECS = {
@@ -67,12 +69,58 @@ def _ci_workflow() -> dict[str, object]:
     return loaded
 
 
+def _playwright_configs_from_package_scripts() -> set[str]:
+    configs: set[str] = set()
+    for script in _package_scripts().values():
+        tokens = shlex.split(script)
+        if tokens[:3] != ["npx", "playwright", "test"]:
+            continue
+        explicit_configs = {
+            token.removeprefix("--config=")
+            for token in tokens
+            if token.startswith("--config=")
+        }
+        configs.update(explicit_configs or {"playwright.config.ts"})
+    return configs
+
+
+def _output_dirs_from_playwright_configs(configs: set[str]) -> set[str]:
+    output_dirs: set[str] = set()
+    for config in configs:
+        config_text = (_UI_ROOT / config).read_text(encoding="utf-8")
+        output_dirs.update(re.findall(r'outputDir:\s*"([^"]+)"', config_text))
+    return output_dirs
+
+
 def _resolved_smoke_specs() -> set[str]:
     return {
         path.name
         for pattern in _smoke_test_match_patterns()
         for path in (REPO_ROOT / "apps" / "ui" / _smoke_test_dir()).glob(pattern)
     }
+
+
+def test_ui_tooling_covers_playwright_configs_and_ignores_generated_results() -> None:
+    playwright_configs = _playwright_configs_from_package_scripts()
+    biome = json.loads(_UI_BIOME_JSON.read_text(encoding="utf-8"))
+    files_includes = set(biome["files"]["includes"])
+    linter_includes = set(biome["linter"]["includes"])
+    formatter_includes = set(biome["formatter"]["includes"])
+    output_dirs = _output_dirs_from_playwright_configs(playwright_configs)
+
+    assert playwright_configs == {
+        "playwright.config.ts",
+        "playwright.smoke.config.ts",
+        "playwright.smoke.msw.config.ts",
+        "playwright.visual-audit.config.ts",
+    }
+    assert playwright_configs <= linter_includes
+    assert playwright_configs <= formatter_includes
+    assert "!!test-results" not in files_includes
+    assert "!test-results" in files_includes
+    assert "!tests/test-results" in files_includes
+    assert output_dirs
+    assert all(output_dir.startswith("test-results/") for output_dir in output_dirs)
 
 
 def test_ui_smoke_command_and_config_alignment() -> None:

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -76,9 +76,7 @@ def _playwright_configs_from_package_scripts() -> set[str]:
         if tokens[:3] != ["npx", "playwright", "test"]:
             continue
         explicit_configs = {
-            token.removeprefix("--config=")
-            for token in tokens
-            if token.startswith("--config=")
+            token.removeprefix("--config=") for token in tokens if token.startswith("--config=")
         }
         configs.update(explicit_configs or {"playwright.config.ts"})
     return configs

--- a/apps/ui/biome.json
+++ b/apps/ui/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "files": {
     "ignoreUnknown": true,
     "includes": [
@@ -8,8 +8,9 @@
       "!src/contracts",
       "!src/constants.ts",
       "!package-lock.json",
+      "!test-results",
+      "!tests/test-results",
       "!!dist",
-      "!!test-results",
       "!!tests/snapshots"
     ]
   },
@@ -20,6 +21,8 @@
       "tests/**/*.ts",
       "playwright.config.ts",
       "playwright.smoke.config.ts",
+      "playwright.smoke.msw.config.ts",
+      "playwright.visual-audit.config.ts",
       "vite.config.ts",
       "vitest.config.ts",
       "take-screenshot.mjs",
@@ -39,6 +42,8 @@
       "index.html",
       "playwright.config.ts",
       "playwright.smoke.config.ts",
+      "playwright.smoke.msw.config.ts",
+      "playwright.visual-audit.config.ts",
       "vite.config.ts",
       "vitest.config.ts",
       "take-screenshot.mjs",

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -45,7 +45,7 @@ export const visualAuditProjects = [
 export const visualBaseConfig = {
   testDir: "tests",
   testMatch: ["visual.spec.ts"],
-  outputDir: "tests/test-results",
+  outputDir: "test-results/playwright-visual",
   snapshotDir: "tests/snapshots",
   snapshotPathTemplate: "{snapshotDir}/{testFilePath}/{arg}-{projectName}{ext}",
   timeout: 45_000,

--- a/apps/ui/playwright.smoke.msw.config.ts
+++ b/apps/ui/playwright.smoke.msw.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "tests",
   testMatch: ["msw-browser.smoke.spec.ts"],
+  outputDir: "test-results/playwright-smoke-msw",
   timeout: 15_000,
   workers: 1,
   use: {


### PR DESCRIPTION
## What changed
- Add all package-script Playwright config files to Biome lint and format includes.
- Stop force-including generated `test-results` in Biome.
- Move visual Playwright output under `test-results/playwright-visual`.
- Give MSW smoke Playwright output its own `test-results/playwright-smoke-msw` directory.
- Remove the stale `apps/ui/tests/test-results/` gitignore entry and keep generated artifacts under `apps/ui/test-results/`.
- Add a hygiene guard that derives Playwright config files from package scripts and checks Biome/output-dir alignment.

## Why
Tooling should cover every maintained Playwright config while keeping generated test artifacts out of normal lint/format paths.

## Validation
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ui_smoke_contract.py -q`
- `cd apps/ui && npx biome check biome.json playwright.config.ts playwright.smoke.config.ts playwright.smoke.msw.config.ts playwright.visual-audit.config.ts`
- `make ui-typecheck`

## Risks, tradeoffs, edge cases
Low risk. This is tooling/config hygiene only. Existing Biome warnings in `tests/ws_payload_validator.spec.ts` remain warning-level and unchanged.

## Follow-ups
None.