### PR TITLE
Use shared UI bootstrap in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ setup: ## Install backend dev dependencies and UI node_modules
 	@if [ ! -x "$(VENV_PYTHON)" ]; then "$(PYTHON_BOOTSTRAP)" -m venv "$(VENV_DIR)"; fi
 	"$(VENV_PYTHON)" -m pip install --upgrade pip
 	"$(VENV_PYTHON)" -m pip install -e "./apps/server[dev]"
-	cd $(UI_DIR) && npm ci
+	cd $(UI_DIR) && node ../../tools/ui/ensure_ui_bootstrap.mjs
 	git config --local core.hooksPath .githooks
 
 dev: ## Start the source-mounted Docker dev stack with backend reload + Vite HMR

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -e "./apps/server[dev]"
-npm --prefix apps/ui ci
+(cd apps/ui && node ../../tools/ui/ensure_ui_bootstrap.mjs)
 vibesensor-server --reload --config apps/server/config.dev.yaml
 ```
 

--- a/apps/server/tests/hygiene/test_dev_workflow.py
+++ b/apps/server/tests/hygiene/test_dev_workflow.py
@@ -112,6 +112,13 @@ def test_make_dev_target_wraps_docker_dev_compose() -> None:
     )
 
 
+def test_make_setup_reuses_shared_ui_bootstrap_helper() -> None:
+    makefile_text = _MAKEFILE.read_text(encoding="utf-8")
+
+    assert "cd $(UI_DIR) && node ../../tools/ui/ensure_ui_bootstrap.mjs" in makefile_text
+    assert "cd $(UI_DIR) && npm ci" not in makefile_text
+
+
 def test_makefile_exposes_ui_unit_test_target_and_readme_pointer() -> None:
     makefile_text = _MAKEFILE.read_text(encoding="utf-8")
     readme_text = _UI_README.read_text(encoding="utf-8")

--- a/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
+++ b/apps/server/tests/hygiene/test_ui_bootstrap_helper.py
@@ -117,6 +117,10 @@ def test_ui_bootstrap_helper_skips_npm_ci_when_lock_hash_is_current(tmp_path: Pa
 
     assert result.returncode == 0
     assert not log_path.exists()
+    assert (
+        "[ui:bootstrap] Skipping npm ci because node_modules and package-lock marker are current."
+        in result.stdout
+    )
 
 
 def test_ui_bootstrap_helper_check_mode_reports_npm_ci_need(tmp_path: Path) -> None:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -38,9 +38,11 @@ npm run analyze      # Production build + bundle analysis report at dist/bundle-
 npm run typecheck    # Type check without emitting
 ```
 
-Use `npm ci` for normal repo bootstrap and dependency refresh from the checked-in
-lockfile. Only use `npm install` when you are intentionally adding or updating
-UI dependencies so the resulting `package-lock.json` change is deliberate.
+From the repo root, `make setup` uses the shared UI bootstrap helper and records
+the current `package-lock.json` marker after `npm ci`. For UI-only dependency
+refreshes, use `npm ci` from this directory against the checked-in lockfile.
+Only use `npm install` when you are intentionally adding or updating UI
+dependencies so the resulting `package-lock.json` change is deliberate.
 
 The source-mounted Docker dev stack calls `npm run dev:docker` inside the UI
 container. It re-runs `npm ci` only when `node_modules` is missing or the

--- a/tools/ui/ensure_ui_bootstrap.mjs
+++ b/tools/ui/ensure_ui_bootstrap.mjs
@@ -68,6 +68,9 @@ function uiBootstrapStatus(uiDir, skipNpmCi) {
 
 function ensureUiBootstrap(uiDir, status, logPrefix) {
 	if (!status.needsNpmCi) {
+		console.log(
+			`${logPrefix} Skipping npm ci because node_modules and package-lock marker are current.`,
+		);
 		return;
 	}
 	console.log(


### PR DESCRIPTION
## What changed
- Routed `make setup` through `tools/ui/ensure_ui_bootstrap.mjs` instead of raw `npm ci`.
- Made the shared UI bootstrap helper log when it skips `npm ci` because the marker is current.
- Updated root/UI setup guidance to describe the shared marker-backed bootstrap path.
- Added hygiene coverage for Makefile setup wiring and helper skip output.

## Why
Raw `npm ci` in `make setup` installed dependencies but did not write `apps/ui/.npm-ci-lock.sha256`. Docker dev and local CI then saw `node_modules` without a matching marker and repeated `npm ci`.

## Validation
- `ruff format` / `ruff check` on touched Python tests
- `pytest apps/server/tests/hygiene/test_dev_workflow.py apps/server/tests/hygiene/test_ui_bootstrap_helper.py -q`
- `python tools/dev/check_hygiene.py`
- `python tools/tests/plan_validation.py --json-only`
- `python tools/dev/docs_lint.py`
- `make lint`
- `git diff --check`

## Risks and tradeoffs
- `make setup` now depends on Node being available before the helper runs, same as the previous raw `npm ci` path.
- UI-only `npm ci` remains documented for deliberate dependency refreshes, but repo-level setup now uses the marker-backed helper.

Fixes #3620
