### PR TITLE
Harden update and ESP flash lifecycles

### DIFF
--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -8,24 +8,16 @@ import {
   getEspFlashStatus as getEspFlashStatusApi,
   startEspFlash as startEspFlashApi,
 } from "../../api/settings";
-import {
-  ESP_FLASH_POLL_ACTIVE_MS,
-  ESP_FLASH_POLL_IDLE_MS,
-} from "../../config";
+import { ESP_FLASH_POLL_ACTIVE_MS, ESP_FLASH_POLL_IDLE_MS } from "../../config";
 import type {
   EspFlashHistoryPayload,
   EspFlashLogsPayload,
   EspFlashPortsPayload,
   EspFlashStatusPayload,
   EspSerialPortPayload,
-  } from "../../api/types";
+} from "../../api/types";
 import type { EspFlashFeatureRenderState } from "../views/esp_flash_feature_presenter";
-import {
-  batch,
-  computed,
-  signal,
-  type ReadonlySignal,
-} from "../ui_signals";
+import { batch, computed, signal, type ReadonlySignal } from "../ui_signals";
 import {
   createHiddenTabPollingObserverOptions,
   createObservedServerStateQuery,
@@ -103,7 +95,9 @@ export function createEspFlashFeatureWorkflow(
   const availablePorts = signal<readonly EspSerialPortPayload[]>([]);
   const selectedPortValue = signal("__auto__");
   const logText = signal("");
-  const latestAttempts = signal<readonly NonNullable<EspFlashHistoryPayload["attempts"]>[number][]>([]);
+  const latestAttempts = signal<
+    readonly NonNullable<EspFlashHistoryPayload["attempts"]>[number][]
+  >([]);
   const renderState = computed<EspFlashFeatureRenderState>(() => ({
     attempts: [...latestAttempts.value],
     availablePorts: [...availablePorts.value],
@@ -112,17 +106,47 @@ export function createEspFlashFeatureWorkflow(
     selectedPortValue: selectedPortValue.value,
     status: latestStatus.value,
   }));
+  let disposed = false;
+  let statusGeneration = 0;
+  let portsGeneration = 0;
+  let flashInFlight = false;
+  let cancelInFlight = false;
 
   function getRenderState(): EspFlashFeatureRenderState {
     return renderState.value;
   }
 
+  function nextStatusGeneration(): number {
+    statusGeneration += 1;
+    return statusGeneration;
+  }
+
+  function isCurrentStatus(generation: number): boolean {
+    return !disposed && generation === statusGeneration;
+  }
+
+  function nextPortsGeneration(): number {
+    portsGeneration += 1;
+    return portsGeneration;
+  }
+
+  function isCurrentPorts(generation: number): boolean {
+    return !disposed && generation === portsGeneration;
+  }
+
   function updateJourneyPhase(status: EspFlashStatusPayload): void {
+    if (disposed) {
+      return;
+    }
     const phase = status.phase || null;
     const safeState = safeEspFlashState(status.state);
-    const isJourneyPhase = ["validating", "preparing", "erasing", "flashing", "done"].includes(
-      phase || "",
-    );
+    const isJourneyPhase = [
+      "validating",
+      "preparing",
+      "erasing",
+      "flashing",
+      "done",
+    ].includes(phase || "");
     if (isJourneyPhase) {
       lastJourneyPhase.value = phase;
       return;
@@ -133,6 +157,9 @@ export function createEspFlashFeatureWorkflow(
   }
 
   function applyStatus(status: EspFlashStatusPayload): void {
+    if (disposed) {
+      return;
+    }
     updateJourneyPhase(status);
     latestStatus.value = status;
   }
@@ -142,8 +169,9 @@ export function createEspFlashFeatureWorkflow(
       serverStateQueryKeys.espFlash.statusSnapshot(),
     );
     const status = await api.getEspFlashStatus();
-    let logText = status.log_count === 0 ? "" : previous?.logText ?? "";
-    let nextLogIndex = status.log_count === 0 ? 0 : previous?.nextLogIndex ?? 0;
+    let logText = status.log_count === 0 ? "" : (previous?.logText ?? "");
+    let nextLogIndex =
+      status.log_count === 0 ? 0 : (previous?.nextLogIndex ?? 0);
     if (status.log_count > 0) {
       if (nextLogIndex === 0) {
         logText = "";
@@ -164,6 +192,9 @@ export function createEspFlashFeatureWorkflow(
   }
 
   function applyStatusSnapshot(snapshot: EspFlashStatusSnapshot): void {
+    if (disposed) {
+      return;
+    }
     batch(() => {
       applyStatus(snapshot.status);
       latestAttempts.value = snapshot.attempts;
@@ -171,29 +202,56 @@ export function createEspFlashFeatureWorkflow(
     });
   }
 
-  const statusSnapshotQuery = createObservedServerStateQuery<EspFlashStatusSnapshot>({
-    enabled: deps.pollingEnabled,
-    observerOptions: createHiddenTabPollingObserverOptions<EspFlashStatusSnapshot>(
-      (query) => safeEspFlashState(query.state.data?.status.state) === "running"
-        ? ESP_FLASH_POLL_ACTIVE_MS
-        : ESP_FLASH_POLL_IDLE_MS,
-    ),
-    onData: applyStatusSnapshot,
-    queryClient: deps.queryClient,
-    queryFn: fetchStatusSnapshot,
-    queryKey: serverStateQueryKeys.espFlash.statusSnapshot(),
-  });
+  const statusSnapshotQuery =
+    createObservedServerStateQuery<EspFlashStatusSnapshot>({
+      enabled: deps.pollingEnabled,
+      observerOptions:
+        createHiddenTabPollingObserverOptions<EspFlashStatusSnapshot>(
+          (query) =>
+            safeEspFlashState(query.state.data?.status.state) === "running"
+              ? ESP_FLASH_POLL_ACTIVE_MS
+              : ESP_FLASH_POLL_IDLE_MS,
+        ),
+      onData: (snapshot) => {
+        if (!disposed) {
+          applyStatusSnapshot(snapshot);
+        }
+      },
+      queryClient: deps.queryClient,
+      queryFn: fetchStatusSnapshot,
+      queryKey: serverStateQueryKeys.espFlash.statusSnapshot(),
+    });
+
+  async function refreshStatusForGeneration(generation: number): Promise<void> {
+    const snapshot = await fetchStatusSnapshot();
+    if (!isCurrentStatus(generation)) {
+      return;
+    }
+    statusSnapshotQuery.setData(() => snapshot);
+    applyStatusSnapshot(snapshot);
+  }
 
   async function refreshStatus(): Promise<void> {
-    await statusSnapshotQuery.fetch();
+    if (disposed) {
+      return;
+    }
+    const generation = nextStatusGeneration();
+    await refreshStatusForGeneration(generation);
   }
 
   async function refreshPorts(): Promise<void> {
+    if (disposed) {
+      return;
+    }
+    const generation = nextPortsGeneration();
     const payload = await deps.queryClient.fetchQuery({
       queryFn: () => api.getEspFlashPorts(),
       queryKey: serverStateQueryKeys.espFlash.ports(),
       staleTime: 0,
     });
+    if (!isCurrentPorts(generation)) {
+      return;
+    }
     const ports = payload.ports || [];
     batch(() => {
       availablePorts.value = ports;
@@ -204,41 +262,67 @@ export function createEspFlashFeatureWorkflow(
   }
 
   async function startFlash(): Promise<void> {
+    if (disposed || flashInFlight) {
+      return;
+    }
     const latestState = safeEspFlashState(latestStatus.peek().state);
     const ports = availablePorts.peek();
-    if (
-      latestState === "running"
-      || ports.length === 0
-    ) {
+    if (latestState === "running" || ports.length === 0) {
       return;
     }
     const selectedPort = selectedPortValue.peek();
     const autoDetect = selectedPort === "__auto__";
     const port = autoDetect ? null : selectedPort;
+    flashInFlight = true;
+    const generation = nextStatusGeneration();
     try {
       await api.startEspFlash(port, autoDetect);
+      if (!isCurrentStatus(generation)) {
+        return;
+      }
       logText.value = "";
       statusSnapshotQuery.setData(() => undefined);
-      await refreshStatus();
+      await refreshStatusForGeneration(generation);
     } catch (err) {
-      deps.showError(
-        `${deps.t("settings.esp_flash.start_failed")}\n${err instanceof Error ? err.message : String(err)}`,
-      );
+      if (isCurrentStatus(generation)) {
+        deps.showError(
+          `${deps.t("settings.esp_flash.start_failed")}\n${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } finally {
+      flashInFlight = false;
     }
   }
 
   async function cancelFlash(): Promise<void> {
+    if (disposed || cancelInFlight) {
+      return;
+    }
+    cancelInFlight = true;
+    const generation = nextStatusGeneration();
     try {
       await api.cancelEspFlash();
     } catch {
       /* cancel may race the job finishing; resync through polling */
+    } finally {
+      try {
+        if (isCurrentStatus(generation)) {
+          await refreshStatusForGeneration(generation);
+        }
+      } finally {
+        cancelInFlight = false;
+      }
     }
-    await refreshStatus();
   }
 
   return {
     cancelFlash,
     dispose(): void {
+      disposed = true;
+      statusGeneration += 1;
+      portsGeneration += 1;
+      flashInFlight = false;
+      cancelInFlight = false;
       statusSnapshotQuery.dispose();
     },
     getRenderState,
@@ -246,6 +330,9 @@ export function createEspFlashFeatureWorkflow(
     refreshPorts,
     refreshStatus,
     setSelectedPortValue(value: string) {
+      if (disposed) {
+        return;
+      }
       selectedPortValue.value = value || "__auto__";
     },
     startFlash,

--- a/apps/ui/src/app/features/update_feature_workflow.ts
+++ b/apps/ui/src/app/features/update_feature_workflow.ts
@@ -21,12 +21,7 @@ import type {
   UpdateFeatureRenderState,
   UpdateFeatureStartIntent,
 } from "../views/update_feature_presenter";
-import {
-  batch,
-  computed,
-  signal,
-  type ReadonlySignal,
-} from "../ui_signals";
+import { batch, computed, signal, type ReadonlySignal } from "../ui_signals";
 import {
   createHiddenTabPollingObserverOptions,
   createObservedServerStateQuery,
@@ -98,16 +93,20 @@ export function createUpdateFeatureWorkflow(
   const api: UpdateFeatureWorkflowApi = {
     cancelUpdate: deps.api?.cancelUpdate ?? cancelUpdateApi,
     getHealthStatus: deps.api?.getHealthStatus ?? getHealthStatusApi,
-    getUpdateInternetStatus: deps.api?.getUpdateInternetStatus ?? getUpdateInternetStatusApi,
+    getUpdateInternetStatus:
+      deps.api?.getUpdateInternetStatus ?? getUpdateInternetStatusApi,
     getUpdateStatus: deps.api?.getUpdateStatus ?? getUpdateStatusApi,
     startUpdate: deps.api?.startUpdate ?? startUpdateApi,
   };
 
-  const latestInternetStatus = signal<UsbInternetStatusPayload>(fallbackInternetStatus(deps.t));
+  const latestInternetStatus = signal<UsbInternetStatusPayload>(
+    fallbackInternetStatus(deps.t),
+  );
   const latestHealthStatus = signal<HealthStatusPayload | null>(null);
   const latestUpdateStatus = signal<UpdateStatusPayload | null>(null);
   const latestUpdateState = signal<UpdateStatusPayload["state"]>("idle");
-  const latestUpdateTransport = signal<UpdateStartRequestPayload["transport"]>("wifi");
+  const latestUpdateTransport =
+    signal<UpdateStartRequestPayload["transport"]>("wifi");
   const renderState = computed<UpdateFeatureRenderState>(() => ({
     internetStatus: latestInternetStatus.value,
     healthStatus: latestHealthStatus.value,
@@ -115,9 +114,22 @@ export function createUpdateFeatureWorkflow(
     updateState: latestUpdateState.value,
     updateTransport: latestUpdateTransport.value,
   }));
+  let disposed = false;
+  let statusGeneration = 0;
+  let startInFlight = false;
+  let cancelInFlight = false;
 
   function getRenderState(): UpdateFeatureRenderState {
     return renderState.value;
+  }
+
+  function nextStatusGeneration(): number {
+    statusGeneration += 1;
+    return statusGeneration;
+  }
+
+  function isCurrentStatus(generation: number): boolean {
+    return !disposed && generation === statusGeneration;
   }
 
   async function fetchStatusSnapshot(): Promise<UpdateStatusSnapshot> {
@@ -134,36 +146,78 @@ export function createUpdateFeatureWorkflow(
   }
 
   function applyStatusSnapshot(snapshot: UpdateStatusSnapshot): void {
+    if (disposed) {
+      return;
+    }
     batch(() => {
       latestUpdateStatus.value = snapshot.status;
       latestHealthStatus.value = snapshot.health;
       latestInternetStatus.value = snapshot.internet;
       latestUpdateState.value = snapshot.status.state;
-      latestUpdateTransport.value = safeUpdateTransport(snapshot.status.transport);
+      latestUpdateTransport.value = safeUpdateTransport(
+        snapshot.status.transport,
+      );
     });
   }
 
-  const statusSnapshotQuery = createObservedServerStateQuery<UpdateStatusSnapshot>({
-    enabled: deps.pollingEnabled,
-    onError: (error) => {
-      deps.showError(error instanceof Error ? error.message : deps.t("status.unavailable"));
-    },
-    observerOptions: createHiddenTabPollingObserverOptions<UpdateStatusSnapshot>(
-      (query) => query.state.data?.status.state === "running"
-        ? UPDATE_POLL_INTERVAL_RUNNING_MS
-        : UPDATE_POLL_INTERVAL_IDLE_MS,
-    ),
-    onData: applyStatusSnapshot,
-    queryClient: deps.queryClient,
-    queryFn: fetchStatusSnapshot,
-    queryKey: serverStateQueryKeys.update.statusSnapshot(),
-  });
+  const statusSnapshotQuery =
+    createObservedServerStateQuery<UpdateStatusSnapshot>({
+      enabled: deps.pollingEnabled,
+      onError: (error) => {
+        if (!disposed) {
+          deps.showError(
+            error instanceof Error
+              ? error.message
+              : deps.t("status.unavailable"),
+          );
+        }
+      },
+      observerOptions:
+        createHiddenTabPollingObserverOptions<UpdateStatusSnapshot>((query) =>
+          query.state.data?.status.state === "running"
+            ? UPDATE_POLL_INTERVAL_RUNNING_MS
+            : UPDATE_POLL_INTERVAL_IDLE_MS,
+        ),
+      onData: (snapshot) => {
+        if (!disposed) {
+          applyStatusSnapshot(snapshot);
+        }
+      },
+      queryClient: deps.queryClient,
+      queryFn: fetchStatusSnapshot,
+      queryKey: serverStateQueryKeys.update.statusSnapshot(),
+    });
+
+  async function refreshStatusForGeneration(generation: number): Promise<void> {
+    const snapshot = await fetchStatusSnapshot();
+    if (!isCurrentStatus(generation)) {
+      return;
+    }
+    statusSnapshotQuery.setData(() => snapshot);
+    applyStatusSnapshot(snapshot);
+  }
 
   async function refreshStatus(): Promise<void> {
-    await statusSnapshotQuery.fetch();
+    if (disposed) {
+      return;
+    }
+    const generation = nextStatusGeneration();
+    try {
+      await refreshStatusForGeneration(generation);
+    } catch (error) {
+      if (isCurrentStatus(generation)) {
+        deps.showError(
+          error instanceof Error ? error.message : deps.t("status.unavailable"),
+        );
+      }
+      throw error;
+    }
   }
 
   async function startUpdate(intent: UpdateFeatureStartIntent): Promise<void> {
+    if (disposed || startInFlight) {
+      return;
+    }
     if (!intent.canStart) {
       if (intent.transport === "wifi" && !intent.ssid) {
         deps.view.focusSsidInput();
@@ -180,43 +234,70 @@ export function createUpdateFeatureWorkflow(
       return;
     }
 
-    const payload: UpdateStartRequestPayload = intent.transport === "wifi"
-      ? {
-          transport: intent.transport,
-          ssid: intent.ssid,
-          password: intent.password,
-        }
-      : {
-          transport: intent.transport,
-          password: "",
-        };
+    const payload: UpdateStartRequestPayload =
+      intent.transport === "wifi"
+        ? {
+            transport: intent.transport,
+            ssid: intent.ssid,
+            password: intent.password,
+          }
+        : {
+            transport: intent.transport,
+            password: "",
+          };
 
+    startInFlight = true;
+    const generation = nextStatusGeneration();
     try {
       await api.startUpdate(payload);
+      if (!isCurrentStatus(generation)) {
+        return;
+      }
       deps.view.clearPassword();
-      await statusSnapshotQuery.fetch();
+      await refreshStatusForGeneration(generation);
     } catch (err) {
+      if (!isCurrentStatus(generation)) {
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("409")) {
         deps.showError(deps.t("settings.update.already_running"));
       } else {
         deps.showError(`${deps.t("settings.update.start_failed")}\n${msg}`);
       }
+    } finally {
+      startInFlight = false;
     }
   }
 
   async function cancelUpdate(): Promise<void> {
+    if (disposed || cancelInFlight) {
+      return;
+    }
+    cancelInFlight = true;
+    const generation = nextStatusGeneration();
     try {
       await api.cancelUpdate();
-      await statusSnapshotQuery.fetch();
     } catch {
       /* ignore */
+    } finally {
+      try {
+        if (isCurrentStatus(generation)) {
+          await refreshStatusForGeneration(generation);
+        }
+      } finally {
+        cancelInFlight = false;
+      }
     }
   }
 
   return {
     cancelUpdate,
     dispose(): void {
+      disposed = true;
+      statusGeneration += 1;
+      startInFlight = false;
+      cancelInFlight = false;
       statusSnapshotQuery.dispose();
     },
     getRenderState,

--- a/apps/ui/tests/esp_flash_feature_workflow.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_workflow.spec.ts
@@ -6,6 +6,7 @@ import type {
   EspSerialPortPayload,
 } from "../src/api/types";
 import { signal } from "../src/app/ui_signals";
+import { createDeferred, flushAsyncWork } from "./async_test_helpers";
 import { createTestQueryClient } from "./query_client_test_support";
 
 type WorkflowHarness = {
@@ -216,6 +217,156 @@ describe("createEspFlashFeatureWorkflow", () => {
     });
     expect(workflow.getRenderState().logText).toBe("");
     expect(workflow.getRenderState().status.state).toBe("running");
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
+  test("ignores older status refresh results when a newer refresh finishes first", async () => {
+    const harness = createHarness();
+    const olderStatus = createDeferred<EspFlashStatusPayload>();
+    const newerStatus = createDeferred<EspFlashStatusPayload>();
+    const statusRequests = [olderStatus, newerStatus];
+    const workflow = createEspFlashFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async getEspFlashStatus() {
+          const request = statusRequests.shift();
+          if (!request) {
+            throw new Error("unexpected status request");
+          }
+          return request.promise;
+        },
+        async getEspFlashHistory() {
+          return { attempts: [] };
+        },
+      },
+    });
+
+    const olderRefresh = workflow.refreshStatus();
+    await flushAsyncWork();
+    const newerRefresh = workflow.refreshStatus();
+    await flushAsyncWork();
+    newerStatus.resolve(makeStatus({ phase: "flashing", state: "running" }));
+    await newerRefresh;
+    olderStatus.resolve(makeStatus({ phase: "idle", state: "idle" }));
+    await olderRefresh;
+
+    expect(workflow.getRenderState().status.state).toBe("running");
+    expect(workflow.getRenderState().lastJourneyPhase).toBe("flashing");
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
+  test("does not update state or show errors when flash start resolves after disposal", async () => {
+    const harness = createHarness();
+    const start = createDeferred<unknown>();
+    const workflow = createEspFlashFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async getEspFlashPorts() {
+          return { ports: [makePort()] };
+        },
+        async startEspFlash() {
+          return start.promise;
+        },
+      },
+    });
+
+    await workflow.refreshPorts();
+    const starting = workflow.startFlash();
+    await flushAsyncWork();
+    workflow.dispose();
+    start.resolve({});
+    await starting;
+
+    expect(workflow.getRenderState().status.state).toBe("idle");
+    expect(workflow.getRenderState().logText).toBe("");
+    expect(harness.errors).toEqual([]);
+  });
+
+  test("ignores overlapping flash starts while one is in flight", async () => {
+    const harness = createHarness();
+    const start = createDeferred<unknown>();
+    let startCalls = 0;
+    const workflow = createEspFlashFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async getEspFlashHistory() {
+          return { attempts: [] };
+        },
+        async getEspFlashPorts() {
+          return { ports: [makePort()] };
+        },
+        async getEspFlashStatus() {
+          return makeStatus({ phase: "validating", state: "running" });
+        },
+        async startEspFlash() {
+          startCalls += 1;
+          return start.promise;
+        },
+      },
+    });
+
+    await workflow.refreshPorts();
+    const firstStart = workflow.startFlash();
+    void workflow.startFlash();
+    await flushAsyncWork();
+    start.resolve({});
+    await firstStart;
+
+    expect(startCalls).toBe(1);
+    expect(workflow.getRenderState().status.state).toBe("running");
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
+  test("ignores overlapping flash cancels while one is in flight", async () => {
+    const harness = createHarness();
+    const cancel = createDeferred<unknown>();
+    let cancelCalls = 0;
+    const workflow = createEspFlashFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async cancelEspFlash() {
+          cancelCalls += 1;
+          return cancel.promise;
+        },
+        async getEspFlashHistory() {
+          return { attempts: [] };
+        },
+        async getEspFlashStatus() {
+          return makeStatus();
+        },
+      },
+    });
+
+    const firstCancel = workflow.cancelFlash();
+    void workflow.cancelFlash();
+    await flushAsyncWork();
+    cancel.resolve({});
+    await firstCancel;
+
+    expect(cancelCalls).toBe(1);
     expect(harness.errors).toEqual([]);
     workflow.dispose();
   });

--- a/apps/ui/tests/update_feature_workflow.spec.ts
+++ b/apps/ui/tests/update_feature_workflow.spec.ts
@@ -9,6 +9,7 @@ import type {
   UsbInternetStatusPayload,
 } from "../src/api/types";
 import { signal } from "../src/app/ui_signals";
+import { createDeferred, flushAsyncWork } from "./async_test_helpers";
 import { createHealthyUpdateStatus } from "./maintenance_payload_test_support";
 import { createTestQueryClient } from "./query_client_test_support";
 
@@ -274,15 +275,186 @@ describe("createUpdateFeatureWorkflow", () => {
           return makeInternet();
         },
         async getUpdateStatus() {
-          throw new Error("Invalid update status response: /state Expected one of [\"idle\",\"running\",\"success\",\"failed\"]");
+          throw new Error(
+            'Invalid update status response: /state Expected one of ["idle","running","success","failed"]',
+          );
         },
       },
     });
 
-    await expect(workflow.refreshStatus()).rejects.toThrow(/Invalid update status response: \/state/);
-    expect(harness.errors).toContain(
-      "Invalid update status response: /state Expected one of [\"idle\",\"running\",\"success\",\"failed\"]",
+    await expect(workflow.refreshStatus()).rejects.toThrow(
+      /Invalid update status response: \/state/,
     );
+    expect(harness.errors).toContain(
+      'Invalid update status response: /state Expected one of ["idle","running","success","failed"]',
+    );
+    workflow.dispose();
+  });
+
+  test("ignores older refresh results when a newer status refresh finishes first", async () => {
+    const harness = createHarness();
+    const olderStatus = createDeferred<UpdateStatusPayload>();
+    const newerStatus = createDeferred<UpdateStatusPayload>();
+    const statusRequests = [olderStatus, newerStatus];
+    const workflow = createUpdateFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      view: createViewPorts(harness),
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async getHealthStatus() {
+          return makeHealth();
+        },
+        async getUpdateInternetStatus() {
+          return makeInternet();
+        },
+        async getUpdateStatus() {
+          const request = statusRequests.shift();
+          if (!request) {
+            throw new Error("unexpected status request");
+          }
+          return request.promise;
+        },
+      },
+    });
+
+    const olderRefresh = workflow.refreshStatus();
+    await flushAsyncWork();
+    const newerRefresh = workflow.refreshStatus();
+    await flushAsyncWork();
+    newerStatus.resolve(makeStatus({ phase: "installing", state: "running" }));
+    await newerRefresh;
+    olderStatus.resolve(makeStatus({ phase: "idle", state: "idle" }));
+    await olderRefresh;
+
+    expect(workflow.getRenderState().updateState).toBe("running");
+    expect(workflow.getRenderState().updateStatus?.phase).toBe("installing");
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
+  test("does not clear password or show errors when start resolves after disposal", async () => {
+    const harness = createHarness();
+    const start = createDeferred<unknown>();
+    const workflow = createUpdateFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      view: createViewPorts(harness),
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async startUpdate() {
+          return start.promise;
+        },
+      },
+    });
+
+    const starting = workflow.startUpdate({
+      canStart: true,
+      password: "secret",
+      ssid: "Workshop Wi-Fi",
+      transport: "wifi",
+      usbAvailable: false,
+    });
+    await flushAsyncWork();
+    workflow.dispose();
+    start.resolve({});
+    await starting;
+
+    expect(harness.viewCalls).toEqual([]);
+    expect(harness.errors).toEqual([]);
+  });
+
+  test("ignores overlapping update start requests while one is in flight", async () => {
+    const harness = createHarness();
+    const start = createDeferred<unknown>();
+    let startCalls = 0;
+    const workflow = createUpdateFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      view: createViewPorts(harness),
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async getHealthStatus() {
+          return makeHealth();
+        },
+        async getUpdateInternetStatus() {
+          return makeInternet();
+        },
+        async getUpdateStatus() {
+          return makeStatus({ phase: "installing", state: "running" });
+        },
+        async startUpdate() {
+          startCalls += 1;
+          return start.promise;
+        },
+      },
+    });
+    const intent = {
+      canStart: true,
+      password: "secret",
+      ssid: "Workshop Wi-Fi",
+      transport: "wifi" as const,
+      usbAvailable: false,
+    };
+
+    const firstStart = workflow.startUpdate(intent);
+    void workflow.startUpdate(intent);
+    await flushAsyncWork();
+    start.resolve({});
+    await firstStart;
+
+    expect(startCalls).toBe(1);
+    expect(harness.viewCalls).toEqual(["clearPassword"]);
+    expect(harness.errors).toEqual([]);
+    workflow.dispose();
+  });
+
+  test("ignores overlapping update cancel requests while one is in flight", async () => {
+    const harness = createHarness();
+    const cancel = createDeferred<unknown>();
+    let cancelCalls = 0;
+    const workflow = createUpdateFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      view: createViewPorts(harness),
+      pollingEnabled: signal(false),
+      queryClient: createTestQueryClient(),
+      api: {
+        async cancelUpdate() {
+          cancelCalls += 1;
+          return cancel.promise;
+        },
+        async getHealthStatus() {
+          return makeHealth();
+        },
+        async getUpdateInternetStatus() {
+          return makeInternet();
+        },
+        async getUpdateStatus() {
+          return makeStatus();
+        },
+      },
+    });
+
+    const firstCancel = workflow.cancelUpdate();
+    void workflow.cancelUpdate();
+    await flushAsyncWork();
+    cancel.resolve({});
+    await firstCancel;
+
+    expect(cancelCalls).toBe(1);
+    expect(harness.errors).toEqual([]);
     workflow.dispose();
   });
 });


### PR DESCRIPTION
## What changed
- Added disposed flags to update and ESP flash workflows.
- Added request-generation guards for manual update status, ESP status, and ESP port refreshes.
- Guarded polling callbacks so disposed workflows do not apply state or show errors.
- Added in-flight guards for update start/cancel and ESP flash start/cancel.
- Suppressed stale/disposed side effects: password clearing, error toasts, log/status writes, port selection resets, and status snapshots.
- Added focused workflow regressions for stale older refreshes, disposal during start, and double-click start/cancel behavior.

## Why
Slow update or ESP flash requests could mutate detached UI state after navigation/remount. Overlapping clicks could also let older async results win last.

## Validation
- `npx biome format --write ...`
- `npx biome lint ...`
- `npm run typecheck:tests`
- `npx vitest run tests/update_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts`
- `PYTHON=/workspace/VibeSensor/apps/server/.venv/bin/python npm run typecheck`
- `git diff --check`

## Risks / tradeoffs
- A repeated start/cancel click while the same operation is in flight is ignored, not queued.
- Manual refreshes now use explicit generation-checked fetch/apply logic so stale responses cannot overwrite newer state.

## Follow-ups
- None for this issue.

Fixes #3609.
