### PR TITLE
Harden settings cars lifecycle

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -571,6 +571,29 @@ export function createCarsFeatureWorkflow(
     loadSpecsStep(generation);
   }
 
+  async function addWizardCar(
+    name: string,
+    carType: string,
+    aspects: Record<string, number | string>,
+    orderReferenceStatus: CarOrderReferenceStatus,
+    variant?: string,
+  ): Promise<boolean> {
+    try {
+      await deps.addCarFromWizard(
+        name,
+        carType,
+        aspects,
+        orderReferenceStatus,
+        variant,
+      );
+    } catch {
+      deps.view.focus("finish");
+      return false;
+    }
+    isOpen.value = false;
+    return true;
+  }
+
   return {
     closeWizard(): void {
       invalidateWizardLoads();
@@ -592,7 +615,7 @@ export function createCarsFeatureWorkflow(
           deps.view.focus("gearbox-option");
           return false;
         }
-        await deps.addCarFromWizard(
+        return addWizardCar(
           buildWizardCarName(state.brand, state.model, state.selectedVariant),
           state.carType || "Custom",
           {
@@ -615,8 +638,6 @@ export function createCarsFeatureWorkflow(
           },
           state.selectedVariant?.name,
         );
-        isOpen.value = false;
-        return true;
       }
 
       const missingFocusTarget = missingManualInputFocusTarget(inputs);
@@ -625,7 +646,7 @@ export function createCarsFeatureWorkflow(
         return false;
       }
 
-      await deps.addCarFromWizard(
+      return addWizardCar(
         buildWizardCarName(state.brand, state.model, state.selectedVariant),
         state.carType || "Custom",
         {
@@ -644,8 +665,6 @@ export function createCarsFeatureWorkflow(
         },
         state.selectedVariant?.name,
       );
-      isOpen.value = false;
-      return true;
     },
 
     getRenderState,

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -112,6 +112,30 @@ export function createSettingsCarsModule(
       ctx.ports.activeSettingsTabId.value === "carTab",
   );
   const buildCarListRenderModel = createSettingsCarListRenderModelMemo();
+  let disposed = false;
+  let requestGeneration = 0;
+  let mutationInFlight = false;
+
+  function nextRequestGeneration(): number {
+    requestGeneration += 1;
+    return requestGeneration;
+  }
+
+  function isCurrent(generation: number): boolean {
+    return !disposed && generation === requestGeneration;
+  }
+
+  function beginMutation(): number | null {
+    if (disposed || mutationInFlight) {
+      return null;
+    }
+    mutationInFlight = true;
+    return nextRequestGeneration();
+  }
+
+  function finishMutation(): void {
+    mutationInFlight = false;
+  }
 
   function hasValidActiveCar(): boolean {
     return carSelection.hasResolvedActiveCar.value;
@@ -156,14 +180,23 @@ export function createSettingsCarsModule(
   function renderCarList(): void {}
 
   function clearHighlightedCarFeedback(): void {
+    if (disposed) {
+      return;
+    }
     highlightedCar.value = null;
   }
 
   function showCarCreationSuccess(carId: string, carName: string): void {
+    if (disposed) {
+      return;
+    }
     highlightedCar.value = { carId, carName };
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
+    if (disposed) {
+      return;
+    }
     applyCarsPayloadToSettings(settings.car, payload);
     if (
       highlightedCar.value &&
@@ -180,6 +213,9 @@ export function createSettingsCarsModule(
   }
 
   function syncActiveCarToInputs(): void {
+    if (disposed) {
+      return;
+    }
     copyActiveCarAspects(carSelection.activeCar.value, settings);
     if (hasValidActiveCar()) {
       ctx.ports.syncAnalysisInputs();
@@ -193,6 +229,11 @@ export function createSettingsCarsModule(
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ): Promise<void> {
+    const generation = beginMutation();
+    if (generation === null) {
+      throw new Error("A car settings operation is already in progress.");
+    }
+    let failureMessageKey = "settings.car.create_failed";
     try {
       const payload: CarUpsertRequest = {
         aspects: {
@@ -212,8 +253,11 @@ export function createSettingsCarsModule(
         payload.variant = variant;
       }
       const createdPayload = await transport.createCar(payload);
+      if (!isCurrent(generation)) {
+        throw new Error("Stale car creation result ignored.");
+      }
       if (!Array.isArray(createdPayload.cars)) {
-        return;
+        throw new Error("Car creation response did not include cars.");
       }
       ctx.queryClient.setQueryData(
         serverStateQueryKeys.settings.cars(),
@@ -222,9 +266,13 @@ export function createSettingsCarsModule(
       syncCarsPayload(createdPayload);
       const newCar = createdPayload.cars[createdPayload.cars.length - 1];
       if (!newCar) {
-        return;
+        throw new Error("Car creation response did not include a created car.");
       }
+      failureMessageKey = "settings.car.activate_failed";
       const activatedPayload = await transport.activateCar(newCar.id);
+      if (!isCurrent(generation)) {
+        throw new Error("Stale car activation result ignored.");
+      }
       ctx.queryClient.setQueryData(
         serverStateQueryKeys.settings.cars(),
         activatedPayload,
@@ -233,24 +281,35 @@ export function createSettingsCarsModule(
       syncActiveCarToInputs();
       showCarCreationSuccess(newCar.id, newCar.name);
       ctx.ports.refreshSpectrumDecorations();
-    } catch (_err) {
-      // Preserve the current wizard behavior: failed creation does not close over
-      // extra UI state or grow a second error-handling path outside settings.
+    } catch (error) {
+      if (isCurrent(generation)) {
+        services.showError(t(failureMessageKey));
+      }
+      throw error;
+    } finally {
+      finishMutation();
     }
   }
 
   async function loadCarsFromServer(): Promise<void> {
+    if (disposed) {
+      return;
+    }
+    const generation = nextRequestGeneration();
     const payload = await ctx.queryClient.fetchQuery({
       queryFn: () => transport.loadCars(),
       queryKey: serverStateQueryKeys.settings.cars(),
       staleTime: 0,
     });
+    if (!isCurrent(generation)) {
+      return;
+    }
     syncCarsPayload(payload);
     syncActiveCarToInputs();
   }
 
   async function handleActivateCar(carId: string): Promise<void> {
-    if (!carId) {
+    if (disposed || !carId) {
       return;
     }
     const car = findCar(carId);
@@ -261,8 +320,15 @@ export function createSettingsCarsModule(
       services.showError(t("settings.car.activate_incomplete"));
       return;
     }
+    const generation = beginMutation();
+    if (generation === null) {
+      return;
+    }
     try {
       const payload = await transport.activateCar(carId);
+      if (!isCurrent(generation)) {
+        return;
+      }
       ctx.queryClient.setQueryData(
         serverStateQueryKeys.settings.cars(),
         payload,
@@ -272,21 +338,32 @@ export function createSettingsCarsModule(
       clearHighlightedCarFeedback();
       ctx.ports.refreshSpectrumDecorations();
     } catch (_err) {
-      services.showError(t("settings.car.activate_failed"));
+      if (isCurrent(generation)) {
+        services.showError(t("settings.car.activate_failed"));
+      }
+    } finally {
+      finishMutation();
     }
   }
 
   async function handleCompleteCar(carId: string): Promise<void> {
-    if (!carId) {
+    if (disposed || !carId) {
       return;
     }
     const car = findCar(carId);
     if (!car) {
       return;
     }
+    const generation = beginMutation();
+    if (generation === null) {
+      return;
+    }
     try {
       if (car.id !== settings.car.activeCarId.value) {
         const payload = await transport.activateCar(carId);
+        if (!isCurrent(generation)) {
+          return;
+        }
         ctx.queryClient.setQueryData(
           serverStateQueryKeys.settings.cars(),
           payload,
@@ -295,26 +372,40 @@ export function createSettingsCarsModule(
         syncActiveCarToInputs();
         ctx.ports.refreshSpectrumDecorations();
       }
+      if (!isCurrent(generation)) {
+        return;
+      }
       clearHighlightedCarFeedback();
       ctx.ports.openAnalysisTab();
     } catch (_err) {
-      services.showError(t("settings.car.activate_failed"));
+      if (isCurrent(generation)) {
+        services.showError(t("settings.car.activate_failed"));
+      }
+    } finally {
+      finishMutation();
     }
   }
 
   async function handleDeleteCar(carId: string): Promise<void> {
-    if (!carId) {
+    if (disposed || !carId) {
       return;
     }
     const car = findCar(carId);
     const confirmed = await services.requestConfirmation(
       t("settings.car.delete_confirm", { name: car?.name || "" }),
     );
-    if (!confirmed) {
+    if (disposed || !confirmed) {
+      return;
+    }
+    const generation = beginMutation();
+    if (generation === null) {
       return;
     }
     try {
       const payload = await transport.deleteCar(carId);
+      if (!isCurrent(generation)) {
+        return;
+      }
       ctx.queryClient.setQueryData(
         serverStateQueryKeys.settings.cars(),
         payload,
@@ -324,7 +415,11 @@ export function createSettingsCarsModule(
       clearHighlightedCarFeedback();
       ctx.ports.refreshSpectrumDecorations();
     } catch (_err) {
-      services.showError(t("settings.car.delete_failed"));
+      if (isCurrent(generation)) {
+        services.showError(t("settings.car.delete_failed"));
+      }
+    } finally {
+      finishMutation();
     }
   }
 
@@ -367,6 +462,9 @@ export function createSettingsCarsModule(
     addCarFromWizard,
     bindHandlers,
     dispose(): void {
+      disposed = true;
+      requestGeneration += 1;
+      mutationInFlight = false;
       disposeHighlightedCarSync?.();
       disposeHighlightedCarSync = null;
     },

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -280,6 +280,7 @@
   "settings.car.guidance.no_active_detail": "Use Activate on a ready row, or Finish setup on an incomplete row, to unlock the rest of Settings.",
   "settings.car.delete_confirm": "Delete car \"{name}\"? This cannot be undone.",
   "settings.car.cannot_delete_last": "Cannot delete the last car.",
+  "settings.car.create_failed": "Failed to add car.",
   "settings.car.delete_failed": "Failed to delete car.",
   "settings.car.activate_failed": "Failed to activate car.",
   "settings.car.activate_incomplete": "Finish the car setup in Analysis before activating it.",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -280,6 +280,7 @@
   "settings.car.guidance.no_active_detail": "Gebruik Activeren op een volledige rij, of Setup afronden op een onvolledige rij, om de rest van Instellingen vrij te geven.",
   "settings.car.delete_confirm": "Auto \"{name}\" verwijderen? Dit kan niet ongedaan worden gemaakt.",
   "settings.car.cannot_delete_last": "Kan de laatste auto niet verwijderen.",
+  "settings.car.create_failed": "Kan auto niet toevoegen.",
   "settings.car.delete_failed": "Kan auto niet verwijderen.",
   "settings.car.activate_failed": "Kan auto niet activeren.",
   "settings.car.activate_incomplete": "Rond de auto-instellingen eerst af in Analyse voordat je deze activeert.",

--- a/apps/ui/tests/cars_feature_workflow_lifecycle.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow_lifecycle.spec.ts
@@ -70,6 +70,35 @@ function makeModel(model: string, carType: string): CarLibraryModel {
 }
 
 describe("createCarsFeatureWorkflow async lifecycle", () => {
+  test("keeps the wizard open when adding the car fails", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => {
+        throw new Error("create failed");
+      },
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      queryClient: createTestQueryClient(),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+    await workflow.submitCustomBrand("BMW");
+    await workflow.submitCustomType("Coupe");
+    await workflow.submitCustomModel("M3");
+    workflow.handleManualInputChanged("tireWidth", "245");
+    const closed = await workflow.finishWizard();
+
+    expect(closed).toBe(false);
+    expect(workflow.getRenderState().isOpen).toBe(true);
+    expect(harness.focuses).toContain("finish");
+  });
+
   test("ignores brand load results after the wizard closes", async () => {
     const harness = createHarness();
     const brands = createDeferred<string[]>();

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -369,8 +369,9 @@ test("settings cars module creates and activates wizard cars through the shared 
   ]);
 });
 
-test("settings cars module preserves current silent wizard failure behavior", async () => {
+test("settings cars module propagates wizard creation failures", async () => {
   const lifecycleCalls: string[] = [];
+  const errors: string[] = [];
   const module = createSettingsCarsModule({
     queryClient: createTestQueryClient(),
     settings: createAppState().settings,
@@ -398,7 +399,9 @@ test("settings cars module preserves current silent wizard failure behavior", as
     services: {
       t: (key) => key,
       requestConfirmation: async () => true,
-      showError: () => undefined,
+      showError: (message) => {
+        errors.push(message);
+      },
     },
     formatting: {
       fmt: (value, digits = 0) => Number(value).toFixed(digits),
@@ -419,7 +422,10 @@ test("settings cars module preserves current silent wizard failure behavior", as
     },
   });
 
-  await module.addCarFromWizard("My Car", "Custom", { tire_width_mm: 225 });
+  await expect(
+    module.addCarFromWizard("My Car", "Custom", { tire_width_mm: 225 }),
+  ).rejects.toThrow("network failed");
 
+  expect(errors).toEqual(["settings.car.create_failed"]);
   expect(lifecycleCalls).toEqual([]);
 });

--- a/apps/ui/tests/settings_cars_module_lifecycle.spec.ts
+++ b/apps/ui/tests/settings_cars_module_lifecycle.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from "vitest";
+import { createSettingsCarsModule } from "../src/app/features/settings_cars_module";
+import { serverStateQueryKeys } from "../src/app/features/server_state_query_keys";
+import { signal } from "../src/app/ui_signals";
+import { createAppState } from "../src/app/ui_app_state";
+import type { CarsListPanelView } from "../src/app/views/cars_panel";
+import type { CarsPayload } from "../src/api/types";
+import { createDeferred, flushAsyncWork } from "./async_test_helpers";
+import { createTestQueryClient } from "./query_client_test_support";
+
+function makePayload(activeCarId: string): CarsPayload {
+  return {
+    active_car_id: activeCarId,
+    cars: [
+      {
+        id: "car-1",
+        name: "Existing",
+        type: "Hatchback",
+        variant: null,
+        aspects: {
+          current_gear_ratio: 0.82,
+          final_drive_ratio: 3.9,
+          rim_in: 16,
+          tire_aspect_pct: 55,
+          tire_width_mm: 205,
+        },
+      },
+      {
+        id: "car-2",
+        name: "Track",
+        type: "Coupe",
+        variant: null,
+        aspects: {
+          current_gear_ratio: 0.72,
+          final_drive_ratio: 3.23,
+          rim_in: 19,
+          tire_aspect_pct: 40,
+          tire_width_mm: 245,
+        },
+      },
+    ],
+  };
+}
+
+function createModuleHarness(
+  overrides: {
+    transport?: Parameters<typeof createSettingsCarsModule>[0]["transport"];
+    requestConfirmation?: () => Promise<boolean>;
+  } = {},
+) {
+  const appState = createAppState();
+  const queryClient = createTestQueryClient();
+  const errors: string[] = [];
+  const lifecycleCalls: string[] = [];
+  const panel: CarsListPanelView = {
+    actions: signal(null),
+    model: signal(null),
+  };
+  const module = createSettingsCarsModule({
+    queryClient,
+    settings: appState.settings,
+    panels: {
+      analysisPanel: {
+        carAvailability: signal(null),
+      },
+      panel,
+    },
+    ports: {
+      activeViewId: signal("settingsView"),
+      activeSettingsTabId: signal("carTab"),
+      openAnalysisTab: () => {
+        lifecycleCalls.push("openAnalysisTab");
+      },
+      openCarWizard: () => undefined,
+      refreshSpectrumDecorations: () => {
+        lifecycleCalls.push("refreshSpectrumDecorations");
+      },
+      syncAnalysisInputs: () => {
+        lifecycleCalls.push("syncAnalysisInputs");
+      },
+    },
+    services: {
+      t: (key) => key,
+      requestConfirmation: overrides.requestConfirmation ?? (async () => true),
+      showError: (message) => {
+        errors.push(message);
+      },
+    },
+    formatting: {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    },
+    transport: overrides.transport,
+  });
+  return { appState, errors, lifecycleCalls, module, panel, queryClient };
+}
+
+test("settings cars module keeps wizard open failure observable when activation after create fails", async () => {
+  const createdPayload = makePayload("car-1");
+  const harness = createModuleHarness({
+    transport: {
+      async activateCar() {
+        throw new Error("activation failed");
+      },
+      async createCar() {
+        return createdPayload;
+      },
+    },
+  });
+
+  await expect(
+    harness.module.addCarFromWizard("Track", "Coupe", {
+      tire_width_mm: 245,
+    }),
+  ).rejects.toThrow("activation failed");
+
+  expect(harness.errors).toEqual(["settings.car.activate_failed"]);
+  expect(
+    harness.queryClient.getQueryData(serverStateQueryKeys.settings.cars()),
+  ).toEqual(createdPayload);
+  expect(harness.appState.settings.car.activeCarId.value).toBe("car-1");
+  expect(harness.lifecycleCalls).toEqual([]);
+});
+
+test("settings cars module ignores load results after disposal", async () => {
+  const load = createDeferred<CarsPayload>();
+  const harness = createModuleHarness({
+    transport: {
+      async loadCars() {
+        return load.promise;
+      },
+    },
+  });
+
+  const loading = harness.module.loadCarsFromServer();
+  await flushAsyncWork();
+  harness.module.dispose();
+  load.resolve(makePayload("car-2"));
+  await loading;
+
+  expect(harness.appState.settings.car.activeCarId.value).toBeNull();
+  expect(harness.lifecycleCalls).toEqual([]);
+  expect(harness.errors).toEqual([]);
+});
+
+test("settings cars module ignores activate results after disposal", async () => {
+  const activate = createDeferred<CarsPayload>();
+  const harness = createModuleHarness({
+    transport: {
+      async activateCar() {
+        return activate.promise;
+      },
+    },
+  });
+  harness.module.bindHandlers();
+  harness.module.syncCarsPayload(makePayload("car-1"));
+
+  harness.panel.actions.value?.onAction({ type: "activate", carId: "car-2" });
+  await flushAsyncWork();
+  harness.module.dispose();
+  activate.resolve(makePayload("car-2"));
+  await flushAsyncWork();
+
+  expect(harness.appState.settings.car.activeCarId.value).toBe("car-1");
+  expect(harness.lifecycleCalls).toEqual([]);
+  expect(harness.errors).toEqual([]);
+});
+
+test("settings cars module ignores overlapping car mutations while one is in flight", async () => {
+  const activate = createDeferred<CarsPayload>();
+  const activateRequests: string[] = [];
+  const harness = createModuleHarness({
+    transport: {
+      async activateCar(carId) {
+        activateRequests.push(carId);
+        return activate.promise;
+      },
+    },
+  });
+  harness.module.bindHandlers();
+  harness.module.syncCarsPayload(makePayload("car-1"));
+
+  harness.panel.actions.value?.onAction({ type: "activate", carId: "car-2" });
+  harness.panel.actions.value?.onAction({ type: "activate", carId: "car-1" });
+  await flushAsyncWork();
+  activate.resolve(makePayload("car-2"));
+  await flushAsyncWork();
+
+  expect(activateRequests).toEqual(["car-2"]);
+  expect(harness.appState.settings.car.activeCarId.value).toBe("car-2");
+  expect(harness.lifecycleCalls).toEqual([
+    "syncAnalysisInputs",
+    "refreshSpectrumDecorations",
+  ]);
+  expect(harness.errors).toEqual([]);
+});


### PR DESCRIPTION
## What changed
- Propagated settings-car wizard create/activate failures instead of swallowing them.
- Kept the car wizard open when `addCarFromWizard(...)` rejects.
- Added disposed and request-generation guards around settings-car load/create/activate/complete/delete flows.
- Added a single mutation in-flight guard so overlapping car mutations cannot race the older result over newer state.
- Suppressed stale/disposed state writes, error toasts, analysis sync, decoration refresh, and tab-open side effects.
- Added focused lifecycle regressions for wizard failure, create/activate failure, disposed load/activate results, and overlapping activation.

## Why
Failed car creation could look successful and close the wizard. Slow settings-car requests could also update settings or call UI ports after dispose, or race overlapping actions.

## Validation
- `npx biome format --write ...`
- `npx biome lint ...`
- `npm run typecheck:tests`
- `npx vitest run tests/settings_cars_module.spec.ts tests/settings_cars_module_lifecycle.spec.ts tests/cars_feature_workflow.spec.ts tests/cars_feature_workflow_lifecycle.spec.ts`
- `PYTHON=/workspace/VibeSensor/apps/server/.venv/bin/python npm run typecheck`
- `git diff --check`

## Risks / tradeoffs
- A second car mutation while one is in flight is ignored instead of queued. This favors safe state over replaying stale clicks.
- Create success followed by activation failure leaves the created car data visible but does not close the wizard or claim success.

## Follow-ups
- None for this issue.

Fixes #3607.
