### PR TITLE
Serialize overlapping local CI write sets

### DIFF
--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import threading
+import time
 from pathlib import Path
 
 from tests._paths import REPO_ROOT
@@ -241,3 +243,68 @@ def test_main_warns_about_skipped_external_workflow_actions(
     assert "release-smoke (Download release-smoke UI static artifact)" in output
     assert "actions/download-artifact@" in output
     assert "without --skip-ui-build" in output
+
+
+def test_main_serializes_jobs_with_overlapping_workspace_write_sets(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=False)
+    jobs = {
+        "frontend-typecheck": [module.Step("UI typecheck", ["true"])],
+        "backend-contract-drift": [module.Step("Contract sync", ["true"])],
+    }
+    outputs: list[str] = []
+    active_jobs = 0
+    max_active_jobs = 0
+    lock = threading.Lock()
+
+    monkeypatch.setattr(module, "_job_steps", lambda _python_cmd: jobs)
+    monkeypatch.setattr(module, "_run_bootstrap", lambda _steps: 0)
+    monkeypatch.setattr(module, "_emit", outputs.append)
+    monkeypatch.setattr(
+        module,
+        "_job_workspace_write_sets",
+        lambda: {
+            "frontend-typecheck": ("ui-generated-contracts",),
+            "backend-contract-drift": ("ui-generated-contracts",),
+        },
+    )
+
+    def _fake_run_job(name, _steps, results):
+        nonlocal active_jobs, max_active_jobs
+        with lock:
+            active_jobs += 1
+            max_active_jobs = max(max_active_jobs, active_jobs)
+        time.sleep(0.02)
+        with lock:
+            active_jobs -= 1
+        results[name] = module.JobResult(
+            name=name,
+            ok=True,
+            failed_step=None,
+            return_code=0,
+            duration_s=0.0,
+            log_path=tmp_path / f"{name}.log",
+        )
+
+    monkeypatch.setattr(module, "_run_job", _fake_run_job)
+
+    assert (
+        module.main(
+            [
+                "--job",
+                "frontend-typecheck",
+                "--job",
+                "backend-contract-drift",
+            ]
+        )
+        == 0
+    )
+
+    output = "\n".join(outputs)
+    assert "shared workspace write-set serialization" in output
+    assert "ui-generated-contracts: frontend-typecheck, backend-contract-drift" in output
+    assert max_active_jobs == 1

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -122,3 +122,19 @@ def test_skipped_external_actions_are_explicit_and_substituted() -> None:
         and not action.local_substitute
     ]
     assert unsupported_required_artifact_actions == []
+
+
+def test_common_local_jobs_declare_shared_workspace_write_sets() -> None:
+    module = _load_ci_manifest_module()
+
+    jobs = module.ci_workflow_jobs()
+    assert set(jobs["frontend-typecheck"].workspace_write_sets) == {"ui-generated-contracts"}
+    assert set(jobs["backend-contract-drift"].workspace_write_sets) == {"ui-generated-contracts"}
+    assert set(jobs["release-smoke"].workspace_write_sets) == {
+        "ui-generated-contracts",
+        "ui-dist",
+        "server-static",
+        "server-dist",
+        "release-smoke-artifacts",
+    }
+    assert set(jobs["ui-smoke"].workspace_write_sets) == {"ui-test-results"}

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -48,6 +48,19 @@ _ACTION_INPUT_EQ_RE = re.compile(
     r"^\${{\s*inputs\.([A-Za-z0-9_-]+)\s*==\s*'([^']+)'\s*}}$"
 )
 _MATRIX_TOKEN_RE = re.compile(r"\${{\s*matrix\.([A-Za-z0-9_-]+)\s*}}")
+_JOB_WORKSPACE_WRITE_SETS = {
+    "backend-contract-drift": ("ui-generated-contracts",),
+    "frontend-typecheck": ("ui-generated-contracts",),
+    "ui-unit": ("ui-test-results",),
+    "ui-smoke": ("ui-test-results",),
+    "release-smoke": (
+        "ui-generated-contracts",
+        "ui-dist",
+        "server-static",
+        "server-dist",
+        "release-smoke-artifacts",
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -74,6 +87,7 @@ class CiWorkflowJob:
     job_name: str
     steps: tuple[CiWorkflowStep, ...]
     skipped_actions: tuple[CiWorkflowSkippedAction, ...] = ()
+    workspace_write_sets: tuple[str, ...] = ()
 
     def commands_named(self, names: Collection[str]) -> tuple[str, ...]:
         commands: list[str] = []
@@ -402,6 +416,9 @@ def ci_workflow_jobs() -> dict[str, CiWorkflowJob]:
                 job_name=expanded_job_name,
                 steps=tuple(normalized_steps),
                 skipped_actions=tuple(skipped_actions),
+                workspace_write_sets=_JOB_WORKSPACE_WRITE_SETS.get(
+                    expanded_job_name, ()
+                ),
             )
     return result
 

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -194,6 +194,26 @@ def _run_job(name: str, steps: list[Step], results: dict[str, JobResult]) -> Non
         )
 
 
