### PR TITLE
Avoid UDP ingest sample copy

### DIFF
--- a/apps/server/tests/adapters/udp/test_protocol.py
+++ b/apps/server/tests/adapters/udp/test_protocol.py
@@ -109,6 +109,20 @@ def test_data_roundtrip() -> None:
     np.testing.assert_array_equal(decoded.samples, samples)
 
 
+def test_parse_data_returns_read_only_view_over_datagram_payload() -> None:
+    client_id = bytes.fromhex("010203040506")
+    samples = np.array([[1, 2, 3], [4, 5, 6], [-2, -1, 0]], dtype=np.int16)
+    pkt = pack_data(client_id=client_id, seq=17, t0_us=123_456_789, samples=samples)
+
+    decoded = parse_data(pkt)
+
+    assert decoded.samples.flags.owndata is False
+    assert decoded.samples.flags.writeable is False
+    assert np.shares_memory(decoded.samples, np.frombuffer(pkt, dtype=np.uint8))
+    with pytest.raises(ValueError, match="read-only"):
+        decoded.samples[0, 0] = 99
+
+
 def test_parse_identify_cmd() -> None:
     client_id = bytes.fromhex("112233445566")
     cmd = pack_cmd_identify(client_id, cmd_seq=42, duration_ms=1500)

--- a/apps/server/tests/adapters/udp/test_udp_data_rx.py
+++ b/apps/server/tests/adapters/udp/test_udp_data_rx.py
@@ -41,6 +41,62 @@ async def test_datagram_received_queues_work_before_processing(fake_transport, d
 
 
 @pytest.mark.asyncio
+async def test_parse_to_ingest_keeps_representative_sensor_frames_as_read_only_views(
+    fake_transport,
+    drain_queue,
+) -> None:
+    registry = Mock()
+    registry.update_from_data.side_effect = [
+        DataUpdateResult(),
+        DataUpdateResult(),
+        DataUpdateResult(),
+    ]
+    registry.get.return_value = SimpleNamespace(sample_rate_hz=800)
+    processor = Mock()
+    raw_capture_sink = Mock()
+    proto = DataDatagramProtocol(
+        registry=registry,
+        processor=processor,
+        raw_capture_sink=raw_capture_sink,
+        queue_maxsize=8,
+    )
+    proto.connection_made(fake_transport)
+
+    frame_samples = 200
+    for sensor_index, client_id in enumerate(
+        (
+            bytes.fromhex("010203040506"),
+            bytes.fromhex("112233445566"),
+            bytes.fromhex("aabbccddeeff"),
+        )
+    ):
+        samples = (
+            np.arange(frame_samples * 3, dtype=np.int16).reshape(frame_samples, 3) + sensor_index
+        )
+        proto.datagram_received(
+            pack_data(client_id, seq=sensor_index + 1, t0_us=100_000, samples=samples),
+            ("127.0.0.1", 10001 + sensor_index),
+        )
+
+    await drain_queue(proto, timeout=1.0)
+
+    assert processor.ingest.call_count == 3
+    assert raw_capture_sink.capture_raw_samples.call_count == 3
+    for ingest_call, raw_capture_call in zip(
+        processor.ingest.call_args_list,
+        raw_capture_sink.capture_raw_samples.call_args_list,
+        strict=True,
+    ):
+        ingest_samples = ingest_call.args[1]
+        raw_capture_samples = raw_capture_call.kwargs["samples"]
+        assert ingest_samples is raw_capture_samples
+        assert ingest_samples.shape == (frame_samples, 3)
+        assert ingest_samples.dtype == np.dtype("<i2")
+        assert ingest_samples.flags.owndata is False
+        assert ingest_samples.flags.writeable is False
+
+
+@pytest.mark.asyncio
 async def test_datagram_queue_backpressure_drops_when_full(
     fake_transport,
     drain_queue,

--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -331,8 +331,13 @@ def parse_data(data: bytes) -> DataMessage:
         bytes_per_sample=BYTES_PER_SAMPLE,
     )
 
-    payload = memoryview(data)[DATA_HEADER_BYTES:]
-    samples = np.frombuffer(payload, dtype=_SAMPLE_DTYPE).reshape(sample_count, ACCEL_AXES).copy()
+    samples = np.frombuffer(
+        data,
+        dtype=_SAMPLE_DTYPE,
+        count=sample_count * ACCEL_AXES,
+        offset=DATA_HEADER_BYTES,
+    ).reshape(sample_count, ACCEL_AXES)
+    samples.setflags(write=False)
     return DataMessage(
         client_id=client_id,
         seq=seq,


### PR DESCRIPTION
## What changed
- `parse_data()` now returns a read-only int16 view over the DATA datagram payload instead of copying it.
- Live ingest and raw capture receive the same parsed sample view; raw capture still copies when it persists bytes.
- Added parser ownership coverage and a multi-sensor 200-sample parse-to-ingest/raw-capture regression.

## Why
The UDP DATA hot path copied int16 samples during parsing, then live processing immediately copied again when converting to float32. The parser copy was avoidable memory churn on every sensor frame.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/adapters/udp/protocol.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_udp_data_rx.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/adapters/udp/protocol.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_udp_data_rx.py`
- `apps/server/.venv/bin/pytest apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_udp_data_rx.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/adapters/udp apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py apps/server/tests/integration/test_sensor_failure_e2e_pipeline.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Parsed DATA sample arrays are now explicitly read-only views.
- Code that needs ownership must copy; raw capture already does this when converting samples to persisted bytes.
- Live processing still converts to float32 before mutating or scaling.
- Datagram-backed arrays keep the datagram bytes alive through the parsed message lifetime.

## Follow-ups
None.
