### PR TITLE
Document Pi config preset in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,7 @@ Preset files ship with the repo for common environments:
 |---|---|
 | `config.dev.yaml` | Native-dev overrides (port 8000, no GPS, relative paths) |
 | `config.docker.yaml` | Docker-compose overrides |
+| `config.pi.yaml` | Raspberry Pi deployment overlay copied to `/etc/vibesensor/config.yaml` by install/image flows |
 
 **Quick start for local dev:**
 

--- a/apps/server/tests/hygiene/test_contributing_config_presets.py
+++ b/apps/server/tests/hygiene/test_contributing_config_presets.py
@@ -1,0 +1,20 @@
+"""Guard contributor config preset docs against shipped backend preset drift."""
+
+from __future__ import annotations
+
+import re
+
+from tests._paths import REPO_ROOT
+
+
+def test_contributing_lists_all_backend_config_presets() -> None:
+    contributing_text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    preset_table = contributing_text.split("Preset files ship with the repo", maxsplit=1)[1].split(
+        "**Quick start for local dev:**", maxsplit=1
+    )[0]
+    documented_presets = set(re.findall(r"`(config\.[a-z0-9_-]+\.yaml)`", preset_table))
+    shipped_presets = {
+        preset_path.name for preset_path in (REPO_ROOT / "apps" / "server").glob("config.*.yaml")
+    }
+
+    assert shipped_presets <= documented_presets


### PR DESCRIPTION
Fixes #3518

## What changed
- Added `config.pi.yaml` to the `CONTRIBUTING.md` config preset table.
- Described it as the Raspberry Pi deployment overlay copied to `/etc/vibesensor/config.yaml` by install/image flows.
- Added a hygiene test that requires all shipped backend `config.*.yaml` presets to be listed in the contributor preset table.

## Why
The repo ships and uses a Pi preset. Contributor docs only listed dev/docker presets, which made the deployment preset look unsupported or hidden.

## Validation
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_contributing_config_presets.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_contributing_config_presets.py -q`
- `make docs-lint`
- `make lint` through repo hygiene/static checks; local root env still lacks `deptry`
- Remaining lint steps run directly in the backend dev env: `deptry`, `lint-imports`, backend static guards, preflight configs, docs lint, contract sync check

## Risks / tradeoffs / edge cases
Docs-only behavior change. The guard checks the preset table specifically, not incidental mentions elsewhere in `CONTRIBUTING.md`.
