### PR TITLE
Restore real privacy guard hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,10 +3,12 @@ set -euo pipefail
 
 guard_script="tools/privacy/privacy_guard.py"
 
-if [[ ! -f "${guard_script}" ]]; then
-	echo "[vibesensor hooks] Skipping privacy guard: ${guard_script} is not present in this checkout." >&2
-	echo "[vibesensor hooks] Use 'make format' for canonical Python formatting and see CONTRIBUTING.md for the supported local validation commands." >&2
-	exit 0
+if [[ -x ".venv/bin/python" ]]; then
+	python_bin=".venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+	python_bin="python3"
+else
+	python_bin="python"
 fi
 
-python "${guard_script}" check-staged
+"${python_bin}" "${guard_script}" check-staged

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,10 +3,12 @@ set -euo pipefail
 
 guard_script="tools/privacy/privacy_guard.py"
 
-if [[ ! -f "${guard_script}" ]]; then
-  echo "[vibesensor hooks] Skipping privacy guard: ${guard_script} is not present in this checkout." >&2
-  echo "[vibesensor hooks] Use 'make format' for canonical Python formatting and see CONTRIBUTING.md for the supported local validation commands." >&2
-  exit 0
+if [[ -x ".venv/bin/python" ]]; then
+  python_bin=".venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+  python_bin="python3"
+else
+  python_bin="python"
 fi
 
 while read -r local_ref local_sha remote_ref remote_sha; do
@@ -25,5 +27,5 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     commit_range="${remote_sha}..${local_sha}"
   fi
 
-  python "${guard_script}" check-range "${commit_range}"
+  "${python_bin}" "${guard_script}" check-range "${commit_range}"
 done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,10 @@ git config core.hooksPath .githooks
 Current hook behavior:
 
 - Hooks are safe to enable.
-- The optional privacy guard only runs when `tools/privacy/privacy_guard.py` exists.
+- The privacy guard scans staged and pushed additions for high-confidence secret
+  material and sensitive local-only files.
+- Hooks prefer `.venv/bin/python` after `make setup`, then fall back to `python3`
+  or `python` for bootstrap-only checkouts.
 - If a hook blocks you unexpectedly, use the commands below directly and then investigate instead of guessing.
 
 ## Validation workflow
@@ -184,7 +187,7 @@ unless a hot-path custom validator is explicitly justified.
 
 ## Common failure cases
 
