### PR TITLE
Use configured Python in main release

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -76,8 +76,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          python_bin="${{ steps.setup-python.outputs.python-path }}"
           wheel_path="$(echo apps/server/dist/*.whl)"
-          PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.releases.release_validation validate-wheel-metadata \
+          PYTHONPATH=apps/server "${python_bin}" -m vibesensor.use_cases.updates.releases.release_validation validate-wheel-metadata \
             --wheel-path "${wheel_path}" \
             --expected-version "${{ steps.version.outputs.version }}"
 
@@ -98,10 +99,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install pipx
-          python -m pipx ensurepath
+          python_bin="${{ steps.setup-python.outputs.python-path }}"
+          "${python_bin}" -m pip install pipx
+          "${python_bin}" -m pipx ensurepath
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          pipx install platformio
+          "${python_bin}" -m pipx install platformio
 
       - name: Detect firmware directory
         id: firmware_dir
@@ -177,7 +179,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH=apps/server python -m vibesensor.use_cases.updates.releases.release_validation validate-firmware-manifest \
+          python_bin="${{ steps.setup-python.outputs.python-path }}"
+          PYTHONPATH=apps/server "${python_bin}" -m vibesensor.use_cases.updates.releases.release_validation validate-firmware-manifest \
             --dist-dir "${{ steps.firmware_dir.outputs.path }}/dist"
 
       - name: Create firmware bundle

--- a/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
+++ b/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -18,6 +19,7 @@ _CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _APP_ARTIFACTS = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "app_artifacts.sh"
 _PI_GEN_REPO = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "pi_gen_repo.sh"
 _PREREQS = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "prereqs.sh"
+_BARE_PYTHON_RE = re.compile(r"(?<![\w$\"'/.-])python(?:\s|$)")
 
 
 def _load_yaml(path: Path) -> dict[str, object]:
@@ -79,6 +81,17 @@ def test_workflows_use_configured_python_runtime_paths() -> None:
     assert "tools/release/main_release.py build-wheel" in main_release_text
     assert "tools/release/main_release.py generate-firmware-manifest" in main_release_text
     assert "tools/release/main_release.py cleanup-releases" in main_release_text
+
+    for step in release_steps[setup_index + 1 :]:
+        if not isinstance(step, dict):
+            continue
+        run_script = step.get("run")
+        if not isinstance(run_script, str):
+            continue
+        assert not _BARE_PYTHON_RE.search(run_script), (
+            f"main-release step {step.get('name')!r} uses bare python after "
+            "setup-python exposes steps.setup-python.outputs.python-path"
+        )
 
     weekly_text = _WEEKLY_PI_IMAGE.read_text(encoding="utf-8")
     assert "uses: ./.github/actions/build-pi-image" in weekly_text


### PR DESCRIPTION
Fixes #3519

## What changed
- Switched main-release wheel metadata validation to `steps.setup-python.outputs.python-path`.
- Switched PlatformIO setup from bare `python`/`pipx` commands to `"${python_bin}" -m pip` and `"${python_bin}" -m pipx`.
- Switched firmware manifest validation to the configured Python runtime.
- Added a workflow hygiene guard that rejects bare `python` in main-release steps after setup-python exposes the configured runtime.

## Why
Release validation and firmware setup must use the same Python runtime as build and smoke validation. Bare `python` can drift with runner defaults.

## Validation
- `uv run --python 3.13 --extra dev ruff check tests/hygiene/test_workflow_python_runtime_usage.py`
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_workflow_python_runtime_usage.py tests/hygiene/test_main_release_workflow.py -q`
- search confirms no bare `python` commands remain in `.github/workflows/main-release.yml`
- `make lint` through repo hygiene/static checks; local root env still lacks `deptry`
- Remaining lint steps run directly in the backend dev env: `deptry`, `lint-imports`, backend static guards, preflight configs, docs lint, contract sync check

## Risks / tradeoffs / edge cases
Workflow-only change. PlatformIO still installs through pipx, but pipx is invoked as a module of the configured Python runtime instead of relying on whichever `python` or `pipx` is first on PATH.
