### PR TITLE
Make ShellCheck target discovery dynamic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ./.github/actions/setup-python
+
       - name: Install ShellCheck
         run: |
           sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,6 @@
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
 LINT_TARGETS := $(SERVER_DIR)/vibesensor $(SERVER_DIR)/tests tools
-SHELLCHECK_TARGETS := \
-	.githooks/pre-commit \
-	.githooks/pre-push \
-	apps/server/scripts/hotspot_nmcli.sh \
-	apps/server/scripts/install_pi.sh \
-	apps/server/scripts/vibesensor_update_sudo.sh \
-	apps/ui/dev-docker.sh \
-	infra/pi-image/pi-gen/build.sh \
-	infra/pi-image/pi-gen/lib/app_artifacts.sh \
-	infra/pi-image/pi-gen/lib/artifacts.sh \
-	infra/pi-image/pi-gen/lib/common.sh \
-	infra/pi-image/pi-gen/lib/image_validation.sh \
-	infra/pi-image/pi-gen/lib/mirror.sh \
-	infra/pi-image/pi-gen/lib/pi_gen_repo.sh \
-	infra/pi-image/pi-gen/lib/prereqs.sh \
-	infra/pi-image/pi-gen/lib/stage_assembly.sh \
-	infra/pi-image/pi-gen/templates/export-image/04-vibesensor-trim/00-run.sh \
-	infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template \
-	infra/pi-image/pi-gen/templates/stage-vibesensor/prerun.sh.template \
-	infra/pi-image/pi-gen/validate-image.sh \
-	tools/tests/run_ci_with_act.sh
 PYTHON_VERSION := $(strip $(shell cat .python-version))
 PYTHON_MAJOR := $(word 1,$(subst ., ,$(PYTHON_VERSION)))
 PYTHON_MINOR := $(word 2,$(subst ., ,$(PYTHON_VERSION)))
@@ -71,7 +50,8 @@ format: ## Run Ruff formatter over backend and tooling files
 
 shell-lint: ## Run ShellCheck over deployment, hook, and Pi-image shell scripts
 	@command -v shellcheck >/dev/null 2>&1 || { echo "ERROR: shellcheck is required for make shell-lint." >&2; exit 127; }
