### PR TITLE
Classify non-Python tooling path rules

### DIFF
--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -116,14 +116,46 @@ _SELECTION_CASES = (
     pytest.param(
         SelectionCase(
             changed_files=("tools/config/sync_contract_artifacts.mjs",),
-            expected_jobs=frozenset({"repo_hygiene", "backend_contract_drift"}),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "backend_contract_drift", "frontend_typecheck"}
+            ),
         ),
         id="contract-sync-tool",
     ),
     pytest.param(
         SelectionCase(
+            changed_files=("tools/config/sync_shared_contracts_to_ui.mjs",),
+            expected_jobs=frozenset(
+                {"repo_hygiene", "backend_contract_drift", "frontend_typecheck"}
+            ),
+        ),
+        id="shared-contract-sync-tool",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("tools/ui/ensure_ui_bootstrap.mjs",),
+            expected_jobs=frozenset({"repo_hygiene", "frontend_typecheck"}),
+        ),
+        id="ui-node-tool",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("tools/dev/future_node_helper.cjs",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="generic-node-tool",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("tools/dev/future_shell_helper.sh",),
+            expected_jobs=frozenset({"repo_hygiene", "shell_lint"}),
+        ),
+        id="generic-shell-tool",
+    ),
+    pytest.param(
+        SelectionCase(
             changed_files=("tools/tests/run_ci_with_act.sh",),
-            expected_jobs=frozenset({"shell_lint"}),
+            expected_jobs=frozenset({"repo_hygiene", "shell_lint"}),
         ),
         id="shell-script-only",
     ),

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -34,6 +34,10 @@ FIRMWARE_NATIVE_BACKEND_TRIGGER_FILES = {
     "apps/server/vibesensor/adapters/udp/protocol_validator.py",
 }
 PYTHON_TOOL_PREFIX = "tools/"
+NODE_TOOL_EXTENSIONS = (".mjs", ".cjs")
+SHELL_TOOL_EXTENSIONS = (".sh", ".sh.template")
+UI_TOOL_PREFIXES = ("tools/ui/",)
+CONFIG_TOOL_PREFIXES = ("tools/config/",)
 DOCS_LINT_TOOL_FILES = {"tools/dev/docs_lint.py"}
 REPO_HYGIENE_TOOL_FILES = {"tools/dev/check_hygiene.py"}
 BACKEND_STATIC_GUARD_TOOL_FILES = {"tools/dev/verify_backend_static_guards.py"}
@@ -41,7 +45,6 @@ BACKEND_TEST_TOOL_FILES = {"tools/tests/run_backend_parallel.py"}
 RELEASE_TRIGGER_FILES = {"tools/tests/run_release_smoke.py", "tools/build_ui_static.py"}
 E2E_TRIGGER_FILES = {"tools/tests/run_e2e_parallel.py", "apps/server/Dockerfile.e2e"}
 SHELL_LINT_TRIGGER_PREFIXES = (".githooks/", "infra/pi-image/")
-SHELL_LINT_EXTENSIONS = (".sh", ".sh.template")
 CONTRACT_SYNC_TRIGGER_FILES = {
     "apps/ui/package.json",
     "apps/ui/src/contracts/http_api_schema.json",
@@ -102,7 +105,7 @@ def is_markdown_path(path: str) -> bool:
 
 def is_shell_lint_path(path: str) -> bool:
     normalized = PurePosixPath(path).as_posix()
-    return normalized.endswith(SHELL_LINT_EXTENSIONS) or any(
+    return normalized.endswith(SHELL_TOOL_EXTENSIONS) or any(
         normalized.startswith(prefix) for prefix in SHELL_LINT_TRIGGER_PREFIXES
     )
 
@@ -150,6 +153,23 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         path.startswith(PYTHON_TOOL_PREFIX) and path.endswith(".py")
         for path in non_docs_paths
     )
+    node_tool_changed = any(
+        path.startswith(PYTHON_TOOL_PREFIX) and path.endswith(NODE_TOOL_EXTENSIONS)
+        for path in non_docs_paths
+    )
+    shell_tool_changed = any(
+        path.startswith(PYTHON_TOOL_PREFIX) and path.endswith(SHELL_TOOL_EXTENSIONS)
+        for path in non_docs_paths
+    )
+    ui_tool_changed = any(
+        any(path.startswith(prefix) for prefix in UI_TOOL_PREFIXES)
+        for path in non_docs_paths
+    )
+    config_node_tool_changed = any(
+        any(path.startswith(prefix) for prefix in CONFIG_TOOL_PREFIXES)
+        and path.endswith(NODE_TOOL_EXTENSIONS)
+        for path in non_docs_paths
+    )
     docs_lint_tool_changed = any(
         path in DOCS_LINT_TOOL_FILES for path in non_docs_paths
     )
@@ -173,6 +193,8 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         or backend_changed
         or frontend_changed
         or python_tool_changed
+        or node_tool_changed
+        or shell_tool_changed
         or contract_sync_changed
         or pi_image_changed,
         shell_lint=full_stack or shell_lint_changed,
@@ -182,9 +204,15 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
         or backend_static_guard_tool_changed
         or pi_image_changed,
         backend_preflight=full_stack or backend_changed,
-        backend_contract_drift=full_stack or backend_changed or contract_sync_changed,
+        backend_contract_drift=full_stack
+        or backend_changed
+        or contract_sync_changed
+        or config_node_tool_changed,
         backend_typecheck=full_stack or backend_changed,
-        frontend_typecheck=full_stack or frontend_changed,
+        frontend_typecheck=full_stack
+        or frontend_changed
+        or ui_tool_changed
+        or config_node_tool_changed,
         ui_smoke=full_stack or frontend_changed,
         backend_tests=full_stack
         or backend_changed


### PR DESCRIPTION
## What changed
- Added explicit CI path-rule buckets for non-Python `tools/` helpers.
- `tools/ui/**` now selects repo hygiene and frontend quality/typecheck.
- `tools/config/*.{mjs,cjs}` now selects repo hygiene, contract drift, and frontend typecheck.
- Generic `tools/**/*.{mjs,cjs}` now selects repo hygiene.
- `tools/**/*.{sh,sh.template}` now selects repo hygiene plus shell lint.
- Added matrix tests for current and future representative tooling paths.

## Why
Node and shell tooling under `tools/` affects CI and local workflows, but only Python tooling had broad path-rule coverage. These changes prevent non-Python tooling changes from silently selecting weak or empty CI coverage.

## Validation
- `ruff format` / `ruff check` on touched files
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ci_path_rules.py -q`
- `make lint` reached the known local `deptry` binary gap after earlier checks.
- Explicit fallback lint/static/preflight/docs/contract checks passed.

## Risks, tradeoffs, edge cases
- Some tooling-only PRs will run more CI than before by design.
- Runtime product behavior is unchanged.
- Frontend typecheck is intentionally selected for UI/bootstrap tooling and config sync scripts that affect generated UI contracts.

## Follow-ups
None.

Closes #3524