### PR TITLE
Add ShellCheck coverage for deployment scripts

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,7 +11,7 @@ else
   python_bin="python"
 fi
 
-while read -r local_ref local_sha remote_ref remote_sha; do
+while read -r _local_ref local_sha _remote_ref remote_sha; do
   if [[ -z "${local_sha:-}" || "${local_sha}" == "0000000000000000000000000000000000000000" ]]; then
     continue
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       run_docs_lint: ${{ steps.scope.outputs.run_docs_lint }}
       run_repo_hygiene: ${{ steps.scope.outputs.run_repo_hygiene }}
+      run_shell_lint: ${{ steps.scope.outputs.run_shell_lint }}
       run_backend_lint: ${{ steps.scope.outputs.run_backend_lint }}
       run_backend_static_guards: ${{ steps.scope.outputs.run_backend_static_guards }}
       run_backend_preflight: ${{ steps.scope.outputs.run_backend_preflight }}
@@ -83,6 +84,25 @@ jobs:
 
       - name: Repo hygiene checks
         run: python tools/dev/check_hygiene.py
+
+  shell-lint:
+    name: Shell lint
+    needs:
+      - ci-scope
+    if: ${{ needs.ci-scope.outputs.run_shell_lint == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: ShellCheck deployment scripts
+        run: make shell-lint
 
   backend-static-guards:
     name: Backend static guards

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,30 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format shell-lint lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
 LINT_TARGETS := $(SERVER_DIR)/vibesensor $(SERVER_DIR)/tests tools
+SHELLCHECK_TARGETS := \
+	.githooks/pre-commit \
+	.githooks/pre-push \
+	apps/server/scripts/hotspot_nmcli.sh \
+	apps/server/scripts/install_pi.sh \
+	apps/server/scripts/vibesensor_update_sudo.sh \
+	apps/ui/dev-docker.sh \
+	infra/pi-image/pi-gen/build.sh \
+	infra/pi-image/pi-gen/lib/app_artifacts.sh \
+	infra/pi-image/pi-gen/lib/artifacts.sh \
+	infra/pi-image/pi-gen/lib/common.sh \
+	infra/pi-image/pi-gen/lib/image_validation.sh \
+	infra/pi-image/pi-gen/lib/mirror.sh \
+	infra/pi-image/pi-gen/lib/pi_gen_repo.sh \
+	infra/pi-image/pi-gen/lib/prereqs.sh \
+	infra/pi-image/pi-gen/lib/stage_assembly.sh \
+	infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh \
+	infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template \
+	infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template \
+	infra/pi-image/pi-gen/validate-image.sh \
+	tools/tests/run_ci_with_act.sh
 PYTHON_VERSION := $(strip $(shell cat .python-version))
 PYTHON_MAJOR := $(word 1,$(subst ., ,$(PYTHON_VERSION)))
 PYTHON_MINOR := $(word 2,$(subst ., ,$(PYTHON_VERSION)))
@@ -48,11 +69,16 @@ format: ## Run Ruff formatter over backend and tooling files
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" -m ruff format $(LINT_TARGETS)
 
+shell-lint: ## Run ShellCheck over deployment, hook, and Pi-image shell scripts
+	@command -v shellcheck >/dev/null 2>&1 || { echo "ERROR: shellcheck is required for make shell-lint." >&2; exit 127; }
+	shellcheck --severity=warning -x -s bash $(SHELLCHECK_TARGETS)
+
 lint: ## Run repo hygiene, dependency/static guards, docs lint, and contract drift checks
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" -m ruff check $(LINT_TARGETS) && \
 	"$$PYTHON" -m ruff format --check $(LINT_TARGETS) && \
 	"$$PYTHON" tools/dev/check_hygiene.py && \
+	$(MAKE) --no-print-directory shell-lint && \
 	cd $(SERVER_DIR) && deptry . tests --config pyproject.toml && lint-imports --config pyproject.toml && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
 	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.dev.yaml && \
 	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.docker.yaml && \

--- a/apps/server/scripts/hotspot_nmcli.sh
+++ b/apps/server/scripts/hotspot_nmcli.sh
@@ -138,6 +138,7 @@ resolve_hotspot_config_cli() {
   return 1
 }
 
+# shellcheck disable=SC2154  # Bash expands BASH_LINENO/BASH_COMMAND inside the ERR trap at runtime.
 trap 'rc=$?; failed_line=${BASH_LINENO[0]:-0}; failed_cmd=${BASH_COMMAND:-unknown}; echo "ERROR rc=${rc} line=${failed_line} cmd=${failed_cmd}" >&2; dump_all error; write_summary FAILED "${rc}"; exit "${rc}"' ERR
 trap 'rc=$?; echo "EXIT rc=${rc}"' EXIT
 

--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -122,6 +122,27 @@ _SELECTION_CASES = (
     ),
     pytest.param(
         SelectionCase(
+            changed_files=("tools/tests/run_ci_with_act.sh",),
+            expected_jobs=frozenset({"shell_lint"}),
+        ),
+        id="shell-script-only",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=(".githooks/pre-push",),
+            expected_jobs=frozenset({"shell_lint"}),
+        ),
+        id="githook-only",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template",),
+            expected_jobs=frozenset({"shell_lint"}),
+        ),
+        id="pi-image-shell-template",
+    ),
+    pytest.param(
+        SelectionCase(
             changed_files=("apps/server/Dockerfile",),
             expected_jobs=_FULL_STACK,
         ),

--- a/apps/ui/dev-docker.sh
+++ b/apps/ui/dev-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 bootstrap_helper="$script_dir/../../tools/ui/ensure_ui_bootstrap.mjs"
 
 node "$bootstrap_helper" --log-prefix "[dev:docker]"

--- a/infra/pi-image/pi-gen/lib/app_artifacts.sh
+++ b/infra/pi-image/pi-gen/lib/app_artifacts.sh
@@ -1,6 +1,6 @@
 compute_ui_hash() {
   (
-    cd "${REPO_ROOT}"
+    cd "${REPO_ROOT}" || exit
     git ls-files \
       apps/ui \
       tools/config/sync_shared_contracts_to_ui.mjs \
@@ -124,7 +124,7 @@ build_app_artifacts() {
   sync_dir_contents "${APP_PUBLIC_DIR}" "${build_root}/apps/server/vibesensor/static"
 
   (
-    cd "${build_root}"
+    cd "${build_root}" || exit
     "${VS_PYTHON_BIN}" -m venv .build-venv
     ./.build-venv/bin/pip install --upgrade pip build >/dev/null
     ./.build-venv/bin/python -m build --wheel apps/server
@@ -138,6 +138,7 @@ build_app_artifacts() {
   fi
   cp -f "${wheel_path}" "${APP_WHEEL_DIR}/"
   APP_WHEEL_PATH="${APP_WHEEL_DIR}/$(basename "${wheel_path}")"
+  # shellcheck disable=SC2034  # Consumed by stage_assembly.sh after this library is sourced.
   APP_WHEEL_FILE="$(basename "${APP_WHEEL_PATH}")"
 
   {
@@ -159,6 +160,7 @@ require_prebuilt_app_artifacts() {
     echo "Run BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh first."
     exit 1
   fi
+  # shellcheck disable=SC2034  # Consumed by stage_assembly.sh after this library is sourced.
   APP_WHEEL_FILE="$(basename "${APP_WHEEL_PATH}")"
   if [ ! -f "${APP_PUBLIC_DIR}/index.html" ]; then
     echo "Missing prebuilt UI assets in ${APP_PUBLIC_DIR}."

--- a/infra/pi-image/pi-gen/lib/common.sh
+++ b/infra/pi-image/pi-gen/lib/common.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2034  # This library initializes globals consumed by other pi-gen libraries.
 init_pi_gen_env() {
   SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
   REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"

--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -602,7 +602,7 @@ exit(crypt($plain, $shadow_hash) eq $shadow_hash ? 0 : 1);
   sudo grep -n 'vibesensor_.*sudo\|vibesensor_obd_admin.py' "${ROOT_MNT}/etc/sudoers.d/vibesensor-update"
 
   echo "=== Validation: vibesensor systemd units ==="
-  ls -la "${ROOT_MNT}/etc/systemd/system" | grep -i vibesensor || true
+  find "${ROOT_MNT}/etc/systemd/system" -maxdepth 1 -iname '*vibesensor*' -print || true
 
   echo "=== Validation: first user preconfigured, wizard disabled ==="
   grep -n "^${VS_FIRST_USER_NAME}:" "${ROOT_MNT}/etc/passwd"

--- a/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
+++ b/infra/pi-image/pi-gen/lib/pi_gen_repo.sh
@@ -156,7 +156,7 @@ configure_incremental_build() {
 
 run_pi_gen_build() {
   (
-    cd "${PI_GEN_DIR}"
+    cd "${PI_GEN_DIR}" || exit
     CONTINUE=1 PRESERVE_CONTAINER=1 ./build-docker.sh
   )
 }

--- a/infra/pi-image/pi-gen/lib/prereqs.sh
+++ b/infra/pi-image/pi-gen/lib/prereqs.sh
@@ -11,6 +11,7 @@ ensure_output_dirs() {
 
 apply_fast_mode() {
   if [ "${FAST}" = "1" ]; then
+    # shellcheck disable=SC2034  # build.sh reads VALIDATE after this sourced helper mutates it.
     VALIDATE=0
   fi
 }

--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
@@ -270,6 +270,7 @@ After=regenerate_ssh_host_keys.service
 ExecStartPre=/bin/sh -c 'if ! ls /etc/ssh/ssh_host_*_key >/dev/null 2>&1; then /usr/bin/ssh-keygen -A; fi'
 SSHUNIT
 
+# shellcheck disable=SC2050  # Template placeholder is replaced with 0/1 before pi-gen executes this script.
 if [ "__SSH_FIRST_BOOT_DEBUG__" = "1" ]; then
   install -d "${ROOTFS_DIR}/usr/local/sbin"
   cat >"${ROOTFS_DIR}/usr/local/sbin/vibesensor-ssh-debug" <<'SSHDEBUG'

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -39,6 +39,8 @@ BACKEND_STATIC_GUARD_TOOL_FILES = {"tools/dev/verify_backend_static_guards.py"}
 BACKEND_TEST_TOOL_FILES = {"tools/tests/run_backend_parallel.py"}
 RELEASE_TRIGGER_FILES = {"tools/tests/run_release_smoke.py", "tools/build_ui_static.py"}
 E2E_TRIGGER_FILES = {"tools/tests/run_e2e_parallel.py", "apps/server/Dockerfile.e2e"}
+SHELL_LINT_TRIGGER_PREFIXES = (".githooks/", "infra/pi-image/")
+SHELL_LINT_EXTENSIONS = (".sh", ".sh.template")
 CONTRACT_SYNC_TRIGGER_FILES = {
     "apps/ui/package.json",
     "apps/ui/src/contracts/http_api_schema.json",
@@ -55,6 +57,7 @@ CONTRACT_SYNC_TRIGGER_FILES = {
 class WorkflowJobSelection:
     docs_lint: bool = False
     repo_hygiene: bool = False
+    shell_lint: bool = False
     backend_lint: bool = False
     backend_static_guards: bool = False
     backend_preflight: bool = False
@@ -93,6 +96,13 @@ def is_markdown_path(path: str) -> bool:
         normalized.endswith(".md")
         or normalized in DOC_FILES
         or normalized.startswith("docs/")
+    )
+
+
+def is_shell_lint_path(path: str) -> bool:
+    normalized = PurePosixPath(path).as_posix()
+    return normalized.endswith(SHELL_LINT_EXTENSIONS) or any(
+        normalized.startswith(prefix) for prefix in SHELL_LINT_TRIGGER_PREFIXES
     )
 
 
@@ -149,6 +159,7 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
     )
     release_tool_changed = any(path in RELEASE_TRIGGER_FILES for path in non_docs_paths)
     e2e_tool_changed = any(path in E2E_TRIGGER_FILES for path in non_docs_paths)
+    shell_lint_changed = any(is_shell_lint_path(path) for path in non_docs_paths)
 
     return WorkflowJobSelection(
         docs_lint=full_stack or docs_changed or docs_lint_tool_changed,
@@ -158,6 +169,7 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         or frontend_changed
         or python_tool_changed
         or contract_sync_changed,
+        shell_lint=full_stack or shell_lint_changed,
         backend_lint=full_stack or backend_changed or python_tool_changed,
         backend_static_guards=full_stack
         or backend_changed

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -16,6 +16,7 @@ _CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 _INSTALL_STEP_NAMES = frozenset(
     {
         "Install dependencies",
+        "Install ShellCheck",
         "Install PlatformIO dependencies",
         "Install UI dependencies",
     }


### PR DESCRIPTION
## What changed
- Added `make shell-lint` for hooks, server deployment scripts, UI dev shell helper, Pi-image scripts/templates, and the local CI shell runner.
- Folded `make shell-lint` into `make lint`.
- Added a CI `Shell lint` job that installs ShellCheck and runs the new target.
- Added `run_shell_lint` CI scope output and path rules for shell-only changes.
- Updated CI manifest/scope tests so local CI and workflow job selection stay aligned.
- Fixed existing ShellCheck warnings where safe and added narrow inline disables for template placeholders and sourced-library globals.

## Why
These scripts touch install, first boot, hotspot, sudo update, and Pi-image behavior. ShellCheck gives cheap static coverage for high-risk deployment paths.

## Validation
- `make shell-lint`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ci_path_rules.py tests/hygiene/test_ci_changed_scope.py -q`
- `make lint` through ShellCheck, repo hygiene, CI manifest sync, docs/static/contract checks; root env lacked `deptry`, so remaining lint steps were rerun through `uv --extra dev` and passed.
- `.venv/bin/python tools/tests/run_ci_parallel.py --job shell-lint`
- focused code-review pass

## Risks / tradeoffs / edge cases
- CI now installs ShellCheck in a dedicated job, so shell-only changes get coverage without running unrelated backend/frontend jobs.
- ShellCheck runs at warning severity with Bash semantics because several checked files are sourced libraries or generated shell templates.
- A few warnings are intentionally suppressed inline where ShellCheck cannot see cross-file variable use or template substitution.

## Follow-ups / out of scope
- Broader shell-script refactors are out of scope; this PR adds the guardrail and only fixes warnings needed to make it useful.

Closes #3514
