### PR TITLE
Deduplicate shared repo-tooling helpers

### DIFF
--- a/apps/server/tests/hygiene/test_loc_check.py
+++ b/apps/server/tests/hygiene/test_loc_check.py
@@ -46,7 +46,7 @@ def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
             stderr="",
         )
 
-    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _fake_run)
 
     assert module._tracked_files(repo_root) == ["apps/server/main.py", "README.md"]
 
@@ -75,7 +75,7 @@ def test_main_falls_back_to_repo_walk_outside_git_checkout(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main([]) == 0
 
@@ -107,7 +107,7 @@ def test_main_fails_when_optional_loc_threshold_is_exceeded(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main(["--fail-over", "2"]) == 1
 
@@ -136,7 +136,7 @@ def test_main_passes_when_optional_loc_threshold_is_not_exceeded(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main(["--fail-over", "2"]) == 0
 
@@ -160,7 +160,7 @@ def test_main_fails_for_unallowlisted_large_python_function(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main(["--file-fail-over", "100", "--function-fail-over", "2"]) == 1
 
@@ -200,7 +200,7 @@ def test_main_allows_reviewed_file_and_function_allowlist(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main([]) == 0
 
@@ -237,7 +237,7 @@ def test_main_fails_when_allowlisted_file_or_function_grows(
     def _raise_git_failure(*args, **kwargs):  # type: ignore[no-untyped-def]
         raise subprocess.CalledProcessError(128, args[0])
 
-    monkeypatch.setattr(module.subprocess, "run", _raise_git_failure)
+    monkeypatch.setattr(module._repo_tooling_support.subprocess, "run", _raise_git_failure)
 
     assert module.main([]) == 1
 

--- a/apps/server/tests/hygiene/test_repo_tooling_support.py
+++ b/apps/server/tests/hygiene/test_repo_tooling_support.py
@@ -1,0 +1,74 @@
+"""Guard shared repo-tooling helper behavior."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_REPO_TOOLING_SUPPORT = REPO_ROOT / "tools" / "repo_tooling_support.py"
+
+
+def _load_repo_tooling_support_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "repo_tooling_support_test_module",
+        _REPO_TOOLING_SUPPORT,
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_REPO_TOOLING_SUPPORT}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_shell_command_preserves_chains_and_normalizes_command_token() -> None:
+    module = _load_repo_tooling_support_module()
+
+    def _normalize_python(token: str) -> str:
+        if Path(token.strip("\"'")).name.startswith("python"):
+            return "python"
+        return token
+
+    assert (
+        module.normalize_shell_command(
+            "env FOO=bar /opt/bin/python3 -m pytest && echo done",
+            command_token_normalizer=_normalize_python,
+        )
+        == "env FOO=bar python -m pytest && echo done"
+    )
+
+
+def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
+    module = _load_repo_tooling_support_module()
+    repo_root = Path("/tmp/nonexistent")
+
+    def _fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
+        assert args == (
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "ls-files",
+                "--cached",
+            ],
+        )
+        assert kwargs["check"] is True
+        assert kwargs["text"] is True
+        assert kwargs["capture_output"] is True
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout="tools/dev/check_hygiene.py\ntools/tests/ci_workflow_manifest.py\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    assert module.tracked_files(repo_root, excluded_dirs=()) == [
+        "tools/dev/check_hygiene.py",
+        "tools/tests/ci_workflow_manifest.py",
+    ]

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -17,6 +17,19 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
 _UI_BOOTSTRAP_HELPER_WORKFLOW_CMD = "node ../../tools/ui/ensure_ui_bootstrap.mjs"
 _UI_DERIVATIVE_SETUP_WORKFLOW_CMD = "npm run setup:generated-contracts"
 _UI_MANUAL_CHUNK_PACKAGE_RE = re.compile(r'"/(?!node_modules/)((?:@[^/]+/)?[^/]+)/"')
@@ -1593,37 +1606,17 @@ def _normalize_python_token(token: str) -> str:
 
 
 def _normalize_tokenized_command(tokens: list[str]) -> str:
-    if not tokens:
-        return ""
-    normalized = list(tokens)
-    command_index = 0
-    if normalized[0] == "env":
-        command_index = 1
-        while command_index < len(normalized) and "=" in normalized[command_index]:
-            command_index += 1
-        if command_index >= len(normalized):
-            return shlex.join(normalized)
-    normalized[command_index] = _normalize_python_token(normalized[command_index])
-    return shlex.join(normalized)
+    return _repo_tooling_support.normalize_tokenized_command(
+        tokens,
+        command_token_normalizer=_normalize_python_token,
+    )
 
 
 def _normalize_shell_command(command: str) -> str:
-    tokens = shlex.split(command)
-    if "&&" not in tokens:
-        return _normalize_tokenized_command(tokens)
-
-    parts: list[str] = []
-    current: list[str] = []
-    for token in tokens:
-        if token == "&&":
-            if current:
-                parts.append(_normalize_tokenized_command(current))
-                current = []
-            continue
-        current.append(token)
-    if current:
-        parts.append(_normalize_tokenized_command(current))
-    return " && ".join(parts)
+    return _repo_tooling_support.normalize_shell_command(
+        command,
+        command_token_normalizer=_normalize_python_token,
+    )
 
 
 def _normalize_env(env: Mapping[str, object] | None) -> str:

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -11,8 +11,8 @@ Exit 0 if clean, 1 if violations found.
 
 from __future__ import annotations
 
+import importlib.util
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -63,33 +63,28 @@ GENERATED_REPO_PATH_REFERENCES = {
     "apps/ui/src/constants.ts",
 }
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
+
 
 def _walk_files(repo_root: Path) -> list[str]:
-    files: list[str] = []
-    for path in repo_root.rglob("*"):
-        if not path.is_file():
-            continue
-        rel = path.relative_to(repo_root)
-        if any(part in EXCLUDED_DIRS for part in rel.parts):
-            continue
-        files.append(rel.as_posix())
-    return files
+    return _repo_tooling_support.walk_files(repo_root, EXCLUDED_DIRS)
 
 
 def _tracked_files(repo_root: Path) -> list[str]:
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "ls-files", "--cached"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tracked = [line for line in result.stdout.splitlines() if line]
-        if tracked:
-            return tracked
-    except (OSError, subprocess.CalledProcessError):
-        pass
-    return _walk_files(repo_root)
+    return _repo_tooling_support.tracked_files(repo_root, EXCLUDED_DIRS)
 
 
 def _check_large_code_blocks(docs_files: list[str]) -> list[str]:

--- a/tools/dev/fuzz_analysis_engine.py
+++ b/tools/dev/fuzz_analysis_engine.py
@@ -9,9 +9,9 @@ script writes a JSON reproduction artifact under ``artifacts/fuzz/``.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
-import signal
 import subprocess
 import sys
 import tempfile
@@ -25,6 +25,19 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
 ARTIFACT_DIR = REPO_ROOT / "artifacts" / "fuzz"
 
 SENSOR_FIXTURES: tuple[dict[str, str], ...] = (
@@ -689,22 +702,7 @@ def _build_worker_command(
 
 
 def _terminate_processes(processes: Sequence[subprocess.Popen[str]]) -> None:
-    alive = [process for process in processes if process.poll() is None]
-    for process in alive:
-        process.send_signal(signal.SIGTERM)
-    deadline = time.monotonic() + 5.0
-    while alive and time.monotonic() < deadline:
-        alive = [process for process in alive if process.poll() is None]
-        if alive:
-            time.sleep(0.1)
-    for process in alive:
-        process.kill()
-    for process in processes:
-        try:
-            process.wait(timeout=1.0)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=1.0)
+    _repo_tooling_support.terminate_processes(processes)
 
 
 def _run_worker_main(config: FuzzConfig) -> dict[str, object]:

--- a/tools/dev/fuzz_processing_pipeline.py
+++ b/tools/dev/fuzz_processing_pipeline.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
-import signal
 import subprocess
 import sys
 import tempfile
@@ -22,6 +22,19 @@ from typing import Any, Literal
 import numpy as np
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
 ARTIFACT_DIR = REPO_ROOT / "artifacts" / "fuzz"
 
 TargetName = Literal["strength", "fft", "processor", "all"]
@@ -205,22 +218,7 @@ def _build_worker_command(
 
 
 def _terminate_processes(processes: Sequence[subprocess.Popen[str]]) -> None:
-    alive = [process for process in processes if process.poll() is None]
-    for process in alive:
-        process.send_signal(signal.SIGTERM)
-    deadline = time.monotonic() + 5.0
-    while alive and time.monotonic() < deadline:
-        alive = [process for process in alive if process.poll() is None]
-        if alive:
-            time.sleep(0.1)
-    for process in alive:
-        process.kill()
-    for process in processes:
-        try:
-            process.wait(timeout=1.0)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=1.0)
+    _repo_tooling_support.terminate_processes(processes)
 
 
 def _strength_case_strategy(st: Any) -> Any:

--- a/tools/dev/loc_check.py
+++ b/tools/dev/loc_check.py
@@ -21,14 +21,29 @@ from __future__ import annotations
 
 import argparse
 import ast
-from dataclasses import dataclass
+import importlib.util
 import os
-import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = REPO_ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
 
 TOP_N = 25
 DEFAULT_FILE_THRESHOLD_LINES = 1200
@@ -218,31 +233,11 @@ def _load_allowlist(path: Path) -> MaintainabilityAllowlist:
 
 
 def _walk_files(repo_root: Path) -> list[str]:
-    files: list[str] = []
-    for path in repo_root.rglob("*"):
-        if not path.is_file():
-            continue
-        rel = path.relative_to(repo_root)
-        if any(part in EXCLUDE_DIRS for part in rel.parts):
-            continue
-        files.append(rel.as_posix())
-    return files
+    return _repo_tooling_support.walk_files(repo_root, EXCLUDE_DIRS)
 
 
 def _tracked_files(repo_root: Path) -> list[str]:
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "ls-files", "--cached"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        tracked = [line for line in result.stdout.splitlines() if line]
-        if tracked:
-            return tracked
-    except (OSError, subprocess.CalledProcessError):
-        pass
-    return _walk_files(repo_root)
+    return _repo_tooling_support.tracked_files(repo_root, EXCLUDE_DIRS)
 
 
 def _should_check(path: str) -> bool:

--- a/tools/repo_tooling_support.py
+++ b/tools/repo_tooling_support.py
@@ -1,0 +1,139 @@
+"""Shared helpers for repository tooling scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from types import ModuleType
+
+CommandTokenNormalizer = Callable[[str], str]
+
+
+def walk_files(repo_root: Path, excluded_dirs: Iterable[str]) -> list[str]:
+    excluded = set(excluded_dirs)
+    files: list[str] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(repo_root)
+        if any(part in excluded for part in rel.parts):
+            continue
+        files.append(rel.as_posix())
+    return files
+
+
+def tracked_files(repo_root: Path, excluded_dirs: Iterable[str]) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "--cached"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tracked = [line for line in result.stdout.splitlines() if line]
+        if tracked:
+            return tracked
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    return walk_files(repo_root, excluded_dirs)
+
+
+def normalize_tokenized_command(
+    tokens: list[str],
+    *,
+    command_token_normalizer: CommandTokenNormalizer | None = None,
+) -> str:
+    if not tokens:
+        return ""
+    normalized = list(tokens)
+    command_index = 0
+    if normalized[0] == "env":
+        command_index = 1
+        while command_index < len(normalized) and "=" in normalized[command_index]:
+            command_index += 1
+        if command_index >= len(normalized):
+            return shlex.join(normalized)
+    if command_token_normalizer is not None:
+        normalized[command_index] = command_token_normalizer(normalized[command_index])
+    return shlex.join(normalized)
+
+
+def normalize_shell_command(
+    command: str,
+    *,
+    command_token_normalizer: CommandTokenNormalizer | None = None,
+) -> str:
+    tokens = shlex.split(command)
+    if "&&" not in tokens:
+        return normalize_tokenized_command(
+            tokens,
+            command_token_normalizer=command_token_normalizer,
+        )
+
+    parts: list[str] = []
+    current: list[str] = []
+    for token in tokens:
+        if token == "&&":
+            if current:
+                parts.append(
+                    normalize_tokenized_command(
+                        current,
+                        command_token_normalizer=command_token_normalizer,
+                    )
+                )
+                current = []
+            continue
+        current.append(token)
+    if current:
+        parts.append(
+            normalize_tokenized_command(
+                current,
+                command_token_normalizer=command_token_normalizer,
+            )
+        )
+    return " && ".join(parts)
+
+
+def load_module_from_path(module_name: str, module_path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_parallel_runner_support(current_file: str | Path) -> ModuleType:
+    helper_path = Path(current_file).with_name("_parallel_runner_support.py")
+    return load_module_from_path("_parallel_runner_support", helper_path)
+
+
+def terminate_processes(
+    processes: Sequence[subprocess.Popen[str]],
+    *,
+    grace_seconds: float = 5.0,
+    wait_timeout_seconds: float = 1.0,
+) -> None:
+    alive = [process for process in processes if process.poll() is None]
+    for process in alive:
+        process.send_signal(signal.SIGTERM)
+    deadline = time.monotonic() + grace_seconds
+    while alive and time.monotonic() < deadline:
+        alive = [process for process in alive if process.poll() is None]
+        if alive:
+            time.sleep(0.1)
+    for process in alive:
+        process.kill()
+    for process in processes:
+        try:
+            process.wait(timeout=wait_timeout_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=wait_timeout_seconds)

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import re
 import shlex
 from collections.abc import Collection, Mapping
@@ -12,6 +13,19 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_repo_tooling_support():
+    helper_path = ROOT / "tools" / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_repo_tooling_support = _load_repo_tooling_support()
 _CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 _INSTALL_STEP_NAMES = frozenset(
     {
@@ -105,26 +119,11 @@ def _substitute_matrix_values(
 
 
 def _normalize_tokenized_command(tokens: list[str]) -> str:
-    return shlex.join(tokens)
+    return _repo_tooling_support.normalize_tokenized_command(tokens)
 
 
 def _normalize_shell_command(command: str) -> str:
-    tokens = shlex.split(command)
-    if "&&" not in tokens:
-        return _normalize_tokenized_command(tokens)
-
-    parts: list[str] = []
-    current: list[str] = []
-    for token in tokens:
-        if token == "&&":
-            if current:
-                parts.append(_normalize_tokenized_command(current))
-                current = []
-            continue
-        current.append(token)
-    if current:
-        parts.append(_normalize_tokenized_command(current))
-    return " && ".join(parts)
+    return _repo_tooling_support.normalize_shell_command(command)
 
 
 def _normalize_env(env: Mapping[str, object] | None) -> str:

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -19,19 +19,18 @@ from contextlib import contextmanager
 from pathlib import Path
 
 
-def _load_parallel_runner_support():
-    helper_path = Path(__file__).with_name("_parallel_runner_support.py")
-    spec = importlib.util.spec_from_file_location(
-        "_parallel_runner_support", helper_path
-    )
+def _load_repo_tooling_support():
+    helper_path = Path(__file__).resolve().parents[1] / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
     if spec is None or spec.loader is None:
-        raise ImportError(f"Unable to load parallel runner helpers from {helper_path}")
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-_parallel_runner_support = _load_parallel_runner_support()
+_repo_tooling_support = _load_repo_tooling_support()
+_parallel_runner_support = _repo_tooling_support.load_parallel_runner_support(__file__)
 resolve_duration_cache_path = _parallel_runner_support.duration_cache_path
 read_duration_cache = _parallel_runner_support.load_duration_cache
 merge_duration_observations = _parallel_runner_support.merge_duration_observations

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -32,19 +32,18 @@ from vibesensor.use_cases.isolated_server_runtime import (
 )
 
 
-def _load_parallel_runner_support():
-    helper_path = Path(__file__).with_name("_parallel_runner_support.py")
-    spec = importlib.util.spec_from_file_location(
-        "_parallel_runner_support", helper_path
-    )
+def _load_repo_tooling_support():
+    helper_path = Path(__file__).resolve().parents[1] / "repo_tooling_support.py"
+    spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
     if spec is None or spec.loader is None:
-        raise ImportError(f"Unable to load parallel runner helpers from {helper_path}")
+        raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-_parallel_runner_support = _load_parallel_runner_support()
+_repo_tooling_support = _load_repo_tooling_support()
+_parallel_runner_support = _repo_tooling_support.load_parallel_runner_support(__file__)
 resolve_duration_cache_path = _parallel_runner_support.duration_cache_path
 read_duration_cache = _parallel_runner_support.load_duration_cache
 merge_duration_observations = _parallel_runner_support.merge_duration_observations


### PR DESCRIPTION
Fixes #3590

## What changed
- Added `tools/repo_tooling_support.py` for shared repo-tooling primitives.
- Moved tracked-file discovery, shell command normalization, parallel-runner support loading, and fuzzer process termination behavior into the shared module.
- Kept script-local wrappers where existing callers/tests use private helper names.
- Added focused shared-helper tests and updated LOC tests to patch the shared subprocess boundary.

## Why
Duplicate helper bodies had drift risk across hygiene, CI manifest, docs lint, LOC checks, parallel runners, and fuzzers. One implementation is safer.

## Validation
- `apps/server/.venv/bin/python -m ruff format ...`
- `apps/server/.venv/bin/python -m ruff check ...`
- `apps/server/.venv/bin/python -m pytest apps/server/tests/hygiene/test_repo_tooling_support.py apps/server/tests/hygiene/test_loc_check.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py`
- `apps/server/.venv/bin/python tools/dev/check_hygiene.py`
- `apps/server/.venv/bin/python tools/dev/docs_lint.py`
- `make maintainability-check`
- `apps/server/.venv/bin/python tools/tests/run_backend_parallel.py --help`
- `apps/server/.venv/bin/python tools/tests/run_e2e_parallel.py --help`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks / tradeoffs / edges
- Medium change: many tooling entrypoints now depend on one shared helper file.
- Loader stays explicit by file path to avoid sys.path/PYTHONPATH hacks blocked by hygiene checks.
- Behavior intentionally unchanged; wrappers keep existing private helper surfaces.

## Follow-ups
None.