### PR TITLE
Refresh contributing CI job names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,13 @@ The blocking jobs live in
 "Commands" plus [docs/testing.md](docs/testing.md) when you need the matching
 local reproduction flow.
 
-`backend-quality` includes docs lint, so documentation drift and broken local
-markdown links fail PR validation early.
+Backend checks are split by concern. `backend-lint` covers formatting and
+linting, `repo-hygiene` covers repository policy checks,
+`backend-static-guards` covers architecture/static guardrails,
+`backend-preflight` covers config preflight, `docs-lint` covers documentation
+drift and local markdown links, and `backend-contract-drift` covers generated
+contract sync. Use those workflow job names when matching a CI failure to a
+local reproduction command.
 
 Use `release-smoke` when you need confidence in the packaged wheel and bundled
 static assets. Use `e2e` when you need confidence in the Docker/runtime path.

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -65,3 +65,22 @@ def test_backend_quality_jobs_are_split_into_focused_gates() -> None:
         "docs-lint",
         "backend-contract-drift",
     }.issubset(job_names)
+
+
+def test_contributing_docs_reference_focused_backend_ci_gates() -> None:
+    module = _load_ci_manifest_module()
+    job_names = set(module.all_job_names())
+    contributing_text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    assert "backend-quality" not in contributing_text
+    focused_gate_names = {
+        "backend-lint",
+        "repo-hygiene",
+        "backend-static-guards",
+        "backend-preflight",
+        "docs-lint",
+        "backend-contract-drift",
+    }
+    assert focused_gate_names.issubset(job_names)
+    for gate_name in focused_gate_names:
+        assert gate_name in contributing_text


### PR DESCRIPTION
Fixes #3517

## What changed
- Replaced the retired `backend-quality` guidance in `CONTRIBUTING.md`.
- Listed the current focused backend CI gates: `backend-lint`, `repo-hygiene`, `backend-static-guards`, `backend-preflight`, `docs-lint`, and `backend-contract-drift`.
- Added a workflow-manifest hygiene test that rejects `backend-quality` in contributor docs and requires the focused gate names.

## Why
The contributing guide should match the actual CI surface. A retired job name sends contributors and agents to the wrong failure target.

## Validation
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_ci_workflow_manifest.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ci_workflow_manifest.py -q`
- `uv run --python 3.13 --extra dev python tools/dev/docs_lint.py`
- search confirms `backend-quality` remains only in workflow guard code/tests, not contributor docs
- `make lint` through repo hygiene/static checks; local root env still lacks `deptry`
- Remaining lint steps run directly in the backend dev env: `deptry`, `lint-imports`, backend static guards, preflight configs, docs lint, contract sync check

## Risks / tradeoffs / edge cases
Docs-only behavior change. The test intentionally keeps the retired-name ban scoped to `CONTRIBUTING.md` so existing workflow guard code can still assert the old job stays absent.
