### PR TITLE
Wait for killed updater subprocesses

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_runner.py
+++ b/apps/server/tests/use_cases/updates/test_update_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,31 @@ class _StaticRunner(CommandRunner):
     ) -> tuple[int, str, str]:
         self.calls.append((list(args), timeout, env))
         return (self._response.returncode, self._response.stdout, self._response.stderr)
+
+
+class _CancellableProcess:
+    def __init__(self, *, block_wait: bool = False) -> None:
+        self.returncode: int | None = None
+        self.block_wait = block_wait
+        self.communicate_started = asyncio.Event()
+        self.wait_called = asyncio.Event()
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        self.communicate_started.set()
+        await asyncio.sleep(60)
+        return (b"", b"")
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.wait_called.set()
+        if self.block_wait:
+            await asyncio.sleep(60)
+        await asyncio.sleep(0)
+        return self.returncode if self.returncode is not None else 0
 
 
 @pytest.mark.asyncio
@@ -80,3 +106,55 @@ async def test_status_command_reporter_logs_redacted_command_output_and_exit_cod
     assert any("[connecting_wifi] stdout: stdout line" in line for line in status.status.log_tail)
     assert any("[connecting_wifi] stderr: psk=***" in line for line in status.status.log_tail)
     assert any("[connecting_wifi] exit code: 7" in line for line in status.status.log_tail)
+
+
+@pytest.mark.asyncio
+async def test_command_runner_waits_for_killed_process_on_task_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _CancellableProcess()
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        return process
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.runner.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    task = asyncio.create_task(CommandRunner().run(["sleep", "60"], timeout=30))
+    await asyncio.wait_for(process.communicate_started.wait(), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
+
+    assert process.killed is True
+    assert process.wait_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_command_runner_bounds_wait_after_timeout_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _CancellableProcess(block_wait=True)
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):  # type: ignore[no-untyped-def]
+        del args, kwargs
+        return process
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.runner.COMMAND_KILL_WAIT_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.runner.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    result = await CommandRunner().run(["sleep", "60"], timeout=0.01)
+
+    assert result == (124, "", "Command timed out")
+    assert process.killed is True
+    assert process.wait_called.is_set()

--- a/apps/server/vibesensor/use_cases/updates/runner.py
+++ b/apps/server/vibesensor/use_cases/updates/runner.py
@@ -13,8 +13,10 @@ from typing import Protocol
 from vibesensor.use_cases.updates.privilege import build_sudo_args
 
 LOGGER = logging.getLogger(__name__)
+COMMAND_KILL_WAIT_S = 5.0
 
 __all__ = [
+    "COMMAND_KILL_WAIT_S",
     "CommandExecutionReporter",
     "CommandExecutionResult",
     "CommandRunner",
@@ -64,6 +66,22 @@ class CommandExecutionReporter(Protocol):
     ) -> None: ...
 
 
+async def _kill_process(
+    proc: asyncio.subprocess.Process,
+    *,
+    wait_timeout_s: float | None = None,
+) -> None:
+    with contextlib.suppress(ProcessLookupError, OSError):
+        proc.kill()
+    kill_wait_s = COMMAND_KILL_WAIT_S if wait_timeout_s is None else wait_timeout_s
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=kill_wait_s)
+    except ProcessLookupError:
+        pass
+    except TimeoutError:
+        LOGGER.warning("Killed command process did not exit within %.1fs.", kill_wait_s)
+
+
 class CommandRunner:
     """Execute shell commands.  Override for testing."""
 
@@ -91,19 +109,14 @@ class CommandRunner:
                 stderr_bytes.decode(errors="replace"),
             )
         except TimeoutError:
-            try:
-                if proc is not None:
-                    proc.kill()
-                    await proc.wait()
-            except ProcessLookupError:
-                pass  # process already exited
+            if proc is not None:
+                await _kill_process(proc)
             LOGGER.warning("Command timed out after %.0fs: %s", timeout, " ".join(args))
             return (124, "", "Command timed out")
         except asyncio.CancelledError:
             # Kill the subprocess so it doesn't outlive the cancelled task.
             if proc is not None:
-                with contextlib.suppress(ProcessLookupError, OSError):
-                    proc.kill()
+                await _kill_process(proc)
             raise
         except FileNotFoundError:
             LOGGER.warning("Command not found: %s", args[0] if args else "(empty)", exc_info=True)


### PR DESCRIPTION
## What changed
- Added one bounded updater subprocess kill/wait cleanup helper.
- Timeout and task-cancellation paths now both kill and wait briefly for the child to be reaped.
- Cancellation still re-raises `CancelledError`; timeout still returns `124`.
- Added regressions for cancellation cleanup and bounded timeout cleanup.

## Why
The old cancellation path killed the child but did not await `proc.wait()`. That made updater cancellation cleanup less deterministic than timeout cleanup and could leave reaping to the event loop.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/use_cases/updates/runner.py apps/server/tests/use_cases/updates/test_update_runner.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/use_cases/updates/runner.py apps/server/tests/use_cases/updates/test_update_runner.py`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/test_update_runner.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/test_update_runner.py apps/server/tests/use_cases/updates/test_update_manager_core.py apps/server/tests/use_cases/updates/test_update_manager_async.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Cancellation still propagates to callers.
- Timeout behavior remains a non-throwing `124` result.
- Cleanup wait is bounded at 5 seconds to avoid replacing one hang with another.
- Process-already-exited cases remain tolerated.

## Follow-ups
None.
