### PR TITLE
Generate realistic ACT pull request events

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ Commands
 - `make docs-lint`
 - `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
-- `act -j backend-lint -W .github/workflows/ci.yml` (run a single CI job locally via `act`; requires Docker)
+- `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a single CI job locally via `act` with generated pull-request event data; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
 - `python3 tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
@@ -81,7 +81,7 @@ Validation chooser
 Command gotchas
 - `make ui-typecheck` is the default frontend gate because it materializes generated UI contract artifacts before linting and TypeScript checks.
 - Raw `cd apps/ui && npm run typecheck` or `npm run build` can fail when generated UI contract files are stale; run `make sync-contracts` or `make ui-typecheck` first when backend contracts changed.
-- `act` requires Docker and is best for targeted GitHub workflow parity, not docs-only changes.
+- `act` requires Docker; prefer `tools/tests/run_ci_with_act.sh` when validating PR changed-file CI scope because it generates base/head SHAs for the pull-request event.
 - PlatformIO must be installed before `cd firmware/esp && pio run`.
 - Pi image builds are expensive; use the narrow `BUILD_MODE=app` or `BUILD_MODE=image` path unless both layers changed.
 - The local Docker stack is for runtime integration behavior, not docs-only, instruction-only, or pure unit-test changes.

--- a/apps/server/tests/hygiene/test_ci_changed_scope.py
+++ b/apps/server/tests/hygiene/test_ci_changed_scope.py
@@ -14,6 +14,7 @@ from tests._paths import REPO_ROOT
 
 _CI_PATH_RULES = REPO_ROOT / "tools" / "tests" / "ci_path_rules.py"
 _CI_CHANGED_SCOPE = REPO_ROOT / "tools" / "tests" / "ci_changed_scope.py"
+_ACT_EVENT = REPO_ROOT / "tools" / "tests" / "act_event.py"
 
 
 def _load_module(name: str, path: Path) -> ModuleType:
@@ -67,4 +68,60 @@ def test_pull_request_event_outputs_match_path_rules(
         ci_changed_scope._selection_for_github_event()
         == ci_changed_scope.workflow_job_selection(changed_files).github_outputs()
     )
+    assert merge_base_calls == [("base-sha", "head-sha")]
+
+
+def test_act_pull_request_event_helper_writes_non_empty_changed_scope_shas(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _load_module("ci_path_rules", _CI_PATH_RULES)
+    ci_changed_scope = _load_module("ci_changed_scope_for_act_event_test", _CI_CHANGED_SCOPE)
+    module = _load_module("act_event_local_test", _ACT_EVENT)
+
+    def fake_run(command, **_kwargs):
+        assert command[:3] == ["git", "rev-parse", "--verify"]
+        ref = command[3]
+        return module.subprocess.CompletedProcess(
+            command,
+            0 if ref == "origin/main" else 1,
+        )
+
+    def fake_check_output(command, **_kwargs):
+        assert command[0] == "git"
+        match tuple(command[1:]):
+            case ("merge-base", "origin/main", "HEAD"):
+                return "base-sha"
+            case ("rev-parse", "--abbrev-ref", "HEAD"):
+                return "issue-branch"
+            case ("rev-parse", "HEAD"):
+                return "head-sha"
+        raise AssertionError(f"unexpected git command: {command}")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.subprocess, "check_output", fake_check_output)
+
+    output_path = tmp_path / "act-event.json"
+    assert module.main(["--output", str(output_path)]) == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    pull_request = payload["pull_request"]
+    assert pull_request["base"] == {"ref": "origin/main", "sha": "base-sha"}
+    assert pull_request["head"] == {"ref": "issue-branch", "sha": "head-sha"}
+
+    merge_base_calls: list[tuple[str, str]] = []
+
+    def fake_changed_files_for_merge_base(base_sha: str, head_sha: str) -> tuple[str, ...]:
+        merge_base_calls.append((base_sha, head_sha))
+        return ("tools/tests/run_ci_with_act.sh",)
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(output_path))
+    monkeypatch.setattr(
+        ci_changed_scope,
+        "_changed_files_for_merge_base",
+        fake_changed_files_for_merge_base,
+    )
+
+    ci_changed_scope._selection_for_github_event()
     assert merge_base_calls == [("base-sha", "head-sha")]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -291,8 +291,10 @@ Prerequisites: Docker and [`act`](https://nektosact.com/installation/index.html)
 # List available CI jobs
 act -l -W .github/workflows/ci.yml
 
-# Run all CI jobs (push event)
-act -W .github/workflows/ci.yml
+# Run all CI jobs for the current branch as a pull_request event.
+# Generate the event first so ci-scope sees real base/head SHAs.
+python3 tools/tests/act_event.py --output /tmp/vibesensor-act-event.json
+act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
 
 # Run a single job
 act -j backend-lint -W .github/workflows/ci.yml
@@ -308,19 +310,23 @@ act -j backend-tests -W .github/workflows/ci.yml
 act -j ui-smoke -W .github/workflows/ci.yml
 act -j release-smoke -W .github/workflows/ci.yml
 
-# Run with pull_request event (uses the included event payload)
-act pull_request -W .github/workflows/ci.yml -e tools/tests/act-event.json
+# Use a non-default base ref when needed.
+python3 tools/tests/act_event.py --base-ref main --output /tmp/vibesensor-act-event.json
+act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
 ```
 
 ### Optional wrapper (convenience only)
 
 A thin shell wrapper is provided at `tools/tests/run_ci_with_act.sh`. It checks
