### PR TITLE
Fix UI contract sync Python runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ./.github/actions/setup-backend
+      - id: setup-backend
+        uses: ./.github/actions/setup-backend
 
       - uses: actions/setup-node@v6
         with:
@@ -196,6 +197,8 @@ jobs:
 
       - name: Materialize missing UI generated contract derivatives
         working-directory: apps/ui
+        env:
+          PYTHON: ${{ steps.setup-backend.outputs.python-path }}
         run: npm run setup:generated-contracts
 
       - name: Authoritative contract sync check
@@ -270,16 +273,23 @@ jobs:
           cache: "npm"
           cache-dependency-path: apps/ui/package-lock.json
 
+      - id: setup-python
+        uses: ./.github/actions/setup-python
+
       - name: Install UI dependencies
         working-directory: apps/ui
         run: node ../../tools/ui/ensure_ui_bootstrap.mjs
 
       - name: Sync generated UI contract derivatives
         working-directory: apps/ui
+        env:
+          PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: npm run sync:generated-contracts
 
       - name: UI typecheck
         working-directory: apps/ui
+        env:
+          PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: npm run typecheck
 
   ui-unit:
@@ -304,12 +314,17 @@ jobs:
           cache: "npm"
           cache-dependency-path: apps/ui/package-lock.json
 
+      - id: setup-python
+        uses: ./.github/actions/setup-python
+
       - name: Install UI dependencies
         working-directory: apps/ui
         run: node ../../tools/ui/ensure_ui_bootstrap.mjs
 
       - name: UI Vitest unit suite
         working-directory: apps/ui
+        env:
+          PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: npm run test:unit
 
       - name: Upload UI unit test artifacts
@@ -343,6 +358,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: apps/ui/package-lock.json
 
+      - id: setup-python
+        uses: ./.github/actions/setup-python
+
       - id: playwright-browser-cache
         uses: actions/cache@v5
         with:
@@ -363,6 +381,7 @@ jobs:
       - name: UI smoke tests
         working-directory: apps/ui
         env:
+          PYTHON: ${{ steps.setup-python.outputs.python-path }}
           PLAYWRIGHT_SMOKE_WORKERS: 4
         run: npm run test:smoke
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,9 @@ ui-lint: ## Run UI lint checks
 	cd $(UI_DIR) && npm run lint
 
 ui-typecheck: ## Materialize UI-derived contracts, then run lint and TypeScript type checking
-	cd $(UI_DIR) && npm run sync:generated-contracts && npm run lint && npm run lint:deps && npm run lint:unused && npm run typecheck
+	@$(RESOLVE_PYTHON) \
+	cd $(UI_DIR) && PYTHON="$$PYTHON" npm run sync:generated-contracts && npm run lint && npm run lint:deps && npm run lint:unused && PYTHON="$$PYTHON" npm run typecheck
 
 ui-test: ## Run UI unit tests
