### PR TITLE
Split fast local CI from CI-lite

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,8 @@ Commands
 - `python3 tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
 - `make doctor` (reports local prerequisites, including host `shellcheck` for local `shell-lint` parity)
 - `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
+- `make test-ci-fast` (fast local CI gates: lint, docs, static guards, and type checks; no browser/release/firmware/e2e/backend test suites)
+- `make test-ci-lite` (non-Docker workflow jobs except e2e; includes backend shards, UI smoke, release smoke, and firmware native tests)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
 - `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a single CI job locally via `act` with generated pull-request event data; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
@@ -73,6 +75,7 @@ Commands
 
 Validation chooser
 - Start with `make plan-validation` for changed-file CI scope; use `python3 tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
+- Use `make test-ci-fast` for a broad but fast local gate before heavier browser/release/backend suites; use `make test-ci-lite` only when you want the larger non-Docker workflow surface except e2e.
 - Local `shell-lint` parity requires host `shellcheck`; use ACT when you need CI to install ShellCheck inside the workflow job.
 - Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
 - Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed plan-validation test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -86,7 +86,11 @@ plan-validation: ## Plan changed-file validation from CI path rules
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/plan_validation.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
 
-test-ci-lite: ## Run the non-Docker blocking CI subset locally
+test-ci-fast: ## Run fast local CI gates without browser, release, firmware, e2e, or backend test suites
+	@$(RESOLVE_PYTHON) \
+	"$$PYTHON" tools/tests/run_ci_parallel.py --ci-fast
+
+test-ci-lite: ## Run non-Docker workflow jobs except E2E locally
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/run_ci_parallel.py --ci-lite
 

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -281,6 +281,21 @@ def test_main_reports_missing_shellcheck_before_running_shell_lint(
     assert "run the job through ACT" in output
 
 
+def test_manifest_shell_operator_steps_run_through_bash(tmp_path: Path) -> None:
+    module = _load_ci_parallel_module()
+    step = module._step_from_manifest_command(
+        "shell operators",
+        "set -euo pipefail && printf ok",
+    )
+
+    assert step.shell is True
+    assert step.cmd == ["set -euo pipefail && printf ok"]
+    with (tmp_path / "step.log").open("w", encoding="utf-8") as log_file:
+        assert module._run_step(step, log_file) == 0
+
+    assert "ok" in (tmp_path / "step.log").read_text(encoding="utf-8")
+
+
 def test_main_serializes_jobs_with_overlapping_workspace_write_sets(
     monkeypatch,
     tmp_path: Path,

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -86,6 +86,51 @@ def test_contributing_docs_reference_focused_backend_ci_gates() -> None:
         assert gate_name in contributing_text
 
 
+def test_ci_fast_jobs_are_lint_docs_static_and_typecheck_gates() -> None:
+    module = _load_ci_manifest_module()
+
+    fast_jobs = set(module.ci_fast_job_names())
+
+    assert {
+        "backend-lint",
+        "repo-hygiene",
+        "shell-lint",
+        "backend-static-guards",
+        "backend-preflight",
+        "docs-lint",
+        "backend-contract-drift",
+        "backend-typecheck",
+        "frontend-quality",
+        "frontend-typecheck",
+    } == fast_jobs
+    assert not any(job_name.startswith("backend-tests-") for job_name in fast_jobs)
+    assert {
+        "ui-unit",
+        "ui-smoke",
+        "release-smoke",
+        "firmware-native-tests",
+        "e2e",
+    }.isdisjoint(fast_jobs)
+
+
+def test_ci_lite_jobs_are_non_docker_blocking_jobs_except_e2e() -> None:
+    module = _load_ci_manifest_module()
+
+    lite_jobs = set(module.ci_lite_job_names())
+
+    assert "e2e" not in lite_jobs
+    assert {
+        "backend-tests-1",
+        "backend-tests-2",
+        "backend-tests-3",
+        "backend-tests-4",
+        "backend-tests-5",
+        "ui-smoke",
+        "release-smoke",
+        "firmware-native-tests",
+    }.issubset(lite_jobs)
+
+
 def test_release_smoke_local_manifest_builds_ui_static_instead_of_downloading_artifact() -> None:
     module = _load_ci_manifest_module()
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,8 @@
 - Use `make plan-validation` (`python3 tools/tests/plan_validation.py`) first to turn the current diff into the CI-backed validation plan.
 - Use `python3 tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
 - Use `python3 tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
+- Use `make test-ci-fast` for lint, docs, static guards, and type checks without browser, release, firmware, e2e, or backend test suites.
+- Use `make test-ci-lite` for the larger non-Docker workflow surface except e2e; it still includes backend shards, UI smoke, release smoke, and firmware native tests.
 - Local `shell-lint` parity requires host `shellcheck`; `make doctor` reports it, and ACT/GitHub CI install it inside the workflow job.
 - Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
 - Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
@@ -113,7 +115,7 @@ and complete in under 5 seconds.
 
 ## Running tests
 
-Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-lite` for the non-Docker blocking-CI subset, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
+Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-fast` for lint/docs/static/typecheck gates without heavy suites, `make test-ci-lite` for non-Docker workflow jobs except e2e, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
 
 Main local tiers:
 
@@ -129,7 +131,8 @@ make test-changed
 # Fast iteration — backend unit tests
 make test
 
-# Non-Docker blocking-CI subset
+# Fast non-Docker CI gates, then larger non-Docker CI except e2e
+make test-ci-fast
 make test-ci-lite
 
 # Full local runner

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1631,7 +1631,12 @@ def _normalize_local_step(step) -> str:
     if step.cwd != ROOT:
         cwd_prefix = f"cd {step.cwd.relative_to(ROOT).as_posix()} && "
     env_prefix = _normalize_env(step.env)
-    return f"{cwd_prefix}{env_prefix}{_normalize_tokenized_command(step.cmd)}"
+    command = (
+        step.cmd[0]
+        if getattr(step, "shell", False)
+        else _normalize_tokenized_command(step.cmd)
+    )
+    return f"{cwd_prefix}{env_prefix}{command}"
 
 
 def _local_runner_commands() -> tuple[dict[str, list[str]], list[str], list[str]]:
@@ -1789,32 +1794,28 @@ def check_ci_command_sync() -> list[str]:
     return errors
 
 
-def _makefile_ci_lite_status() -> tuple[bool, bool]:
-    text = (ROOT / "Makefile").read_text(encoding="utf-8")
-    legacy_var_present = "CI_LITE_JOBS :=" in text or "CI_LITE_JOBS:=" in text
-    uses_ci_lite_flag = "tools/tests/run_ci_parallel.py --ci-lite" in text
-    return legacy_var_present, uses_ci_lite_flag
-
-
 def check_ci_lite_job_sync() -> list[str]:
     """Verify CI-lite entrypoints derive from the shared workflow manifest."""
     manifest = _load_ci_manifest_module()
     ci_parallel = _load_ci_parallel_module()
-    expected = list(manifest.ci_lite_job_names())
-    actual = list(ci_parallel.CI_LITE_JOB_NAMES)
     errors: list[str] = []
-    if actual != expected:
-        errors.append(
-            "run_ci_parallel.py CI-lite jobs drifted from the workflow manifest: "
-            f"expected={expected!r} actual={actual!r}"
-        )
-    legacy_var_present, uses_ci_lite_flag = _makefile_ci_lite_status()
-    if legacy_var_present:
+    for name, manifest_names, runner_names in (
+        ("CI-fast", manifest.ci_fast_job_names(), ci_parallel.CI_FAST_JOB_NAMES),
+        ("CI-lite", manifest.ci_lite_job_names(), ci_parallel.CI_LITE_JOB_NAMES),
+    ):
+        expected = list(manifest_names)
+        actual = list(runner_names)
+        if actual != expected:
+            errors.append(
+                f"run_ci_parallel.py {name} jobs drifted from the workflow manifest: "
+                f"expected={expected!r} actual={actual!r}"
+            )
+    makefile_text = (ROOT / "Makefile").read_text(encoding="utf-8")
+    if "CI_LITE_JOBS :=" in makefile_text or "CI_LITE_JOBS:=" in makefile_text:
         errors.append("Makefile must not define a mirrored CI_LITE_JOBS variable.")
-    if not uses_ci_lite_flag:
-        errors.append(
-            "Makefile test-ci-lite must invoke tools/tests/run_ci_parallel.py --ci-lite."
-        )
+    for target, flag in (("test-ci-fast", "--ci-fast"), ("test-ci-lite", "--ci-lite")):
+        if f"tools/tests/run_ci_parallel.py {flag}" not in makefile_text:
+            errors.append(f"Makefile {target} must invoke run_ci_parallel.py {flag}.")
     return errors
 
 

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -29,13 +29,27 @@ _repo_tooling_support = _load_repo_tooling_support()
 _CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 _INSTALL_STEP_NAMES = frozenset(
     {
+        "Configure backend virtualenv",
         "Install dependencies",
         "Install ShellCheck",
         "Install PlatformIO dependencies",
         "Install UI dependencies",
+        "Prepare retry helper",
+        "Report backend virtualenv cache hit",
+        "Report backend virtualenv cache miss",
     }
 )
 _CI_LITE_EXCLUDED_JOBS = frozenset({"e2e"})
+_CI_FAST_EXCLUDED_JOBS = frozenset(
+    {
+        "e2e",
+        "firmware-native-tests",
+        "release-smoke",
+        "ui-smoke",
+        "ui-unit",
+    }
+)
+_CI_FAST_EXCLUDED_PREFIXES = ("backend-tests-",)
 _WORKFLOW_ONLY_EXCLUDED_JOBS = frozenset({"ci-scope", "ui-build-artifact"})
 _PYTHON_PATH_TOKENS = frozenset(
     {
@@ -437,4 +451,13 @@ def ci_lite_job_names() -> tuple[str, ...]:
         job_name
         for job_name in ci_workflow_jobs()
         if job_name not in _CI_LITE_EXCLUDED_JOBS
+    )
+
+
+def ci_fast_job_names() -> tuple[str, ...]:
+    return tuple(
+        job_name
+        for job_name in ci_workflow_jobs()
+        if job_name not in _CI_FAST_EXCLUDED_JOBS
+        and not job_name.startswith(_CI_FAST_EXCLUDED_PREFIXES)
     )

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -40,6 +40,7 @@ def _load_ci_workflow_manifest_module():
 
 _CI_MANIFEST = _load_ci_workflow_manifest_module()
 ALL_JOB_NAMES = _CI_MANIFEST.all_job_names()
+CI_FAST_JOB_NAMES = _CI_MANIFEST.ci_fast_job_names()
 CI_LITE_JOB_NAMES = _CI_MANIFEST.ci_lite_job_names()
 
 
@@ -49,6 +50,7 @@ class Step:
     cmd: list[str]
     cwd: Path = ROOT
     env: dict[str, str] | None = None
+    shell: bool = False
 
 
 @dataclass(frozen=True)
@@ -140,12 +142,16 @@ def _shared_ui_workspace_would_race(
 
 
 def _run_step(step: Step, log_file) -> int:
-    log_file.write(f"$ {_format_cmd(step.cmd)}\n")
+    formatted_cmd = step.cmd[0] if step.shell else _format_cmd(step.cmd)
+    log_file.write(f"$ {formatted_cmd}\n")
     env = None if step.env is None else {**os.environ, **step.env}
+    command: str | list[str] = step.cmd[0] if step.shell else step.cmd
     proc = subprocess.run(
-        step.cmd,
+        command,
         cwd=str(step.cwd),
         env=env,
+        shell=step.shell,
+        executable="/bin/bash" if step.shell else None,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -250,11 +256,13 @@ def _bootstrap_steps(
 
 
 def _step_from_manifest_command(label: str, command: str) -> Step:
-    tokens = shlex.split(command)
+    command_text = command
+    tokens = shlex.split(command_text)
     cwd = ROOT
     if len(tokens) >= 3 and tokens[0] == "cd" and tokens[2] == "&&":
         cwd = ROOT / tokens[1]
-        tokens = tokens[3:]
+        _cd_prefix, _separator, command_text = command_text.partition(" && ")
+        tokens = shlex.split(command_text)
 
     env: dict[str, str] | None = None
     if tokens and tokens[0] == "env":
@@ -266,8 +274,20 @@ def _step_from_manifest_command(label: str, command: str) -> Step:
             index += 1
         env = parsed_env or None
         tokens = tokens[index:]
+        command_text = shlex.join(tokens)
 
-    return Step(label, tokens, cwd=cwd, env=env)
+    shell = _requires_shell(command_text, tokens)
+    return Step(
+        label, [command_text] if shell else tokens, cwd=cwd, env=env, shell=shell
+    )
+
+
+def _requires_shell(command: str, tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    if tokens[0] in {"set"}:
+        return True
+    return any(operator in command for operator in (" && ", " || ", " | ", ";"))
 
 
 def _job_steps(python_cmd: str) -> dict[str, list[Step]]:
@@ -416,9 +436,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Run only selected job(s). Repeat to run multiple jobs.",
     )
     parser.add_argument(
+        "--ci-fast",
+        action="store_true",
+        help="Run fast local CI gates: lint, docs, static guards, and type checks.",
+    )
+    parser.add_argument(
         "--ci-lite",
         action="store_true",
-        help="Run the non-Docker blocking CI subset derived from the workflow manifest.",
+        help="Run non-Docker workflow jobs except E2E, including heavier browser/release/backend suites.",
     )
     parser.add_argument(
         "--skip-bootstrap",
@@ -431,8 +456,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip npm ci bootstrap even when node_modules is missing.",
     )
     args = parser.parse_args(argv)
-    if args.job and args.ci_lite:
-        parser.error("--ci-lite cannot be combined with --job")
+    selected_modes = sum(bool(mode) for mode in (args.job, args.ci_fast, args.ci_lite))
+    if selected_modes > 1:
+        parser.error("--job, --ci-fast, and --ci-lite are mutually exclusive")
 
     python_cmd = sys.executable
     LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -440,11 +466,14 @@ def main(argv: list[str] | None = None) -> int:
     all_jobs = _job_steps(python_cmd)
     job_write_sets = _job_workspace_write_sets()
     job_host_tools = _job_host_tools()
-    selected_jobs = (
-        args.job
-        if args.job
-        else list(CI_LITE_JOB_NAMES if args.ci_lite else ALL_JOB_NAMES)
-    )
+    if args.job:
+        selected_jobs = args.job
+    elif args.ci_fast:
+        selected_jobs = list(CI_FAST_JOB_NAMES)
+    elif args.ci_lite:
+        selected_jobs = list(CI_LITE_JOB_NAMES)
+    else:
+        selected_jobs = list(ALL_JOB_NAMES)
     _emit_skipped_action_warnings(selected_jobs)
     _emit_workspace_write_set_warnings(selected_jobs, job_write_sets)
     if not _check_host_tool_prerequisites(selected_jobs, job_host_tools):


### PR DESCRIPTION
Closes #3617.

What changed:
- Added `make test-ci-fast` backed by workflow-manifest `ci_fast_job_names()`.
- Added `run_ci_parallel.py --ci-fast` for lint, docs, static guards, and type checks only.
- Kept `test-ci-lite` as the larger non-Docker workflow surface except E2E, and documented that it still includes backend shards, UI smoke, release smoke, and firmware native tests.
- Pinned fast/lite job membership in hygiene tests.
- Skipped GitHub-only setup-backend helper steps in local workflow commands; local runner bootstrap owns that setup.

Why:
- `test-ci-lite` sounded cheap but still ran heavy suites.
- Agents and humans need a clear fast gate before heavier local workflow validation.

Validation:
- `ruff format/check` on touched Python files.
- `pytest apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_ci_parallel_bootstrap.py -q`
- `python tools/dev/check_hygiene.py`
- `python tools/tests/run_ci_parallel.py --ci-fast --skip-bootstrap`
- `python tools/tests/plan_validation.py --json-only`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

Risks / tradeoffs:
- `test-ci-fast` is intentionally not a full confidence gate.
- `test-ci-lite` behavior is preserved, but its description is now explicit.
- Local runner still uses documented substitutes for GitHub-only setup/cache actions.

Follow-ups:
- None for this issue.
