### PR TITLE
Bound release publish gh calls

### DIFF
--- a/.github/workflows/weekly-pi-image.yml
+++ b/.github/workflows/weekly-pi-image.yml
@@ -109,4 +109,5 @@ jobs:
             --title "${{ steps.metadata.outputs.release_name }}" \
             --notes-file "${notes_file}" \
             --make-latest false \
+            --upload-timeout 5400 \
             "${release_args[@]}"

--- a/apps/server/tests/hygiene/test_publish_github_release.py
+++ b/apps/server/tests/hygiene/test_publish_github_release.py
@@ -26,9 +26,18 @@ def _load_publish_github_release_module():
 def test_existing_release_id_uses_repo_endpoint_without_repo_flag(monkeypatch) -> None:
     module = _load_publish_github_release_module()
     commands: list[list[str]] = []
+    timeouts: list[float] = []
 
-    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+    def _fake_run(
+        command: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+        context: str,
+        timeout_s: float,
+    ):
         commands.append(list(command))
+        timeouts.append(timeout_s)
         return subprocess.CompletedProcess(
             command,
             0,
@@ -38,8 +47,16 @@ def test_existing_release_id_uses_repo_endpoint_without_repo_flag(monkeypatch) -
 
     monkeypatch.setattr(module, "_run", _fake_run)
 
-    assert module._existing_release_id("owner/repo", "server-v2026.3.28") == 123
+    assert (
+        module._existing_release_id(
+            "owner/repo",
+            "server-v2026.3.28",
+            timeout_s=12.0,
+        )
+        == 123
+    )
     assert commands == [["gh", "api", "repos/owner/repo/releases/tags/server-v2026.3.28"]]
+    assert timeouts == [12.0]
 
 
 def test_main_creates_release_without_repo_flag_and_uploads_with_repo_flag(
@@ -53,9 +70,16 @@ def test_main_creates_release_without_repo_flag_and_uploads_with_repo_flag(
     asset_file = tmp_path / "artifact.zip"
     asset_file.write_text("artifact", encoding="utf-8")
 
-    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag: None)
+    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag, *, timeout_s: None)
 
-    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+    def _fake_run(
+        command: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+        context: str,
+        timeout_s: float,
+    ):
         commands.append(list(command))
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
@@ -98,9 +122,16 @@ def test_main_updates_existing_release_without_repo_flag(monkeypatch, tmp_path: 
     asset_file = tmp_path / "artifact.zip"
     asset_file.write_text("artifact", encoding="utf-8")
 
-    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag: 77)
+    monkeypatch.setattr(module, "_existing_release_id", lambda repo, tag, *, timeout_s: 77)
 
-    def _fake_run(command: list[str], *, check: bool = True, capture_output: bool = False):
+    def _fake_run(
+        command: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+        context: str,
+        timeout_s: float,
+    ):
         commands.append(list(command))
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
@@ -132,3 +163,93 @@ def test_main_updates_existing_release_without_repo_flag(monkeypatch, tmp_path: 
 
     assert upload_command[:3] == ["gh", "release", "upload"]
     assert upload_command[-2:] == ["-R", "owner/repo"]
+
+
+def test_run_reports_timeout_with_command_context(monkeypatch) -> None:
+    module = _load_publish_github_release_module()
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            ["gh", "api", "repos/owner/repo/releases"],
+            timeout=5,
+            output="partial stdout",
+            stderr="partial stderr",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _timeout)
+
+    try:
+        module._run(
+            ["gh", "api", "repos/owner/repo/releases"],
+            capture_output=True,
+            context="Create release 'server-v1' in owner/repo",
+            timeout_s=5,
+        )
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected SystemExit")
+
+    assert "Create release 'server-v1' in owner/repo timed out after 5s" in message
+    assert "command: gh api repos/owner/repo/releases" in message
+    assert "stdout: partial stdout" in message
+    assert "stderr: partial stderr" in message
+
+
+def test_run_reports_nonzero_exit_with_output_excerpt(monkeypatch) -> None:
+    module = _load_publish_github_release_module()
+
+    def _failed(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            ["gh", "release", "upload"],
+            2,
+            stdout="upload stdout",
+            stderr="upload stderr",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _failed)
+
+    try:
+        module._run(
+            ["gh", "release", "upload"],
+            capture_output=True,
+            context="Upload 1 asset(s) to release 'server-v1' in owner/repo",
+            timeout_s=30,
+        )
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected SystemExit")
+
+    assert "failed with exit code 2" in message
+    assert "command: gh release upload" in message
+    assert "stdout: upload stdout" in message
+    assert "stderr: upload stderr" in message
+
+
+def test_existing_release_id_reports_malformed_json(monkeypatch) -> None:
+    module = _load_publish_github_release_module()
+
+    def _fake_run(
+        command: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+        context: str,
+        timeout_s: float,
+    ):
+        return subprocess.CompletedProcess(command, 0, stdout="{not-json", stderr="")
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    try:
+        module._existing_release_id("owner/repo", "server-v2026.3.28", timeout_s=10)
+    except SystemExit as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected SystemExit")
+
+    assert "Malformed GitHub release lookup JSON" in message
+    assert "server-v2026.3.28" in message
+    assert "owner/repo" in message
+    assert "stdout: {not-json" in message

--- a/tools/publish_github_release.py
+++ b/tools/publish_github_release.py
@@ -5,28 +5,78 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
+GH_API_TIMEOUT_SECONDS = 60.0
+GH_RELEASE_UPLOAD_TIMEOUT_SECONDS = 30 * 60.0
+_OUTPUT_EXCERPT_CHARS = 1200
+
+
+def _output_excerpt(output: str | None) -> str:
+    if not output:
+        return ""
+    stripped = output.strip()
+    if len(stripped) <= _OUTPUT_EXCERPT_CHARS:
+        return stripped
+    return f"{stripped[:_OUTPUT_EXCERPT_CHARS]}…"
+
 
 def _run(
-    command: list[str], *, check: bool = True, capture_output: bool = False
+    command: list[str],
+    *,
+    check: bool = True,
+    capture_output: bool = False,
+    context: str,
+    timeout_s: float,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        command,
-        check=check,
-        capture_output=capture_output,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=capture_output,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        details = [
+            f"{context} timed out after {timeout_s:g}s",
+            f"command: {shlex.join(command)}",
+        ]
+        stdout = _output_excerpt(exc.stdout)
+        stderr = _output_excerpt(exc.stderr)
+        if stdout:
+            details.append(f"stdout: {stdout}")
+        if stderr:
+            details.append(f"stderr: {stderr}")
+        raise SystemExit("\n".join(details)) from exc
+    except OSError as exc:
+        raise SystemExit(
+            f"{context} failed to start: {exc}\ncommand: {shlex.join(command)}"
+        ) from exc
+    if check and result.returncode != 0:
+        details = [
+            f"{context} failed with exit code {result.returncode}",
+            f"command: {shlex.join(command)}",
+        ]
+        stdout = _output_excerpt(result.stdout)
+        stderr = _output_excerpt(result.stderr)
+        if stdout:
+            details.append(f"stdout: {stdout}")
+        if stderr:
+            details.append(f"stderr: {stderr}")
+        raise SystemExit("\n".join(details))
+    return result
 
 
 def _repo_api_endpoint(repo: str, path: str) -> str:
     return f"repos/{repo}/{path.lstrip('/')}"
 
 
-def _existing_release_id(repo: str, tag: str) -> int | None:
+def _existing_release_id(repo: str, tag: str, *, timeout_s: float) -> int | None:
     result = _run(
         [
             "gh",
@@ -35,14 +85,24 @@ def _existing_release_id(repo: str, tag: str) -> int | None:
         ],
         check=False,
         capture_output=True,
+        context=f"Lookup release {tag!r} in {repo}",
+        timeout_s=timeout_s,
     )
     if result.returncode != 0:
         return None
-    payload = json.loads(result.stdout)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        stdout = _output_excerpt(result.stdout)
+        raise SystemExit(
+            f"Malformed GitHub release lookup JSON for tag {tag!r} in {repo}: "
+            f"{exc.msg} at line {exc.lineno} column {exc.colno}"
+            + (f"\nstdout: {stdout}" if stdout else "")
+        ) from exc
     release_id = payload.get("id")
     if not isinstance(release_id, int):
         raise SystemExit(
-            f"Unexpected release payload for tag {tag!r}: missing integer id"
+            f"Unexpected release payload for tag {tag!r} in {repo}: missing integer id"
         )
     return release_id
 
@@ -52,6 +112,13 @@ def _validate_assets(asset_paths: list[str]) -> list[str]:
     if missing:
         raise SystemExit(f"missing release assets: {', '.join(missing)}")
     return asset_paths
+
+
+def _positive_timeout(value: str) -> float:
+    timeout_s = float(value)
+    if timeout_s <= 0:
+        raise argparse.ArgumentTypeError("timeout must be greater than zero")
+    return timeout_s
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -82,6 +149,18 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Print the computed release payload and assets without calling GitHub.",
     )
+    parser.add_argument(
+        "--gh-api-timeout",
+        type=_positive_timeout,
+        default=GH_API_TIMEOUT_SECONDS,
+        help="Timeout in seconds for GitHub API metadata calls.",
+    )
+    parser.add_argument(
+        "--upload-timeout",
+        type=_positive_timeout,
+        default=GH_RELEASE_UPLOAD_TIMEOUT_SECONDS,
+        help="Timeout in seconds for GitHub release asset uploads.",
+    )
     args = parser.parse_args(argv)
 
     notes_path = Path(args.notes_file)
@@ -110,7 +189,9 @@ def main(argv: list[str] | None = None) -> None:
         payload_file = handle.name
 
     try:
-        release_id = _existing_release_id(args.repo, args.tag)
+        release_id = _existing_release_id(
+            args.repo, args.tag, timeout_s=args.gh_api_timeout
+        )
         if release_id is None:
             _run(
                 [
@@ -123,7 +204,10 @@ def main(argv: list[str] | None = None) -> None:
                     _repo_api_endpoint(args.repo, "releases"),
                     "--input",
                     payload_file,
-                ]
+                ],
+                capture_output=True,
+                context=f"Create release {args.tag!r} in {args.repo}",
+                timeout_s=args.gh_api_timeout,
             )
         else:
             _run(
@@ -137,7 +221,10 @@ def main(argv: list[str] | None = None) -> None:
                     _repo_api_endpoint(args.repo, f"releases/{release_id}"),
                     "--input",
                     payload_file,
-                ]
+                ],
+                capture_output=True,
+                context=f"Update release {args.tag!r} in {args.repo}",
+                timeout_s=args.gh_api_timeout,
             )
         _run(
             [
@@ -149,7 +236,9 @@ def main(argv: list[str] | None = None) -> None:
                 "--clobber",
                 "-R",
                 args.repo,
-            ]
+            ],
+            context=f"Upload {len(assets)} asset(s) to release {args.tag!r} in {args.repo}",
+            timeout_s=args.upload_timeout,
         )
     finally:
         Path(payload_file).unlink(missing_ok=True)


