### PR TITLE
Add CI-backed validation planner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,6 +53,8 @@ Commands
 - `make sync-contracts`
 - `make ui-typecheck` (default frontend validation path: materialize generated UI contract artifacts, then run UI lint and TypeScript checks)
 - `make docs-lint`
+- `make plan-validation` (primary AI/dev validation planner: changed-file CI plan, local command, ACT command, and JSON summary)
+- `python3 tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
 - `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a single CI job locally via `act` with generated pull-request event data; requires Docker)
@@ -69,6 +71,7 @@ Commands
 - `docker compose build --pull && docker compose up -d`
 
 Validation chooser
+- Start with `make plan-validation` for changed-file CI scope; use `python3 tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
 - Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
 - Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.
 - Frontend logic, contracts, or composition: `make ui-typecheck`; for bundle behavior also run `cd apps/ui && npm ci && npm run build`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed plan-validation test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -81,6 +81,10 @@ test: ## Run the fast backend pytest suite
 test-changed: ## Run heuristic checks for files changed vs origin/main
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/run_changed.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
+
+plan-validation: ## Plan changed-file validation from CI path rules
+	@$(RESOLVE_PYTHON) \
+	"$$PYTHON" tools/tests/plan_validation.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
 
 test-ci-lite: ## Run the non-Docker blocking CI subset locally
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/tests/hygiene/test_plan_validation.py
+++ b/apps/server/tests/hygiene/test_plan_validation.py
@@ -1,0 +1,82 @@
+"""Guard the AI/dev validation planner."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+
+from tests._paths import REPO_ROOT
+
+_PLAN_VALIDATION = REPO_ROOT / "tools" / "tests" / "plan_validation.py"
+
+
+def _load_plan_validation_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "plan_validation_local_for_tests", _PLAN_VALIDATION
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_PLAN_VALIDATION}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_changed_files(
+    module: ModuleType,
+    monkeypatch,
+    changed_files: tuple[str, ...],
+) -> None:
+    monkeypatch.setattr(module._RUN_CHANGED, "_resolve_base_ref", lambda _ref: "origin/main")
+    monkeypatch.setattr(module._RUN_CHANGED, "_changed_files", lambda _base: changed_files)
+
+
+def test_plan_validation_uses_ci_path_rules_for_docs_only_changes(monkeypatch) -> None:
+    module = _load_plan_validation_module()
+    _install_changed_files(module, monkeypatch, ("docs/testing.md",))
+
+    plan = module.build_validation_plan("origin/main")
+
+    assert plan.ci_jobs == ("docs-lint",)
+    assert plan.local_jobs == ("docs-lint",)
+    assert plan.act_jobs == ("docs-lint",)
+    assert plan.local_command[-2:] == ("--job", "docs-lint")
+    assert plan.act_command[-2:] == ("-j", "docs-lint")
+    assert plan.parity == "approximate"
+    assert plan.unsupported == ()
+    assert plan.github_outputs["run_docs_lint"] == "true"
+    assert plan.github_outputs["run_backend_tests"] == "false"
+
+
+def test_plan_validation_expands_backend_tests_for_local_runner(monkeypatch) -> None:
+    module = _load_plan_validation_module()
+    _install_changed_files(
+        module,
+        monkeypatch,
+        ("apps/server/vibesensor/use_cases/run/post_analysis_executor.py",),
+    )
+
+    plan = module.build_validation_plan("origin/main")
+
+    assert "backend-tests" in plan.ci_jobs
+    assert "backend-tests" in plan.act_jobs
+    assert all(f"backend-tests-{index}" in plan.local_jobs for index in range(1, 6))
+    assert plan.github_outputs["run_backend_tests"] == "true"
+
+
+def test_plan_validation_marks_release_smoke_as_approximate_not_unsupported(
+    monkeypatch,
+) -> None:
+    module = _load_plan_validation_module()
+    _install_changed_files(module, monkeypatch, ("tools/tests/run_release_smoke.py",))
+
+    plan = module.build_validation_plan("origin/main")
+
+    assert "ui-build-artifact" in plan.ci_jobs
+    assert "release-smoke" in plan.ci_jobs
+    assert "release-smoke" in plan.local_jobs
+    assert "repo-hygiene" in plan.local_jobs
+    assert "backend-lint" in plan.local_jobs
+    assert plan.parity == "approximate"
+    assert plan.unsupported == ()
+    assert any("ui-build-artifact" in note for note in plan.approximations)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,8 +7,9 @@
 - Firmware build/flash guidance lives in `firmware/esp/README.md`.
 - Pi-image build/validation guidance lives in `infra/pi-image/pi-gen/README.md`.
 - `make format` is the canonical Python formatting command for backend and tooling files; no other Python formatter is supported in the repo workflow.
-- Use `make test-ci-lite` (`python3 tools/tests/run_ci_parallel.py --ci-lite`) for the non-Docker blocking-CI subset.
-- Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner.
+- Use `make plan-validation` (`python3 tools/tests/plan_validation.py`) first to turn the current diff into the CI-backed validation plan.
+- Use `python3 tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
+- Use `python3 tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
 - Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
 - Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
 - The full end-to-end verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
@@ -111,11 +112,16 @@ and complete in under 5 seconds.
 
 ## Running tests
 
-Backend/local CI tiers: `make test-changed` for a fast changed-file heuristic, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `act -W .github/workflows/ci.yml` (required before finalizing) to run the real GitHub workflow locally in Docker.
+Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity.
 
 Main local tiers:
 
 ```bash
