### PR TITLE
Refresh AI template validation examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_change_request.md
+++ b/.github/ISSUE_TEMPLATE/ai_change_request.md
@@ -22,10 +22,11 @@ assignees: []
 ```bash
 # example
 make lint
-pytest -q apps/server/tests/config/test_config.py -k my_case
+make typecheck-backend
+pytest -q apps/server/tests/app/test_config.py -k my_case
 make test-all
 # (optional faster CI-parity subset)
-python3 tools/tests/run_ci_parallel.py --job preflight --job tests
+python3 tools/tests/run_ci_parallel.py --job backend-preflight --job backend-tests-1
 ```
 
 ## Acceptance Criteria

--- a/apps/server/tests/hygiene/test_ai_issue_template_commands.py
+++ b/apps/server/tests/hygiene/test_ai_issue_template_commands.py
@@ -1,0 +1,72 @@
+"""Guard executable command examples in the AI change request template."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import shlex
+import sys
+
+from tests._paths import REPO_ROOT
+
+_AI_TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "ai_change_request.md"
+_CI_MANIFEST = REPO_ROOT / "tools" / "tests" / "ci_workflow_manifest.py"
+_FENCED_BASH_RE = re.compile(r"```bash\n(?P<body>.*?)\n```", re.DOTALL)
+
+
+def _load_ci_manifest_module():
+    spec = importlib.util.spec_from_file_location("ci_manifest_for_ai_template_test", _CI_MANIFEST)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CI_MANIFEST}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _template_shell_commands() -> list[list[str]]:
+    template = _AI_TEMPLATE.read_text(encoding="utf-8")
+    commands: list[list[str]] = []
+    for match in _FENCED_BASH_RE.finditer(template):
+        for raw_line in match.group("body").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            commands.append(shlex.split(line))
+    return commands
+
+
+def _run_ci_jobs(tokens: list[str]) -> list[str]:
+    jobs: list[str] = []
+    iterator = iter(tokens)
+    for token in iterator:
+        if token == "--job":
+            jobs.append(next(iterator))
+        elif token.startswith("--job="):
+            jobs.append(token.removeprefix("--job="))
+    return jobs
+
+
+def _repo_path_tokens(tokens: list[str]) -> set[str]:
+    return {
+        token
+        for token in tokens[1:]
+        if "/" in token and not token.startswith("-") and not token.startswith("http")
+    }
+
+
+def test_ai_change_request_validation_examples_reference_real_paths_and_ci_jobs() -> None:
+    commands = _template_shell_commands()
+    valid_ci_jobs = set(_load_ci_manifest_module().all_job_names())
+
+    assert commands
+    assert ["make", "lint"] in commands
+    assert ["make", "typecheck-backend"] in commands
+    assert ["make", "test-all"] in commands
+
+    for tokens in commands:
+        for path_token in _repo_path_tokens(tokens):
+            assert (REPO_ROOT / path_token).exists(), f"{path_token} does not exist"
+        if "tools/tests/run_ci_parallel.py" in tokens:
+            jobs = _run_ci_jobs(tokens)
+            assert jobs
+            assert set(jobs) <= valid_ci_jobs


### PR DESCRIPTION
## What changed
- Updated the AI change request template validation examples.
- Replaced the stale config test path with `apps/server/tests/app/test_config.py`.
- Added `make typecheck-backend` as a canonical backend validation example.
- Replaced invalid local CI job names with `backend-preflight` and `backend-tests-1`.
- Added a hygiene test that parses fenced bash examples, checks referenced paths exist, and validates `run_ci_parallel.py --job` names against the CI manifest.

## Why
The template steers AI-generated work. Stale commands get copied into PR instructions and fail late.

## Validation
- `uv run --python 3.13 --extra dev ruff format tests/hygiene/test_ai_issue_template_commands.py`
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_ai_issue_template_commands.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ai_issue_template_commands.py -q`
- `.venv/bin/python tools/dev/docs_lint.py`
- Stale-example scan for old path and invalid job names

## Risks, tradeoffs, edge cases
Low risk. This changes an issue template and adds a static guard only. The guard intentionally checks fenced bash examples so future template edits stay executable.

## Follow-ups
None.