### PR TITLE
Replace placeholder security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,33 @@
 # Security Policy
 
-## Supported Versions
+## Supported scope
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+VibeSensor is an active-development lab project. Security fixes are handled on
+`main` first and are included in the latest GitHub release when a release is
+needed for Raspberry Pi or firmware users.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Target | Security support |
+| ------ | ---------------- |
+| `main` | Supported |
+| Latest GitHub release | Supported when a fix needs a release artifact |
+| Older releases, branches, forks, or local deployments | Not supported |
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Use GitHub private vulnerability reporting from this repository's Security tab
+when it is available. Include the affected component, reproduction steps, impact,
+and any logs or screenshots that do not expose real credentials.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+If private vulnerability reporting is unavailable, open a GitHub issue titled
+`Security disclosure request` with no exploit details, secrets, logs, or affected
+host information. A maintainer will move the discussion to a private channel.
+
+Do not publish proof-of-concept exploit details until a maintainer has confirmed
+the report and a fix or mitigation is available.
+
+## Expected response
+
+Security reports are triaged against the active `main` branch. Accepted reports
+are fixed on `main` and released when users need a new artifact. Reports for
+unsupported old releases or local forks may be declined unless they also affect
+the supported scope above.


### PR DESCRIPTION
## What changed
- Replaced the default `SECURITY.md` template text.
- Removed fictional supported-version rows.
- Documented active-development support for `main` and latest release artifacts.
- Added a private vulnerability reporting path and a safe fallback request flow.
- Documented expected triage and release behavior.

## Why
The old template text gave misleading public security support and reporting signals.

## Validation
- `.venv/bin/python tools/dev/docs_lint.py`
- Placeholder scan for old template/version text in `SECURITY.md`

## Risks, tradeoffs, edge cases
Low risk. This is documentation only. The fallback path avoids publishing exploit details if GitHub private vulnerability reporting is unavailable.

## Follow-ups
None.