### PR TITLE
Support update sudo wrapper install

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -9,6 +9,8 @@ HOTSPOT_HEAL_SERVICE_TEMPLATE="${PI_DIR}/systemd/vibesensor-hotspot-self-heal.se
 HOTSPOT_HEAL_TIMER_TEMPLATE="${PI_DIR}/systemd/vibesensor-hotspot-self-heal.timer"
 SERVER_PYPROJECT="${PI_DIR}/pyproject.toml"
 RUNTIME_POLICY_DOC="docs/runtime_support_matrix.md"
+UPDATE_SUDO_WRAPPER="${PI_DIR}/scripts/vibesensor_update_sudo.sh"
+UPDATE_SUDOERS="/etc/sudoers.d/vibesensor-update"
 VENV_DIR="${PI_DIR}/.venv"
 SKIP_SERVICE_START="${VIBESENSOR_SKIP_SERVICE_START:-0}"
 
@@ -101,6 +103,7 @@ validate_supported_python "${PYTHON_BIN}"
 "${VENV_DIR}/bin/vibesensor-config-preflight" "${PI_DIR}/config.pi.yaml" >/dev/null
 
 run_as_root install -d /etc/vibesensor
+run_as_root install -d /etc/sudoers.d
 run_as_root install -d /etc/tmpfiles.d
 run_as_root install -d -m 0755 /var/lib/vibesensor
 run_as_root install -d -m 0755 /var/lib/vibesensor/rollback
@@ -108,6 +111,16 @@ run_as_root install -d -m 0755 /var/log/vibesensor
 run_as_root install -d -m 0755 /var/log/wifi
 run_as_root chown "${SERVICE_USER}:${SERVICE_USER}" /var/lib/vibesensor /var/lib/vibesensor/rollback /var/log/vibesensor
 run_as_root chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"
+if [ ! -f "${UPDATE_SUDO_WRAPPER}" ]; then
+  echo "ERROR: Missing update sudo wrapper at ${UPDATE_SUDO_WRAPPER}." >&2
+  exit 1
+fi
+run_as_root chmod 0755 "${UPDATE_SUDO_WRAPPER}"
+run_as_root install -o root -g root -m 0440 /dev/null "${UPDATE_SUDOERS}"
+run_as_root tee "${UPDATE_SUDOERS}" >/dev/null <<EOF
+${SERVICE_USER} ALL=(root) NOPASSWD: ${UPDATE_SUDO_WRAPPER}
+EOF
+run_as_root chmod 0440 "${UPDATE_SUDOERS}"
 
 # Refresh ESP firmware cache from GitHub Releases (requires network).
 # This downloads the latest prebuilt firmware bundle so the device can flash

--- a/apps/server/scripts/vibesensor_update_sudo.sh
+++ b/apps/server/scripts/vibesensor_update_sudo.sh
@@ -1,37 +1,125 @@
 #!/usr/bin/env bash
 # Restricted sudo wrapper for VibeSensor system update.
 # Only allows a whitelist of commands that the update process needs.
-# Install via: sudo cp scripts/vibesensor_update_sudo.sh /usr/local/bin/
-# Add to sudoers: vibesensor ALL=(root) NOPASSWD: /usr/local/bin/vibesensor_update_sudo.sh
+# install_pi.sh installs the matching sudoers entry for the service user.
 set -euo pipefail
 
