### PR TITLE
Report ShellCheck prerequisite in local CI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,6 +55,7 @@ Commands
 - `make docs-lint`
 - `make plan-validation` (primary AI/dev validation planner: changed-file CI plan, local command, ACT command, and JSON summary)
 - `python3 tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
+- `make doctor` (reports local prerequisites, including host `shellcheck` for local `shell-lint` parity)
 - `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a single CI job locally via `act` with generated pull-request event data; requires Docker)
@@ -72,6 +73,7 @@ Commands
 
 Validation chooser
 - Start with `make plan-validation` for changed-file CI scope; use `python3 tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
+- Local `shell-lint` parity requires host `shellcheck`; use ACT when you need CI to install ShellCheck inside the workflow job.
 - Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
 - Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.
 - Frontend logic, contracts, or composition: `make ui-typecheck`; for bundle behavior also run `cd apps/ui && npm ci && npm run build`.

--- a/apps/server/tests/hygiene/test_check_prerequisites.py
+++ b/apps/server/tests/hygiene/test_check_prerequisites.py
@@ -85,3 +85,34 @@ def test_check_docker_requires_compose_v2_even_if_legacy_binary_exists(monkeypat
         ),
         ("docker daemon", "OK", "reachable"),
     ]
+
+
+def test_check_shellcheck_reports_missing_local_ci_prerequisite(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(module, "_which", lambda _command: None)
+
+    result = module._check_shellcheck()
+
+    assert result.name == "shellcheck"
+    assert result.status == "WARN"
+    assert "local shell-lint CI parity" in result.message
+
+
+def test_check_shellcheck_reports_installed_version(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(module, "_which", lambda command: "/usr/bin/shellcheck")
+    monkeypatch.setattr(
+        module,
+        "_run",
+        lambda command: (True, "ShellCheck - shell script analysis tool\nversion: 0.10.0\n"),
+    )
+
+    result = module._check_shellcheck()
+
+    assert (result.name, result.status, result.message) == (
+        "shellcheck",
+        "OK",
+        "version: 0.10.0",
+    )

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -245,6 +245,42 @@ def test_main_warns_about_skipped_external_workflow_actions(
     assert "without --skip-ui-build" in output
 
 
+def test_main_reports_missing_shellcheck_before_running_shell_lint(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    outputs: list[str] = []
+
+    monkeypatch.setattr(
+        module,
+        "_job_steps",
+        lambda _python_cmd: {"shell-lint": [module.Step("ShellCheck", ["make"])]},
+    )
+    monkeypatch.setattr(module, "_job_workspace_write_sets", lambda: {"shell-lint": ()})
+    monkeypatch.setattr(module, "_job_host_tools", lambda: {"shell-lint": ("shellcheck",)})
+    monkeypatch.setattr(module.shutil, "which", lambda _tool: None)
+    monkeypatch.setattr(
+        module,
+        "_run_bootstrap",
+        lambda _steps: (_ for _ in ()).throw(AssertionError("bootstrap should not run")),
+    )
+    monkeypatch.setattr(
+        module,
+        "_run_job",
+        lambda _name, _steps, _results: (_ for _ in ()).throw(AssertionError("job should not run")),
+    )
+    monkeypatch.setattr(module, "_emit", outputs.append)
+
+    assert module.main(["--job", "shell-lint"]) == 2
+
+    output = "\n".join(outputs)
+    assert "missing host prerequisites" in output
+    assert "shell-lint requires shellcheck" in output
+    assert "run the job through ACT" in output
+
+
 def test_main_serializes_jobs_with_overlapping_workspace_write_sets(
     monkeypatch,
     tmp_path: Path,

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -138,3 +138,9 @@ def test_common_local_jobs_declare_shared_workspace_write_sets() -> None:
         "release-smoke-artifacts",
     }
     assert set(jobs["ui-smoke"].workspace_write_sets) == {"ui-test-results"}
+
+
+def test_shell_lint_declares_host_shellcheck_prerequisite() -> None:
+    module = _load_ci_manifest_module()
+
+    assert module.ci_workflow_jobs()["shell-lint"].host_tools == ("shellcheck",)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,7 @@
 - Use `make plan-validation` (`python3 tools/tests/plan_validation.py`) first to turn the current diff into the CI-backed validation plan.
 - Use `python3 tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
 - Use `python3 tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
+- Local `shell-lint` parity requires host `shellcheck`; `make doctor` reports it, and ACT/GitHub CI install it inside the workflow job.
 - Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
 - Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
 - The full end-to-end verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
@@ -112,7 +113,7 @@ and complete in under 5 seconds.
 
 ## Running tests
 
-Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity.
+Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
 
 Main local tiers:
 

--- a/tools/dev/check_prerequisites.py
+++ b/tools/dev/check_prerequisites.py
@@ -139,6 +139,27 @@ def _check_npm() -> CheckResult:
     return CheckResult("npm", "OK", output.strip())
 
 
+def _check_shellcheck() -> CheckResult:
+    if _which("shellcheck") is None:
+        return CheckResult(
+            "shellcheck",
+            "WARN",
+            "missing (required for make shell-lint and local shell-lint CI parity)",
+        )
+    ok, output = _run(["shellcheck", "--version"])
+    if not ok:
+        return CheckResult(
+            "shellcheck",
+            "WARN",
+            f"installed but unhealthy: {_first_line(output)}",
+        )
+    version_line = next(
+        (line for line in output.splitlines() if line.startswith("version:")),
+        _first_line(output),
+    )
+    return CheckResult("shellcheck", "OK", version_line)
+
+
 def _check_docker() -> list[CheckResult]:
     results: list[CheckResult] = []
     if _which("docker") is None:
@@ -209,10 +230,13 @@ def main() -> int:
         _check_node(expected_node),
         _check_npm(),
     ]
+    local_ci_results = [_check_shellcheck()]
     docker_results = _check_docker()
     firmware_results = [_check_platformio()]
 
     _print_section("Core development prerequisites:", core_results)
+    print()
+    _print_section("Local CI parity prerequisites:", local_ci_results)
     print()
     _print_section("Docker workflow availability:", docker_results)
     print()
@@ -222,7 +246,12 @@ def main() -> int:
     core_failures = [result for result in core_results if result.status == "FAIL"]
     warnings = [
         result
-        for result in [*core_results, *docker_results, *firmware_results]
+        for result in [
+            *core_results,
+            *local_ci_results,
+            *docker_results,
+            *firmware_results,
+        ]
         if result.status == "WARN"
     ]
 

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -61,6 +61,9 @@ _JOB_WORKSPACE_WRITE_SETS = {
         "release-smoke-artifacts",
     ),
 }
+_JOB_HOST_TOOLS = {
+    "shell-lint": ("shellcheck",),
+}
 
 
 @dataclass(frozen=True)
@@ -88,6 +91,7 @@ class CiWorkflowJob:
     steps: tuple[CiWorkflowStep, ...]
     skipped_actions: tuple[CiWorkflowSkippedAction, ...] = ()
     workspace_write_sets: tuple[str, ...] = ()
+    host_tools: tuple[str, ...] = ()
 
     def commands_named(self, names: Collection[str]) -> tuple[str, ...]:
         commands: list[str] = []
@@ -419,6 +423,7 @@ def ci_workflow_jobs() -> dict[str, CiWorkflowJob]:
                 workspace_write_sets=_JOB_WORKSPACE_WRITE_SETS.get(
                     expanded_job_name, ()
                 ),
+                host_tools=_JOB_HOST_TOOLS.get(expanded_job_name, ()),
             )
     return result
 

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -8,6 +8,7 @@ import importlib.util
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -287,6 +288,13 @@ def _job_workspace_write_sets() -> dict[str, tuple[str, ...]]:
     }
 
 
+def _job_host_tools() -> dict[str, tuple[str, ...]]:
+    return {
+        job_name: job.host_tools
+        for job_name, job in _CI_MANIFEST.ci_workflow_jobs().items()
+    }
+
+
 def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
     jobs = _CI_MANIFEST.ci_workflow_jobs()
     warned = False
@@ -305,6 +313,37 @@ def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
                 else "; no local substitute"
             )
             _emit(f"[ci-local] - {job_name}{action_name}: {action.uses}{substitute}")
+
+
+def _missing_host_tools(
+    selected_jobs: list[str],
+    job_host_tools: dict[str, tuple[str, ...]],
+) -> dict[str, tuple[str, ...]]:
+    missing_by_job: dict[str, tuple[str, ...]] = {}
+    for job_name in selected_jobs:
+        missing = tuple(
+            tool for tool in job_host_tools[job_name] if shutil.which(tool) is None
+        )
+        if missing:
+            missing_by_job[job_name] = missing
+    return missing_by_job
+
+
+def _check_host_tool_prerequisites(
+    selected_jobs: list[str],
+    job_host_tools: dict[str, tuple[str, ...]],
+) -> bool:
+    missing = _missing_host_tools(selected_jobs, job_host_tools)
+    if not missing:
+        return True
+    _emit("[ci-local] missing host prerequisites for selected jobs:")
+    for job_name, tools in missing.items():
+        _emit(
+            f"[ci-local] - {job_name} requires {', '.join(tools)}. "
+            "GitHub CI installs these inside the job; install them locally or run "
+            "the job through ACT for workflow-managed prerequisites."
+        )
+    return False
 
 
 def _overlapping_workspace_write_sets(
@@ -400,6 +439,7 @@ def main(argv: list[str] | None = None) -> int:
 
     all_jobs = _job_steps(python_cmd)
     job_write_sets = _job_workspace_write_sets()
+    job_host_tools = _job_host_tools()
     selected_jobs = (
         args.job
         if args.job
@@ -407,6 +447,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     _emit_skipped_action_warnings(selected_jobs)
     _emit_workspace_write_set_warnings(selected_jobs, job_write_sets)
+    if not _check_host_tool_prerequisites(selected_jobs, job_host_tools):
+        return 2
 
     if _shared_ui_workspace_would_race(
         selected_jobs,


### PR DESCRIPTION
## What changed
- Added manifest host-tool metadata for `shell-lint`.
- `run_ci_parallel.py` now checks selected jobs for required host tools before bootstrap/job execution.
- Missing `shellcheck` now fails with a targeted local-vs-GitHub prerequisite message.
- `make doctor` reports local ShellCheck availability.
- Updated testing and AI guidance for local `shell-lint` parity versus ACT/GitHub workflow installs.
- Added hygiene tests for manifest metadata, runner preflight, and doctor reporting.

## Why
GitHub CI installs ShellCheck inside the `shell-lint` job.
The local runner skips install steps.
Clean local environments could fail deep in `make shell-lint` with unclear parity context.

## Validation
- `ruff format` / `ruff check` on touched Python files.
- `pytest apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_check_prerequisites.py -q`
- `python tools/tests/plan_validation.py --json-only`
- `make doctor`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- The local runner does not install system packages.
- It now fails fast and points users to local install or ACT when workflow-managed prerequisites are needed.
- Existing `make shell-lint` behavior is unchanged.

## Follow-ups
- None for this issue.

Closes #3616.
