### PR TITLE
Prune failed report cache locks

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import csv
 import io
 import json
+import threading
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -190,11 +192,70 @@ async def test_report_pdf_cache_retries_after_build_failure() -> None:
         await cache.get_or_build(cache_key, _build)
 
     assert cache.get(cache_key) is None
+    assert cache._locks == {}
+    assert cache._lock_users == {}
 
     pdf = await cache.get_or_build(cache_key, _build)
 
     assert pdf == b"%PDF-success"
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_prunes_distinct_failed_build_locks() -> None:
+    cache = HistoryReportPdfCache()
+
+    def _build() -> bytes:
+        raise RuntimeError("boom")
+
+    for index in range(REPORT_PDF_CACHE_MAX_ENTRIES * 3):
+        cache_key = (f"run-{index}", "en", None, index, "{}", f"analysis-{index}", "none")
+        with pytest.raises(RuntimeError, match="boom"):
+            await cache.get_or_build(cache_key, _build)
+
+    assert cache._locks == {}
+    assert cache._lock_users == {}
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_serializes_concurrent_callers_for_same_key() -> None:
+    cache = HistoryReportPdfCache()
+    cache_key = ("run-concurrent", "en", None, 12, "{}", "analysis", "none")
+    first_build_started = threading.Event()
+    release_first_build = threading.Event()
+    counter_lock = threading.Lock()
+    calls = 0
+    active_builds = 0
+    max_active_builds = 0
+
+    def _build() -> bytes:
+        nonlocal active_builds, calls, max_active_builds
+        with counter_lock:
+            calls += 1
+            active_builds += 1
+            max_active_builds = max(max_active_builds, active_builds)
+        first_build_started.set()
+        if not release_first_build.wait(timeout=1.0):
+            raise RuntimeError("timed out waiting to release build")
+        with counter_lock:
+            active_builds -= 1
+        return b"%PDF-concurrent"
+
+    first = asyncio.create_task(cache.get_or_build(cache_key, _build))
+    assert await asyncio.to_thread(first_build_started.wait, 1.0)
+
+    second = asyncio.create_task(cache.get_or_build(cache_key, _build))
+    await asyncio.sleep(0.05)
+
+    assert calls == 1
+    release_first_build.set()
+    first_pdf, second_pdf = await asyncio.gather(first, second)
+
+    assert first_pdf == second_pdf == b"%PDF-concurrent"
+    assert calls == 1
+    assert max_active_builds == 1
+    assert cache._lock_users == {}
+    assert cache._locks[cache_key] is not None
 
 
 @pytest.mark.asyncio
@@ -209,12 +270,17 @@ async def test_report_pdf_cache_evicts_lru_entries_via_public_api() -> None:
         built = await cache.get_or_build(key, lambda index=index: f"%PDF-{index}".encode())
         assert built == f"%PDF-{index}".encode()
 
+    assert len(cache._locks) == REPORT_PDF_CACHE_MAX_ENTRIES
     assert cache.get(keys[0]) == b"%PDF-0"
 
     assert await cache.get_or_build(keys[-1], lambda: b"%PDF-new") == b"%PDF-new"
 
     assert cache.get(keys[1]) is None
     assert cache.get(keys[0]) == b"%PDF-0"
+    assert keys[1] not in cache._locks
+    assert keys[0] in cache._locks
+    assert keys[-1] in cache._locks
+    assert len(cache._locks) == REPORT_PDF_CACHE_MAX_ENTRIES
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/history/report_cache.py
+++ b/apps/server/vibesensor/use_cases/history/report_cache.py
@@ -14,11 +14,12 @@ REPORT_PDF_CACHE_MAX_ENTRIES = 16
 class HistoryReportPdfCache:
     """LRU PDF cache plus per-key build coordination."""
 
-    __slots__ = ("_entries", "_locks")
+    __slots__ = ("_entries", "_lock_users", "_locks")
 
     def __init__(self) -> None:
         self._entries: OrderedDict[ReportPdfCacheKey, bytes] = OrderedDict()
         self._locks: dict[ReportPdfCacheKey, asyncio.Lock] = {}