-ALLOWED_CMDS=(
-  "nmcli"
-  "python3"
-  "pip"
-  "systemd-run"
-  "systemctl"
-  "timeout"
-  "rfkill"
-)
+ALLOWED_COMMAND_NAMES=("nmcli" "python3" "systemd-run" "systemctl")
 
 if [ $# -lt 1 ]; then
   echo "Usage: $0 <command> [args...]" >&2
   exit 1
 fi
 
-CMD_BASE="$(basename "$1")"
-ALLOWED=0
-for acmd in "${ALLOWED_CMDS[@]}"; do
-  if [ "${CMD_BASE}" = "${acmd}" ]; then
-    ALLOWED=1
-    break
-  fi
-done
+canonical_path() {
+  readlink -f -- "$1"
+}
 
-if [ "${ALLOWED}" -ne 1 ]; then
-  echo "vibesensor_update_sudo: command '${CMD_BASE}' is not allowed" >&2
+resolve_command_path() {
+  local command_name="$1"
+  local resolved
+  if ! resolved="$(command -v -- "${command_name}" 2>/dev/null)"; then
+    return 1
+  fi
+  canonical_path "${resolved}"
+}
+
+resolve_requested_command() {
+  local requested="$1"
+  if [[ "${requested}" == */* ]]; then
+    if [ ! -x "${requested}" ]; then
+      return 1
+    fi
+    canonical_path "${requested}"
+    return
+  fi
+  resolve_command_path "${requested}"
+}
+
+allowed_command_name_for_path() {
+  local requested_path="$1"
+  local command_name allowed_path
+  for command_name in "${ALLOWED_COMMAND_NAMES[@]}"; do
+    if allowed_path="$(resolve_command_path "${command_name}")" && [ "${requested_path}" = "${allowed_path}" ]; then
+      printf '%s\n' "${command_name}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+nmcli_subcommand_allowed() {
+  local args=("$@")
+  local idx=0
+  local token top_level second third
+  while [ "${idx}" -lt "${#args[@]}" ]; do
+    token="${args[${idx}]}"
+    case "${token}" in
+      --wait|-f)
+        if [ $((idx + 1)) -ge "${#args[@]}" ]; then
+          return 1
+        fi
+        idx=$((idx + 2))
+        ;;
+      -t)
+        idx=$((idx + 1))
+        ;;
+      *)
+        top_level="${token}"
+        second="${args[$((idx + 1))]:-}"
+        third="${args[$((idx + 2))]:-}"
+        case "${top_level}:${second}:${third}" in
+          connection:up:*|connection:down:*|connection:delete:*|connection:add:*|connection:modify:*|connection:show:*)
+            return 0
+            ;;
+          device:up:*|dev:wifi:list)
+            return 0
+            ;;
+        esac
+        return 1
+        ;;
+    esac
+  done
+  return 1
+}
+
+invocation_allowed() {
+  local command_name="$1"
+  shift
+  case "${command_name}" in
+    nmcli)
+      nmcli_subcommand_allowed "$@"
+      ;;
+    python3)
+      [ "$#" -eq 2 ] && [ "$1" = "-c" ] && [ "$2" = "pass" ]
+      ;;
+    systemctl)
+      [ "$#" -eq 2 ] && [ "$1" = "restart" ] && [ "$2" = "vibesensor.service" ]
+      ;;
+    systemd-run)
+      [ "$#" -eq 6 ] && \
+        [ "$1" = "--unit" ] && \
+        [ "$2" = "vibesensor-post-update-restart" ] && \
+        [ "$3" = "--on-active=2s" ] && \
+        [ "$4" = "systemctl" ] && \
+        [ "$5" = "restart" ] && \
+        [ "$6" = "vibesensor.service" ]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+REQUESTED_PATH="$(resolve_requested_command "$1" || true)"
+COMMAND_NAME=""
+if [ -n "${REQUESTED_PATH}" ]; then
+  COMMAND_NAME="$(allowed_command_name_for_path "${REQUESTED_PATH}" || true)"
+fi
+
+if [ -z "${COMMAND_NAME}" ] || ! invocation_allowed "${COMMAND_NAME}" "${@:2}"; then
+  echo "vibesensor_update_sudo: command '$1' is not allowed" >&2
   exit 126
 fi
 
-exec "$@"
+exec "${REQUESTED_PATH}" "${@:2}"

--- a/apps/server/tests/hygiene/test_update_sudo_wrapper.py
+++ b/apps/server/tests/hygiene/test_update_sudo_wrapper.py
@@ -1,0 +1,100 @@
+"""Guard the updater sudo wrapper install and allowlist behavior."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from tests._paths import REPO_ROOT, SERVER_ROOT
+
+_WRAPPER = SERVER_ROOT / "scripts" / "vibesensor_update_sudo.sh"
+
+
+def _write_tool(bin_dir: Path, name: str) -> Path:
+    path = bin_dir / name
+    path.write_text("#!/usr/bin/env bash\nprintf '%s\\n' \"$0 $*\"\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _run_wrapper(tmp_path: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    for name in ("nmcli", "python3", "systemctl", "systemd-run"):
+        _write_tool(bin_dir, name)
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    return subprocess.run(
+        ["bash", os.fspath(_WRAPPER), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_update_sudo_wrapper_allows_expected_update_commands(tmp_path: Path) -> None:
+    allowed_commands = [
+        ["python3", "-c", "pass"],
+        ["nmcli", "connection", "up", "VibeSensor-uplink"],
+        ["nmcli", "--wait", "45", "device", "up", "usb0"],
+        ["systemctl", "restart", "vibesensor.service"],
+        [
+            "systemd-run",
+            "--unit",
+            "vibesensor-post-update-restart",
+            "--on-active=2s",
+            "systemctl",
+            "restart",
+            "vibesensor.service",
+        ],
+    ]
+
+    for command in allowed_commands:
+        result = _run_wrapper(tmp_path, command)
+        assert result.returncode == 0, result.stderr
+
+
+def test_update_sudo_wrapper_rejects_basename_spoofing(tmp_path: Path) -> None:
+    evil_dir = tmp_path / "evil"
+    evil_dir.mkdir()
+    evil_nmcli = _write_tool(evil_dir, "nmcli")
+
+    result = _run_wrapper(tmp_path, [os.fspath(evil_nmcli), "connection", "up", "x"])
+
+    assert result.returncode == 126
+    assert "is not allowed" in result.stderr
+
+
+def test_update_sudo_wrapper_rejects_unexpected_subcommands(tmp_path: Path) -> None:
+    result = _run_wrapper(tmp_path, ["nmcli", "general", "status"])
+
+    assert result.returncode == 126
+    assert "is not allowed" in result.stderr
+
+
+def test_update_sudo_wrapper_rejects_malformed_nmcli_options(tmp_path: Path) -> None:
+    result = _run_wrapper(tmp_path, ["nmcli", "--wait"])
+
+    assert result.returncode == 126
+    assert "is not allowed" in result.stderr
+
+
+def test_manual_pi_install_installs_update_sudoers_entry() -> None:
+    install_pi = (SERVER_ROOT / "scripts" / "install_pi.sh").read_text(encoding="utf-8")
+
+    assert 'UPDATE_SUDO_WRAPPER="${PI_DIR}/scripts/vibesensor_update_sudo.sh"' in install_pi
+    assert 'UPDATE_SUDOERS="/etc/sudoers.d/vibesensor-update"' in install_pi
+    assert 'if [ ! -f "${UPDATE_SUDO_WRAPPER}" ]; then' in install_pi
+    assert "${SERVICE_USER} ALL=(root) NOPASSWD: ${UPDATE_SUDO_WRAPPER}" in install_pi
+    assert 'run_as_root install -o root -g root -m 0440 /dev/null "${UPDATE_SUDOERS}"' in install_pi
+    assert 'run_as_root chmod 0440 "${UPDATE_SUDOERS}"' in install_pi
+
+
+def test_pi_image_validation_requires_update_sudo_wrapper() -> None:
+    validation = (
+        REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "image_validation.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "/opt/VibeSensor/apps/server/scripts/vibesensor_update_sudo.sh" in validation
+    assert "update sudo wrapper entry missing" in validation

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -216,7 +216,12 @@ sudo journalctl -u vibesensor.service -n 200 --no-pager
 5. The updater now aborts before touching the live environment if it cannot write a fresh rollback snapshot or cannot verify free disk space for the rollback area. Treat either condition as an infrastructure problem to fix first, not a retry-until-it-works event.
 6. If rollback metadata is missing, the updater will only trust the newest rollback wheel after structural archive validation; if checksum metadata exists, a mismatch should be treated as a broken rollback snapshot, not a transient install failure.
 7. The Update panel now shows operational health from `/api/health`; use its degradation reasons, data-loss counts, and persistence status as the first operator-facing signal before digging through logs. Key degradation reasons include `persistence_write_error` (DB write failures), `persistence_samples_dropped` (samples lost during recording), and `last_analysis_failed` (most recent post-analysis run errored). The health response also exposes `samples_written`, `samples_dropped`, `last_completed_run_id`, and `last_completed_run_error` in its persistence section for detailed diagnostics.
-8. If emergency patching was used to restore service, follow up with the repo fix, validation, and a successful updater rerun so the device returns to wheel-managed state.
+8. Manual Pi installs create `/etc/sudoers.d/vibesensor-update` for the service
+   user. It must point at
+   `/opt/VibeSensor/apps/server/scripts/vibesensor_update_sudo.sh` for the
+   standard install layout; custom clone paths must use the exact installed
+   script path.
+9. If emergency patching was used to restore service, follow up with the repo fix, validation, and a successful updater rerun so the device returns to wheel-managed state.
 
 ## Local release readiness
 

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -187,6 +187,11 @@ validate_image_artifact() {
     exit 1
   fi
 
+  if [ ! -x "${ROOT_MNT}/opt/VibeSensor/apps/server/scripts/vibesensor_update_sudo.sh" ]; then
+    echo "Validation failed: missing executable ${ROOT_MNT}/opt/VibeSensor/apps/server/scripts/vibesensor_update_sudo.sh"
+    exit 1
+  fi
+
   if [ ! -x "${ROOT_MNT}/opt/VibeSensor/apps/server/scripts/vibesensor_obd_admin.py" ]; then
     echo "Validation failed: missing executable ${ROOT_MNT}/opt/VibeSensor/apps/server/scripts/vibesensor_obd_admin.py"
     exit 1
@@ -194,6 +199,12 @@ validate_image_artifact() {
 
   if [ ! -f "${ROOT_MNT}/etc/sudoers.d/vibesensor-update" ]; then
     echo "Validation failed: missing ${ROOT_MNT}/etc/sudoers.d/vibesensor-update"
+    exit 1
+  fi
+
+  if ! sudo grep -Fq '/opt/VibeSensor/apps/server/scripts/vibesensor_update_sudo.sh' \
+    "${ROOT_MNT}/etc/sudoers.d/vibesensor-update"; then
+    echo "Validation failed: update sudo wrapper entry missing from ${ROOT_MNT}/etc/sudoers.d/vibesensor-update"
     exit 1
   fi
 


### PR DESCRIPTION
## What changed
- Kept `vibesensor_update_sudo.sh` as the supported update privilege helper.
- Made `install_pi.sh` verify the helper exists, mark it executable, and install `/etc/sudoers.d/vibesensor-update` with restrictive permissions.
- Tightened the wrapper from basename matching to canonical executable resolution plus allowed update subcommands.
- Added Pi image validation for the wrapper and sudoers entry.
- Documented the manual Pi install sudoers path.
- Added hygiene coverage for allowed commands, basename spoofing, malformed `nmcli` options, installer wiring, and image validation.

## Why
The repo had a privileged update helper but no complete install, validation, or operator guidance path. That is unsafe ambiguity. The helper is now a real supported artifact with guardrails.

## Validation
- `bash -n apps/server/scripts/vibesensor_update_sudo.sh apps/server/scripts/install_pi.sh infra/pi-image/pi-gen/lib/image_validation.sh`
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_update_sudo_wrapper.py`
- `uv run --python 3.13 --extra dev pytest tests/use_cases/updates/test_update_manager_models.py tests/hygiene/test_install_offline_artifact_guardrails.py tests/hygiene/test_install_pi_runtime_policy.py tests/hygiene/test_update_sudo_wrapper.py -q`
- `make lint` through repo hygiene/static/docs/contract checks; root env lacked `deptry`, so remaining lint steps were rerun through `uv --extra dev` and passed.

## Risks / tradeoffs / edge cases
- Wrapper now denies commands outside the supported update shapes. That is intentional. Future updater privilege needs must add explicit allowlist coverage and tests.
- `nmcli` remains flexible for dynamic connection names, SSIDs, UUIDs, interfaces, and PSKs, but only for the top-level updater command families currently used.
- Custom clone paths are supported by installing sudoers against the actual `${PI_DIR}` path.

## Follow-ups / out of scope
- ShellCheck CI coverage is separate issue #3514.

Closes #3512
