### PR TITLE
Return explicit ESP flash cancel code

### DIFF
--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from vibesensor.use_cases.updates.firmware.esp_flash_runner import (
+    FLASH_CANCELLED_RETURN_CODE,
+    SubprocessFlashCommandRunner,
+)
+
+
+class _FakeStdout:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    async def readline(self) -> bytes:
+        await asyncio.sleep(0)
+        if not self._lines:
+            return b""
+        return self._lines.pop(0)
+
+
+class _FakeFlashProcess:
+    def __init__(self, lines: list[bytes]) -> None:
+        self.stdout = _FakeStdout(lines)
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        await asyncio.sleep(0)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+@pytest.mark.asyncio
+async def test_subprocess_flash_runner_returns_cancel_code_before_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeFlashProcess([])
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        return process
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.firmware.esp_flash_runner.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+    lines: list[str] = []
+
+    result = await SubprocessFlashCommandRunner().run(
+        ["esptool.py", "erase_flash"],
+        cwd="/tmp",
+        line_cb=lines.append,
+        cancel_event=cancel_event,
+    )
+
+    assert result == FLASH_CANCELLED_RETURN_CODE
+    assert lines == ["Flash cancelled by request"]
+    assert process.terminated is True
+    assert process.killed is False
+
+
+@pytest.mark.asyncio
+async def test_subprocess_flash_runner_returns_cancel_code_during_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeFlashProcess([b"Connecting...\n"])
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        return process
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.firmware.esp_flash_runner.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    cancel_event = asyncio.Event()
+    lines: list[str] = []
+
+    def _line_cb(line: str) -> None:
+        lines.append(line)
+        if line == "Connecting...":
+            cancel_event.set()
+
+    result = await SubprocessFlashCommandRunner().run(
+        ["esptool.py", "write_flash"],
+        cwd="/tmp",
+        line_cb=_line_cb,
+        cancel_event=cancel_event,
+    )
+
+    assert result == FLASH_CANCELLED_RETURN_CODE
+    assert lines == ["Connecting...", "Flash cancelled by request"]
+    assert process.terminated is True
+    assert process.killed is False

--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
@@ -11,8 +11,9 @@ from collections.abc import Callable
 from vibesensor.use_cases.updates.firmware.esp_flash_types import FlashCommandRunner
 
 LOGGER = logging.getLogger(__name__)
+FLASH_CANCELLED_RETURN_CODE = 130
 
-__all__ = ["SubprocessFlashCommandRunner"]
+__all__ = ["FLASH_CANCELLED_RETURN_CODE", "SubprocessFlashCommandRunner"]
 
 
 class SubprocessFlashCommandRunner(FlashCommandRunner):
@@ -38,8 +39,11 @@ class SubprocessFlashCommandRunner(FlashCommandRunner):
         if proc.stdout is None:  # pragma: no cover – PIPE always sets stdout
             raise RuntimeError("subprocess stdout is None despite PIPE setting")
         started_at = time.monotonic()
+        cancelled = False
         while proc.returncode is None:
             if cancel_event.is_set():
+                line_cb("Flash cancelled by request")
+                cancelled = True
                 proc.terminate()
                 break
             if timeout_s is not None and (time.monotonic() - started_at) > timeout_s:
@@ -62,4 +66,6 @@ class SubprocessFlashCommandRunner(FlashCommandRunner):
             with contextlib.suppress(ProcessLookupError):
                 proc.kill()
             await proc.wait()
+        if cancelled:
+            return FLASH_CANCELLED_RETURN_CODE
         return proc.returncode or 0


### PR DESCRIPTION
Fixes #3593

## What changed
- Added `FLASH_CANCELLED_RETURN_CODE = 130` to the subprocess ESP flash runner.
- When cancellation is requested, the runner now emits `Flash cancelled by request`.
- Cancelled subprocess runs still terminate/wait/kill as before, but now return the explicit cancellation code instead of `proc.returncode or 0`.
- Added focused runner tests for cancel-before-output and cancel-during-output paths.

## Why
Cancelled flash operations must not be reported as successful if the subprocess exits with `0` after termination. The log should also show that cancellation was requested.

## Validation
- `apps/server/.venv/bin/python -m ruff format apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py`
- `apps/server/.venv/bin/python -m ruff check apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py`
- `apps/server/.venv/bin/python -m pytest apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks / tradeoffs / edges
- Small firmware-update behavior change.
- Cancellation code is fixed at 130, matching common interrupted-command convention.
- Timeout behavior still returns 124 and is unchanged.

## Follow-ups
None.