-	shellcheck --severity=warning -x -s bash $(SHELLCHECK_TARGETS)
+	@$(RESOLVE_PYTHON) \
+	shellcheck --severity=warning -x -s bash $$("$$PYTHON" tools/dev/shellcheck_targets.py)
 
 lint: ## Run repo hygiene, dependency/static guards, docs lint, and contract drift checks
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/tests/hygiene/test_shellcheck_targets.py
+++ b/apps/server/tests/hygiene/test_shellcheck_targets.py
@@ -1,0 +1,90 @@
+"""Guard ShellCheck target discovery against stale manually curated lists."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_MAKEFILE = REPO_ROOT / "Makefile"
+_SHELLCHECK_TARGETS = REPO_ROOT / "tools" / "dev" / "shellcheck_targets.py"
+_SHELL_SUFFIXES = (".sh", ".sh.template")
+_SHELL_SHEBANG_RE = re.compile(r"^#!.*\b(?:ba|da|k|z)?sh\b")
+
+
+def _load_shellcheck_targets_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "shellcheck_targets_local_test", _SHELLCHECK_TARGETS
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_SHELLCHECK_TARGETS}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git_lines(*args: str) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return tuple(line for line in result.stdout.splitlines() if line.strip())
+
+
+def _tracked_executable_files() -> set[str]:
+    executable: set[str] = set()
+    for line in _git_lines("ls-files", "--stage"):
+        metadata, _, path = line.partition("\t")
+        mode = metadata.split(maxsplit=1)[0]
+        if mode == "100755":
+            executable.add(path)
+    return executable
+
+
+def _has_shell_shebang(path: Path) -> bool:
+    try:
+        first_line = path.read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+    except (IndexError, OSError):
+        return False
+    return _SHELL_SHEBANG_RE.search(first_line) is not None
+
+
+def _expected_shellcheck_targets(allowlist: set[str]) -> tuple[str, ...]:
+    executable = _tracked_executable_files()
+    targets: list[str] = []
+    for rel_path in _git_lines("ls-files"):
+        if rel_path in allowlist:
+            continue
+        path = REPO_ROOT / rel_path
+        if not path.is_file():
+            continue
+        if (
+            rel_path.startswith(".githooks/")
+            or rel_path.endswith(_SHELL_SUFFIXES)
+            or (rel_path in executable and _has_shell_shebang(path))
+        ):
+            targets.append(rel_path)
+    return tuple(sorted(targets))
+
+
+def test_shellcheck_targets_are_discovered_from_tracked_files() -> None:
+    module = _load_shellcheck_targets_module()
+    allowlist = set(module.SHELLCHECK_ALLOWLIST)
+
+    assert all(reason.strip() for reason in module.SHELLCHECK_ALLOWLIST.values())
+    assert tuple(module.shellcheck_targets()) == _expected_shellcheck_targets(allowlist)
+
+
+def test_make_shell_lint_uses_dynamic_target_discovery() -> None:
+    makefile = _MAKEFILE.read_text(encoding="utf-8")
+
+    assert "SHELLCHECK_TARGETS :=" not in makefile
+    assert '"$$PYTHON" tools/dev/shellcheck_targets.py' in makefile
+    assert "shellcheck --severity=warning -x -s bash" in makefile

--- a/apps/server/tests/hygiene/test_shellcheck_targets.py
+++ b/apps/server/tests/hygiene/test_shellcheck_targets.py
@@ -9,8 +9,11 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import yaml
+
 from tests._paths import REPO_ROOT
 
+_CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _MAKEFILE = REPO_ROOT / "Makefile"
 _SHELLCHECK_TARGETS = REPO_ROOT / "tools" / "dev" / "shellcheck_targets.py"
 _SHELL_SUFFIXES = (".sh", ".sh.template")
@@ -88,3 +91,21 @@ def test_make_shell_lint_uses_dynamic_target_discovery() -> None:
     assert "SHELLCHECK_TARGETS :=" not in makefile
     assert '"$$PYTHON" tools/dev/shellcheck_targets.py' in makefile
     assert "shellcheck --severity=warning -x -s bash" in makefile
+
+
+def test_ci_shell_lint_sets_up_python_for_dynamic_target_discovery() -> None:
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["shell-lint"]["steps"]
+    assert isinstance(steps, list)
+
+    setup_python_index = next(
+        index
+        for index, step in enumerate(steps)
+        if isinstance(step, dict) and step.get("uses") == "./.github/actions/setup-python"
+    )
+    shellcheck_index = next(
+        index
+        for index, step in enumerate(steps)
+        if isinstance(step, dict) and step.get("name") == "ShellCheck deployment scripts"
+    )
+    assert setup_python_index < shellcheck_index

--- a/tools/dev/shellcheck_targets.py
+++ b/tools/dev/shellcheck_targets.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Discover tracked shell scripts and templates covered by ShellCheck."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SHELLCHECK_ALLOWLIST: dict[str, str] = {}
+_SHELL_SUFFIXES = (".sh", ".sh.template")
+_SHELL_SHEBANG_RE = re.compile(r"^#!.*\b(?:ba|da|k|z)?sh\b")
+
+
+def _git_lines(*args: str) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return tuple(line for line in result.stdout.splitlines() if line.strip())
+
+
+def _tracked_files() -> tuple[str, ...]:
+    return _git_lines("ls-files")
+
+
+def _tracked_executable_files() -> set[str]:
+    executable: set[str] = set()
+    for line in _git_lines("ls-files", "--stage"):
+        metadata, _, path = line.partition("\t")
+        mode = metadata.split(maxsplit=1)[0]
+        if mode == "100755":
+            executable.add(path)
+    return executable
+
+
+def _has_shell_shebang(path: Path) -> bool:
+    try:
+        first_line = path.read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+    except (IndexError, OSError):
+        return False
+    return _SHELL_SHEBANG_RE.search(first_line) is not None
+
+
+def shellcheck_targets() -> tuple[str, ...]:
+    executable = _tracked_executable_files()
+    targets: list[str] = []
+    for rel_path in _tracked_files():
+        if rel_path in SHELLCHECK_ALLOWLIST:
+            continue
+        path = ROOT / rel_path
+        if not path.is_file():
+            continue
+        if (
+            rel_path.startswith(".githooks/")
+            or rel_path.endswith(_SHELL_SUFFIXES)
+            or (rel_path in executable and _has_shell_shebang(path))
+        ):
+            targets.append(rel_path)
+    return tuple(sorted(targets))
+
+
+def main() -> None:
+    for rel_path in shellcheck_targets():
+        print(rel_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3579.

What changed:
- Removed the curated \`SHELLCHECK_TARGETS\` Makefile list.
- Added \`tools/dev/shellcheck_targets.py\` to discover tracked ShellCheck targets dynamically.
- Discovery covers \`.githooks/*\`, \`*.sh\`, \`*.sh.template\`, and executable tracked files with shell shebangs.
- Added hygiene tests for discovery parity, allowlist reasons, and Makefile wiring.

Why:
- New shell scripts should not miss ShellCheck just because a Makefile list was not updated.
- The lint gate should track repo state directly.

Validation:
- \`python3 -m ruff format tools/dev/shellcheck_targets.py apps/server/tests/hygiene/test_shellcheck_targets.py\`
- \`python3 -m ruff check tools/dev/shellcheck_targets.py apps/server/tests/hygiene/test_shellcheck_targets.py\`
- \`apps/server/.venv/bin/python tools/dev/shellcheck_targets.py\`
- \`uv run --python 3.13 --extra dev pytest tests/hygiene/test_shellcheck_targets.py tests/hygiene/test_run_changed.py tests/hygiene/test_ci_path_rules.py -q\`
- \`make shell-lint\`
- \`apps/server/.venv/bin/python tools/dev/check_hygiene.py\`

Risks / tradeoffs / edge cases:
- Discovery is intentionally scoped to tracked files. Untracked local scratch scripts are not linted.
- Future exclusions must be explicit in the helper allowlist with a reason.

Follow-ups:
- None.