### PR TITLE
Add maintainability size gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
       - uses: ./.github/actions/setup-backend
 
       - name: Repo hygiene checks
-        run: python tools/dev/check_hygiene.py
+        run: |
+          python tools/dev/check_hygiene.py
+          python tools/dev/loc_check.py
 
   shell-lint:
     name: Shell lint

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format shell-lint lint typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -58,6 +58,7 @@ lint: ## Run repo hygiene, dependency/static guards, docs lint, and contract dri
 	"$$PYTHON" -m ruff check $(LINT_TARGETS) && \
 	"$$PYTHON" -m ruff format --check $(LINT_TARGETS) && \
 	"$$PYTHON" tools/dev/check_hygiene.py && \
+	"$$PYTHON" tools/dev/loc_check.py && \
 	$(MAKE) --no-print-directory shell-lint && \
 	cd $(SERVER_DIR) && deptry . tests --config pyproject.toml && lint-imports --config pyproject.toml && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
 	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.dev.yaml && \
@@ -115,9 +116,12 @@ smoke: ## Run simulator and websocket smoke checks against a local server
 	"$$PYTHON" -m vibesensor.adapters.simulator.sim_sender --count 3 --duration 20 --server-host 127.0.0.1 --no-auto-server && \
 	"$$PYTHON" -m vibesensor.adapters.simulator.ws_smoke --uri ws://127.0.0.1:8000/ws --min-clients 3 --timeout 35
 
