### PR TITLE
Bound report PDF cache bytes

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -21,6 +21,7 @@ from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.report_cache import (
+    REPORT_PDF_CACHE_MAX_BYTES,
     REPORT_PDF_CACHE_MAX_ENTRIES,
     HistoryReportPdfCache,
 )
@@ -281,6 +282,47 @@ async def test_report_pdf_cache_evicts_lru_entries_via_public_api() -> None:
     assert keys[0] in cache._locks
     assert keys[-1] in cache._locks
     assert len(cache._locks) == REPORT_PDF_CACHE_MAX_ENTRIES
+    stats = cache.stats()
+    assert stats.entry_count == REPORT_PDF_CACHE_MAX_ENTRIES
+    assert stats.total_bytes == sum(len(cache.get(key) or b"") for key in keys)
+    assert stats.max_entries == REPORT_PDF_CACHE_MAX_ENTRIES
+    assert stats.max_bytes == REPORT_PDF_CACHE_MAX_BYTES
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_evicts_lru_entries_to_stay_within_byte_budget() -> None:
+    cache = HistoryReportPdfCache(max_entries=10, max_bytes=10)
+    keys = [
+        (f"run-{index}", "en", None, index, "{}", f"analysis-{index}", "none") for index in range(3)
+    ]
+
+    for index, key in enumerate(keys):
+        assert (
+            await cache.get_or_build(key, lambda index=index: bytes([index]) * 4)
+            == bytes([index]) * 4
+        )
+
+    assert cache.get(keys[0]) is None
+    assert cache.get(keys[1]) == bytes([1]) * 4
+    assert cache.get(keys[2]) == bytes([2]) * 4
+    assert keys[0] not in cache._locks
+    assert cache.stats().entry_count == 2
+    assert cache.stats().total_bytes == 8
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_skips_oversized_single_pdf() -> None:
+    cache = HistoryReportPdfCache(max_entries=10, max_bytes=4)
+    cache_key = ("run-big", "en", None, 1, "{}", "analysis-big", "none")
+
+    pdf = await cache.get_or_build(cache_key, lambda: b"12345")
+
+    assert pdf == b"12345"
+    assert cache.get(cache_key) is None
+    assert cache.stats().entry_count == 0
+    assert cache.stats().total_bytes == 0
+    assert cache._locks == {}
+    assert cache._lock_users == {}
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/history/report_cache.py
+++ b/apps/server/vibesensor/use_cases/history/report_cache.py
@@ -5,21 +5,57 @@ from __future__ import annotations
 import asyncio
 from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from vibesensor.shared.types.report_cache import ReportPdfCacheKey
 
 REPORT_PDF_CACHE_MAX_ENTRIES = 16
+REPORT_PDF_CACHE_MAX_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryReportPdfCacheStats:
+    """Current PDF cache memory-budget state."""
+
+    entry_count: int
+    total_bytes: int
+    max_entries: int
+    max_bytes: int
 
 
 class HistoryReportPdfCache:
     """LRU PDF cache plus per-key build coordination."""
 
-    __slots__ = ("_entries", "_lock_users", "_locks")
+    __slots__ = (
+        "_entries",
+        "_lock_users",
+        "_locks",
+        "_max_bytes",
+        "_max_entries",
+        "_total_bytes",
+    )
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_entries: int = REPORT_PDF_CACHE_MAX_ENTRIES,
+        max_bytes: int = REPORT_PDF_CACHE_MAX_BYTES,
+    ) -> None:
         self._entries: OrderedDict[ReportPdfCacheKey, bytes] = OrderedDict()
         self._locks: dict[ReportPdfCacheKey, asyncio.Lock] = {}
         self._lock_users: dict[ReportPdfCacheKey, int] = {}
+        self._max_entries = max_entries
+        self._max_bytes = max_bytes
+        self._total_bytes = 0
+
+    def stats(self) -> HistoryReportPdfCacheStats:
+        """Return cache size statistics for telemetry and diagnostics."""
+        return HistoryReportPdfCacheStats(
+            entry_count=len(self._entries),
+            total_bytes=self._total_bytes,
+            max_entries=self._max_entries,
+            max_bytes=self._max_bytes,
+        )
 
     def get(self, cache_key: ReportPdfCacheKey) -> bytes | None:
         """Return a cached PDF and refresh its LRU position."""