-	cd $(UI_DIR) && npm run test:unit
+	@$(RESOLVE_PYTHON) \
+	cd $(UI_DIR) && PYTHON="$$PYTHON" npm run test:unit

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -3,6 +3,7 @@ FROM node:22-slim AS ui-build
 WORKDIR /app/apps/ui
 
 RUN apt-get update && apt-get install -y --no-install-recommends python3 && rm -rf /var/lib/apt/lists/*
+ENV PYTHON=/usr/bin/python3
 
 COPY apps/ui/package*.json ./
 RUN npm ci
@@ -10,6 +11,7 @@ RUN npm ci
 RUN mkdir -p /app/tools/config /app/apps/server/vibesensor/shared
 # Copy the shared-code inputs early so UI rebuilds only invalidate when these contracts change.
 COPY tools/config/sync_shared_contracts_to_ui.mjs /app/tools/config/sync_shared_contracts_to_ui.mjs
+COPY tools/config/python_runtime.mjs /app/tools/config/python_runtime.mjs
 COPY tools/config/generate_ui_shared_constants.py /app/tools/config/generate_ui_shared_constants.py
 COPY apps/server/vibesensor/shared/locations.py /app/apps/server/vibesensor/shared/locations.py
 COPY apps/server/vibesensor/shared/strength_fields.py /app/apps/server/vibesensor/shared/strength_fields.py

--- a/apps/server/tests/hygiene/test_build_ui_static.py
+++ b/apps/server/tests/hygiene/test_build_ui_static.py
@@ -61,6 +61,7 @@ def _install_fake_subprocess(
     def _fake_run(
         command: list[str],
         cwd: str | Path | None = None,
+        env: dict[str, str] | None = None,
         check: bool = False,
         capture_output: bool = False,
         text: bool = False,
@@ -68,6 +69,9 @@ def _install_fake_subprocess(
         del cwd, check, capture_output, text
         command_list = [str(part) for part in command]
         commands.append(command_list)
+        if command_list[:2] == ["npm", "run"]:
+            assert env is not None
+            assert env["PYTHON"] == sys.executable
         if command_list[:2] == ["git", "-C"]:
             return subprocess.CompletedProcess(command_list, 0, stdout=f"{git_head}\n", stderr="")
         if command_list[:2] == ["npm", "run"] and command_list[2] in {

--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -117,7 +117,7 @@ def test_makefile_exposes_ui_unit_test_target_and_readme_pointer() -> None:
     readme_text = _UI_README.read_text(encoding="utf-8")
 
     assert "ui-test: ## Run UI unit tests" in makefile_text
-    assert "cd $(UI_DIR) && npm run test:unit" in makefile_text
+    assert 'cd $(UI_DIR) && PYTHON="$$PYTHON" npm run test:unit' in makefile_text
     assert "make ui-test                 # same unit suite from the repo root" in readme_text
 
 

--- a/apps/server/tests/hygiene/test_pi_app_artifacts_contract_sync.py
+++ b/apps/server/tests/hygiene/test_pi_app_artifacts_contract_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 from tests._paths import REPO_ROOT
@@ -52,6 +53,7 @@ esac
     env = os.environ | {
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "FAKE_NPM_LOG": str(command_log),
+        "VS_PYTHON_BIN": sys.executable,
     }
     subprocess.run(
         [

--- a/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
+++ b/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
@@ -19,6 +19,9 @@ _CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _APP_ARTIFACTS = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "app_artifacts.sh"
 _PI_GEN_REPO = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "pi_gen_repo.sh"
 _PREREQS = REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "lib" / "prereqs.sh"
+_CONTRACT_SYNC = REPO_ROOT / "tools" / "config" / "sync_contract_artifacts.mjs"
+_UI_CONTRACT_SYNC = REPO_ROOT / "tools" / "config" / "sync_shared_contracts_to_ui.mjs"
+_PYTHON_RUNTIME = REPO_ROOT / "tools" / "config" / "python_runtime.mjs"
 _BARE_PYTHON_RE = re.compile(r"(?<![\w$\"'/.-])python(?:\s|$)")
 
 
@@ -126,11 +129,28 @@ def test_workflows_use_configured_python_runtime_paths() -> None:
         '"${{ steps.setup-python.outputs.python-path }}" tools/dev/docs_lint.py'
     )
 
+    frontend_typecheck_steps = ci["jobs"]["frontend-typecheck"]["steps"]
+    assert isinstance(frontend_typecheck_steps, list)
+    sync_step = next(
+        step
+        for step in frontend_typecheck_steps
+        if isinstance(step, dict) and step.get("name") == "Sync generated UI contract derivatives"
+    )
+    assert sync_step["env"]["PYTHON"] == "${{ steps.setup-python.outputs.python-path }}"
+    typecheck_step = next(
+        step
+        for step in frontend_typecheck_steps
+        if isinstance(step, dict) and step.get("name") == "UI typecheck"
+    )
+    assert typecheck_step["env"]["PYTHON"] == "${{ steps.setup-python.outputs.python-path }}"
+
 
 def test_pi_image_release_scripts_accept_configured_python_path() -> None:
     app_artifacts = _APP_ARTIFACTS.read_text(encoding="utf-8")
     assert '"${VS_PYTHON_BIN}" -m venv .build-venv' in app_artifacts
     assert "python3 -m venv" not in app_artifacts
+    assert 'PYTHON="${VS_PYTHON_BIN}" npm run sync:generated-contracts' in app_artifacts
+    assert 'PYTHON="${VS_PYTHON_BIN}" npm run build' in app_artifacts
 
     pi_gen_repo = _PI_GEN_REPO.read_text(encoding="utf-8")
     assert "\"${VS_PYTHON_BIN}\" - <<'PY'" in pi_gen_repo
@@ -138,3 +158,15 @@ def test_pi_image_release_scripts_accept_configured_python_path() -> None:
 
     prereqs = _PREREQS.read_text(encoding="utf-8")
     assert 'require_cmd "${VS_PYTHON_BIN}"' in prereqs
+
+
+def test_contract_sync_tools_do_not_fall_back_to_ambient_python3() -> None:
+    runtime_text = _PYTHON_RUNTIME.read_text(encoding="utf-8")
+    assert ".python-version" in runtime_text
+    assert "python${match[1]}.${match[2]}" in runtime_text
+
+    for path in (_CONTRACT_SYNC, _UI_CONTRACT_SYNC):
+        text = path.read_text(encoding="utf-8")
+        assert "resolveConfiguredPythonCommand(root)" in text
+        assert "process.env.PYTHON ||" not in text
+        assert "|| 'python3'" not in text

--- a/infra/pi-image/pi-gen/lib/app_artifacts.sh
+++ b/infra/pi-image/pi-gen/lib/app_artifacts.sh
@@ -4,6 +4,7 @@ compute_ui_hash() {
     git ls-files \
       apps/ui \
       tools/config/sync_shared_contracts_to_ui.mjs \
+      tools/config/python_runtime.mjs \
       | LC_ALL=C sort \
       | xargs sha256sum \
       | sha256sum \
@@ -50,9 +51,9 @@ build_ui_bundle() {
 
   if [ "${should_build}" = "1" ]; then
     echo "Syncing generated UI contracts"
-    (cd "${ui_dir}" && npm run sync:generated-contracts)
+    (cd "${ui_dir}" && PYTHON="${VS_PYTHON_BIN}" npm run sync:generated-contracts)
     echo "Building UI bundle"
-    (cd "${ui_dir}" && npm run build)
+    (cd "${ui_dir}" && PYTHON="${VS_PYTHON_BIN}" npm run build)
     if [ -z "${current_hash}" ]; then
       current_hash="$(compute_ui_hash || true)"
     fi

--- a/tools/build_ui_static.py
+++ b/tools/build_ui_static.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 # Keep in sync with vibesensor.use_cases.updates.status.UI_BUILD_METADATA_FILE
@@ -47,8 +49,13 @@ def _hash_tree(root: Path, *, ignore_names: set[str]) -> str:
     return hasher.hexdigest()
 
 
-def _run(command: list[str], cwd: Path) -> None:
-    subprocess.run(command, cwd=cwd, check=True)
+def _run(command: list[str], cwd: Path, *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        env={**os.environ, **env} if env is not None else None,
+        check=True,
+    )
 
 
 def _git_head_commit(repo_root: Path) -> str:
@@ -103,15 +110,16 @@ def main(argv: list[str] | None = None) -> None:
     if args.skip_npm_ci:
         bootstrap_cmd.append("--skip-npm-ci")
     _run(bootstrap_cmd, cwd=ui_dir)
-    _run(["npm", "run", "sync:generated-contracts"], cwd=ui_dir)
+    ui_contract_env = {"PYTHON": sys.executable}
+    _run(["npm", "run", "sync:generated-contracts"], cwd=ui_dir, env=ui_contract_env)
     if not args.skip_typecheck:
-        _run(["npm", "run", "typecheck"], cwd=ui_dir)
+        _run(["npm", "run", "typecheck"], cwd=ui_dir, env=ui_contract_env)
     build_script = (
         "build:prevalidated-contracts"
         if args.assume_prevalidated_contracts
         else "build"
     )
-    _run(["npm", "run", build_script], cwd=ui_dir)
+    _run(["npm", "run", build_script], cwd=ui_dir, env=ui_contract_env)
 
     shutil.rmtree(static_dir, ignore_errors=True)
     static_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/config/python_runtime.mjs
+++ b/tools/config/python_runtime.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export function resolveConfiguredPythonCommand(root) {
+	const envPython = process.env.PYTHON?.trim();
+	if (envPython) {
+		return envPython;
+	}
+
+	const version = readFileSync(resolve(root, '.python-version'), 'utf8').trim();
+	const match = version.match(/^(\d+)\.(\d+)(?:\.\d+)?$/);
+	if (!match) {
+		throw new Error(`Unable to resolve Python command from .python-version: ${version}`);
+	}
+	return `python${match[1]}.${match[2]}`;
+}

--- a/tools/config/sync_contract_artifacts.mjs
+++ b/tools/config/sync_contract_artifacts.mjs
@@ -1,11 +1,12 @@
 import { spawnSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveConfiguredPythonCommand } from './python_runtime.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const root = resolve(__dirname, '../..');
-const pythonCmd = process.env.PYTHON || 'python3';
+const pythonCmd = resolveConfiguredPythonCommand(root);
 const contractReferenceScript = resolve(root, 'tools/config/generate_contract_reference_doc.py');
 const uiDerivativeSyncScript = resolve(root, 'tools/config/sync_shared_contracts_to_ui.mjs');
 

--- a/tools/config/sync_shared_contracts_to_ui.mjs
+++ b/tools/config/sync_shared_contracts_to_ui.mjs
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { resolveConfiguredPythonCommand } from './python_runtime.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -160,7 +161,7 @@ function generateWsSchemaModule() {
 }
 
 function generateSharedConstants() {
-	const pythonCmd = process.env.PYTHON || 'python3';
+	const pythonCmd = resolveConfiguredPythonCommand(root);
 	const result = spawnSync(pythonCmd, [constantsGeneratorSrc], {
 		cwd: root,
 		encoding: 'utf8',

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1454,6 +1454,10 @@ def _validate_server_dockerfile(
             errors.append(
                 f"{label} UI node tag {docker_node!r} does not match .nvmrc {expected_node!r}."
             )
+        if "ENV PYTHON=/usr/bin/python3" not in dockerfile_text:
+            errors.append(
+                f"{label} UI build stage must pass an explicit Python path into npm contract sync."
+            )
     elif docker_node is not None:
         errors.append(
             f"{label} must stay backend-only and must not include a ui-build stage."
@@ -1624,7 +1628,7 @@ def _normalize_shell_command(command: str) -> str:
 def _normalize_env(env: Mapping[str, object] | None) -> str:
     if not env:
         return ""
-    parts = [f"{key}={env[key]}" for key in sorted(env)]
+    parts = [f"{key}={shlex.quote(str(env[key]))}" for key in sorted(env)]
     return f"env {' '.join(parts)} "
 
 
@@ -1865,6 +1869,20 @@ def check_contract_sync_entrypoint() -> list[str]:
             )
         if rel_path not in gitignore_text:
             errors.append(f".gitignore must ignore {rel_path}.")
+
+    for rel_path in (
+        "tools/config/sync_contract_artifacts.mjs",
+        "tools/config/sync_shared_contracts_to_ui.mjs",
+    ):
+        text = (ROOT / rel_path).read_text(encoding="utf-8")
+        if "resolveConfiguredPythonCommand(root)" not in text:
+            errors.append(
+                f"{rel_path} must resolve Python through tools/config/python_runtime.mjs."
+            )
+        if "process.env.PYTHON ||" in text or "|| 'python3'" in text:
+            errors.append(
+                f"{rel_path} must not fall back to ambient python3; use the configured Python runtime."
+            )
 
     workflow = _load_ci_workflow()
     jobs = workflow.get("jobs")
@@ -2470,7 +2488,7 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
                 isinstance(step_name, str)
                 and step_name == "UI smoke tests"
                 and normalized_command
-                == "cd apps/ui && env PLAYWRIGHT_SMOKE_WORKERS=4 npm run test:smoke"
+                == "cd apps/ui && env PLAYWRIGHT_SMOKE_WORKERS=4 PYTHON='${{ steps.setup-python.outputs.python-path }}' npm run test:smoke"
             ):
                 ui_smoke_command_ok = True
             uses = step.get("uses")

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -130,7 +130,7 @@ def _normalize_shell_command(command: str) -> str:
 def _normalize_env(env: Mapping[str, object] | None) -> str:
     if not env:
         return ""
-    parts = [f"{key}={env[key]}" for key in sorted(env)]
+    parts = [f"{key}={shlex.quote(str(env[key]))}" for key in sorted(env)]
     return f"env {' '.join(parts)} "
 
 
@@ -238,9 +238,17 @@ def _normalized_ci_steps(raw_step: Mapping[str, object]) -> tuple[CiWorkflowStep
 
 def _replace_python_placeholders(command: str, python_cmd: str) -> str:
     tokens = shlex.split(command)
-    replaced = [
-        python_cmd if token in _PYTHON_PATH_TOKENS else token for token in tokens
-    ]
+    replaced: list[str] = []
+    for token in tokens:
+        if token in _PYTHON_PATH_TOKENS:
+            replaced.append(python_cmd)
+            continue
+        if "=" in token:
+            key, value = token.split("=", 1)
+            if value in _PYTHON_PATH_TOKENS:
+                replaced.append(f"{key}={python_cmd}")
+                continue
+        replaced.append(token)
     return _normalize_shell_command(" ".join(shlex.quote(token) for token in replaced))
 
 


### PR DESCRIPTION
Closes #3577.

What changed:
- Added a shared Node resolver for contract-sync Python: explicit \`PYTHON\` first, otherwise the command derived from \`.python-version\`.
- Removed ambient \`python3\` fallback from contract sync and UI derivative sync.
- Passed explicit Python paths through CI UI contract steps, \`tools/build_ui_static.py\`, Makefile UI targets, Pi app artifact builds, and the Docker UI build stage.
- Added hygiene coverage so the fallback does not come back.

Why:
- Generated UI constants must use the same configured Python runtime as backend contracts and CI setup.
- Ambient runner/container \`python3\` can drift from repo runtime policy.

Validation:
- \`python3 -m ruff format ... && python3 -m ruff check ...\`
- \`uv run --python 3.13 --extra dev pytest tests/hygiene/test_build_ui_static.py tests/hygiene/test_workflow_python_runtime_usage.py tests/hygiene/test_dev_workflow.py tests/hygiene/test_pi_app_artifacts_contract_sync.py tests/hygiene/test_ui_smoke_contract.py tests/hygiene/test_ci_parallel_bootstrap.py -q\`
- \`apps/server/.venv/bin/python tools/dev/check_hygiene.py\`
- \`make sync-contracts\`
- \`make sync-contracts CHECK=1\`

Risks / tradeoffs / edge cases:
- Direct npm contract-sync commands now resolve \`pythonX.Y\` from \`.python-version\` when \`PYTHON\` is not set. Hosts without that configured interpreter fail fast instead of silently using a mismatched \`python3\`.
- Docker UI build still uses Debian \`/usr/bin/python3\`, but now passes it explicitly. That preserves the current image shape while removing hidden ambient resolution.

Follow-ups:
- None.