### PR TITLE
Add ESP flash timeout kill fallback

### DIFF
--- a/apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py
@@ -6,6 +6,7 @@ import pytest
 
 from vibesensor.use_cases.updates.firmware.esp_flash_runner import (
     FLASH_CANCELLED_RETURN_CODE,
+    FLASH_TIMEOUT_RETURN_CODE,
     SubprocessFlashCommandRunner,
 )
 
@@ -21,10 +22,22 @@ class _FakeStdout:
         return self._lines.pop(0)
 
 
+class _BlockingStdout:
+    async def readline(self) -> bytes:
+        await asyncio.sleep(60)
+        return b""
+
+
 class _FakeFlashProcess:
-    def __init__(self, lines: list[bytes]) -> None:
-        self.stdout = _FakeStdout(lines)
+    def __init__(
+        self,
+        lines: list[bytes] | None = None,
+        *,
+        ignore_terminate: bool = False,
+    ) -> None:
+        self.stdout = _FakeStdout(lines or [])
         self.returncode: int | None = None
+        self.ignore_terminate = ignore_terminate
         self.terminated = False
         self.killed = False
 
@@ -38,6 +51,8 @@ class _FakeFlashProcess:
     async def wait(self) -> int:
         await asyncio.sleep(0)
         if self.returncode is None:
+            if self.ignore_terminate and not self.killed:
+                await asyncio.sleep(60)
             self.returncode = 0
         return self.returncode
 
@@ -106,3 +121,38 @@ async def test_subprocess_flash_runner_returns_cancel_code_during_output(
     assert lines == ["Connecting...", "Flash cancelled by request"]
     assert process.terminated is True
     assert process.killed is False
+
+
+@pytest.mark.asyncio
+async def test_subprocess_flash_runner_kills_timed_out_process_that_ignores_terminate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeFlashProcess(ignore_terminate=True)
+    process.stdout = _BlockingStdout()
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        return process
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.firmware.esp_flash_runner.FLASH_SHUTDOWN_WAIT_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.firmware.esp_flash_runner.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    lines: list[str] = []
+
+    result = await SubprocessFlashCommandRunner().run(
+        ["esptool.py", "write_flash"],
+        cwd="/tmp",
+        line_cb=lines.append,
+        cancel_event=asyncio.Event(),
+        timeout_s=0.01,
+    )
+
+    assert result == FLASH_TIMEOUT_RETURN_CODE
+    assert lines == ["Command timed out after 0s"]
+    assert process.terminated is True
+    assert process.killed is True

--- a/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py
@@ -12,8 +12,31 @@ from vibesensor.use_cases.updates.firmware.esp_flash_types import FlashCommandRu
 
 LOGGER = logging.getLogger(__name__)
 FLASH_CANCELLED_RETURN_CODE = 130
+FLASH_TIMEOUT_RETURN_CODE = 124
+FLASH_SHUTDOWN_WAIT_S = 5.0
 
-__all__ = ["FLASH_CANCELLED_RETURN_CODE", "SubprocessFlashCommandRunner"]
+__all__ = [
+    "FLASH_CANCELLED_RETURN_CODE",
+    "FLASH_SHUTDOWN_WAIT_S",
+    "FLASH_TIMEOUT_RETURN_CODE",
+    "SubprocessFlashCommandRunner",
+]
+
+
+async def _terminate_process(
+    proc: asyncio.subprocess.Process,
+    *,
+    wait_timeout_s: float | None = None,
+) -> None:
+    proc.terminate()
+    shutdown_wait_s = FLASH_SHUTDOWN_WAIT_S if wait_timeout_s is None else wait_timeout_s
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=shutdown_wait_s)
+    except TimeoutError:
+        LOGGER.warning("Process did not exit after SIGTERM; sending SIGKILL.")
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        await proc.wait()
 
 
 class SubprocessFlashCommandRunner(FlashCommandRunner):
@@ -39,18 +62,15 @@ class SubprocessFlashCommandRunner(FlashCommandRunner):
         if proc.stdout is None:  # pragma: no cover – PIPE always sets stdout
             raise RuntimeError("subprocess stdout is None despite PIPE setting")
         started_at = time.monotonic()
-        cancelled = False
         while proc.returncode is None:
             if cancel_event.is_set():
                 line_cb("Flash cancelled by request")
-                cancelled = True
-                proc.terminate()
-                break
+                await _terminate_process(proc)
+                return FLASH_CANCELLED_RETURN_CODE
             if timeout_s is not None and (time.monotonic() - started_at) > timeout_s:
                 line_cb(f"Command timed out after {int(timeout_s)}s")
-                proc.terminate()
-                await proc.wait()
-                return 124
+                await _terminate_process(proc)
+                return FLASH_TIMEOUT_RETURN_CODE
             try:
                 line = await asyncio.wait_for(proc.stdout.readline(), timeout=0.25)
             except TimeoutError:
@@ -59,13 +79,4 @@ class SubprocessFlashCommandRunner(FlashCommandRunner):
                 await proc.wait()
                 break
             line_cb(line.decode("utf-8", errors="replace").rstrip("\n"))
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5.0)
-        except TimeoutError:
-            LOGGER.warning("Process did not exit after SIGTERM; sending SIGKILL.")
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            await proc.wait()
-        if cancelled:
-            return FLASH_CANCELLED_RETURN_CODE
         return proc.returncode or 0


### PR DESCRIPTION
## What changed
- Added one bounded ESP flash subprocess shutdown helper.
- Timeout and cancel paths now both terminate, wait briefly, then kill if the child ignores SIGTERM.
- Added an explicit timeout return-code constant and a regression for a timed-out child that ignores terminate.

## Why
Timeout already fired, but the old timeout branch awaited `proc.wait()` with no bound. A stuck flash child could hang the runner after timeout.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/use_cases/updates/firmware/esp_flash_runner.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/firmware/test_esp_flash_manager.py apps/server/tests/use_cases/updates/firmware/test_esp_flash_runner.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Timeout code stays `124`.
- Cancel code stays `130`.
- Shutdown wait stays 5 seconds before SIGKILL.
- Normal successful subprocess exit path is unchanged.

## Follow-ups
None.