@@ -55,10 +91,20 @@ class HistoryReportPdfCache:
 
     def _put(self, cache_key: ReportPdfCacheKey, pdf: bytes) -> None:
         """Insert a PDF into the LRU cache and prune related coordination state."""
+        existing_pdf = self._entries.pop(cache_key, None)
+        if existing_pdf is not None:
+            self._total_bytes -= len(existing_pdf)
+        if len(pdf) > self._max_bytes:
+            self._prune_stale_locks()
+            return
         self._entries[cache_key] = pdf
+        self._total_bytes += len(pdf)
         self._entries.move_to_end(cache_key)
-        while len(self._entries) > REPORT_PDF_CACHE_MAX_ENTRIES:
-            evicted_key, _ = self._entries.popitem(last=False)
+        while self._entries and (
+            len(self._entries) > self._max_entries or self._total_bytes > self._max_bytes
+        ):
+            evicted_key, evicted_pdf = self._entries.popitem(last=False)
+            self._total_bytes -= len(evicted_pdf)
             if self._lock_users.get(evicted_key, 0) == 0:
                 self._locks.pop(evicted_key, None)
         self._prune_stale_locks()
@@ -79,7 +125,7 @@ class HistoryReportPdfCache:
 
     def _prune_stale_locks(self) -> None:
         """Drop unlocked coordination locks whose cache entries were already evicted."""
-        if len(self._locks) > REPORT_PDF_CACHE_MAX_ENTRIES * 2:
+        if len(self._locks) > self._max_entries * 2:
             stale_keys = [
                 key
                 for key, lock in self._locks.items()

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -63,7 +63,10 @@ class HistoryReportService:
                 request = await self._loader.load_report_request(run_id, requested_lang)
                 cached_pdf = self._pdf_cache.get(request.cache_key)
                 if cached_pdf is not None:
+                    stats = self._pdf_cache.stats()
                     span.set_attribute("vibesensor.cache_hit", True)
+                    span.set_attribute("vibesensor.report_pdf_cache.entries", stats.entry_count)
+                    span.set_attribute("vibesensor.report_pdf_cache.bytes", stats.total_bytes)
                     return HistoryReportPdf(content=cached_pdf, filename=request.filename)
 
                 pdf = await self._pdf_cache.get_or_build(
@@ -73,5 +76,8 @@ class HistoryReportService:
             except Exception as exc:
                 mark_span_error(span, exc)
                 raise
+            stats = self._pdf_cache.stats()
             span.set_attribute("vibesensor.cache_hit", False)
+            span.set_attribute("vibesensor.report_pdf_cache.entries", stats.entry_count)
+            span.set_attribute("vibesensor.report_pdf_cache.bytes", stats.total_bytes)
             return HistoryReportPdf(content=pdf, filename=request.filename)


### PR DESCRIPTION
## What changed
- Added a byte budget to `HistoryReportPdfCache` in addition to the entry-count budget.
- Tracked total cached PDF bytes and evicted oldest entries until both budgets are satisfied.
- Skipped caching any single PDF larger than the byte budget while still returning it to the caller.
- Added cache stats and report-service span attributes for cache entry count and total bytes.
- Added tests for count stats, byte-budget eviction, and oversized single-PDF behavior.

## Why
Entry-count limits do not bound memory when cached PDFs are large. The cache now has a hard byte ceiling for Pi-sized deployments.

## Validation
- `PATH=apps/server/.venv/bin:$PATH ruff format apps/server/vibesensor/use_cases/history/report_cache.py apps/server/vibesensor/use_cases/history/reports.py apps/server/tests/use_cases/history/test_history_service_edges.py`
- `PATH=apps/server/.venv/bin:$PATH ruff check apps/server/vibesensor/use_cases/history/report_cache.py apps/server/vibesensor/use_cases/history/reports.py apps/server/tests/use_cases/history/test_history_service_edges.py`
- `PATH=apps/server/.venv/bin:$PATH pytest apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_history_http_services.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks / tradeoffs
- PDFs larger than the byte budget are built and returned but not cached. That avoids unbounded memory retention at the cost of rebuilding oversized PDFs.
- Default byte budget is 16 MiB and can be overridden when constructing the cache.

## Follow-ups
- None for this issue.
