### PR TITLE
Validate documented Make targets

### DIFF
--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -1,0 +1,42 @@
+"""Guard docs lint command-reference checks."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_DOCS_LINT = REPO_ROOT / "tools" / "dev" / "docs_lint.py"
+
+
+def _load_docs_lint_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("docs_lint_local_for_tests", _DOCS_LINT)
+    assert spec is not None and spec.loader is not None, f"Unable to load {_DOCS_LINT}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_make_command_target_lint_rejects_stale_documented_targets(
+    tmp_path: Path,
+) -> None:
+    module = _load_docs_lint_module()
+    (tmp_path / "Makefile").write_text(
+        ".PHONY: coverage lint\ncoverage:\n\tpytest\nlint:\n\truff check .\n",
+        encoding="utf-8",
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    docs_path = docs_dir / "testing.md"
+    docs_path.write_text(
+        "```bash\nmake coverage\nmake coverage-html\n```\nInline command: `make lint`.\n",
+        encoding="utf-8",
+    )
+
+    assert module._check_make_command_targets(["docs/testing.md"], tmp_path) == [
+        "docs/testing.md: documented make target does not exist: coverage-html"
+    ]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -390,8 +390,10 @@ Use coverage runs to expose untested paths before they become release risk.
 
 ```bash
 make coverage
-make coverage-html
-make coverage-strict
+
+# Optional pytest-cov overrides pass through COV_OPTS.
+COV_OPTS="--cov-report=html --cov-report=term-missing:skip-covered" make coverage
+COV_OPTS="--cov-fail-under=80 --cov-report=term-missing:skip-covered" make coverage
 ```
 
 For direct control over thresholds and output:

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -62,6 +62,9 @@ REPO_PATH_PREFIXES = (
 GENERATED_REPO_PATH_REFERENCES = {
     "apps/ui/src/constants.ts",
 }
+MAKE_COMMAND_RE = re.compile(r"(?<![\w./-])make\s+(?P<args>[^`#\n]*)")
+MAKE_TARGET_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+MAKE_OPTION_ARGS = {"-C", "-f", "--file", "--directory"}
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -190,6 +193,80 @@ def _read_text(repo_root: Path, relative_path: str) -> str | None:
         return (repo_root / relative_path).read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None
+
+
+def _makefile_targets(repo_root: Path) -> set[str]:
+    makefile_text = _read_text(repo_root, "Makefile")
+    if makefile_text is None:
+        return set()
+    targets: set[str] = set()
+    for line in makefile_text.splitlines():
+        if not line or line.startswith(("\t", " ", "#")) or ":" not in line:
+            continue
+        raw_targets = line.split(":", 1)[0].strip().split()
+        for target in raw_targets:
+            if MAKE_TARGET_RE.fullmatch(target):
+                targets.add(target)
+    return targets
+
+
+def _markdown_code_snippets(text: str) -> list[str]:
+    snippets: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            snippets.append(line)
+    snippets.extend(match.group(1) for match in re.finditer(r"`([^`\n]+)`", text))
+    return snippets
+
+
+def _first_make_target(args: str) -> str | None:
+    tokens = [token.strip(".,;:)") for token in args.split()]
+    skip_next = False
+    for token in tokens:
+        if not token:
+            continue
+        if skip_next:
+            skip_next = False
+            continue
+        if token in {"&&", "||", "|"}:
+            return None
+        if token in MAKE_OPTION_ARGS:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        if "=" in token or token.startswith("$"):
+            continue
+        if MAKE_TARGET_RE.fullmatch(token):
+            return token
+    return None
+
+
+def _check_make_command_targets(
+    markdown_files: list[str], repo_root: Path
+) -> list[str]:
+    """Flag documented make targets that do not exist in the Makefile."""
+    targets = _makefile_targets(repo_root)
+    if not targets:
+        return ["Makefile targets could not be loaded for docs command lint"]
+
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        for snippet in _markdown_code_snippets(text):
+            for match in MAKE_COMMAND_RE.finditer(snippet):
+                target = _first_make_target(match.group("args"))
+                if target is not None and target not in targets:
+                    issues.append(
+                        f"{path}: documented make target does not exist: {target}"
+                    )
+    return issues
 
 
 def _check_ai_guidance_stack(markdown_files: list[str], repo_root: Path) -> list[str]:
@@ -353,6 +430,7 @@ def main() -> int:
     issues.extend(_check_ai_guidance_stack(markdown_files, repo_root))
     issues.extend(_check_guidance_script_references(markdown_files, repo_root))
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))
+    issues.extend(_check_make_command_targets(markdown_files, repo_root))
 
     if issues:
         print(f"❌ {len(issues)} docs issue(s):")
@@ -361,7 +439,7 @@ def main() -> int:
         return 1
 
     print(
-        "✅ No docs misuse, runtime docs access, broken local markdown links, or AI guidance stack drift detected."
+        "✅ No docs misuse, runtime docs access, broken local markdown links, stale make commands, or AI guidance stack drift detected."
     )
     return 0
 


### PR DESCRIPTION
## What changed

- Removed nonexistent `make coverage-html` and `make coverage-strict` from `docs/testing.md`.
- Documented supported `make coverage` plus `COV_OPTS` pytest-cov overrides.
- Extended `docs_lint.py` to validate documented `make` targets against the real Makefile.
- Added hygiene coverage for stale documented Makefile targets.

## Why

Testing docs are the validation source for contributors and AI agents. Stale Makefile targets cause local validation to fail before the intended checks run.

## Validation

- `ruff format`
- `ruff check`
- `pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases

- Docs lint only checks `make` commands inside fenced code blocks and inline code spans to avoid prose false positives.
- Commands using environment overrides remain supported as long as the actual Makefile target exists.

## Follow-ups

- None.
