### PR TITLE
Guard CI path rules against empty selections

### DIFF
--- a/apps/server/tests/hygiene/test_ci_path_rules.py
+++ b/apps/server/tests/hygiene/test_ci_path_rules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from dataclasses import dataclass, fields
 from types import ModuleType
@@ -13,6 +14,18 @@ from tests._paths import REPO_ROOT
 
 _CI_PATH_RULES = REPO_ROOT / "tools" / "tests" / "ci_path_rules.py"
 _FULL_STACK = None
+_EMPTY_SELECTION_ALLOWLIST = {
+    "artifacts/.gitkeep": "Placeholder only; no CI behavior changes.",
+    "artifacts/fuzz/analysis-driveshaft-order-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/analysis-engine-order-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/analysis-known-imbalance.json": "Static fuzz fixture.",
+    "artifacts/fuzz/analysis-quiet-baseline.json": "Static fuzz fixture.",
+    "artifacts/fuzz/analysis-summary-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/analysis-wheel-order-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/fft-spike-filter-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/processor-multi-client-basic.json": "Static fuzz fixture.",
+    "artifacts/fuzz/strength-spectrum-basic.json": "Static fuzz fixture.",
+}
 
 
 def _load_ci_path_rules_module() -> ModuleType:
@@ -46,6 +59,17 @@ def _selected_jobs(module: ModuleType, changed_files: tuple[str, ...]) -> frozen
         for field in fields(module.WorkflowJobSelection)
         if getattr(selection, field.name)
     )
+
+
+def _tracked_files() -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return tuple(path for path in result.stdout.splitlines() if path.strip())
 
 
 _SELECTION_CASES = (
@@ -151,6 +175,41 @@ _SELECTION_CASES = (
             expected_jobs=frozenset({"repo_hygiene", "shell_lint"}),
         ),
         id="generic-shell-tool",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=(".dockerignore",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="root-dockerignore",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=(".gitattributes",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="root-gitattributes",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=(".vscode/settings.json",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="vscode-settings",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("tools/dev/test_marker_policy_allowlist.yml",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="tool-yaml-config",
+    ),
+    pytest.param(
+        SelectionCase(
+            changed_files=("tools/tests/act-event.json",),
+            expected_jobs=frozenset({"repo_hygiene"}),
+        ),
+        id="tool-json-config",
     ),
     pytest.param(
         SelectionCase(
@@ -299,3 +358,16 @@ def test_workflow_job_selection_matrix(ci_path_rules: ModuleType, case: Selectio
     )
     assert expected_jobs is not None
     assert _selected_jobs(ci_path_rules, case.changed_files) == expected_jobs
+
+
+def test_meaningful_tracked_files_do_not_select_empty_ci_jobs(
+    ci_path_rules: ModuleType,
+) -> None:
+    tracked_files = set(_tracked_files())
+    assert set(_EMPTY_SELECTION_ALLOWLIST) <= tracked_files
+
+    empty_selection_paths = {
+        path for path in tracked_files if not _selected_jobs(ci_path_rules, (path,))
+    }
+
+    assert empty_selection_paths == set(_EMPTY_SELECTION_ALLOWLIST)

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -13,6 +13,16 @@ DOC_FILES = {
     "CHANGELOG.md",
     ".github/copilot-instructions.md",
 }
+REPO_HYGIENE_TRIGGER_FILES = {
+    ".actrc",
+    ".dockerignore",
+    ".gitattributes",
+    ".gitignore",
+    ".rgignore",
+    ".secrets.act.example",
+    ".vscode/settings.json",
+    "LICENSE",
+}
 FULL_STACK_TRIGGER_FILES = {
     "Makefile",
     ".python-version",
@@ -36,6 +46,7 @@ FIRMWARE_NATIVE_BACKEND_TRIGGER_FILES = {
 PYTHON_TOOL_PREFIX = "tools/"
 NODE_TOOL_EXTENSIONS = (".mjs", ".cjs")
 SHELL_TOOL_EXTENSIONS = (".sh", ".sh.template")
+TOOL_CONFIG_EXTENSIONS = (".json", ".yml", ".yaml")
 UI_TOOL_PREFIXES = ("tools/ui/",)
 CONFIG_TOOL_PREFIXES = ("tools/config/",)
 DOCS_LINT_TOOL_FILES = {"tools/dev/docs_lint.py"}
@@ -176,6 +187,14 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
     repo_hygiene_tool_changed = any(
         path in REPO_HYGIENE_TOOL_FILES for path in non_docs_paths
     )
+    repo_hygiene_config_changed = any(
+        path in REPO_HYGIENE_TRIGGER_FILES
+        or (
+            path.startswith(PYTHON_TOOL_PREFIX)
+            and path.endswith(TOOL_CONFIG_EXTENSIONS)
+        )
+        for path in non_docs_paths
+    )
     backend_static_guard_tool_changed = any(
         path in BACKEND_STATIC_GUARD_TOOL_FILES for path in non_docs_paths
     )
@@ -189,6 +208,7 @@ def workflow_job_selection(changed_files: Iterable[str]) -> WorkflowJobSelection
     return WorkflowJobSelection(
         docs_lint=full_stack or docs_changed or docs_lint_tool_changed,
         repo_hygiene=full_stack
+        or repo_hygiene_config_changed
         or repo_hygiene_tool_changed
         or backend_changed
         or frontend_changed


### PR DESCRIPTION
## What changed
- Added repo-hygiene path-rule coverage for meaningful root metadata and local CI config files.
- Added repo-hygiene coverage for `tools/` JSON/YAML config and allowlist files.
- Added a tracked-file hygiene test that runs every tracked path through `workflow_job_selection`.
- Kept an explicit empty-selection allowlist only for inert placeholder/fuzz fixture artifacts.

## Why
CI path selection should not silently map meaningful tracked files to no jobs. The new guard makes that invariant executable and forces future exceptions to be explicit.

## Validation
- `ruff format` / `ruff check` on touched files
- `uv run --python 3.13 --extra dev pytest tests/hygiene/test_ci_path_rules.py -q`
- Explicit scan confirmed only allowlisted inert artifact/fuzz files select no jobs.
- `make lint` reached the known local `deptry` binary gap after earlier checks.
- Explicit fallback lint/static/preflight/docs/contract checks passed.

## Risks, tradeoffs, edge cases
- Some metadata/config-only PRs now run repo hygiene by design.
- Fuzz fixtures and `.gitkeep` placeholders remain intentionally inert through a named allowlist.
- Product runtime behavior is unchanged.

## Follow-ups
None.

Closes #3526