### PR TITLE
Bound updater command output capture

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_runner.py
+++ b/apps/server/tests/use_cases/updates/test_update_runner.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
 from test_support.update_status import build_update_status_harness
 
 from vibesensor.use_cases.updates.runner import (
+    COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
     CommandExecutionResult,
     CommandRunner,
     UpdateCommandExecutor,
@@ -30,18 +32,21 @@ class _StaticRunner(CommandRunner):
         return (self._response.returncode, self._response.stdout, self._response.stderr)
 
 
+class _BlockingStream:
+    async def read(self, n: int = -1) -> bytes:
+        del n
+        await asyncio.sleep(60)
+        return b""
+
+
 class _CancellableProcess:
     def __init__(self, *, block_wait: bool = False) -> None:
         self.returncode: int | None = None
         self.block_wait = block_wait
-        self.communicate_started = asyncio.Event()
+        self.stdout = _BlockingStream()
+        self.stderr = _BlockingStream()
         self.wait_called = asyncio.Event()
         self.killed = False
-
-    async def communicate(self) -> tuple[bytes, bytes]:
-        self.communicate_started.set()
-        await asyncio.sleep(60)
-        return (b"", b"")
 
     def kill(self) -> None:
         self.killed = True
@@ -50,6 +55,8 @@ class _CancellableProcess:
     async def wait(self) -> int:
         self.wait_called.set()
         if self.block_wait:
+            await asyncio.sleep(60)
+        if self.returncode is None:
             await asyncio.sleep(60)
         await asyncio.sleep(0)
         return self.returncode if self.returncode is not None else 0
@@ -124,7 +131,7 @@ async def test_command_runner_waits_for_killed_process_on_task_cancellation(
     )
 
     task = asyncio.create_task(CommandRunner().run(["sleep", "60"], timeout=30))
-    await asyncio.wait_for(process.communicate_started.wait(), timeout=1)
+    await asyncio.wait_for(process.wait_called.wait(), timeout=1)
 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -158,3 +165,25 @@ async def test_command_runner_bounds_wait_after_timeout_kill(
     assert result == (124, "", "Command timed out")
     assert process.killed is True
     assert process.wait_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_command_runner_bounds_stdout_and_stderr_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.runner.COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES",
+        16,
+    )
+    script = (
+        "import sys; "
+        "sys.stdout.write('out-' + 'A' * 40 + '-tail'); "
+        "sys.stderr.write('err-' + 'B' * 40 + '-tail')"
+    )
+
+    result = await CommandRunner().run([sys.executable, "-c", script], timeout=5)
+
+    assert result[0] == 0
+    assert result[1] == "[output truncated to last 16 bytes]\n" + ("A" * 11) + "-tail"
+    assert result[2] == "[output truncated to last 16 bytes]\n" + ("B" * 11) + "-tail"
+    assert COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES == 64 * 1024

--- a/apps/server/vibesensor/use_cases/updates/runner.py
+++ b/apps/server/vibesensor/use_cases/updates/runner.py
@@ -14,9 +14,11 @@ from vibesensor.use_cases.updates.privilege import build_sudo_args
 
 LOGGER = logging.getLogger(__name__)
 COMMAND_KILL_WAIT_S = 5.0
+COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES = 64 * 1024
 
 __all__ = [
     "COMMAND_KILL_WAIT_S",
+    "COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES",
     "CommandExecutionReporter",
     "CommandExecutionResult",
     "CommandRunner",
@@ -82,6 +84,52 @@ async def _kill_process(
         LOGGER.warning("Killed command process did not exit within %.1fs.", kill_wait_s)
 
 
+def _append_bounded(buffer: bytearray, chunk: bytes, *, limit_bytes: int) -> bool:
+    if limit_bytes <= 0:
+        buffer.clear()
+        return bool(chunk)
+    if len(chunk) >= limit_bytes:
+        buffer[:] = chunk[-limit_bytes:]
+        return True
+    buffer.extend(chunk)
+    excess = len(buffer) - limit_bytes
+    if excess > 0:
+        del buffer[:excess]
+        return True
+    return False
+
+
+async def _read_bounded_stream(
+    stream: asyncio.StreamReader | None,
+    *,
+    limit_bytes: int,
+) -> tuple[bytes, bool]:
+    if stream is None:
+        return (b"", False)
+    buffer = bytearray()
+    truncated = False
+    while chunk := await stream.read(8192):
+        truncated = _append_bounded(buffer, chunk, limit_bytes=limit_bytes) or truncated
+    return (bytes(buffer), truncated)
+
+
+def _decode_command_output(data: bytes, *, truncated: bool, limit_bytes: int) -> str:
+    decoded = data.decode(errors="replace")
+    if not truncated:
+        return decoded
+    return f"[output truncated to last {limit_bytes} bytes]\n{decoded}"
+
+
+async def _cancel_output_tasks(
+    *tasks: asyncio.Task[tuple[bytes, bool]] | None,
+) -> None:
+    pending_tasks = [task for task in tasks if task is not None and not task.done()]
+    for task in pending_tasks:
+        task.cancel()
+    if pending_tasks:
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+
 class CommandRunner:
     """Execute shell commands.  Override for testing."""
 
@@ -95,6 +143,8 @@ class CommandRunner:
         """Return (returncode, stdout, stderr)."""
         merged_env = {**os.environ, **env} if env else None
         proc: asyncio.subprocess.Process | None = None
+        stdout_task: asyncio.Task[tuple[bytes, bool]] | None = None
+        stderr_task: asyncio.Task[tuple[bytes, bool]] | None = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *args,
@@ -102,21 +152,45 @@ class CommandRunner:
                 stderr=asyncio.subprocess.PIPE,
                 env=merged_env,
             )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            stdout_task = asyncio.create_task(
+                _read_bounded_stream(
+                    proc.stdout,
+                    limit_bytes=COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
+                ),
+            )
+            stderr_task = asyncio.create_task(
+                _read_bounded_stream(
+                    proc.stderr,
+                    limit_bytes=COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
+                ),
+            )
+            await asyncio.wait_for(proc.wait(), timeout=timeout)
+            stdout_bytes, stdout_truncated = await stdout_task
+            stderr_bytes, stderr_truncated = await stderr_task
             return (
                 proc.returncode if proc.returncode is not None else 0,
-                stdout_bytes.decode(errors="replace"),
-                stderr_bytes.decode(errors="replace"),
+                _decode_command_output(
+                    stdout_bytes,
+                    truncated=stdout_truncated,
+                    limit_bytes=COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
+                ),
+                _decode_command_output(
+                    stderr_bytes,
+                    truncated=stderr_truncated,
+                    limit_bytes=COMMAND_OUTPUT_CAPTURE_LIMIT_BYTES,
+                ),
             )
         except TimeoutError:
             if proc is not None:
                 await _kill_process(proc)
+            await _cancel_output_tasks(stdout_task, stderr_task)
             LOGGER.warning("Command timed out after %.0fs: %s", timeout, " ".join(args))
             return (124, "", "Command timed out")
         except asyncio.CancelledError:
             # Kill the subprocess so it doesn't outlive the cancelled task.
             if proc is not None:
                 await _kill_process(proc)
+            await _cancel_output_tasks(stdout_task, stderr_task)
             raise
         except FileNotFoundError:
             LOGGER.warning("Command not found: %s", args[0] if args else "(empty)", exc_info=True)


### PR DESCRIPTION
## What changed
- Replaced full updater subprocess output capture with concurrent bounded stdout/stderr readers.
- Kept the last 64 KiB per stream and added an explicit truncation marker when data is dropped.
- Cancelled pending output reader tasks during timeout and task-cancellation cleanup.
- Added a regression that writes beyond the cap to stdout and stderr.

## Why
Updater commands can emit large failure output. Reporter logs already trim to 500 characters, but the runner still held complete stdout/stderr in memory first. That is avoidable risk on the Pi.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/use_cases/updates/runner.py apps/server/tests/use_cases/updates/test_update_runner.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/use_cases/updates/runner.py apps/server/tests/use_cases/updates/test_update_runner.py`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/test_update_runner.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/updates/test_update_runner.py apps/server/tests/use_cases/updates/test_update_manager_core.py apps/server/tests/use_cases/updates/test_update_manager_async.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Returned stdout/stderr may now include a truncation marker and only the tail of very large output.
- Return codes, timeout result `124`, and cancellation propagation stay unchanged.
- Reporter-level 500-character log truncation stays unchanged.
- The stream cap is fixed at 64 KiB per stream.

## Follow-ups
None.
