### PR TITLE
Remove unused rapidocr dev dependency

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -54,7 +54,6 @@ dev = [
   "pytest-randomly>=3.16,<5",
   "pytest-timeout>=2.4.0,<3",
   "pytest-xdist>=3.8.0,<4",
-  "rapidocr-onnxruntime>=1.2.3,<1.3",
   "ruff>=0.15.10,<0.16",
 ]
 


### PR DESCRIPTION
Fixes #3588

## What changed
- Removed `rapidocr-onnxruntime` from the backend `dev` optional dependency group.

## Why
The repo has no `rapidocr` or `onnxruntime` imports, tests, tooling, or docs. Keeping the package only adds install weight and pin maintenance.

## Validation
- Repo search for `rapidocr` / `onnxruntime` outside ignored envs found no matches.
- `cd apps/server && .venv/bin/python -m deptry . tests --config pyproject.toml`
- `apps/server/.venv/bin/python tools/dev/check_hygiene.py`
- `git diff --check`

## Risks / tradeoffs
- If OCR/PDF-image parsing returns later, the dependency should be reintroduced with a concrete import/test owner.
- Local `.venv` has no `pip` module, so no local reinstall was possible for this metadata-only removal.

## Follow-ups
- None.