+def _run_job_with_workspace_locks(
+    name: str,
+    steps: list[Step],
+    results: dict[str, JobResult],
+    workspace_write_sets: tuple[str, ...],
+    workspace_locks: dict[str, threading.Lock],
+) -> None:
+    ordered_write_sets = tuple(sorted(workspace_write_sets))
+    acquired: list[threading.Lock] = []
+    try:
+        for write_set in ordered_write_sets:
+            lock = workspace_locks[write_set]
+            lock.acquire()
+            acquired.append(lock)
+        _run_job(name, steps, results)
+    finally:
+        for lock in reversed(acquired):
+            lock.release()
+
+
 def _bootstrap_steps(
     python_cmd: str,
     run_npm_ci: bool,
@@ -260,6 +280,13 @@ def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
     }
 
 
+def _job_workspace_write_sets() -> dict[str, tuple[str, ...]]:
+    return {
+        job_name: job.workspace_write_sets
+        for job_name, job in _CI_MANIFEST.ci_workflow_jobs().items()
+    }
+
+
 def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
     jobs = _CI_MANIFEST.ci_workflow_jobs()
     warned = False
@@ -278,6 +305,36 @@ def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
                 else "; no local substitute"
             )
             _emit(f"[ci-local] - {job_name}{action_name}: {action.uses}{substitute}")
+
+
+def _overlapping_workspace_write_sets(
+    selected_jobs: list[str],
+    job_write_sets: dict[str, tuple[str, ...]],
+) -> dict[str, tuple[str, ...]]:
+    jobs_by_write_set: dict[str, list[str]] = {}
+    for job_name in selected_jobs:
+        for write_set in job_write_sets[job_name]:
+            jobs_by_write_set.setdefault(write_set, []).append(job_name)
+    return {
+        write_set: tuple(job_names)
+        for write_set, job_names in sorted(jobs_by_write_set.items())
+        if len(job_names) > 1
+    }
+
+
+def _emit_workspace_write_set_warnings(
+    selected_jobs: list[str],
+    job_write_sets: dict[str, tuple[str, ...]],
+) -> None:
+    overlaps = _overlapping_workspace_write_sets(selected_jobs, job_write_sets)
+    if not overlaps:
+        return
+    _emit("[ci-local] shared workspace write-set serialization:")
+    for write_set, job_names in overlaps.items():
+        _emit(
+            f"[ci-local] - {write_set}: {', '.join(job_names)}; serialized locally "
+            "because GitHub jobs use isolated checkouts"
+        )
 
 
 def _selected_jobs_require_platformio(selected_jobs: list[str]) -> bool:
@@ -342,12 +399,14 @@ def main(argv: list[str] | None = None) -> int:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     all_jobs = _job_steps(python_cmd)
+    job_write_sets = _job_workspace_write_sets()
     selected_jobs = (
         args.job
         if args.job
         else list(CI_LITE_JOB_NAMES if args.ci_lite else ALL_JOB_NAMES)
     )
     _emit_skipped_action_warnings(selected_jobs)
+    _emit_workspace_write_set_warnings(selected_jobs, job_write_sets)
 
     if _shared_ui_workspace_would_race(
         selected_jobs,
@@ -384,10 +443,21 @@ def main(argv: list[str] | None = None) -> int:
     started = time.monotonic()
     results: dict[str, JobResult] = {}
     threads: list[threading.Thread] = []
+    workspace_locks = {
+        write_set: threading.Lock()
+        for job_name in selected_jobs
+        for write_set in job_write_sets[job_name]
+    }
     for job_name in selected_jobs:
         thread = threading.Thread(
-            target=_run_job,
-            args=(job_name, all_jobs[job_name], results),
+            target=_run_job_with_workspace_locks,
+            args=(
+                job_name,
+                all_jobs[job_name],
+                results,
+                job_write_sets[job_name],
+                workspace_locks,
+            ),
             daemon=False,
         )
         thread.start()


### PR DESCRIPTION
## What changed
- Added local CI workspace write-set metadata to the workflow manifest.
- Marked common mutating jobs:
  - `frontend-typecheck` / `backend-contract-drift`: generated UI contracts.
  - `release-smoke`: generated contracts, UI dist, server static, server dist, release-smoke artifacts.
  - `ui-smoke`: UI test results.
- Added write-set locks in `run_ci_parallel.py`.
- Selected jobs with overlapping write sets now print a serialization warning and run those critical sections one at a time.
- Added hygiene coverage for manifest metadata and runner serialization.

## Why
GitHub jobs run in isolated checkouts.
The local runner shares one checkout.
Overlapping local writers can create false failures or false passes.

## Validation
- `ruff format` / `ruff check` on touched files.
- `pytest apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ci_workflow_manifest.py -q`
- `python tools/tests/plan_validation.py --json-only`
- `python tools/tests/run_ci_parallel.py --help`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- This serializes only declared write-set overlaps, not every shared workspace read/write.
- Metadata is explicit and test-backed so new high-risk writers can be added without changing runner scheduling.
- Jobs without overlapping write sets still run in parallel.

## Follow-ups
- None for this issue.

Closes #3614.
