### PR TITLE
Make local CI action gaps explicit

### DIFF
--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -214,3 +214,30 @@ def test_main_skips_ui_bootstrap_step_when_helper_reports_clean_workspace(
     assert module.main(["--job", "frontend-typecheck"]) == 0
 
     assert all(step.label != "ui deps: ensure bootstrap" for step in captured["bootstrap_steps"])
+
+
+def test_main_warns_about_skipped_external_workflow_actions(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=False)
+    release_smoke_step = module.Step(
+        "Release smoke validation",
+        ["python3", "tools/tests/run_release_smoke.py"],
+    )
+    _captured, outputs = _install_main_harness(
+        module,
+        monkeypatch,
+        tmp_path,
+        {"release-smoke": [release_smoke_step]},
+    )
+
+    assert module.main(["--job", "release-smoke"]) == 0
+
+    output = "\n".join(outputs)
+    assert "[ci-local] skipped external workflow actions:" in output
+    assert "release-smoke (Download release-smoke UI static artifact)" in output
+    assert "actions/download-artifact@" in output
+    assert "without --skip-ui-build" in output

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -84,3 +84,41 @@ def test_contributing_docs_reference_focused_backend_ci_gates() -> None:
     assert focused_gate_names.issubset(job_names)
     for gate_name in focused_gate_names:
         assert gate_name in contributing_text
+
+
+def test_release_smoke_local_manifest_builds_ui_static_instead_of_downloading_artifact() -> None:
+    module = _load_ci_manifest_module()
+
+    job = module.ci_workflow_jobs()["release-smoke"]
+    runnable_commands = tuple(spec.command for spec in job.local_runnable_steps("python"))
+
+    assert any("tools/tests/run_release_smoke.py" in command for command in runnable_commands)
+    assert all("--skip-ui-build" not in command for command in runnable_commands)
+    assert all("ui-static.tar.gz" not in command for command in runnable_commands)
+
+
+def test_skipped_external_actions_are_explicit_and_substituted() -> None:
+    module = _load_ci_manifest_module()
+
+    jobs = module.ci_workflow_jobs()
+    release_smoke_downloads = [
+        action
+        for action in jobs["release-smoke"].skipped_actions
+        if action.uses.startswith("actions/download-artifact@")
+    ]
+    assert len(release_smoke_downloads) == 1
+    assert release_smoke_downloads[0].local_substitute
+    assert "without --skip-ui-build" in release_smoke_downloads[0].local_substitute
+
+    unsupported_required_artifact_actions = [
+        (job_name, action.uses)
+        for job_name, job in jobs.items()
+        for action in job.skipped_actions
+        if (
+            action.uses.startswith("actions/download-artifact@")
+            or action.uses.startswith("actions/upload-artifact@")
+            or action.uses.startswith("actions/cache@")
+        )
+        and not action.local_substitute
+    ]
+    assert unsupported_required_artifact_actions == []

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -63,9 +63,17 @@ class CiWorkflowStep:
 
 
 @dataclass(frozen=True)
+class CiWorkflowSkippedAction:
+    name: str
+    uses: str
+    local_substitute: str | None = None
+
+
+@dataclass(frozen=True)
 class CiWorkflowJob:
     job_name: str
     steps: tuple[CiWorkflowStep, ...]
+    skipped_actions: tuple[CiWorkflowSkippedAction, ...] = ()
 
     def commands_named(self, names: Collection[str]) -> tuple[str, ...]:
         commands: list[str] = []
@@ -86,10 +94,15 @@ class CiWorkflowJob:
             if step.name in _INSTALL_STEP_NAMES:
                 continue
             for command in step.commands:
+                local_command = _local_command_substitute(
+                    self.job_name, step.name, command
+                )
+                if local_command is None:
+                    continue
                 specs.append(
                     RunnableCommandSpec(
                         label=step.name,
-                        command=_replace_python_placeholders(command, python_cmd),
+                        command=_replace_python_placeholders(local_command, python_cmd),
                     )
                 )
         return tuple(specs)
@@ -235,6 +248,73 @@ def _normalized_ci_steps(raw_step: Mapping[str, object]) -> tuple[CiWorkflowStep
     return tuple(normalized_steps)
 
 
+def _local_action_skipped_actions(
+    action_ref: str, raw_with: Mapping[str, object] | None
+) -> tuple[CiWorkflowSkippedAction, ...]:
+    action_file = _local_action_file(action_ref)
+    if action_file is None:
+        return ()
+    action = _load_yaml_mapping(action_file)
+    runs = action.get("runs")
+    if not isinstance(runs, Mapping):
+        return ()
+    raw_steps = runs.get("steps")
+    if not isinstance(raw_steps, list):
+        return ()
+    action_inputs = _resolved_action_inputs(action, raw_with)
+    skipped: list[CiWorkflowSkippedAction] = []
+    for action_step in raw_steps:
+        if not isinstance(action_step, Mapping):
+            continue
+        if not _action_step_enabled(action_step, action_inputs):
+            continue
+        skipped.extend(_skipped_ci_actions(action_step))
+    return tuple(skipped)
+
+
+def _skipped_ci_actions(
+    raw_step: Mapping[str, object],
+) -> tuple[CiWorkflowSkippedAction, ...]:
+    uses = raw_step.get("uses")
+    if not isinstance(uses, str):
+        return ()
+    raw_with = raw_step.get("with")
+    with_mapping = raw_with if isinstance(raw_with, Mapping) else None
+    if _local_action_file(uses) is not None:
+        return _local_action_skipped_actions(uses, with_mapping)
+    return (
+        CiWorkflowSkippedAction(
+            name=str(raw_step.get("name", "")),
+            uses=uses,
+        ),
+    )
+
+
+def _local_action_substitute(job_name: str, step_name: str, uses: str) -> str | None:
+    if job_name == "release-smoke" and uses.startswith("actions/download-artifact@"):
+        return "local release-smoke builds UI static directly by running run_release_smoke.py without --skip-ui-build"
+    if uses.startswith("actions/upload-artifact@"):
+        return "local runner writes job logs under artifacts/ai/logs/ci_local instead of uploading artifacts"
+    if uses.startswith("actions/cache@"):
+        return "local runner uses the existing workspace/cache state; cache restore/save is CI-only"
+    if uses.startswith("actions/setup-node@"):
+        return "local runner relies on the configured local Node runtime and UI bootstrap helper"
+    if uses.startswith("actions/setup-python@"):
+        return "local runner uses the current Python executable and replaces workflow python-path placeholders"
+    return None
+
+
+def _local_command_substitute(
+    job_name: str, step_name: str, command: str
+) -> str | None:
+    if job_name == "release-smoke":
+        if step_name == "Restore release-smoke UI static artifact":
+            return None
+        if step_name == "Release smoke validation":
+            return command.replace(" --skip-ui-build", "")
+    return command
+
+
 def _replace_python_placeholders(command: str, python_cmd: str) -> str:
     tokens = shlex.split(command)
     replaced: list[str] = []
@@ -301,13 +381,25 @@ def ci_workflow_jobs() -> dict[str, CiWorkflowJob]:
             if not isinstance(raw_steps, list):
                 continue
             normalized_steps: list[CiWorkflowStep] = []
+            skipped_actions: list[CiWorkflowSkippedAction] = []
             for raw_step in raw_steps:
                 if not isinstance(raw_step, Mapping):
                     continue
                 normalized_steps.extend(_normalized_ci_steps(raw_step))
+                skipped_actions.extend(
+                    CiWorkflowSkippedAction(
+                        name=action.name,
+                        uses=action.uses,
+                        local_substitute=_local_action_substitute(
+                            expanded_job_name, action.name, action.uses
+                        ),
+                    )
+                    for action in _skipped_ci_actions(raw_step)
+                )
             result[expanded_job_name] = CiWorkflowJob(
                 job_name=expanded_job_name,
                 steps=tuple(normalized_steps),
+                skipped_actions=tuple(skipped_actions),
             )
     return result
 

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -260,6 +260,26 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
     }
 
 
+def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
+    jobs = _CI_MANIFEST.ci_workflow_jobs()
+    warned = False
+    for job_name in selected_jobs:
+        skipped_actions = jobs[job_name].skipped_actions
+        if not skipped_actions:
+            continue
+        if not warned:
+            _emit("[ci-local] skipped external workflow actions:")
+            warned = True
+        for action in skipped_actions:
+            action_name = f" ({action.name})" if action.name else ""
+            substitute = (
+                f"; local substitute: {action.local_substitute}"
+                if action.local_substitute
+                else "; no local substitute"
+            )
+            _emit(f"[ci-local] - {job_name}{action_name}: {action.uses}{substitute}")
+
+
 def _selected_jobs_require_platformio(selected_jobs: list[str]) -> bool:
     jobs = _CI_MANIFEST.ci_workflow_jobs()
     return any(jobs[job_name].requires_platformio for job_name in selected_jobs)
@@ -327,6 +347,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.job
         else list(CI_LITE_JOB_NAMES if args.ci_lite else ALL_JOB_NAMES)
     )
+    _emit_skipped_action_warnings(selected_jobs)
 
     if _shared_ui_workspace_would_race(
         selected_jobs,


### PR DESCRIPTION
## What changed

- Track skipped external workflow actions in the local CI manifest.
- Add explicit local substitutes for setup/cache/artifact actions.
- Make local `release-smoke` build UI static directly by running without `--skip-ui-build`.
- Print selected-job warnings for skipped external actions and substitutes.
- Add hygiene coverage for artifact/cache substitute gaps.

## Why

Local CI runner ignored `uses:` actions. That hid parity gaps, especially `release-smoke`, where CI downloads a UI artifact but local execution had no artifact producer.

## Validation

- `ruff format`
- `ruff check`
- `pytest apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py -q`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases

- Warnings are additive runner output.
- Local `release-smoke` is still not byte-for-byte CI artifact restore; it is now explicit and builds the UI static assets locally instead.
- Workflow-only upload/download behavior remains CI-only unless a local substitute is declared.

## Follow-ups

- None.
