### PR TITLE
Tighten UI TypeScript strictness

### DIFF
--- a/apps/ui/src/app/features/cars_tire_setup.ts
+++ b/apps/ui/src/app/features/cars_tire_setup.ts
@@ -10,6 +10,19 @@ interface TireDimensions {
 
 type AspectsRecord = Record<string, number | string | null | undefined>;
 
+interface TireSetupAspects {
+  rim_in: number;
+  tire_aspect_pct: number;
+  tire_width_mm: number;
+  front_tire_width_mm?: number;
+  front_tire_aspect_pct?: number;
+  front_rim_in?: number;
+  rear_tire_width_mm?: number;
+  rear_tire_aspect_pct?: number;
+  rear_rim_in?: number;
+  default_axle_for_speed?: string;
+}
+
 function isPositiveNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
@@ -112,13 +125,13 @@ export function formatSavedCarTireSummary(
 
 export function tireSetupAspectsFromOption(
   option: CarLibraryTireOption,
-): Record<string, number | string> {
+): TireSetupAspects | Record<string, never> {
   const front = tireOptionFront(option);
   const rear = tireOptionRear(option);
   if (!front || !rear) {
     return {};
   }
-  const payload: Record<string, number | string> = {
+  const payload: TireSetupAspects = {
     rim_in: option.rim_in,
     tire_aspect_pct: option.tire_aspect_pct,
     tire_width_mm: option.tire_width_mm,

--- a/apps/ui/src/vite-env.d.ts
+++ b/apps/ui/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMetaEnv {
+  readonly VITE_UI_MSW_MODE?: string;
+}

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -13,6 +13,11 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "strict": true,
+    // UI boundary-safety policy: ratchet strictness beyond baseline `strict`
+    // as production source and the test typecheck baseline are paid down.
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "skipLibCheck": true,
     "noEmit": true,
     "types": [

--- a/apps/ui/tsconfig.test.json
+++ b/apps/ui/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // Production source is gated first; test fixtures still carry
+    // index-signature dot-access debt tracked by the test typecheck baseline.
+    "noPropertyAccessFromIndexSignature": false,
     "types": [
       "vite/client",
       "vitest"


### PR DESCRIPTION
Fixes #3589

## What changed
- Enabled `noFallthroughCasesInSwitch`, `noImplicitOverride`, and production `noPropertyAccessFromIndexSignature` in `apps/ui/tsconfig.json`.
- Documented the UI strictness ratchet policy in the TypeScript config.
- Added a production-first test config override for existing test fixture index-signature dot-access debt.
- Added explicit `TireSetupAspects` typing for car tire setup payloads.
- Added `ImportMetaEnv.VITE_UI_MSW_MODE` typing so mock-mode env access is explicit.

## Why
These flags catch control-flow, override, and index-signature mistakes beyond baseline `strict` without forcing a broad optional/indexed-access refactor in the same PR.

## Validation
- `PYTHON=/workspace/VibeSensor/apps/server/.venv/bin/python npm run typecheck`
- `npm run typecheck:tests`
- `PYTHON=/workspace/VibeSensor/apps/server/.venv/bin/python make ui-typecheck`
- `apps/server/.venv/bin/python tools/dev/check_hygiene.py`
- `npx biome lint tsconfig.json tsconfig.test.json src/app/features/cars_tire_setup.ts src/main.ts src/mocks/browser.ts src/vite-env.d.ts`
- `git diff --check`

## Risks / tradeoffs
- Test files still opt out of `noPropertyAccessFromIndexSignature` because existing fixtures have broad dot-access debt. Production source is gated first.
- `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` still produce broader source diagnostics and are left for separate focused cleanup.

## Follow-ups
- Pay down test fixture index-signature dot access and remove the test override.
- Enable `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` in later slices.