### PR TITLE
Keep runtime data out of Docker contexts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,16 @@ artifacts/
 apps/ui/dist
 apps/ui/test-results
 
+# Runtime data
+apps/server/data/*.csv
+apps/server/data/*.jsonl
+apps/server/data/*.log
+apps/server/data/*.db
+apps/server/data/*.db-shm
+apps/server/data/*.db-wal
+apps/server/data/clients.json
+apps/server/wifi-secrets.env
+
 # Test directories (not needed at runtime)
 apps/server/tests/
 apps/server/tests_e2e/

--- a/apps/server/tests/hygiene/test_dockerignore_runtime_data.py
+++ b/apps/server/tests/hygiene/test_dockerignore_runtime_data.py
@@ -1,0 +1,26 @@
+"""Guard Docker build contexts against local server runtime data."""
+
+from __future__ import annotations
+
+from tests._paths import REPO_ROOT
+
+
+def _ignore_patterns(path: str) -> set[str]:
+    return {
+        line.strip()
+        for line in (REPO_ROOT / path).read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def test_dockerignore_mirrors_server_runtime_data_gitignore_patterns() -> None:
+    gitignore_patterns = _ignore_patterns(".gitignore")
+    dockerignore_patterns = _ignore_patterns(".dockerignore")
+    server_runtime_patterns = {
+        pattern
+        for pattern in gitignore_patterns
+        if pattern.startswith("apps/server/data/") or pattern == "apps/server/wifi-secrets.env"
+    }
+
+    assert server_runtime_patterns
+    assert server_runtime_patterns <= dockerignore_patterns


### PR DESCRIPTION
## What changed
- Added server runtime-data exclusions to `.dockerignore`.
- Covered CSV, JSONL, logs, SQLite sidecars, `clients.json`, and `wifi-secrets.env`.
- Added a hygiene test that derives server runtime-only patterns from `.gitignore` and requires `.dockerignore` to mirror them.

## Why
`apps/server/Dockerfile` and `apps/server/Dockerfile.e2e` copy `apps/server` into images. Gitignored local runtime files should not enter Docker build contexts or images.

## Validation
- `uv run --python 3.13 --extra dev ruff format tests/hygiene/test_dockerignore_runtime_data.py`
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_dockerignore_runtime_data.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_dockerignore_runtime_data.py -q`

## Risks, tradeoffs, edge cases
Low risk. Runtime behavior is unchanged. Docker builds may now omit local ignored runtime files that should never be packaged.

## Follow-ups
None.