+# CI-backed changed-file validation plan
+make plan-validation
+python3 tools/tests/plan_validation.py --run
+python3 tools/tests/plan_validation.py --act
+
 # Changed-file heuristic (current branch vs origin/main, fallback to main)
 make test-changed
 

--- a/tools/tests/ci_path_rules.py
+++ b/tools/tests/ci_path_rules.py
@@ -34,6 +34,7 @@ FULL_STACK_TRIGGER_FILES = {
     "tools/tests/ci_changed_scope.py",
     "tools/tests/ci_path_rules.py",
     "tools/tests/ci_workflow_manifest.py",
+    "tools/tests/plan_validation.py",
     "tools/tests/run_ci_parallel.py",
 }
 FULL_STACK_TRIGGER_PREFIXES = (".github/",)

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -291,6 +291,8 @@ def _skipped_ci_actions(
 
 
 def _local_action_substitute(job_name: str, step_name: str, uses: str) -> str | None:
+    if uses.startswith("actions/checkout@"):
+        return "local runner uses the current checked-out workspace"
     if job_name == "release-smoke" and uses.startswith("actions/download-artifact@"):
         return "local release-smoke builds UI static directly by running run_release_smoke.py without --skip-ui-build"
     if uses.startswith("actions/upload-artifact@"):

--- a/tools/tests/plan_validation.py
+++ b/tools/tests/plan_validation.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Plan local validation from the current diff using CI path rules."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+_CI_PATH_RULES_PATH = Path(__file__).with_name("ci_path_rules.py")
+_CI_MANIFEST_PATH = Path(__file__).with_name("ci_workflow_manifest.py")
+_RUN_CHANGED_PATH = Path(__file__).with_name("run_changed.py")
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_CI_PATH_RULES = _load_module("ci_path_rules_for_plan_validation", _CI_PATH_RULES_PATH)
+_CI_MANIFEST = _load_module("ci_manifest_for_plan_validation", _CI_MANIFEST_PATH)
+_RUN_CHANGED = _load_module("run_changed_for_plan_validation", _RUN_CHANGED_PATH)
+
+BACKEND_TEST_JOBS = tuple(f"backend-tests-{index}" for index in range(1, 6))
+
+
+@dataclass(frozen=True)
+class SelectionMapping:
+    field_name: str
+    ci_jobs: tuple[str, ...]
+    local_jobs: tuple[str, ...]
+    act_jobs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidationPlan:
+    base_ref: str
+    changed_files: tuple[str, ...]
+    ci_jobs: tuple[str, ...]
+    local_jobs: tuple[str, ...]
+    act_jobs: tuple[str, ...]
+    local_command: tuple[str, ...]
+    act_command: tuple[str, ...]
+    parity: str
+    approximations: tuple[str, ...] = ()
+    unsupported: tuple[str, ...] = ()
+    github_outputs: dict[str, str] = field(default_factory=dict)
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "base_ref": self.base_ref,
+            "changed_files": list(self.changed_files),
+            "ci_jobs": list(self.ci_jobs),
+            "local_jobs": list(self.local_jobs),
+            "act_jobs": list(self.act_jobs),
+            "local_command": list(self.local_command),
+            "act_command": list(self.act_command),
+            "parity": self.parity,
+            "approximations": list(self.approximations),
+            "unsupported": list(self.unsupported),
+            "github_outputs": self.github_outputs,
+        }
+
+
+SELECTION_MAPPINGS = (
+    SelectionMapping("docs_lint", ("docs-lint",), ("docs-lint",), ("docs-lint",)),
+    SelectionMapping(
+        "repo_hygiene", ("repo-hygiene",), ("repo-hygiene",), ("repo-hygiene",)
+    ),
+    SelectionMapping("shell_lint", ("shell-lint",), ("shell-lint",), ("shell-lint",)),
+    SelectionMapping(
+        "backend_lint", ("backend-lint",), ("backend-lint",), ("backend-lint",)
+    ),
+    SelectionMapping(
+        "backend_static_guards",
+        ("backend-static-guards",),
+        ("backend-static-guards",),
+        ("backend-static-guards",),
+    ),
+    SelectionMapping(
+        "backend_preflight",
+        ("backend-preflight",),
+        ("backend-preflight",),
+        ("backend-preflight",),
+    ),
+    SelectionMapping(
+        "backend_contract_drift",
+        ("backend-contract-drift",),
+        ("backend-contract-drift",),
+        ("backend-contract-drift",),
+    ),
+    SelectionMapping(
+        "backend_typecheck",
+        ("backend-typecheck",),
+        ("backend-typecheck",),
+        ("backend-typecheck",),
+    ),
+    SelectionMapping(
+        "frontend_typecheck",
+        ("frontend-quality", "frontend-typecheck", "ui-unit"),
+        ("frontend-quality", "frontend-typecheck", "ui-unit"),
+        ("frontend-quality", "frontend-typecheck", "ui-unit"),
+    ),
+    SelectionMapping("ui_smoke", ("ui-smoke",), ("ui-smoke",), ("ui-smoke",)),
+    SelectionMapping(
+        "backend_tests",
+        ("backend-tests",),
+        BACKEND_TEST_JOBS,
+        ("backend-tests",),
+    ),
+    SelectionMapping(
+        "release_smoke",
+        ("ui-build-artifact", "release-smoke"),
+        ("release-smoke",),
+        ("ui-build-artifact", "release-smoke"),
+    ),
+    SelectionMapping(
+        "firmware_native_tests",
+        ("firmware-native-tests",),
+        ("firmware-native-tests",),
+        ("firmware-native-tests",),
+    ),
+    SelectionMapping("e2e", ("e2e",), ("e2e",), ("e2e",)),
+)
+
+
+def _dedupe(items: list[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(items))
+
+
+def _selected_jobs(
+    selection,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    ci_jobs: list[str] = []
+    local_jobs: list[str] = []
+    act_jobs: list[str] = []
+    for mapping in SELECTION_MAPPINGS:
+        if getattr(selection, mapping.field_name):
+            ci_jobs.extend(mapping.ci_jobs)
+            local_jobs.extend(mapping.local_jobs)
+            act_jobs.extend(mapping.act_jobs)
+    return _dedupe(ci_jobs), _dedupe(local_jobs), _dedupe(act_jobs)
+
+
+def _local_command(local_jobs: tuple[str, ...]) -> tuple[str, ...]:
+    if not local_jobs:
+        return ()
+    command = [sys.executable, "tools/tests/run_ci_parallel.py"]
+    for job in local_jobs:
+        command.extend(("--job", job))
+    return tuple(command)
+
+
+def _act_command(base_ref: str, act_jobs: tuple[str, ...]) -> tuple[str, ...]:
+    if not act_jobs:
+        return ()
+    command = ["./tools/tests/run_ci_with_act.sh", "--base-ref", base_ref]
+    for job in act_jobs:
+        command.extend(("-j", job))
+    return tuple(command)
+
+
+def _parity_notes(
+    local_jobs: tuple[str, ...],
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    jobs = _CI_MANIFEST.ci_workflow_jobs()
+    approximations: list[str] = []
+    unsupported: list[str] = []
+    if "release-smoke" in local_jobs:
+        approximations.append(
+            "release-smoke: CI restores ui-build-artifact; local runner builds UI static directly"
+        )
+    for job_name in local_jobs:
+        job = jobs.get(job_name)
+        if job is None:
+            unsupported.append(f"{job_name}: no local workflow manifest entry")
+            continue
+        skipped_with_substitutes: list[str] = []
+        for action in job.skipped_actions:
+            action_label = action.name or action.uses
+            if action.local_substitute:
+                skipped_with_substitutes.append(action.uses)
+            else:
+                unsupported.append(
+                    f"{job_name}: skips {action.uses} ({action_label}) without local substitute"
+                )
+        if skipped_with_substitutes:
+            approximations.append(
+                f"{job_name}: skips external actions with local substitutes: "
+                + ", ".join(dict.fromkeys(skipped_with_substitutes))
+            )
+    if unsupported:
+        parity = "unsupported"
+    elif approximations:
+        parity = "approximate"
+    else:
+        parity = "exact"
+    return parity, tuple(approximations), tuple(unsupported)
+
+
+def build_validation_plan(requested_base_ref: str | None = None) -> ValidationPlan:
+    base_ref = _RUN_CHANGED._resolve_base_ref(requested_base_ref)
+    changed_files = _RUN_CHANGED._changed_files(base_ref)
+    if not changed_files:
+        return ValidationPlan(
+            base_ref=base_ref,
+            changed_files=(),
+            ci_jobs=(),
+            local_jobs=(),
+            act_jobs=(),
+            local_command=(),
+            act_command=(),
+            parity="exact",
+            github_outputs={},
+        )
+
+    selection = _CI_PATH_RULES.workflow_job_selection(changed_files)
+    ci_jobs, local_jobs, act_jobs = _selected_jobs(selection)
+    parity, approximations, unsupported = _parity_notes(local_jobs)
+    return ValidationPlan(
+        base_ref=base_ref,
+        changed_files=changed_files,
+        ci_jobs=ci_jobs,
+        local_jobs=local_jobs,
+        act_jobs=act_jobs,
+        local_command=_local_command(local_jobs),
+        act_command=_act_command(base_ref, act_jobs),
+        parity=parity,
+        approximations=approximations,
+        unsupported=unsupported,
+        github_outputs=selection.github_outputs(),
+    )
+
+
+def _print_plan(plan: ValidationPlan) -> None:
+    print(f"[validation-plan] base ref: {plan.base_ref}")
+    if not plan.changed_files:
+        print("[validation-plan] no changed files detected")
+    else:
+        print("[validation-plan] changed files:")
+        for path in plan.changed_files:
+            print(f"  - {path}")
+    print(f"[validation-plan] parity: {plan.parity}")
+    if plan.ci_jobs:
+        print(f"[validation-plan] CI jobs: {', '.join(plan.ci_jobs)}")
+    if plan.local_command:
+        print(f"[validation-plan] local: {shlex.join(plan.local_command)}")
+    if plan.act_command:
+        print(f"[validation-plan] act: {shlex.join(plan.act_command)}")
+    for note in plan.approximations:
+        print(f"[validation-plan] approximate: {note}")
+    for note in plan.unsupported:
+        print(f"[validation-plan] unsupported: {note}")
+    print("[validation-plan] json:")
+    print(json.dumps(plan.as_json(), sort_keys=True, separators=(",", ":")))
+
+
+def _run_command(command: tuple[str, ...]) -> int:
+    if not command:
+        return 0
+    return subprocess.run(command, cwd=ROOT, check=False).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref to diff against (default: origin/main, falling back to main).",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run the planned non-Docker local run_ci_parallel.py command.",
+    )
+    parser.add_argument(
+        "--act",
+        action="store_true",
+        help="Run the planned act command instead of run_ci_parallel.py.",
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Print only the compact machine-readable JSON summary.",
+    )
+    args = parser.parse_args(argv)
+    if args.run and args.act:
+        parser.error("--run and --act are mutually exclusive")
+
+    plan = build_validation_plan(args.base_ref)
+    if args.json_only:
+        print(json.dumps(plan.as_json(), sort_keys=True, separators=(",", ":")))
+    else:
+        _print_plan(plan)
+
+    if plan.unsupported and (args.run or args.act):
+        print(
+            "[validation-plan] refusing to run unsupported local CI parity plan",
+            file=sys.stderr,
+        )
+        return 2
+    if args.run:
+        return _run_command(plan.local_command)
+    if args.act:
+        return _run_command(plan.act_command)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed
- Added `tools/tests/plan_validation.py`.
- It resolves the current diff through existing `run_changed.py` logic.
- It maps changed files through `workflow_job_selection()` from `ci_path_rules.py`.
- It prints CI jobs, local `run_ci_parallel.py --job ...`, ACT jobs, parity notes, and compact JSON.
- Added `make plan-validation`.
- Updated AI and testing docs to point agents at the planner first.

## Why
Agents had several near-equivalent validation commands.
Some were fast but not tied to CI scope.
Some over-ran broad suites.
This gives one CI-backed planner before manual choices.

## Validation
- `ruff format` / `ruff check` on touched Python files.
- `pytest apps/server/tests/hygiene/test_plan_validation.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_ci_path_rules.py -q`
- `make plan-validation`
- `python tools/tests/plan_validation.py --json-only`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Planner reuses `run_changed.py` private helpers to preserve exact changed-file behavior.
- Local parity is marked `approximate` when workflow actions have explicit local substitutes.
- Unsupported workflow-only gaps are surfaced and refused for `--run` / `--act`.

## Follow-ups
- None for this issue.

Closes #3613.
