### PR TITLE
Add explicit repository license notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+VibeSensor is not currently distributed under an open-source license.
+
+Copyright remains with the repository owner and contributors. All rights
+reserved.
+
+Viewing and forking this repository on GitHub are permitted only to the extent
+allowed by GitHub's Terms of Service. No additional permission is granted to
+use, copy, modify, distribute, sublicense, or sell any part of this repository.
+
+If you want reuse permission, open an issue to request a license decision before
+using the code outside normal GitHub viewing or forking.

--- a/README.md
+++ b/README.md
@@ -358,3 +358,8 @@ Current behavior:
 - Hooks prefer `.venv/bin/python` after `make setup`, then fall back to `python3`
   or `python` for bootstrap-only checkouts.
 - Use [CONTRIBUTING.md](CONTRIBUTING.md) for the supported local validation and CI reproduction workflow.
+
+## License
+
+VibeSensor is not currently distributed under an open-source license. See
+[LICENSE](LICENSE) for the explicit reuse notice.

--- a/apps/server/tests/hygiene/test_repo_license_notice.py
+++ b/apps/server/tests/hygiene/test_repo_license_notice.py
@@ -1,0 +1,47 @@
+"""Guard that the public repo has explicit reuse terms."""
+
+from __future__ import annotations
+
+from tests._paths import REPO_ROOT
+
+_LICENSE = REPO_ROOT / "LICENSE"
+_README = REPO_ROOT / "README.md"
+_STANDARD_LICENSE_MARKERS = (
+    "mit license",
+    "apache license",
+    "gnu general public license",
+    "bsd 2-clause license",
+    "bsd 3-clause license",
+    "mozilla public license",
+)
+_UNLICENSED_NOTICE_MARKERS = (
+    "not currently distributed under an open-source license",
+    "all rights reserved",
+    "no additional permission is granted",
+)
+
+
+def _has_standard_license(text: str) -> bool:
+    normalized = " ".join(text.lower().split())
+    return any(marker in normalized for marker in _STANDARD_LICENSE_MARKERS)
+
+
+def _has_explicit_unlicensed_notice(text: str) -> bool:
+    normalized = " ".join(text.lower().split())
+    return all(marker in normalized for marker in _UNLICENSED_NOTICE_MARKERS)
+
+
+def test_repo_has_standard_license_or_explicit_unlicensed_notice() -> None:
+    assert _LICENSE.exists(), "Public repos must have LICENSE or explicit unlicensed notice"
+
+    license_text = _LICENSE.read_text(encoding="utf-8")
+    assert _has_standard_license(license_text) or _has_explicit_unlicensed_notice(license_text), (
+        "LICENSE must be a standard license or explicit unlicensed notice"
+    )
+
+
+def test_readme_links_reuse_terms() -> None:
+    readme = _README.read_text(encoding="utf-8")
+
+    assert "## License" in readme
+    assert "[LICENSE](LICENSE)" in readme


### PR DESCRIPTION
## What changed
- Added a `LICENSE` file that explicitly states no open-source license is granted at this time.
- Linked the reuse notice from `README.md`.
- Added a hygiene test requiring either a standard license file or an explicit unlicensed notice.

## Why
The public repo had no top-level license signal, which made reuse terms ambiguous for humans and tooling.

## Validation
- `uv run --python 3.13 --extra dev ruff format tests/hygiene/test_repo_license_notice.py`
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_repo_license_notice.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_repo_license_notice.py -q`
- `.venv/bin/python tools/dev/docs_lint.py`

## Risks, tradeoffs, edge cases
Low risk. This avoids granting reuse rights without owner intent. If the owner later chooses MIT, Apache-2.0, GPL, BSD, or MPL, the guard accepts standard license text.

## Follow-ups
None.