### PR TITLE
Respect CI job needs in local runner

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,7 @@ Commands
 Validation chooser
 - Start with `make plan-validation` for changed-file CI scope; use `python3 tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
 - Use `make test-ci-fast` for a broad but fast local gate before heavier browser/release/backend suites; use `make test-ci-lite` only when you want the larger non-Docker workflow surface except e2e.
+- `run_ci_parallel.py` respects GitHub `needs` order among selected jobs, warns when you select a downstream job without its prerequisites, and reports workflow-only needs it substitutes locally.
 - Local `shell-lint` parity requires host `shellcheck`; use ACT when you need CI to install ShellCheck inside the workflow job.
 - Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
 - Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -243,6 +243,106 @@ def test_main_warns_about_skipped_external_workflow_actions(
     assert "release-smoke (Download release-smoke UI static artifact)" in output
     assert "actions/download-artifact@" in output
     assert "without --skip-ui-build" in output
+    assert "GitHub workflow-only needs not runnable locally" in output
+    assert "release-smoke normally needs ui-build-artifact" in output
+
+
+def test_main_reports_unselected_github_needs(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=False)
+    _captured, outputs = _install_main_harness(
+        module,
+        monkeypatch,
+        tmp_path,
+        {"ui-unit": [module.Step("UI unit tests", ["true"])]},
+    )
+
+    assert module.main(["--job", "ui-unit"]) == 0
+
+    output = "\n".join(outputs)
+    assert "GitHub needs not selected locally" in output
+    assert "ui-unit normally needs frontend-typecheck" in output
+
+
+def test_main_runs_selected_jobs_after_their_github_needs(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=False)
+    jobs = {
+        "frontend-typecheck": [module.Step("UI typecheck", ["true"])],
+        "ui-unit": [module.Step("UI unit tests", ["true"])],
+    }
+    outputs: list[str] = []
+    run_order: list[str] = []
+
+    monkeypatch.setattr(module, "_job_steps", lambda _python_cmd: jobs)
+    monkeypatch.setattr(module, "_job_workspace_write_sets", lambda: {name: () for name in jobs})
+    monkeypatch.setattr(module, "_run_bootstrap", lambda _steps: 0)
+    monkeypatch.setattr(module, "_emit", outputs.append)
+
+    def _fake_run_job(name, _steps, results):
+        run_order.append(name)
+        results[name] = module.JobResult(
+            name=name,
+            ok=True,
+            failed_step=None,
+            return_code=0,
+            duration_s=0.0,
+            log_path=tmp_path / f"{name}.log",
+        )
+
+    monkeypatch.setattr(module, "_run_job", _fake_run_job)
+
+    assert module.main(["--job", "ui-unit", "--job", "frontend-typecheck"]) == 0
+
+    assert run_order == ["frontend-typecheck", "ui-unit"]
+
+
+def test_main_skips_selected_downstream_job_when_github_need_fails(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_ci_parallel_module()
+    _configure_ui_paths(module, monkeypatch, tmp_path)
+    _stub_ui_bootstrap_check(monkeypatch, module, needs_npm_ci=False)
+    jobs = {
+        "frontend-typecheck": [module.Step("UI typecheck", ["false"])],
+        "ui-unit": [module.Step("UI unit tests", ["true"])],
+    }
+    outputs: list[str] = []
+    run_order: list[str] = []
+
+    monkeypatch.setattr(module, "_job_steps", lambda _python_cmd: jobs)
+    monkeypatch.setattr(module, "_job_workspace_write_sets", lambda: {name: () for name in jobs})
+    monkeypatch.setattr(module, "_run_bootstrap", lambda _steps: 0)
+    monkeypatch.setattr(module, "_emit", outputs.append)
+
+    def _fake_run_job(name, _steps, results):
+        run_order.append(name)
+        results[name] = module.JobResult(
+            name=name,
+            ok=False,
+            failed_step="UI typecheck",
+            return_code=1,
+            duration_s=0.0,
+            log_path=tmp_path / f"{name}.log",
+        )
+
+    monkeypatch.setattr(module, "_run_job", _fake_run_job)
+
+    assert module.main(["--job", "frontend-typecheck", "--job", "ui-unit"]) == 1
+
+    output = "\n".join(outputs)
+    assert run_order == ["frontend-typecheck"]
+    assert "[ui-unit] skip (needed job failed: frontend-typecheck)" in output
+    assert "- ui-unit: SKIP (needed job failed: frontend-typecheck)" in output
 
 
 def test_main_reports_missing_shellcheck_before_running_shell_lint(

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -131,6 +131,37 @@ def test_ci_lite_jobs_are_non_docker_blocking_jobs_except_e2e() -> None:
     }.issubset(lite_jobs)
 
 
+def test_workflow_manifest_preserves_local_job_needs() -> None:
+    module = _load_ci_manifest_module()
+
+    jobs = module.ci_workflow_jobs()
+
+    assert jobs["ui-unit"].needs == ("frontend-typecheck",)
+    assert jobs["ui-smoke"].needs == ("frontend-typecheck",)
+    assert set(jobs["firmware-native-tests"].needs) == {
+        "backend-lint",
+        "repo-hygiene",
+        "backend-static-guards",
+        "backend-preflight",
+        "docs-lint",
+        "backend-contract-drift",
+    }
+    assert set(jobs["release-smoke"].needs) == {
+        "backend-lint",
+        "repo-hygiene",
+        "backend-static-guards",
+        "backend-preflight",
+        "docs-lint",
+        "backend-contract-drift",
+        "backend-typecheck",
+        "frontend-quality",
+        "frontend-typecheck",
+    }
+    assert "ci-scope" not in jobs["release-smoke"].needs
+    assert "ui-build-artifact" not in jobs["release-smoke"].needs
+    assert jobs["release-smoke"].workflow_only_needs == ("ui-build-artifact",)
+
+
 def test_release_smoke_local_manifest_builds_ui_static_instead_of_downloading_artifact() -> None:
     module = _load_ci_manifest_module()
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -170,6 +170,13 @@ python3 tools/tests/run_ci_parallel.py --job release-smoke
 make test-full-suite
 ```
 