-prerequisites and passes arguments through to `act`:
+prerequisites, generates a temporary pull-request event from the local checkout
+using `origin/main` then `main` as the base-ref fallback, and passes remaining
+arguments through to `act`:
 
 ```bash
 ./tools/tests/run_ci_with_act.sh -l               # list jobs
-./tools/tests/run_ci_with_act.sh                   # run all CI jobs
-./tools/tests/run_ci_with_act.sh -j backend-lint  # run one job
+./tools/tests/run_ci_with_act.sh                   # run all CI jobs as pull_request
+./tools/tests/run_ci_with_act.sh -j backend-lint  # run one job as pull_request
+./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 ```
 
 ### Secrets

--- a/tools/tests/act-event.json
+++ b/tools/tests/act-event.json
@@ -1,10 +1,12 @@
 {
   "pull_request": {
     "head": {
-      "ref": "local"
+      "ref": "local",
+      "sha": "replace-with-head-sha"
     },
     "base": {
-      "ref": "main"
+      "ref": "main",
+      "sha": "replace-with-base-sha"
     }
   }
 }

--- a/tools/tests/act_event.py
+++ b/tools/tests/act_event.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Generate local act event payloads from the current checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class PullRequestRefs:
+    base_ref: str
+    base_sha: str
+    head_ref: str
+    head_sha: str
+
+
+def _git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+
+
+def _git_has_ref(ref: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            cwd=ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def resolve_base_ref(requested: str | None) -> str:
+    candidates = [requested] if requested else ["origin/main", "main"]
+    for candidate in candidates:
+        if candidate and _git_has_ref(candidate):
+            return candidate
+    raise SystemExit(
+        "No base ref found. Fetch origin/main or rerun with --base-ref <ref> "
+        "(for example main)."
+    )
+
+
+def resolve_pull_request_refs(requested_base_ref: str | None) -> PullRequestRefs:
+    base_ref = resolve_base_ref(requested_base_ref)
+    try:
+        base_sha = _git_output("merge-base", base_ref, "HEAD")
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"Unable to find a common ancestor between {base_ref} and HEAD. "
+            "Fetch the latest history or rerun with --base-ref <ref>."
+        ) from exc
+    return PullRequestRefs(
+        base_ref=base_ref,
+        base_sha=base_sha,
+        head_ref=_git_output("rev-parse", "--abbrev-ref", "HEAD"),
+        head_sha=_git_output("rev-parse", "HEAD"),
+    )
+
+
+def build_pull_request_event(refs: PullRequestRefs) -> dict[str, Any]:
+    return {
+        "pull_request": {
+            "base": {
+                "ref": refs.base_ref,
+                "sha": refs.base_sha,
+            },
+            "head": {
+                "ref": refs.head_ref,
+                "sha": refs.head_sha,
+            },
+        }
+    }
+
+
+def write_pull_request_event(path: Path, refs: PullRequestRefs) -> None:
+    path.write_text(
+        json.dumps(build_pull_request_event(refs), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        help="Base ref for the generated pull_request event (default: origin/main, then main).",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to write the generated event JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    refs = resolve_pull_request_refs(args.base_ref)
+    write_pull_request_event(args.output, refs)
+    print(
+        "[act-event] "
+        f"base={refs.base_ref}@{refs.base_sha} "
+        f"head={refs.head_ref}@{refs.head_sha} "
+        f"event={args.output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/run_ci_with_act.sh
+++ b/tools/tests/run_ci_with_act.sh
@@ -4,14 +4,38 @@
 # optional convenience only.
 #
 # Usage:
-#   ./tools/tests/run_ci_with_act.sh              # run all CI jobs (push event)
+#   ./tools/tests/run_ci_with_act.sh              # run all CI jobs (pull_request event)
 #   ./tools/tests/run_ci_with_act.sh -l            # list available jobs
 #   ./tools/tests/run_ci_with_act.sh -j backend-lint      # run one job
 #   ./tools/tests/run_ci_with_act.sh -j backend-tests-1   # run one backend test shard
+#   ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 #   ./tools/tests/run_ci_with_act.sh <extra act args>     # pass-through
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BASE_REF=""
+PASSTHROUGH_ARGS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base-ref)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: --base-ref requires a value." >&2
+        exit 2
+      fi
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --base-ref=*)
+      BASE_REF="${1#--base-ref=}"
+      shift
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
 
 # ── prerequisite checks ──────────────────────────────────────────────
 if ! command -v docker &>/dev/null; then
@@ -33,11 +57,21 @@ fi
 # ── run act ──────────────────────────────────────────────────────────
 cd "$REPO_ROOT"
 
-EVENT_FILE="tools/tests/act-event.json"
+EVENT_FILE="$(mktemp "${TMPDIR:-/tmp}/vibesensor-act-event.XXXXXX.json")"
+cleanup() {
+  rm -f "$EVENT_FILE"
+}
+trap cleanup EXIT
 
-ACT_ARGS=(-W .github/workflows/ci.yml -e "$EVENT_FILE")
+GENERATE_ARGS=(--output "$EVENT_FILE")
+if [ -n "$BASE_REF" ]; then
+  GENERATE_ARGS+=(--base-ref "$BASE_REF")
+fi
+"${PYTHON:-python3}" tools/tests/act_event.py "${GENERATE_ARGS[@]}"
+
+ACT_ARGS=(pull_request -W .github/workflows/ci.yml -e "$EVENT_FILE")
 if [ -f .secrets.act ]; then
   ACT_ARGS+=(--secret-file .secrets.act)
 fi
 
-exec act "${ACT_ARGS[@]}" "$@"
+act "${ACT_ARGS[@]}" "${PASSTHROUGH_ARGS[@]}"


### PR DESCRIPTION
## What changed

- Added `tools/tests/act_event.py` to generate pull-request event JSON from the local checkout.
- Wired `run_ci_with_act.sh` to generate a temporary `pull_request` event before invoking `act`.
- Added `--base-ref` support with the same `origin/main` then `main` fallback shape as changed-file tooling.
- Updated ACT docs and AI guidance away from the incomplete static event payload.
- Added hygiene coverage proving `ci_changed_scope.py` receives the generated base/head SHAs.

## Why

The wrapper used a static event without `pull_request.base.sha` or `pull_request.head.sha`. That made ACT runs fall back to full-stack changed-file scope instead of matching GitHub PR gating.

## Validation

- `ruff format`
- `ruff check`
- `pytest apps/server/tests/hygiene/test_ci_changed_scope.py -q`
- `shellcheck --severity=warning -x -s bash tools/tests/run_ci_with_act.sh`
- `python tools/dev/docs_lint.py`
- generated-event smoke with `tools/tests/act_event.py --base-ref main`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases

- Wrapper default now runs `act` with a `pull_request` event so CI scope matches PR behavior.
- The static `act-event.json` remains only as a fallback/example payload.
- Docker/act are still required for actual workflow execution.

## Follow-ups

- None.