### PR DESCRIPTION
## What changed
- Added bounded execution for `tools/publish_github_release.py` GitHub CLI calls.
- Added structured diagnostics for timeouts, process start failures, and non-zero exits.
- Validated malformed `gh api releases/tags/...` JSON with repo/tag context.
- Added `--gh-api-timeout` and `--upload-timeout` options.
- Gave the weekly Pi image release a longer upload timeout.
- Added focused release-helper tests for timeout, non-zero exit output, malformed JSON, and timeout propagation.

## Why
Release publishing should fail with a targeted GitHub release diagnostic instead of hanging until the workflow job timeout or surfacing raw JSON/process errors.

## Validation
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH ruff format tools/publish_github_release.py apps/server/tests/hygiene/test_publish_github_release.py`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH ruff check tools/publish_github_release.py apps/server/tests/hygiene/test_publish_github_release.py`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH pytest apps/server/tests/hygiene/test_publish_github_release.py -q`
- `PATH=/workspace/VibeSensor/apps/server/.venv/bin:$PATH make lint`
- `git diff --check`

## Risks / tradeoffs
- Default upload timeout is 30 minutes; weekly Pi image publishing overrides it to 90 minutes for large image artifacts.
- Failed upload output is only included when captured by the subprocess call. Timeout and command context are always included.

## Follow-ups
- None for this issue.