+When multiple selected local jobs have GitHub `needs` relationships,
+`run_ci_parallel.py` runs them in dependency waves and skips selected downstream
+jobs if a selected prerequisite fails. If you select only the downstream job, the
+runner reports the omitted prerequisite so the local-vs-GitHub ordering gap is
+visible. Workflow-only prerequisites that are substituted locally, such as CI
+artifact builder jobs, are reported as non-runnable local dependencies.
+
 `release-smoke` is the packaged-artifact gate. It builds or reuses the server
 wheel, validates packaged static assets, boots the packaged server, and checks
 that `/api/health` reaches readiness. In GitHub CI it now consumes the

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -103,6 +103,8 @@ class CiWorkflowSkippedAction:
 class CiWorkflowJob:
     job_name: str
     steps: tuple[CiWorkflowStep, ...]
+    needs: tuple[str, ...] = ()
+    workflow_only_needs: tuple[str, ...] = ()
     skipped_actions: tuple[CiWorkflowSkippedAction, ...] = ()
     workspace_write_sets: tuple[str, ...] = ()
     host_tools: tuple[str, ...] = ()
@@ -201,6 +203,31 @@ def _normalize_ci_step_commands(step: Mapping[str, object]) -> tuple[str, ...]:
             f"{cwd_prefix}{line_cwd_prefix}{env_prefix}{_normalize_shell_command(line)}"
         )
     return tuple(commands)
+
+
+def _normalized_needs(raw_needs: object) -> tuple[str, ...]:
+    needs = _raw_needs(raw_needs)
+    return tuple(
+        need
+        for need in needs
+        if need != "ci-scope" and need not in _WORKFLOW_ONLY_EXCLUDED_JOBS
+    )
+
+
+def _workflow_only_needs(raw_needs: object) -> tuple[str, ...]:
+    return tuple(
+        need
+        for need in _raw_needs(raw_needs)
+        if need != "ci-scope" and need in _WORKFLOW_ONLY_EXCLUDED_JOBS
+    )
+
+
+def _raw_needs(raw_needs: object) -> tuple[str, ...]:
+    if isinstance(raw_needs, str):
+        return (raw_needs,)
+    if isinstance(raw_needs, list):
+        return tuple(need for need in raw_needs if isinstance(need, str))
+    return ()
 
 
 def _local_action_file(action_ref: str) -> Path | None:
@@ -433,6 +460,10 @@ def ci_workflow_jobs() -> dict[str, CiWorkflowJob]:
             result[expanded_job_name] = CiWorkflowJob(
                 job_name=expanded_job_name,
                 steps=tuple(normalized_steps),
+                needs=_normalized_needs(expanded_job_body.get("needs")),
+                workflow_only_needs=_workflow_only_needs(
+                    expanded_job_body.get("needs")
+                ),
                 skipped_actions=tuple(skipped_actions),
                 workspace_write_sets=_JOB_WORKSPACE_WRITE_SETS.get(
                     expanded_job_name, ()

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -61,6 +61,7 @@ class JobResult:
     return_code: int
     duration_s: float
     log_path: Path
+    skipped_reason: str | None = None
 
 
 def _emit(line: str) -> None:
@@ -315,6 +316,19 @@ def _job_host_tools() -> dict[str, tuple[str, ...]]:
     }
 
 
+def _job_needs() -> dict[str, tuple[str, ...]]:
+    return {
+        job_name: job.needs for job_name, job in _CI_MANIFEST.ci_workflow_jobs().items()
+    }
+
+
+def _job_workflow_only_needs() -> dict[str, tuple[str, ...]]:
+    return {
+        job_name: job.workflow_only_needs
+        for job_name, job in _CI_MANIFEST.ci_workflow_jobs().items()
+    }
+
+
 def _emit_skipped_action_warnings(selected_jobs: list[str]) -> None:
     jobs = _CI_MANIFEST.ci_workflow_jobs()
     warned = False
@@ -396,6 +410,42 @@ def _emit_workspace_write_set_warnings(
         )
 
 
+def _emit_dependency_warnings(
+    selected_jobs: list[str],
+    job_needs: dict[str, tuple[str, ...]],
+    job_workflow_only_needs: dict[str, tuple[str, ...]],
+) -> None:
+    selected = set(selected_jobs)
+    missing_by_job = {
+        job_name: tuple(need for need in job_needs[job_name] if need not in selected)
+        for job_name in selected_jobs
+    }
+    missing_by_job = {
+        job_name: missing for job_name, missing in missing_by_job.items() if missing
+    }
+    if missing_by_job:
+        _emit("[ci-local] GitHub needs not selected locally:")
+        for job_name, missing in missing_by_job.items():
+            _emit(
+                f"[ci-local] - {job_name} normally needs {', '.join(missing)}; "
+                "selected jobs still run, but omitted prerequisites are not modeled."
+            )
+    workflow_only_by_job = {
+        job_name: job_workflow_only_needs[job_name] for job_name in selected_jobs
+    }
+    workflow_only_by_job = {
+        job_name: needs for job_name, needs in workflow_only_by_job.items() if needs
+    }
+    if not workflow_only_by_job:
+        return
+    _emit("[ci-local] GitHub workflow-only needs not runnable locally:")
+    for job_name, needs in workflow_only_by_job.items():
+        _emit(
+            f"[ci-local] - {job_name} normally needs {', '.join(needs)}; "
+            "the local runner reports the dependency-order difference instead."
+        )
+
+
 def _selected_jobs_require_platformio(selected_jobs: list[str]) -> bool:
     jobs = _CI_MANIFEST.ci_workflow_jobs()
     return any(jobs[job_name].requires_platformio for job_name in selected_jobs)
@@ -420,6 +470,89 @@ def _run_bootstrap(steps: list[Step]) -> int:
             _emit(f"[bootstrap] ok '{step.label}' in {elapsed:.1f}s")
     _emit("[bootstrap] success")
     return 0
+
+
+def _skipped_job_result(name: str, reason: str, started: float) -> JobResult:
+    return JobResult(
+        name=name,
+        ok=False,
+        failed_step=None,
+        return_code=0,
+        duration_s=time.monotonic() - started,
+        log_path=LOG_DIR / f"{name}.log",
+        skipped_reason=reason,
+    )
+
+
+def _run_selected_jobs(
+    selected_jobs: list[str],
+    all_jobs: dict[str, list[Step]],
+    job_write_sets: dict[str, tuple[str, ...]],
+    job_needs: dict[str, tuple[str, ...]],
+) -> tuple[dict[str, JobResult], float, bool]:
+    started = time.monotonic()
+    results: dict[str, JobResult] = {}
+    selected = set(selected_jobs)
+    pending = set(selected_jobs)
+    workspace_locks = {
+        write_set: threading.Lock()
+        for job_name in selected_jobs
+        for write_set in job_write_sets[job_name]
+    }
+    while pending:
+        ready = [
+            job_name
+            for job_name in selected_jobs
+            if job_name in pending
+            and all(
+                need not in selected or need in results for need in job_needs[job_name]
+            )
+        ]
+        if not ready:
+            _emit(
+                "[ci-local] unable to resolve selected job dependency order; "
+                f"remaining jobs: {', '.join(sorted(pending))}"
+            )
+            return results, time.monotonic() - started, False
+
+        runnable: list[str] = []
+        for job_name in ready:
+            failed_needs = [
+                need
+                for need in job_needs[job_name]
+                if need in selected and not results[need].ok
+            ]
+            if failed_needs:
+                reason = f"needed job failed: {', '.join(failed_needs)}"
+                _emit(f"[{job_name}] skip ({reason})")
+                with RESULT_LOCK:
+                    results[job_name] = _skipped_job_result(job_name, reason, started)
+                pending.remove(job_name)
+                continue
+            runnable.append(job_name)
+
+        threads: list[threading.Thread] = []
+        for job_name in runnable:
+            thread = threading.Thread(
+                target=_run_job_with_workspace_locks,
+                args=(
+                    job_name,
+                    all_jobs[job_name],
+                    results,
+                    job_write_sets[job_name],
+                    workspace_locks,
+                ),
+                daemon=False,
+            )
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+        for job_name in runnable:
+            pending.remove(job_name)
+
+    return results, time.monotonic() - started, True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -466,6 +599,8 @@ def main(argv: list[str] | None = None) -> int:
     all_jobs = _job_steps(python_cmd)
     job_write_sets = _job_workspace_write_sets()
     job_host_tools = _job_host_tools()
+    job_needs = _job_needs()
+    job_workflow_only_needs = _job_workflow_only_needs()
     if args.job:
         selected_jobs = args.job
     elif args.ci_fast:
@@ -476,6 +611,7 @@ def main(argv: list[str] | None = None) -> int:
         selected_jobs = list(ALL_JOB_NAMES)
     _emit_skipped_action_warnings(selected_jobs)
     _emit_workspace_write_set_warnings(selected_jobs, job_write_sets)
+    _emit_dependency_warnings(selected_jobs, job_needs, job_workflow_only_needs)
     if not _check_host_tool_prerequisites(selected_jobs, job_host_tools):
         return 2
 
@@ -511,41 +647,24 @@ def main(argv: list[str] | None = None) -> int:
     if bootstrap_rc != 0:
         return bootstrap_rc
 
-    started = time.monotonic()
-    results: dict[str, JobResult] = {}
-    threads: list[threading.Thread] = []
-    workspace_locks = {
-        write_set: threading.Lock()
-        for job_name in selected_jobs
-        for write_set in job_write_sets[job_name]
-    }
-    for job_name in selected_jobs:
-        thread = threading.Thread(
-            target=_run_job_with_workspace_locks,
-            args=(
-                job_name,
-                all_jobs[job_name],
-                results,
-                job_write_sets[job_name],
-                workspace_locks,
-            ),
-            daemon=False,
-        )
-        thread.start()
-        threads.append(thread)
-
-    for thread in threads:
-        thread.join()
-
-    elapsed = time.monotonic() - started
+    results, elapsed, ordered = _run_selected_jobs(
+        selected_jobs, all_jobs, job_write_sets, job_needs
+    )
     _emit("\n=== ci-local summary ===")
-    overall_ok = True
+    overall_ok = ordered
     for job_name in selected_jobs:
-        result = results[job_name]
+        result = results.get(job_name)
+        if result is None:
+            overall_ok = False
+            _emit(f"- {job_name}: NOT RUN (dependency order could not be resolved)")
+            continue
         if result.ok:
             _emit(
                 f"- {job_name}: PASS ({result.duration_s:.1f}s) log={result.log_path}"
             )
+            continue
+        if result.skipped_reason is not None:
+            _emit(f"- {job_name}: SKIP ({result.skipped_reason})")
             continue
         overall_ok = False
         _emit(


### PR DESCRIPTION
## What changed
- Parsed GitHub workflow `needs` into the local CI manifest.
- Ran selected local CI jobs in dependency waves instead of starting every job at once.
- Skipped selected downstream jobs when a selected prerequisite fails.
- Reported selected downstream jobs whose GitHub prerequisites were omitted locally.
- Reported workflow-only needs, including the `release-smoke` dependency on the CI-only UI artifact builder.
- Added docs and AI guidance for the new local-vs-GitHub dependency behavior.

## Why
Local CI could run expensive downstream jobs before the gates GitHub would require first. That made failures harder to read and hid ordering differences around artifact-backed jobs.

## Validation
- `ruff format` / `ruff check` on touched Python files
- `pytest apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ci_workflow_manifest.py -q`
- `python tools/dev/check_hygiene.py`
- `python tools/tests/run_ci_parallel.py --ci-fast --skip-bootstrap`
- `python tools/tests/plan_validation.py --json-only`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

## Risks and tradeoffs
- Dependency ordering applies to selected runnable local jobs. If a prerequisite is not selected, the runner warns and still runs the selected job.
- Workflow-only jobs are reported, not executed. `release-smoke` still uses the existing local substitute that builds UI static directly instead of downloading the CI artifact.
- Full `always()` expression emulation stays out of scope; failed selected prerequisites stop downstream jobs, matching the practical GitHub failure-ordering model needed here.

Fixes #3619
