### PR TITLE
Tighten Pi systemd service hardening

### DIFF
--- a/apps/server/scripts/install_pi.sh
+++ b/apps/server/scripts/install_pi.sh
@@ -110,7 +110,7 @@ run_as_root install -d -m 0755 /var/lib/vibesensor/rollback
 run_as_root install -d -m 0755 /var/log/vibesensor
 run_as_root install -d -m 0755 /var/log/wifi
 run_as_root chown "${SERVICE_USER}:${SERVICE_USER}" /var/lib/vibesensor /var/lib/vibesensor/rollback /var/log/vibesensor
-run_as_root chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"
+run_as_root chown -R "${SERVICE_USER}:${SERVICE_USER}" "${VENV_DIR}"
 if [ ! -f "${UPDATE_SUDO_WRAPPER}" ]; then
   echo "ERROR: Missing update sudo wrapper at ${UPDATE_SUDO_WRAPPER}." >&2
   exit 1

--- a/apps/server/systemd/vibesensor.service
+++ b/apps/server/systemd/vibesensor.service
@@ -7,16 +7,20 @@ Wants=network-online.target
 Type=simple
 User=__SERVICE_USER__
 PermissionsStartOnly=true
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_FOWNER CAP_AUDIT_WRITE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE CAP_FOWNER CAP_AUDIT_WRITE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=/var/lib/vibesensor /var/log/vibesensor __VENV_DIR__
 WorkingDirectory=__PI_DIR__
 ExecStartPre=/usr/bin/test -r /etc/vibesensor/config.yaml
-# Updates can touch the release tree and state paths as root, so reassert
-# service-user ownership at startup instead of relying only on install-time chown.
-ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ __PI_DIR__
+# Updates need writable runtime state. Keep startup repair scoped to runtime
+# paths; install/update flows own the virtualenv and release tree setup.
 ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ /var/log/vibesensor /var/lib/vibesensor
 ExecStartPre=/usr/bin/test -w /var/log/vibesensor
 ExecStartPre=/usr/bin/test -w /var/lib/vibesensor
+ExecStartPre=/usr/bin/test -w __VENV_DIR__
 ExecStart=__VENV_DIR__/bin/vibesensor-server --config /etc/vibesensor/config.yaml
 KillSignal=SIGINT
 TimeoutStopSec=20

--- a/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
+++ b/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
@@ -14,8 +14,8 @@ def install_pi_text() -> str:
 _INSTALL_PI_CHECKS: list[tuple[str, str]] = [
     ("python3", "Pi install script must install python3"),
     (
-        'chown -R "${SERVICE_USER}:${SERVICE_USER}" "${PI_DIR}"',
-        "Pi install script must ensure repo ownership for update writes",
+        'chown -R "${SERVICE_USER}:${SERVICE_USER}" "${VENV_DIR}"',
+        "Pi install script must ensure virtualenv ownership for update writes",
     ),
     ("rollback", "Pi install script must create rollback directory for release-based updates"),
     (

--- a/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
+++ b/apps/server/tests/hygiene/test_pi_image_static_guardrails.py
@@ -33,6 +33,34 @@ def test_server_systemd_uses_console_script_entrypoint() -> None:
 
 
 @pytest.mark.smoke
+def test_server_systemd_keeps_steady_state_privileges_narrow() -> None:
+    service_text = (REPO_ROOT / "apps" / "server" / "systemd" / "vibesensor.service").read_text(
+        encoding="utf-8"
+    )
+
+    assert "AmbientCapabilities=CAP_NET_BIND_SERVICE\n" in service_text
+    assert "CapabilityBoundingSet=CAP_NET_BIND_SERVICE\n" in service_text
+    assert "CAP_SETUID" not in service_text
+    assert "CAP_SETGID" not in service_text
+    assert "CAP_DAC_OVERRIDE" not in service_text
+    assert "CAP_FOWNER" not in service_text
+    assert "CAP_AUDIT_WRITE" not in service_text
+    assert "NoNewPrivileges=true" in service_text
+    assert "PrivateTmp=true" in service_text
+    assert "ProtectSystem=full" in service_text
+    assert "ReadWritePaths=/var/lib/vibesensor /var/log/vibesensor __VENV_DIR__" in service_text
+    assert (
+        "ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ __PI_DIR__"
+        not in service_text
+    )
+    assert (
+        "ExecStartPre=/usr/bin/chown -R __SERVICE_USER__:__SERVICE_USER__ "
+        "/var/log/vibesensor /var/lib/vibesensor"
+    ) in service_text
+    assert "ExecStartPre=/usr/bin/test -w __VENV_DIR__" in service_text
+
+
+@pytest.mark.smoke
 def test_pi_image_validation_checks_current_packaged_static_data_layout() -> None:
     validation_text = (
         REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "image_validation.sh"

--- a/tools/dev/test_marker_policy_allowlist.yml
+++ b/tools/dev/test_marker_policy_allowlist.yml
@@ -10,6 +10,7 @@ smoke:
   apps/server/tests/hygiene/test_pi_image_static_guardrails.py:
     test_pi_gen_pipeline_split_files_exist: Pi-image pipeline layout stays in the compact image guard path.
     test_server_systemd_uses_console_script_entrypoint: Packaged server startup wiring stays in the compact image guard path.
+    test_server_systemd_keeps_steady_state_privileges_narrow: Packaged service hardening stays in the compact image guard path.
     test_pi_image_validation_checks_current_packaged_static_data_layout: Pi-image validation stays in the compact static-data guard path.
   apps/server/tests/hygiene/test_runtime_smoke.py:
     test_smoke_health_route_registered: The health route stays in the minimal runtime smoke path.


### PR DESCRIPTION
Fixes #3515

## What changed
- Reduced the Pi service ambient/bounding capability set to `CAP_NET_BIND_SERVICE` only.
- Added `NoNewPrivileges=true`, `PrivateTmp=true`, `ProtectSystem=full`, and explicit write paths for runtime state, logs, and the venv.
- Removed recursive startup ownership repair for the full release tree.
- Kept startup repair scoped to `/var/log/vibesensor` and `/var/lib/vibesensor`.
- Moved virtualenv ownership repair into `install_pi.sh` and added a startup writability check.
- Added static guard coverage for the remaining privilege and ownership contract.

## Why
The long-running Pi server only needs normal service-user access plus low-port bind capability. Broad capabilities and release-tree chown on every restart increase blast radius and make restart work larger than needed.

## Validation
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_install_offline_artifact_guardrails.py tests/hygiene/test_pi_image_static_guardrails.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_install_offline_artifact_guardrails.py tests/hygiene/test_pi_image_static_guardrails.py -q`
- `make shell-lint`
- `make lint` through repo hygiene/static checks; local root env still lacks `deptry`
- Remaining lint steps run directly in the backend dev env: `deptry`, `lint-imports`, backend static guards, preflight configs, docs lint, contract sync check

## Risks / tradeoffs / edge cases
- `CAP_NET_BIND_SERVICE` stays because Pi config still binds to port 80.
- Virtualenv ownership is install-time state now. Startup checks it is writable, but does not recursively repair it.
- Runtime log/state ownership repair remains at startup for update/restart recovery.