+        self._lock_users: dict[ReportPdfCacheKey, int] = {}
 
     def get(self, cache_key: ReportPdfCacheKey) -> bytes | None:
         """Return a cached PDF and refresh its LRU position."""
@@ -35,13 +36,22 @@ class HistoryReportPdfCache:
     ) -> bytes:
         """Reuse or build a cached PDF while serializing concurrent builds per key."""
         build_lock = self._locks.setdefault(cache_key, asyncio.Lock())
-        async with build_lock:
-            cached_pdf = self.get(cache_key)
-            if cached_pdf is not None:
-                return cached_pdf
-            pdf = await asyncio.to_thread(build_pdf)
-            self._put(cache_key, pdf)
-            return pdf
+        self._lock_users[cache_key] = self._lock_users.get(cache_key, 0) + 1
+        try:
+            async with build_lock:
+                cached_pdf = self.get(cache_key)
+                if cached_pdf is not None:
+                    return cached_pdf
+                pdf = await asyncio.to_thread(build_pdf)
+                self._put(cache_key, pdf)
+                return pdf
+        finally:
+            remaining_users = self._lock_users[cache_key] - 1
+            if remaining_users > 0:
+                self._lock_users[cache_key] = remaining_users
+            else:
+                self._lock_users.pop(cache_key, None)
+                self._prune_stale_lock(cache_key, build_lock)
 
     def _put(self, cache_key: ReportPdfCacheKey, pdf: bytes) -> None:
         """Insert a PDF into the LRU cache and prune related coordination state."""
@@ -49,8 +59,23 @@ class HistoryReportPdfCache:
         self._entries.move_to_end(cache_key)
         while len(self._entries) > REPORT_PDF_CACHE_MAX_ENTRIES:
             evicted_key, _ = self._entries.popitem(last=False)
-            self._locks.pop(evicted_key, None)
+            if self._lock_users.get(evicted_key, 0) == 0:
+                self._locks.pop(evicted_key, None)
         self._prune_stale_locks()
+
+    def _prune_stale_lock(
+        self,
+        cache_key: ReportPdfCacheKey,
+        build_lock: asyncio.Lock,
+    ) -> None:
+        """Drop one idle coordination lock when no cache entry owns it."""
+        if (
+            self._locks.get(cache_key) is build_lock
+            and cache_key not in self._entries
+            and not build_lock.locked()
+            and self._lock_users.get(cache_key, 0) == 0
+        ):
+            self._locks.pop(cache_key, None)
 
     def _prune_stale_locks(self) -> None:
         """Drop unlocked coordination locks whose cache entries were already evicted."""
@@ -58,7 +83,11 @@ class HistoryReportPdfCache:
             stale_keys = [
                 key
                 for key, lock in self._locks.items()
-                if key not in self._entries and not lock.locked()
+                if (
+                    key not in self._entries
+                    and not lock.locked()
+                    and self._lock_users.get(key, 0) == 0
+                )
             ]
             for key in stale_keys:
                 self._locks.pop(key, None)


### PR DESCRIPTION
## What changed
- Failed report PDF builds now prune idle per-key cache locks when no cache entry was written.
- Added per-key active-user tracking so concurrent callers for the same key keep sharing one lock.
- Successful cache inserts and LRU eviction still prune lock state for evicted entries.
- Added regressions for failed-build pruning, repeated distinct failures, same-key concurrency, and successful LRU lock behavior.

## Why
Long-lived servers should not retain one lock per failed uncached report key forever.

## Validation
- `apps/server/.venv/bin/ruff format apps/server/vibesensor/use_cases/history/report_cache.py apps/server/tests/use_cases/history/test_history_service_edges.py`
- `apps/server/.venv/bin/ruff check apps/server/vibesensor/use_cases/history/report_cache.py apps/server/tests/use_cases/history/test_history_service_edges.py`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/history/test_history_service_edges.py -q`
- `apps/server/.venv/bin/pytest apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_history_http_services.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks and edge cases
- Waiting callers prevent pruning until they leave `get_or_build()`, preserving same-key serialization.
- Running failed builds still propagate their original exception.
- Cached successful keys retain locks until normal LRU eviction.

## Follow-ups
None.
