### PR TITLE
Fix stale pytest progress guidance

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -12,4 +12,4 @@ Backend tests (`apps/server/tests/**`)
 - Do not create local `FakeState` or fake runtime classes in individual test files. Use the shared `FakeState` from `conftest.py` and customise it via constructor arguments.
 - Do not add private bridge/shim methods to production classes solely for test access. Test sub-components directly (e.g. `proc._store._get_or_create_unlocked`, `proc._metrics.fft_params`) instead of adding pass-through wrappers on the outer class.
 - Oversized test/spec guardrails live in `tools/dev/check_hygiene.py` with the explicit allowlist at `tools/dev/oversized_test_allowlist.yml`; split oversized files by default, and only add an allowlist entry when the file is intentionally large and the reason is documented there.
-- Optional focused backend pytest run (for faster iteration, not a CI substitute): `python3 tools/tests/pytest_progress.py --show-test-names apps/server/tests`.
+- Optional focused backend pytest run (for faster iteration, not a CI substitute): from `apps/server`, run `uv run --python 3.13 --extra dev pytest tests/<module>/ -q`.

--- a/apps/server/tests/AGENTS.md
+++ b/apps/server/tests/AGENTS.md
@@ -8,4 +8,4 @@ Prefer focused test modules over adding to large omnibus regression files. Test 
 
 Default focused validation:
 - `pytest -q apps/server/tests/<module>/`
-- `python3 tools/tests/pytest_progress.py --show-test-names apps/server/tests` when broader backend test visibility is useful.
+- From `apps/server`, run `uv run --python 3.13 --extra dev pytest tests/<module>/ -q` when repo-managed backend dependencies are needed.

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -35,6 +35,14 @@ COPILOT_CANONICAL_MARKER = (
     "This file is the canonical AI guidance entrypoint and short index."
 )
 REPO_MAP_SCOPE_MARKER = "This file is the repo map, not a workflow or policy guide."
+GUIDANCE_SCRIPT_SUFFIXES = (".py", ".sh", ".mjs", ".cjs", ".js")
+GUIDANCE_SCRIPT_STARTS = (
+    ".githooks/",
+    "apps/server/scripts/",
+    "apps/ui/dev-docker.sh",
+    "infra/pi-image/",
+    "tools/",
+)
 
 
 def _walk_files(repo_root: Path) -> list[str]:
@@ -244,6 +252,42 @@ def _check_ai_guidance_stack(markdown_files: list[str], repo_root: Path) -> list
     return issues
 
 
+def _check_guidance_script_references(
+    markdown_files: list[str], repo_root: Path
+) -> list[str]:
+    """Flag repo-local script references in guidance files when the target is absent."""
+    issues: list[str] = []
+    guidance_files = sorted(
+        path
+        for path in markdown_files
+        if path.startswith(".github/instructions/")
+        or path == "AGENTS.md"
+        or path.endswith("/AGENTS.md")
+    )
+    script_re = re.compile(
+        r"(?P<path>(?:"
+        + "|".join(re.escape(prefix) for prefix in GUIDANCE_SCRIPT_STARTS)
+        + r")[A-Za-z0-9._~<>/-]+(?:"
+        + "|".join(re.escape(suffix) for suffix in GUIDANCE_SCRIPT_SUFFIXES)
+        + r"))"
+    )
+
+    for path in guidance_files:
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        for match in script_re.finditer(text):
+            candidate = match.group("path")
+            if "<" in candidate or ">" in candidate:
+                continue
+            if not (repo_root / candidate).is_file():
+                issues.append(
+                    f"{path}: missing repo-local script reference: {candidate}"
+                )
+
+    return issues
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     all_files = _tracked_files(repo_root)
@@ -258,6 +302,7 @@ def main() -> int:
     issues.extend(_check_runtime_docs_reading(source_files))
     issues.extend(_check_markdown_links(markdown_files, repo_root))
     issues.extend(_check_ai_guidance_stack(markdown_files, repo_root))
+    issues.extend(_check_guidance_script_references(markdown_files, repo_root))
 
     if issues:
         print(f"❌ {len(issues)} docs issue(s):")


### PR DESCRIPTION
## What changed
- Replaced stale `tools/tests/pytest_progress.py` guidance with current repo-managed pytest commands.
- Added docs lint coverage for repo-local script references in `.github/instructions/**` and `**/AGENTS.md`.

## Why
The referenced pytest progress helper no longer exists, so copied guidance failed before running useful tests.

## Validation
- `ruff format tools/dev/docs_lint.py`
- `ruff check tools/dev/docs_lint.py`
- `python3 tools/dev/docs_lint.py`
- `make docs-lint`
- searched repo guidance for remaining `pytest_progress.py` references

## Risks / tradeoffs / edge cases
- The lint guard is scoped to script/tooling paths, not every source-file path. Exact architecture path cleanup stays out of scope here.
- Placeholder paths containing `<...>` are ignored so guidance examples can still use module placeholders.

## Follow-ups
None.

Closes #3528