### PR TITLE
Handle invalid frontend timestamps

### DIFF
--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -6,7 +6,7 @@ export function fmt(n: number, digits = 2): string {
 }
 
 function formatDateTime(date: Date, invalidText: string): string {
-  if (Number.isNaN(date.getTime())) {
+  if (!Number.isFinite(date.getTime())) {
     return invalidText;
   }
   return date.toLocaleString();
@@ -14,11 +14,16 @@ function formatDateTime(date: Date, invalidText: string): string {
 
 export function fmtTs(iso: string): string {
   if (!iso) return "--";
-  return formatDateTime(new Date(iso), iso);
+  return formatDateTime(new Date(iso), "--");
 }
 
 export function formatEpochTimestamp(epoch: number | null | undefined): string {
-  if (epoch === null || epoch === undefined || !Number.isFinite(epoch)) {
+  if (
+    epoch === null ||
+    epoch === undefined ||
+    !Number.isFinite(epoch) ||
+    epoch < 0
+  ) {
     return "—";
   }
   return formatDateTime(new Date(epoch * 1000), "—");

--- a/apps/ui/tests/format.spec.ts
+++ b/apps/ui/tests/format.spec.ts
@@ -10,10 +10,13 @@ describe("timestamp formatting helpers", () => {
     expect(formatEpochTimestamp(Date.parse(iso) / 1000)).toBe(expected);
   });
 
-  test("preserves existing empty and invalid fallback text", () => {
+  test("uses fallbacks for empty and invalid timestamps", () => {
     expect(fmtTs("")).toBe("--");
-    expect(fmtTs("not-a-date")).toBe("not-a-date");
+    expect(fmtTs("not-a-date")).toBe("--");
     expect(formatEpochTimestamp(null)).toBe("—");
     expect(formatEpochTimestamp(Number.NaN)).toBe("—");
+    expect(formatEpochTimestamp(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatEpochTimestamp(-1)).toBe("—");
+    expect(formatEpochTimestamp(Number.MAX_VALUE)).toBe("—");
   });
 });


### PR DESCRIPTION
## What changed
- Invalid ISO timestamps now return the same fallback as empty ISO timestamps: `--`.
- Epoch timestamp formatting now rejects null, non-finite, negative, and Date-overflowing values with `—`.
- Added regression coverage for invalid ISO, empty ISO, `NaN`, `Infinity`, negative epoch, and extreme epoch values.

## Why
Malformed timestamp payloads should not leak raw `Invalid Date` text into the UI.

## Validation
- `npx biome format src/format.ts tests/format.spec.ts --write`
- `npx biome lint src/format.ts tests/format.spec.ts`
- `npx vitest run tests/format.spec.ts`
- `npm run lint`
- `PYTHON=/workspace/VibeSensor/apps/server/.venv/bin/python npm run typecheck`
- `git diff --check`

## Risks and edge cases
- Invalid ISO strings no longer display the original malformed value.
- Negative epoch values now show the fallback instead of pre-1970 dates.
- Existing valid ISO strings and non-negative finite epoch seconds still use locale formatting.

## Follow-ups
None.
