### PR TITLE
Clean up partial WorkerPool map submits

### DIFF
--- a/apps/server/tests/infra/workers/test_worker_pool.py
+++ b/apps/server/tests/infra/workers/test_worker_pool.py
@@ -167,6 +167,40 @@ class TestWorkerPool:
         assert stats["rejected_tasks"] == 1
         assert stats["pending_tasks"] == 0
 
+    def test_map_unordered_cancels_partial_batch_when_later_submit_times_out(
+        self,
+        make_pool,
+    ) -> None:
+        pool = make_pool(max_workers=1, max_queue_size=1)
+        release_external, external = _submit_blocking_task(pool)
+        map_item_started = threading.Event()
+
+        _assert_wait_until(
+            "external task to occupy the only worker",
+            lambda: pool.stats()["running_tasks"] == 1,
+        )
+
+        def _work(item: int) -> int:
+            map_item_started.set()
+            return item
+
+        with pytest.raises(TimeoutError, match="saturated"):
+            pool.map_unordered(_work, [1, 2], timeout_s=0.05)
+
+        stats = pool.stats()
+        assert stats["rejected_tasks"] == 1
+        assert stats["pending_tasks"] == 1
+        assert stats["queued_tasks"] == 0
+        assert not map_item_started.is_set()
+
+        release_external.set()
+        assert external.result(timeout=1.0) is True
+        _assert_wait_until(
+            "running external task cleanup",
+            lambda: pool.stats()["pending_tasks"] == 0,
+        )
+        assert not map_item_started.is_set()
+
     def test_shutdown_wakes_blocked_submitter(self, make_pool) -> None:
         pool = make_pool(max_workers=1, max_queue_size=0)
         release_first, first = _submit_blocking_task(pool)

--- a/apps/server/vibesensor/infra/workers/worker_pool.py
+++ b/apps/server/vibesensor/infra/workers/worker_pool.py
@@ -147,6 +147,36 @@ class WorkerPool:
                 self._queued_tasks -= 1
             self._condition.notify_all()
 
+    def _cleanup_map_pending_after_submit_failure(self, pending: dict[Future[R], T]) -> None:
+        cancelled = 0
+        completed = 0
+        running = 0
+        for future, item in pending.items():
+            if future.done():
+                completed += 1
+                if future.cancelled():
+                    continue
+                exception = future.exception()
+                if exception is not None:
+                    LOGGER.warning(
+                        "WorkerPool task failed for item %r while map_unordered() was aborting.",
+                        item,
+                        exc_info=(type(exception), exception, exception.__traceback__),
+                    )
+                continue
+            if future.cancel():
+                cancelled += 1
+                continue
+            running += 1
+        if cancelled or completed or running:
+            LOGGER.warning(
+                "WorkerPool map_unordered() submission failed; cleaned up %d completed "
+                "tasks, cancelled %d queued tasks, and left %d running tasks to finish.",
+                completed,
+                cancelled,
+                running,
+            )
+
     # -- Public API -----------------------------------------------------------
 
     def submit(
@@ -219,6 +249,9 @@ class WorkerPool:
         Submissions respect the pool's bounded outstanding-task contract.
         At most ``max_pending_tasks`` tasks are submitted at a time, so large
         batches do not create an unbounded executor backlog.
+        If a later submission fails after a partial batch was accepted, queued
+        futures are cancelled; already-running futures are allowed to finish
+        and release their counters through their normal completion callback.
 
         Raises
         ------
@@ -242,7 +275,11 @@ class WorkerPool:
                 except StopIteration:
                     exhausted = True
                     break
-                pending[self.submit(fn, item, timeout_s=timeout_s)] = item
+                try:
+                    pending[self.submit(fn, item, timeout_s=timeout_s)] = item
+                except (RuntimeError, TimeoutError):
+                    self._cleanup_map_pending_after_submit_failure(pending)
+                    raise
 
             if not pending:
                 continue


### PR DESCRIPTION
## What changed
- `map_unordered()` now cleans up partially submitted futures when a later submit raises `TimeoutError` or shutdown `RuntimeError`.
- Queued map futures are cancelled. Already-running futures are reported and allowed to finish through normal callbacks.
- Completed task failures seen during abort are logged without masking the submit failure.
- Added a regression for submit timeout after a partial map batch was accepted.

## Why
A bounded submit timeout should not leave hidden queued map work behind after `map_unordered()` fails during batch submission.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/infra/workers/worker_pool.py apps/server/tests/infra/workers/test_worker_pool.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/infra/workers/worker_pool.py apps/server/tests/infra/workers/test_worker_pool.py`
- `apps/server/.venv/bin/pytest apps/server/tests/infra/workers/test_worker_pool.py apps/server/tests/infra/workers/test_worker_pool_runtime_stats.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/infra/workers apps/server/tests/infra/processing/test_compute_all_parallel_cutoff.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Running work cannot be force-cancelled by `Future.cancel()`. It is left to finish and release counters through the existing done callback.
- Queued futures are cancelled when possible, so work that had not started does not run after the submit failure.
- The original submit error is preserved.

## Follow-ups
None.