-loc: ## Run the repo lines-of-code budget check
+maintainability-check: ## Run file/function size maintainability gate
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/dev/loc_check.py
+
+loc: ## Run the repo file/function size maintainability gate
+loc: maintainability-check
 
 docs-lint: ## Run docs lint without the broader lint suite
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -112,7 +112,8 @@ def test_main_fails_when_optional_loc_threshold_is_exceeded(
     assert module.main(["--fail-over", "2"]) == 1
 
     stdout = capsys.readouterr().out
-    assert "FAIL: 1 source file(s) exceed 2 lines:" in stdout
+    assert "FAIL: 1 maintainability size issue(s):" in stdout
+    assert "file exceeds threshold and is not allowlisted" in stdout
     assert "src/main.py" in stdout
     assert "scripts/helper.sh" not in stdout.split("FAIL:", 1)[1]
 
@@ -138,3 +139,108 @@ def test_main_passes_when_optional_loc_threshold_is_not_exceeded(
     monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
 
     assert module.main(["--fail-over", "2"]) == 0
+
+
+def test_main_fails_for_unallowlisted_large_python_function(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text(
+        "def too_large():\n    one = 1\n    two = 2\n    return one + two\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main(["--file-fail-over", "100", "--function-fail-over", "2"]) == 1
+
+    stdout = capsys.readouterr().out
+    assert "function exceeds threshold and is not allowlisted" in stdout
+    assert "src/main.py::too_large" in stdout
+
+
+def test_main_allows_reviewed_file_and_function_allowlist(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text(
+        "def reviewed_large_function():\n    one = 1\n    two = 2\n    return one + two\n",
+        encoding="utf-8",
+    )
+    (repo_root / "tools" / "dev" / "maintainability_allowlist.yml").write_text(
+        "file_threshold_lines: 2\n"
+        "function_threshold_lines: 2\n"
+        "files:\n"
+        "  src/main.py:\n"
+        "    max_lines: 4\n"
+        "    reason: Existing large fixture kept for test coverage.\n"
+        "functions:\n"
+        "  src/main.py::reviewed_large_function:\n"
+        "    max_lines: 4\n"
+        "    reason: Existing large function kept for test coverage.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main([]) == 0
+
+
+def test_main_fails_when_allowlisted_file_or_function_grows(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_loc_check_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / "tools" / "dev").mkdir(parents=True)
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "main.py").write_text(
+        "def reviewed_large_function():\n    one = 1\n    two = 2\n    return one + two\n",
+        encoding="utf-8",
+    )
+    (repo_root / "tools" / "dev" / "maintainability_allowlist.yml").write_text(
+        "file_threshold_lines: 2\n"
+        "function_threshold_lines: 2\n"
+        "files:\n"
+        "  src/main.py:\n"
+        "    max_lines: 3\n"
+        "    reason: Existing large fixture kept for test coverage.\n"
+        "functions:\n"
+        "  src/main.py::reviewed_large_function:\n"
+        "    max_lines: 3\n"
+        "    reason: Existing large function kept for test coverage.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "__file__", str(repo_root / "tools" / "dev" / "loc_check.py"))
+
+    def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(128, args[0])
+
+    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+
+    assert module.main([]) == 1
+
+    stdout = capsys.readouterr().out
+    assert "allowlisted file grew past max_lines" in stdout
+    assert "allowlisted function grew past max_lines" in stdout

--- a/tools/dev/loc_check.py
+++ b/tools/dev/loc_check.py
@@ -1,30 +1,42 @@
 #!/usr/bin/env python3
-"""File-length advisory for maintainability.
+"""File/function-size maintainability gate.
 
-This script reports the longest tracked source files as a refactoring signal.
-Callers can optionally fail when files exceed a given LoC threshold.
+This script reports the longest tracked source files and Python functions as a
+refactoring signal, then fails when a checked item exceeds the configured
+threshold without an explicit allowlist entry.
 
 Guidance:
 - Keep files short where practical.
 - Do not split files mechanically when doing so hurts readability,
   discoverability, or long-term maintainability.
+- Existing oversized files/functions can be allowlisted with a short reason and
+  a max line count. Growth above that max fails until it is deliberately
+  reviewed.
 
-Exit code is 0 by default, or non-zero when ``--fail-over`` is provided and
-one or more files exceed that threshold.
+Exit code is non-zero when a file/function exceeds the configured threshold, an
+allowlisted item grows beyond its max, or the allowlist becomes stale.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
+from dataclasses import dataclass
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 TOP_N = 25
+DEFAULT_FILE_THRESHOLD_LINES = 1200
+DEFAULT_FUNCTION_THRESHOLD_LINES = 200
+DEFAULT_ALLOWLIST = Path("tools/dev/maintainability_allowlist.yml")
 
 # Extensions considered hand-written source
-SOURCE_EXTS = {".py", ".ts", ".js", ".sh", ".c", ".cpp", ".h"}
+SOURCE_EXTS = {".py", ".ts", ".tsx", ".js", ".jsx", ".sh", ".c", ".cpp", ".h"}
 
 # Paths always excluded (build outputs, deps, generated)
 EXCLUDE_DIRS = {
@@ -44,23 +56,165 @@ EXCLUDE_DIRS = {
 EXCLUDE_FILES: set[str] = set()
 
 
+@dataclass(frozen=True)
+class AllowlistEntry:
+    max_lines: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class MaintainabilityAllowlist:
+    file_threshold_lines: int
+    function_threshold_lines: int
+    files: dict[str, AllowlistEntry]
+    functions: dict[str, AllowlistEntry]
+
+
+@dataclass(frozen=True)
+class FileMeasurement:
+    path: str
+    lines: int
+
+
+@dataclass(frozen=True)
+class FunctionMeasurement:
+    path: str
+    qualname: str
+    start_line: int
+    end_line: int
+    lines: int
+
+    @property
+    def target(self) -> str:
+        return f"{self.path}::{self.qualname}"
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Report the longest source files and optionally fail when files "
-            "exceed a line-count threshold."
+            "Report the longest source files/functions and fail when they "
+            "exceed configured line-count thresholds without an allowlist entry."
         )
     )
     parser.add_argument(
         "--fail-over",
         type=int,
         default=None,
-        help="Exit non-zero when one or more checked files exceed this line count.",
+        help=(
+            "Deprecated alias for --file-fail-over. Exit non-zero when one or "
+            "more checked files exceed this line count."
+        ),
+    )
+    parser.add_argument(
+        "--file-fail-over",
+        type=int,
+        default=None,
+        help=(
+            f"File line threshold. Defaults to {DEFAULT_FILE_THRESHOLD_LINES}, "
+            "or the allowlist threshold when present."
+        ),
+    )
+    parser.add_argument(
+        "--function-fail-over",
+        type=int,
+        default=None,
+        help=(
+            f"Python function line threshold. Defaults to "
+            f"{DEFAULT_FUNCTION_THRESHOLD_LINES}, or the allowlist threshold "
+            "when present."
+        ),
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=str(DEFAULT_ALLOWLIST),
+        help=(
+            "YAML allowlist with files/functions, max_lines, and reasons. "
+            f"Defaults to {DEFAULT_ALLOWLIST}."
+        ),
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="Only print the report; do not fail on threshold or allowlist drift.",
     )
     args = parser.parse_args(argv)
-    if args.fail_over is not None and args.fail_over < 0:
-        parser.error("--fail-over must be zero or greater")
+    for option in ("fail_over", "file_fail_over", "function_fail_over"):
+        value = getattr(args, option)
+        if value is not None and value < 0:
+            parser.error(f"--{option.replace('_', '-')} must be zero or greater")
+    if args.fail_over is not None and args.file_fail_over is not None:
+        parser.error("--fail-over and --file-fail-over cannot both be set")
     return args
+
+
+def _read_allowlist_entry(
+    section: str, target: str, raw_entry: object
+) -> AllowlistEntry:
+    if not isinstance(raw_entry, dict):
+        raise ValueError(
+            f"{section}.{target} must be a mapping with max_lines and reason"
+        )
+    max_lines = raw_entry.get("max_lines")
+    reason = raw_entry.get("reason")
+    if not isinstance(max_lines, int) or max_lines < 0:
+        raise ValueError(f"{section}.{target}.max_lines must be a non-negative integer")
+    if not isinstance(reason, str) or not reason.strip():
+        raise ValueError(f"{section}.{target}.reason must be a non-empty string")
+    return AllowlistEntry(max_lines=max_lines, reason=reason.strip())
+
+
+def _read_allowlist_section(
+    section: str, raw_section: object
+) -> dict[str, AllowlistEntry]:
+    if raw_section is None:
+        return {}
+    if not isinstance(raw_section, dict):
+        raise ValueError(f"{section} must be a mapping")
+    entries: dict[str, AllowlistEntry] = {}
+    for target, raw_entry in raw_section.items():
+        if not isinstance(target, str) or not target:
+            raise ValueError(f"{section} keys must be non-empty strings")
+        entries[target] = _read_allowlist_entry(section, target, raw_entry)
+    return entries
+
+
+def _read_positive_int(
+    raw_data: dict[str, Any],
+    key: str,
+    default: int,
+) -> int:
+    raw_value = raw_data.get(key, default)
+    if not isinstance(raw_value, int) or raw_value < 0:
+        raise ValueError(f"{key} must be a non-negative integer")
+    return raw_value
+
+
+def _load_allowlist(path: Path) -> MaintainabilityAllowlist:
+    if not path.exists():
+        return MaintainabilityAllowlist(
+            file_threshold_lines=DEFAULT_FILE_THRESHOLD_LINES,
+            function_threshold_lines=DEFAULT_FUNCTION_THRESHOLD_LINES,
+            files={},
+            functions={},
+        )
+    with path.open(encoding="utf-8") as fh:
+        raw_data = yaml.safe_load(fh) or {}
+    if not isinstance(raw_data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return MaintainabilityAllowlist(
+        file_threshold_lines=_read_positive_int(
+            raw_data,
+            "file_threshold_lines",
+            DEFAULT_FILE_THRESHOLD_LINES,
+        ),
+        function_threshold_lines=_read_positive_int(
+            raw_data,
+            "function_threshold_lines",
+            DEFAULT_FUNCTION_THRESHOLD_LINES,
+        ),
+        files=_read_allowlist_section("files", raw_data.get("files")),
+        functions=_read_allowlist_section("functions", raw_data.get("functions")),
+    )
 
 
 def _walk_files(repo_root: Path) -> list[str]:
@@ -104,46 +258,209 @@ def _should_check(path: str) -> bool:
     return True
 
 
+class _FunctionLengthVisitor(ast.NodeVisitor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.stack: list[str] = []
+        self.measurements: list[FunctionMeasurement] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._visit_function(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        end_line = getattr(node, "end_lineno", None)
+        qualname = ".".join((*self.stack, node.name))
+        if isinstance(end_line, int):
+            self.measurements.append(
+                FunctionMeasurement(
+                    path=self.path,
+                    qualname=qualname,
+                    start_line=node.lineno,
+                    end_line=end_line,
+                    lines=end_line - node.lineno + 1,
+                )
+            )
+        self.stack.append(node.name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+
+def _measure_python_functions(repo_root: Path, path: str) -> list[FunctionMeasurement]:
+    try:
+        source = (repo_root / path).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+    visitor = _FunctionLengthVisitor(path)
+    visitor.visit(tree)
+    return visitor.measurements
+
+
+def _format_file(path: str, lines: int) -> str:
+    return f"{lines:5d}  {path}"
+
+
+def _format_function(function: FunctionMeasurement) -> str:
+    return (
+        f"{function.lines:5d}  {function.target}"
+        f" ({function.start_line}-{function.end_line})"
+    )
+
+
+def _threshold_failures(
+    *,
+    files: list[FileMeasurement],
+    functions: list[FunctionMeasurement],
+    allowlist: MaintainabilityAllowlist,
+    file_threshold: int,
+    function_threshold: int,
+) -> list[str]:
+    failures: list[str] = []
+    measured_files = {measurement.path: measurement for measurement in files}
+    measured_functions = {measurement.target: measurement for measurement in functions}
+
+    for measurement in files:
+        if measurement.lines <= file_threshold:
+            continue
+        entry = allowlist.files.get(measurement.path)
+        if entry is None:
+            failures.append(
+                "file exceeds threshold and is not allowlisted: "
+                f"{_format_file(measurement.path, measurement.lines)} "
+                f"(threshold {file_threshold})"
+            )
+            continue
+        if measurement.lines > entry.max_lines:
+            failures.append(
+                "allowlisted file grew past max_lines: "
+                f"{_format_file(measurement.path, measurement.lines)} "
+                f"(max {entry.max_lines}; reason: {entry.reason})"
+            )
+
+    for measurement in functions:
+        if measurement.lines <= function_threshold:
+            continue
+        entry = allowlist.functions.get(measurement.target)
+        if entry is None:
+            failures.append(
+                "function exceeds threshold and is not allowlisted: "
+                f"{_format_function(measurement)} (threshold {function_threshold})"
+            )
+            continue
+        if measurement.lines > entry.max_lines:
+            failures.append(
+                "allowlisted function grew past max_lines: "
+                f"{_format_function(measurement)} "
+                f"(max {entry.max_lines}; reason: {entry.reason})"
+            )
+
+    for target in sorted(allowlist.files):
+        measurement = measured_files.get(target)
+        if measurement is None:
+            failures.append(f"allowlisted file is no longer tracked source: {target}")
+        elif measurement.lines <= file_threshold:
+            failures.append(
+                "allowlisted file no longer exceeds threshold; remove allowlist entry: "
+                f"{_format_file(measurement.path, measurement.lines)} "
+                f"(threshold {file_threshold})"
+            )
+
+    for target in sorted(allowlist.functions):
+        measurement = measured_functions.get(target)
+        if measurement is None:
+            failures.append(f"allowlisted function is no longer measurable: {target}")
+        elif measurement.lines <= function_threshold:
+            failures.append(
+                "allowlisted function no longer exceeds threshold; remove allowlist entry: "
+                f"{_format_function(measurement)} (threshold {function_threshold})"
+            )
+
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     repo_root = Path(__file__).resolve().parents[2]
+    try:
+        allowlist = _load_allowlist(repo_root / args.allowlist)
+    except ValueError as error:
+        print(f"FAIL: invalid maintainability allowlist: {error}")
+        return 1
+    file_threshold = args.file_fail_over
+    if file_threshold is None:
+        file_threshold = (
+            args.fail_over
+            if args.fail_over is not None
+            else allowlist.file_threshold_lines
+        )
+    function_threshold = (
+        args.function_fail_over
+        if args.function_fail_over is not None
+        else allowlist.function_threshold_lines
+    )
     files = [f for f in _tracked_files(repo_root) if _should_check(f)]
-    measured: list[tuple[str, int]] = []
+    measured_files: list[FileMeasurement] = []
+    measured_functions: list[FunctionMeasurement] = []
 
     for path in files:
         try:
-            with open(repo_root / path) as fh:
+            with open(repo_root / path, encoding="utf-8") as fh:
                 loc = sum(1 for _ in fh)
         except (OSError, UnicodeDecodeError):
             continue
-        measured.append((path, loc))
+        measured_files.append(FileMeasurement(path=path, lines=loc))
+        if path.endswith(".py"):
+            measured_functions.extend(_measure_python_functions(repo_root, path))
 
-    measured.sort(key=lambda item: (-item[1], item[0]))
+    measured_files.sort(key=lambda item: (-item.lines, item.path))
+    measured_functions.sort(key=lambda item: (-item.lines, item.target))
 
     print(
-        "ℹ️  File-length advisory: keep files short where practical, "
+        "ℹ️  Maintainability size gate: keep files/functions short where practical, "
         "without hurting human maintainability."
     )
-    print(f"Showing top {min(TOP_N, len(measured))} longest source files:")
-    for path, loc in measured[:TOP_N]:
-        print(f"   {loc:5d}  {path}")
-
-    if args.fail_over is not None:
-        offenders = [(path, loc) for path, loc in measured if loc > args.fail_over]
-        if offenders:
-            print(
-                f"\nFAIL: {len(offenders)} source file(s) exceed {args.fail_over} lines:"
-            )
-            for path, loc in offenders:
-                print(f"   {loc:5d}  {path}")
-            print(
-                "\nSuggestion: refactor or split these files only when it "
-                "improves clarity and maintainability."
-            )
-            return 1
+    print(
+        f"File threshold: {file_threshold} lines; "
+        f"Python function threshold: {function_threshold} lines."
+    )
+    print(f"Showing top {min(TOP_N, len(measured_files))} longest source files:")
+    for measurement in measured_files[:TOP_N]:
+        print(f"   {_format_file(measurement.path, measurement.lines)}")
 
     print(
-        "\nSuggestion: refactor large files when it improves clarity; "
+        f"\nShowing top {min(TOP_N, len(measured_functions))} "
+        "longest Python functions/methods:"
+    )
+    for measurement in measured_functions[:TOP_N]:
+        print(f"   {_format_function(measurement)}")
+
+    failures = _threshold_failures(
+        files=measured_files,
+        functions=measured_functions,
+        allowlist=allowlist,
+        file_threshold=file_threshold,
+        function_threshold=function_threshold,
+    )
+    if failures and not args.advisory:
+        print(f"\nFAIL: {len(failures)} maintainability size issue(s):")
+        for failure in failures:
+            print(f"   - {failure}")
+        print(
+            "\nSuggestion: refactor/split when it improves clarity, or add a "
+            "reviewed allowlist entry with max_lines and a specific reason."
+        )
+        return 1
+
+    print(
+        "\nSuggestion: refactor large files/functions when it improves clarity; "
         "avoid artificial splits that make maintenance harder."
     )
     return 0

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -1,0 +1,61 @@
+file_threshold_lines: 1200
+function_threshold_lines: 200
+files:
+  tools/dev/check_hygiene.py:
+    max_lines: 3461
+    reason: Monolithic repo hygiene guard retained until checks are split by concern.
+  tools/dev/verify_backend_static_guards.py:
+    max_lines: 2612
+    reason: Static guard collection retained as one entrypoint until guard modules are split.
+  apps/server/vibesensor/use_cases/run/post_analysis_executor.py:
+    max_lines: 1246
+    reason: Whole-run post-analysis orchestration retained until stage runner extraction.
+  apps/server/tests/adapters/pdf/test_report_document_projection.py:
+    max_lines: 1217
+    reason: High-density report projection regression matrix kept together by document-output seam.
+functions:
+  tools/dev/check_hygiene.py::check_docker_ci_dependency_hygiene:
+    max_lines: 637
+    reason: Docker and CI dependency drift checks stay together until split by package-manager concern.
+  tools/dev/check_hygiene.py::check_runtime_policy_drift:
+    max_lines: 323
+    reason: Runtime policy matrix validation stays together until runtime-policy checks are extracted.
+  tools/dev/check_hygiene.py::check_contract_sync_entrypoint:
+    max_lines: 266
+    reason: Contract sync entrypoint guard stays together until workflow/config checks are split.
+  apps/server/vibesensor/use_cases/run/post_analysis_executor.py::run_whole_run_pipeline_stages:
+    max_lines: 228
+    reason: Whole-run stage orchestration retained until table-driven stage runner extraction.
+  apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py::_appendix_c_page:
+    max_lines: 367
+    reason: Dense appendix drawing routine retained until PDF rendering is split into smaller layout helpers.
+  apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py::test_execute_post_analysis_persists_whole_run_diagnosis_summaries:
+    max_lines: 353
+    reason: End-to-end whole-run diagnosis persistence scenario kept together to preserve setup/assertion context.
+  apps/server/vibesensor/adapters/pdf/pdf_timeline_render.py::run_timeline_graph:
+    max_lines: 271
+    reason: Timeline graph rendering path retained until chart layout and drawing steps are separated.
+  apps/server/tests_e2e/test_e2e_docker_user_journeys.py::test_e2e_docker_user_journeys:
+    max_lines: 263
+    reason: Docker user journey scenario intentionally keeps full workflow assertions together.
+  apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py::_draw_vehicle_shell:
+    max_lines: 252
+    reason: Vehicle diagram drawing routine retained until geometry/layout primitives are extracted.
+  apps/server/vibesensor/use_cases/run/raw_capture_replay.py::build_raw_backed_samples:
+    max_lines: 234
+    reason: Raw-capture replay assembly retained until sample-building phases are separated.
+  apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py::test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metadata:
+    max_lines: 230
+    reason: Whole-run order trace persistence scenario kept together to preserve fixture chronology.
+  apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py::test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_metadata:
+    max_lines: 225
+    reason: Whole-run spatial coherence persistence scenario kept together to preserve setup/assertion context.
+  apps/server/tests/integration/test_ingest_backpressure_metrics.py::test_ingest_metrics_hold_ci_budget_under_sensor_load:
+    max_lines: 220
+    reason: Integration load scenario intentionally keeps timing, ingest, and metric assertions in one flow.
+  apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py::_appendix_b_page:
+    max_lines: 207
+    reason: Dense appendix drawing routine retained until PDF rendering is split into smaller layout helpers.
+  apps/server/tests/use_cases/run/test_post_analysis_executor.py::test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar:
+    max_lines: 206
+    reason: Post-analysis context summary persistence scenario kept together to preserve setup/assertion context.


### PR DESCRIPTION
Fixes #3587

## What changed
- Turned `tools/dev/loc_check.py` into a default-failing maintainability gate.
- Added file-size and Python function-size thresholds.
- Added `tools/dev/maintainability_allowlist.yml` with `max_lines` and reasons for current oversized files/functions.
- Fail on new offenders, allowlist growth, stale allowlist entries, and invalid allowlist shape.
- Added `make maintainability-check` and wired the gate into `make lint` and CI repo hygiene.
- Added focused tests for function offenders and allowlist pass/growth behavior.

## Why
The old LOC report was advisory. New large modules or functions could land without a review signal. This keeps existing debt explicit while blocking silent growth.

## Validation
- `apps/server/.venv/bin/python -m ruff format tools/dev/loc_check.py apps/server/tests/hygiene/test_loc_check.py`
- `apps/server/.venv/bin/python -m ruff check tools/dev/loc_check.py apps/server/tests/hygiene/test_loc_check.py`
- `apps/server/.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_loc_check.py`
- `make maintainability-check`
- `apps/server/.venv/bin/python tools/dev/check_hygiene.py`
- `git diff --check`

## Risks / tradeoffs
- The gate is intentionally soft for existing debt: allowlisted offenders can stay, but cannot grow without updating `max_lines` and reason.
- Function-length measurement is Python AST based. TS/JS/sh still get file-size coverage, not function-size coverage.
- The threshold is review-oriented, not a demand for mechanical splits.

## Follow-ups
- Split the allowlisted orchestration/rendering/hygiene functions in separate focused refactors.