### PR TITLE
Fix release metadata source references

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -31,6 +31,13 @@ jobs:
           # workflow_run releases must build the exact commit that completed CI successfully.
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Compute release source SHA
+        id: release_source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
       - name: Set up configured Python runtime
         id: setup-python
         uses: ./.github/actions/setup-python
@@ -164,7 +171,7 @@ jobs:
           python_bin="${{ steps.setup-python.outputs.python-path }}"
           "${python_bin}" tools/release/main_release.py generate-firmware-manifest \
             --firmware-dir "${{ steps.firmware_dir.outputs.path }}" \
-            --generated-from "${GITHUB_SHA}"
+            --generated-from "${{ steps.release_source.outputs.sha }}"
 
       - name: Validate firmware manifest
         shell: bash
@@ -237,7 +244,7 @@ jobs:
           "${python_bin}" tools/publish_github_release.py \
             --repo "${GITHUB_REPOSITORY}" \
             --tag "${{ steps.version.outputs.tag }}" \
-            --target "${GITHUB_SHA}" \
+            --target "${{ steps.release_source.outputs.sha }}" \
             --title "Wheel / ESP release ${{ steps.version.outputs.version }}" \
             --notes-file "${notes_file}" \
             "${release_args[@]}"

--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Compute weekly source SHA
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
       - name: Compute weekly image metadata
         id: metadata
         shell: bash
@@ -67,9 +74,9 @@ jobs:
           cat > "${notes_file}" <<EOF
           Automated weekly Raspberry Pi image snapshot from \`main\`.
 
-          - Commit: \`${GITHUB_SHA}\`
+          - Commit: \`${{ steps.source.outputs.sha }}\`
           - Build label: \`${{ steps.metadata.outputs.build_label }}\`
-          - Asset: \`${{ steps.assets.outputs.artifact_name }}\`
+          - Asset: \`${{ steps.build-image.outputs.release-artifact-name }}\`
           - Flash the image with Raspberry Pi Imager after downloading the release asset.
 
           This workflow reuses \`infra/pi-image/pi-gen/build.sh\` so the weekly image follows the same supported image-build path as local builds.
@@ -91,7 +98,7 @@ jobs:
           "${python_bin}" tools/publish_github_release.py \
             --repo "${GITHUB_REPOSITORY}" \
             --tag "${{ steps.metadata.outputs.tag }}" \
-            --target "${GITHUB_SHA}" \
+            --target "${{ steps.source.outputs.sha }}" \
             --title "${{ steps.metadata.outputs.release_name }}" \
             --notes-file "${notes_file}" \
             --make-latest false \

--- a/apps/server/tests/hygiene/test_main_release_workflow.py
+++ b/apps/server/tests/hygiene/test_main_release_workflow.py
@@ -22,6 +22,15 @@ def test_main_release_workflow_fetches_full_history_and_validates_release_artifa
         if isinstance(step, dict) and step.get("uses") == "actions/checkout@v6"
     )
     assert checkout_step["with"]["fetch-depth"] == 0
+    assert "github.event.workflow_run.head_sha" in checkout_step["with"]["ref"]
+
+    source_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Compute release source SHA"
+    )
+    assert source_step["id"] == "release_source"
+    assert "git rev-parse HEAD" in source_step["run"]
 
     compute_version_step = next(
         step for step in steps if isinstance(step, dict) and step.get("name") == "Compute version"
@@ -65,6 +74,8 @@ def test_main_release_workflow_fetches_full_history_and_validates_release_artifa
     )
     manifest_script = manifest_step["run"]
     assert "tools/release/main_release.py generate-firmware-manifest" in manifest_script
+    assert '--generated-from "${{ steps.release_source.outputs.sha }}"' in manifest_script
+    assert "GITHUB_SHA" not in manifest_script
 
     release_step_names = {
         step.get("name")
@@ -89,6 +100,8 @@ def test_main_release_workflow_labels_and_cleans_only_wheel_esp_releases() -> No
         if isinstance(step, dict) and step.get("name") == "Create combined Wheel / ESP release"
     )
     assert isinstance(create_step["run"], str)
+    assert '--target "${{ steps.release_source.outputs.sha }}"' in create_step["run"]
+    assert "GITHUB_SHA" not in create_step["run"]
 
     cleanup_step = next(
         step

--- a/apps/server/tests/hygiene/test_weekly_pi_image_workflow.py
+++ b/apps/server/tests/hygiene/test_weekly_pi_image_workflow.py
@@ -19,6 +19,13 @@ def test_weekly_pi_image_workflow_uses_native_arm_runner_and_keeps_release_namin
         isinstance(step, dict) and step.get("uses") == "docker/setup-qemu-action@v4"
         for step in steps
     )
+    source_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Compute weekly source SHA"
+    )
+    assert source_step["id"] == "source"
+    assert "git rev-parse HEAD" in source_step["run"]
 
     build_step = next(
         step
@@ -36,6 +43,16 @@ def test_weekly_pi_image_workflow_uses_native_arm_runner_and_keeps_release_namin
         == "weekly-pi-image-${{ steps.metadata.outputs.build_label }}"
     )
     assert build_step["with"]["include-published-artifact"] == "true"
+    publish_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Publish weekly Pi image release"
+    )
+    publish_script = publish_step["run"]
+    assert "${{ steps.assets.outputs.artifact_name }}" not in publish_script
+    assert "${GITHUB_SHA}" not in publish_script
+    assert "${{ steps.build-image.outputs.release-artifact-name }}" in publish_script
+    assert '--target "${{ steps.source.outputs.sha }}"' in publish_script
     step_names = {
         step.get("name")
         for step in steps


### PR DESCRIPTION
## What changed
- Compute the checked-out source SHA in `main-release.yml`.
- Use that SHA for firmware manifest `generated_from` and the Wheel / ESP release target.
- Compute the checked-out source SHA in `weekly-pi-image.yml`.
- Use the weekly build action `release-artifact-name` output in release notes instead of the nonexistent `assets` step.
- Use the checked-out weekly source SHA for notes and release target.
- Add hygiene tests for these workflow metadata contracts.

## Why
Release metadata must point at the commit that actually produced the artifacts, especially when `workflow_run` checks out the CI-passed head SHA.

## Validation
- `uv run --python 3.13 --extra dev ruff format tests/hygiene/test_main_release_workflow.py tests/hygiene/test_weekly_pi_image_workflow.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_main_release_workflow.py tests/hygiene/test_weekly_pi_image_workflow.py tests/hygiene/test_workflow_python_runtime_usage.py -q`

## Risks, tradeoffs, edge cases
Low risk. Build steps are unchanged; only release metadata inputs and notes are corrected to use checked-out HEAD.

## Follow-ups
None.