### PR TITLE
Route Pi image changes to guardrail CI

### DIFF
--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -137,9 +137,49 @@ _SELECTION_CASES = (
     pytest.param(
         SelectionCase(
             changed_files=("infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template",),
-            expected_jobs=frozenset({"shell_lint"}),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "shell_lint", "backend_static_guards", "backend_tests"}
+            ),
         ),
         id="pi-image-shell-template",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("infra/pi-image/pi-gen/build.sh",),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "shell_lint", "backend_static_guards", "backend_tests"}
+            ),
+        ),
+        id="pi-image-build-script",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("infra/pi-image/pi-gen/lib/app_artifacts.sh",),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "shell_lint", "backend_static_guards", "backend_tests"}
+            ),
+        ),
+        id="pi-image-app-artifacts-script",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=(
+                "infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template",
+            ),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "shell_lint", "backend_static_guards", "backend_tests"}
+            ),
+        ),
+        id="pi-image-stage-template",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("infra/pi-image/pi-gen/README.md",),
+            expected_jobs=frozenset(
+                {"docs_lint", "repo_hygiene", "backend_static_guards", "backend_tests"}
+            ),
+        ),
+        id="pi-image-doc",
     ),
     pytest.param(
         SelectionCase(

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -28,6 +28,7 @@ FULL_STACK_TRIGGER_FILES = {
 }
 FULL_STACK_TRIGGER_PREFIXES = (".github/",)
 FIRMWARE_TRIGGER_PREFIXES = ("firmware/", "tools/firmware/")
+PI_IMAGE_TRIGGER_PREFIXES = ("infra/pi-image/",)
 FIRMWARE_NATIVE_BACKEND_TRIGGER_FILES = {
     "apps/server/vibesensor/adapters/udp/protocol.py",
     "apps/server/vibesensor/adapters/udp/protocol_validator.py",
@@ -123,8 +124,12 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
     contract_sync_changed = any(
         path in CONTRACT_SYNC_TRIGGER_FILES for path in normalized
     )
+    pi_image_changed = any(
+        any(path.startswith(prefix) for prefix in PI_IMAGE_TRIGGER_PREFIXES)
+        for path in normalized
+    )
     non_docs_paths = tuple(path for path in normalized if not is_markdown_path(path))
-    if not non_docs_paths and not contract_sync_changed:
+    if not non_docs_paths and not contract_sync_changed and not pi_image_changed:
         return WorkflowJobSelection(docs_lint=True)
 
     full_stack = any(
@@ -168,18 +173,23 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         or backend_changed
         or frontend_changed
         or python_tool_changed
-        or contract_sync_changed,
+        or contract_sync_changed
+        or pi_image_changed,
         shell_lint=full_stack or shell_lint_changed,
         backend_lint=full_stack or backend_changed or python_tool_changed,
         backend_static_guards=full_stack
         or backend_changed
-        or backend_static_guard_tool_changed,
+        or backend_static_guard_tool_changed
+        or pi_image_changed,
         backend_preflight=full_stack or backend_changed,
         backend_contract_drift=full_stack or backend_changed or contract_sync_changed,
         backend_typecheck=full_stack or backend_changed,
         frontend_typecheck=full_stack or frontend_changed,
         ui_smoke=full_stack or frontend_changed,
-        backend_tests=full_stack or backend_changed or backend_test_tool_changed,
+        backend_tests=full_stack
+        or backend_changed
+        or backend_test_tool_changed
+        or pi_image_changed,
         release_smoke=full_stack
         or backend_changed
         or frontend_changed


### PR DESCRIPTION
## What changed
- Added an explicit `infra/pi-image/` trigger to the shared CI path rules.
- Pi-image changes now select `repo-hygiene`, `backend-static-guards`, and `backend-tests`.
- Existing shell lint selection remains in place for Pi-image shell/template paths.
- Pi-image markdown also selects `docs-lint` while still running the guardrail jobs.
- Added representative path-rule cases for Pi-image scripts, templates, and docs.

## Why
Pi-image scripts/templates have dedicated hygiene tests, but Pi-image-only changes could avoid those gates. The path rules now make those guardrails run when that tree changes.

## Validation
- `ruff format` / `ruff check` on touched files
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ci_path_rules.py -q`
- `make lint` reached the known local `deptry` binary gap after earlier checks.
- Explicit fallback lint/static/preflight/docs/contract checks passed.

## Risks, tradeoffs, edge cases
- This increases CI coverage for Pi-image-only PRs by adding backend guardrail jobs.
- Product runtime behavior is unchanged.
- Docs-only Pi-image changes now run docs lint plus the Pi-image guardrails, intentionally avoiding a blind spot under that tree.

## Follow-ups
None.

Closes #3523