-- Hook warning about missing `privacy_guard.py`: this is non-blocking; run the documented validation commands directly.
+- Privacy hook failure: remove the secret material or replace it with a documented placeholder, then rerun the commit or push.
 - Port confusion: production-style access is usually `http://127.0.0.1`, while native dev often uses `http://127.0.0.1:8000`.
 - UI contract drift: follow [apps/ui/README.md#contract-sync](apps/ui/README.md#contract-sync) for the authoritative HTTP/WS/constants sync flow and rerun `make sync-contracts`.
 - Slow or failing end-to-end runs: check Docker status and the operational runbook before debugging application logic.

--- a/README.md
+++ b/README.md
@@ -353,5 +353,8 @@ git config core.hooksPath .githooks
 Current behavior:
 
 - Hooks are safe to enable in normal development.
-- The optional privacy guard only runs when `tools/privacy/privacy_guard.py` exists in the checkout.
+- The privacy guard scans staged and pushed additions for high-confidence secret
+  material and sensitive local-only files.
+- Hooks prefer `.venv/bin/python` after `make setup`, then fall back to `python3`
+  or `python` for bootstrap-only checkouts.
 - Use [CONTRIBUTING.md](CONTRIBUTING.md) for the supported local validation and CI reproduction workflow.

--- a/apps/server/tests/hygiene/test_privacy_guard.py
+++ b/apps/server/tests/hygiene/test_privacy_guard.py
@@ -1,0 +1,93 @@
+"""Guard the local privacy hook implementation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tests._paths import REPO_ROOT
+
+_GUARD = REPO_ROOT / "tools" / "privacy" / "privacy_guard.py"
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(["git", *args], repo)
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init").check_returncode()
+    _git(repo, "config", "user.email", "dev@example.invalid").check_returncode()
+    _git(repo, "config", "user.name", "Dev").check_returncode()
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md").check_returncode()
+    _git(repo, "commit", "-m", "base").check_returncode()
+
+
+def _github_token() -> str:
+    return "ghp_" + ("A" * 36)
+
+
+def test_privacy_guard_check_staged_blocks_staged_tokens(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "leak.txt").write_text(f"token={_github_token()}\n", encoding="utf-8")
+    _git(tmp_path, "add", "leak.txt").check_returncode()
+
+    result = _run([sys.executable, str(_GUARD), "check-staged"], tmp_path)
+
+    assert result.returncode == 1
+    assert "leak.txt:1" in result.stderr
+    assert "GitHub token" in result.stderr
+
+
+def test_privacy_guard_check_range_blocks_sensitive_paths(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / ".secrets.act").write_text("TOKEN=placeholder\n", encoding="utf-8")
+    _git(tmp_path, "add", "-f", ".secrets.act").check_returncode()
+    _git(tmp_path, "commit", "-m", "add secret file").check_returncode()
+
+    result = _run([sys.executable, str(_GUARD), "check-range", "HEAD~1..HEAD"], tmp_path)
+
+    assert result.returncode == 1
+    assert ".secrets.act" in result.stderr
+    assert "sensitive local-only file" in result.stderr
+
+
+def test_privacy_guard_allows_documented_placeholders(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "example.env").write_text(
+        "\n".join(
+            [
+                "API_TOKEN=${GITHUB_TOKEN}",
+                'WIFI_PASSWORD="example-password"',
+                'CLIENT_SECRET="<client-secret>"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "example.env").check_returncode()
+
+    result = _run([sys.executable, str(_GUARD), "check-staged"], tmp_path)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_hooks_run_privacy_guard_with_repo_python_fallbacks() -> None:
+    for hook_name in ("pre-commit", "pre-push"):
+        hook_text = (REPO_ROOT / ".githooks" / hook_name).read_text(encoding="utf-8")
+        assert "tools/privacy/privacy_guard.py" in hook_text
+        assert ".venv/bin/python" in hook_text
+        assert "python3" in hook_text
+        assert "Skipping privacy guard" not in hook_text

--- a/tools/privacy/privacy_guard.py
+++ b/tools/privacy/privacy_guard.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Fail git hooks on high-confidence secret leaks."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_ZERO_SHA = "0" * 40
+_SENSITIVE_PATH_PATTERNS = (
+    re.compile(r"(^|/)\.secrets\.[^/]+$"),
+    re.compile(r"(^|/)wifi-secrets\.env$"),
+    re.compile(r"(^|/)vibesensor_network\.local\.h$"),
+)
+_TOKEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b"), "GitHub token"),
+    (re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), "AWS access key"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"), "Slack token"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key"),
+)
+_QUOTED_SECRET_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    \b(?P<key>[A-Z0-9_-]*
+        (?:PASSWORD|PASSWD|SECRET|TOKEN|API[_-]?KEY|PRIVATE[_-]?KEY|PSK|CLIENT[_-]?SECRET)
+        [A-Z0-9_-]*)\b
+    \s*[:=]\s*
+    (?P<quote>['"])(?P<value>[^'"]+)(?P=quote)
+    """
+)
+_ENV_SECRET_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    ^
+    (?P<key>[A-Z0-9_]*
+        (?:PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|PSK|CLIENT_SECRET)
+        [A-Z0-9_]*)=(?P<value>[^\s#]+)
+    """
+)
+_PLACEHOLDER_VALUES = {
+    "***",
+    "changeme",
+    "dummy",
+    "example",
+    "example-password",
+    "password",
+    "placeholder",
+    "redacted",
+    "secret",
+    "secret-passphrase",
+    "secret123",
+    "test",
+    "test-password",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int | None
+    message: str
+
+    def format(self) -> str:
+        location = self.path if self.line is None else f"{self.path}:{self.line}"
+        return f"{location}: {self.message}"
+
+
+def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _repo_root() -> Path:
+    result = _run_git(["rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or "not inside a git repository")
+    return Path(result.stdout.strip())
+
+
+def _changed_paths(args: list[str], *, repo_root: Path) -> list[str]:
+    result = _run_git([*args, "-z", "--diff-filter=ACMR", "--name-only", "--"], cwd=repo_root)
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip())
+    return [path for path in result.stdout.split("\0") if path]
+
+
+def _diff(args: list[str], *, repo_root: Path) -> str:
+    result = _run_git([*args, "--no-ext-diff", "--unified=0", "--"], cwd=repo_root)
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip())
+    return result.stdout
+
+
+def _is_sensitive_path(path: str) -> bool:
+    return any(pattern.search(path) for pattern in _SENSITIVE_PATH_PATTERNS)
+
+
+def _is_placeholder(value: str) -> bool:
+    normalized = value.strip().strip("'\"").lower()
+    return (
+        normalized in _PLACEHOLDER_VALUES
+        or normalized.startswith("${")
+        or normalized.startswith("$")
+        or (normalized.startswith("<") and normalized.endswith(">"))
+    )
+
+
+def _looks_like_real_secret(value: str) -> bool:
+    stripped = value.strip().strip("'\"")
+    if _is_placeholder(stripped) or len(stripped) < 12:
+        return False
+    classes = sum(
+        bool(pattern.search(stripped))
+        for pattern in (
+            re.compile(r"[a-z]"),
+            re.compile(r"[A-Z]"),
+            re.compile(r"\d"),
+            re.compile(r"[^A-Za-z0-9]"),
+        )
+    )
+    return classes >= 2
+
+
+def _assignment_findings(path: str, line_number: int, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for match in _QUOTED_SECRET_ASSIGNMENT.finditer(text):
+        if _looks_like_real_secret(match.group("value")):
+            findings.append(
+                Finding(path, line_number, f"possible hard-coded secret in `{match.group('key')}`")
+            )
+    env_match = _ENV_SECRET_ASSIGNMENT.search(text)
+    if env_match and _looks_like_real_secret(env_match.group("value")):
+        findings.append(
+            Finding(path, line_number, f"possible hard-coded secret in `{env_match.group('key')}`")
+        )
+    return findings
+
+
+def _content_findings(path: str, line_number: int, text: str) -> list[Finding]:
+    findings = [
+        Finding(path, line_number, f"possible {label}")
+        for pattern, label in _TOKEN_PATTERNS
+        if pattern.search(text)
+    ]
+    findings.extend(_assignment_findings(path, line_number, text))
+    return findings
+
+
+def _scan_added_lines(diff_text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    current_path = ""
+    current_line: int | None = None
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_path = raw_line.removeprefix("+++ b/")
+            current_line = None
+            continue
+        if raw_line.startswith("@@ "):
+            match = re.search(r"\+(\d+)", raw_line)
+            current_line = int(match.group(1)) if match else None
+            continue
+        if not current_path or current_line is None:
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            findings.extend(_content_findings(current_path, current_line, raw_line[1:]))
+            current_line += 1
+        elif raw_line.startswith(" "):
+            current_line += 1
+    return findings
+
+
+def _path_findings(paths: list[str]) -> list[Finding]:
+    return [
+        Finding(path, None, "sensitive local-only file must not be committed")
+        for path in paths
+        if _is_sensitive_path(path)
+    ]
+
+
+def _check(paths_args: list[str], diff_args: list[str], *, repo_root: Path) -> int:
+    findings = _path_findings(_changed_paths(paths_args, repo_root=repo_root))
+    findings.extend(_scan_added_lines(_diff(diff_args, repo_root=repo_root)))
+    if not findings:
+        return 0
+
+    print("[vibesensor privacy guard] Possible secret material detected:", file=sys.stderr)
+    for finding in findings:
+        print(f"  - {finding.format()}", file=sys.stderr)
+    print(
+        "[vibesensor privacy guard] Remove the secret or replace it with a documented placeholder.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def check_staged(repo_root: Path) -> int:
+    return _check(["diff", "--cached"], ["diff", "--cached"], repo_root=repo_root)
+
+
+def check_range(commit_range: str, repo_root: Path) -> int:
+    if commit_range == _ZERO_SHA:
+        return 0
+    return _check(["diff", commit_range], ["diff", commit_range], repo_root=repo_root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("check-staged", help="scan staged additions")
+    range_parser = subparsers.add_parser("check-range", help="scan additions in a commit range")
+    range_parser.add_argument("commit_range")
+    args = parser.parse_args(argv)
+
+    repo_root = _repo_root()
+    if args.command == "check-staged":
+        return check_staged(repo_root)
+    if args.command == "check-range":
+        return check_range(args.commit_range, repo_root)
+    parser.error(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/privacy/privacy_guard.py
+++ b/tools/privacy/privacy_guard.py
@@ -85,7 +85,9 @@ def _repo_root() -> Path:
 
 
 def _changed_paths(args: list[str], *, repo_root: Path) -> list[str]:
-    result = _run_git([*args, "-z", "--diff-filter=ACMR", "--name-only", "--"], cwd=repo_root)
+    result = _run_git(
+        [*args, "-z", "--diff-filter=ACMR", "--name-only", "--"], cwd=repo_root
+    )
     if result.returncode != 0:
         raise SystemExit(result.stderr.strip())
     return [path for path in result.stdout.split("\0") if path]
@@ -133,12 +135,20 @@ def _assignment_findings(path: str, line_number: int, text: str) -> list[Finding
     for match in _QUOTED_SECRET_ASSIGNMENT.finditer(text):
         if _looks_like_real_secret(match.group("value")):
             findings.append(
-                Finding(path, line_number, f"possible hard-coded secret in `{match.group('key')}`")
+                Finding(
+                    path,
+                    line_number,
+                    f"possible hard-coded secret in `{match.group('key')}`",
+                )
             )
     env_match = _ENV_SECRET_ASSIGNMENT.search(text)
     if env_match and _looks_like_real_secret(env_match.group("value")):
         findings.append(
-            Finding(path, line_number, f"possible hard-coded secret in `{env_match.group('key')}`")
+            Finding(
+                path,
+                line_number,
+                f"possible hard-coded secret in `{env_match.group('key')}`",
+            )
         )
     return findings
 
@@ -190,7 +200,9 @@ def _check(paths_args: list[str], diff_args: list[str], *, repo_root: Path) -> i
     if not findings:
         return 0
 
-    print("[vibesensor privacy guard] Possible secret material detected:", file=sys.stderr)
+    print(
+        "[vibesensor privacy guard] Possible secret material detected:", file=sys.stderr
+    )
     for finding in findings:
         print(f"  - {finding.format()}", file=sys.stderr)
     print(
@@ -214,7 +226,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("check-staged", help="scan staged additions")
-    range_parser = subparsers.add_parser("check-range", help="scan additions in a commit range")
+    range_parser = subparsers.add_parser(
+        "check-range", help="scan additions in a commit range"
+    )
     range_parser.add_argument("commit_range")
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
## What changed
- Added `tools/privacy/privacy_guard.py` with `check-staged` and `check-range` modes.
- The guard blocks high-confidence token/private-key leaks and sensitive local-only files.
- Updated pre-commit and pre-push hooks to run the guard instead of skipping missing code.
- Hooks prefer `.venv/bin/python`, then fall back to `python3` or `python`.
- Updated README and CONTRIBUTING hook docs.
- Added hygiene tests for staged checks, range checks, placeholder allowance, and hook wiring.

## Why
`make setup` installed hooks that pointed at a missing privacy guard and then skipped it. That looked protective while doing nothing.

## Validation
- `uv run --python 3.13 --extra dev ruff format ../../tools/privacy/privacy_guard.py tests/hygiene/test_privacy_guard.py`
- `uv run --python 3.13 --extra dev ruff check ../../tools/privacy/privacy_guard.py tests/hygiene/test_privacy_guard.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_privacy_guard.py -q`

## Risks, tradeoffs, edge cases
Medium risk. Hooks now block high-confidence leaks instead of skipping. The guard intentionally allows documented placeholders to keep examples usable. It is not a full secret scanner; it is a repo-local safeguard for obvious leaks and sensitive local-only files.

## Follow-ups
None.