### PR TITLE
Add release GitHub API timeouts

### DIFF
--- a/apps/server/tests/hygiene/test_main_release_scripts.py
+++ b/apps/server/tests/hygiene/test_main_release_scripts.py
@@ -271,3 +271,105 @@ def test_cleanup_releases_reports_missing_tag_and_continues(
     assert "Deleting superseded Wheel / ESP release server-v2026.4.5" in output
     assert "Tag server-v2026.4.5 was already absent" in output
     assert set(deleted_paths) == {"releases/2", "git/refs/tags/server-v2026.4.5"}
+
+
+def test_github_request_uses_timeout_and_returns_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_main_release_module()
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"ok": true}'
+
+    def _fake_urlopen(req, *, timeout):  # type: ignore[no-untyped-def]
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        return _FakeResponse()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(module.request, "urlopen", _fake_urlopen)
+
+    assert module._github_request("GET", "Skamba/VibeSensor", "releases") == {"ok": True}
+    assert captured == {
+        "method": "GET",
+        "url": "https://api.github.com/repos/Skamba/VibeSensor/releases",
+        "timeout": module.GITHUB_API_TIMEOUT_S,
+    }
+
+
+def test_github_request_reports_url_errors_with_method_and_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_main_release_module()
+
+    def _raise_url_error(req, *, timeout):  # type: ignore[no-untyped-def]
+        del req, timeout
+        raise error.URLError("network unavailable")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(module.request, "urlopen", _raise_url_error)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._github_request("GET", "Skamba/VibeSensor", "releases")
+
+    assert str(exc_info.value) == (
+        "GitHub API GET /repos/Skamba/VibeSensor/releases failed: network unavailable"
+    )
+
+
+def test_github_request_reports_timeouts_with_method_path_and_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_main_release_module()
+
+    def _raise_timeout(req, *, timeout):  # type: ignore[no-untyped-def]
+        del req, timeout
+        raise TimeoutError("timed out")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(module.request, "urlopen", _raise_timeout)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._github_request(
+            "DELETE",
+            "Skamba/VibeSensor",
+            "git/refs/tags/server-v2026.4.5",
+        )
+
+    assert str(exc_info.value) == (
+        "GitHub API DELETE "
+        "/repos/Skamba/VibeSensor/git/refs/tags/server-v2026.4.5 "
+        "timed out after 30s."
+    )
+
+
+def test_github_request_preserves_http_errors_for_delete_404_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_main_release_module()
+    http_error = error.HTTPError("https://example.invalid", 404, "missing", None, None)
+
+    def _raise_http_error(req, *, timeout):  # type: ignore[no-untyped-def]
+        del req, timeout
+        raise http_error
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(module.request, "urlopen", _raise_http_error)
+
+    with pytest.raises(error.HTTPError) as exc_info:
+        module._github_request(
+            "DELETE",
+            "Skamba/VibeSensor",
+            "git/refs/tags/server-v2026.4.5",
+        )
+
+    assert exc_info.value is http_error

--- a/tools/release/main_release.py
+++ b/tools/release/main_release.py
@@ -18,6 +18,7 @@ from urllib import error, request
 _STANDARD_ESP32_APP_OFFSET = "0x10000"
 _ENV_OFFSET_RE = re.compile(r"ESP32_APP_OFFSET[^0-9A-Fa-f]*(0x[0-9A-Fa-f]+)")
 _GITHUB_API_BASE = "https://api.github.com"
+GITHUB_API_TIMEOUT_S = 30
 
 
 @dataclass(frozen=True)
@@ -230,8 +231,9 @@ def _github_token() -> str:
 
 
 def _github_request(method: str, repo: str, path: str) -> object | None:
+    api_path = f"/repos/{repo}/{path.lstrip('/')}"
     req = request.Request(
-        f"{_GITHUB_API_BASE}/repos/{repo}/{path.lstrip('/')}",
+        f"{_GITHUB_API_BASE}{api_path}",
         method=method,
         headers={
             "Accept": "application/vnd.github+json",
@@ -239,8 +241,19 @@ def _github_request(method: str, repo: str, path: str) -> object | None:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with request.urlopen(req) as response:
-        payload = response.read().decode("utf-8")
+    try:
+        with request.urlopen(req, timeout=GITHUB_API_TIMEOUT_S) as response:
+            payload = response.read().decode("utf-8")
+    except error.HTTPError:
+        raise
+    except TimeoutError as exc:
+        raise SystemExit(
+            f"GitHub API {method} {api_path} timed out after {GITHUB_API_TIMEOUT_S}s."
+        ) from exc
+    except error.URLError as exc:
+        raise SystemExit(
+            f"GitHub API {method} {api_path} failed: {exc.reason}"
+        ) from exc
     if not payload:
         return None
     return json.loads(payload)


### PR DESCRIPTION
Fixes #3592

## What changed
- Added `GITHUB_API_TIMEOUT_S = 30` to `tools/release/main_release.py`.
- Passed the timeout to direct `urllib.request.urlopen` GitHub API calls.
- Converted non-HTTP URL and timeout failures into `SystemExit` messages with HTTP method and API path context.
- Preserved `HTTPError` pass-through so existing delete-404 cleanup tolerance still works.
- Added focused tests for timeout forwarding, URL diagnostics, timeout diagnostics, and HTTPError preservation.

## Why
Release cleanup should not hang indefinitely on direct GitHub API calls. Failures need enough context to identify the failing API operation.

## Validation
- `apps/server/.venv/bin/python -m ruff format tools/release/main_release.py apps/server/tests/hygiene/test_main_release_scripts.py`
- `apps/server/.venv/bin/python -m ruff check tools/release/main_release.py apps/server/tests/hygiene/test_main_release_scripts.py`
- `apps/server/.venv/bin/python -m pytest apps/server/tests/hygiene/test_main_release_scripts.py`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks / tradeoffs / edges
- Small release-tooling change.
- HTTP status failures keep the previous exception path, so tag-delete 404 tolerance is unchanged.
- Timeout value is fixed at 30 seconds; no runtime config added.

## Follow-ups
None.