### PR TITLE
Clarify ACT changed-scope runs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,7 +60,9 @@ Commands
 - `make test-ci-fast` (fast local CI gates: lint, docs, static guards, and type checks; no browser/release/firmware/e2e/backend test suites)
 - `make test-ci-lite` (non-Docker workflow jobs except e2e; includes backend shards, UI smoke, release smoke, and firmware native tests)
 - `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
-- `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a single CI job locally via `act` with generated pull-request event data; requires Docker)
+- `./tools/tests/run_ci_with_act.sh` (changed-scope ACT/GitHub workflow parity with generated pull-request event data; requires Docker)
+- `./tools/tests/run_ci_with_act.sh --full-stack` (force all CI jobs through `ci-scope`; requires Docker)
+- `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a selected CI job locally via `act`; requires Docker)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
 - `python3 tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
@@ -90,7 +92,7 @@ Validation chooser
 Command gotchas
 - `make ui-typecheck` is the default frontend gate because it materializes generated UI contract artifacts before checking Biome formatting, linting, and TypeScript.
 - Raw `cd apps/ui && npm run typecheck` or `npm run build` can fail when generated UI contract files are stale; run `make sync-contracts` or `make ui-typecheck` first when backend contracts changed.
-- `act` requires Docker; prefer `tools/tests/run_ci_with_act.sh` when validating PR changed-file CI scope because it generates base/head SHAs for the pull-request event.
+- `act` requires Docker; prefer `tools/tests/run_ci_with_act.sh` for PR changed-file CI scope because it generates base/head SHAs for the pull-request event. Use `./tools/tests/run_ci_with_act.sh --full-stack` only when you need to force every gated CI job.
 - PlatformIO must be installed before `cd firmware/esp && pio run`.
 - Pi image builds are expensive; use the narrow `BUILD_MODE=app` or `BUILD_MODE=image` path unless both layers changed.
 - The local Docker stack is for runtime integration behavior, not docs-only, instruction-only, or pure unit-test changes.

--- a/apps/server/tests/hygiene/test_ci_changed_scope.py
+++ b/apps/server/tests/hygiene/test_ci_changed_scope.py
@@ -71,6 +71,31 @@ def test_pull_request_event_outputs_match_path_rules(
     assert merge_base_calls == [("base-sha", "head-sha")]
 
 
+def test_force_full_stack_env_bypasses_changed_file_scope(
+    ci_changed_scope: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload_path = tmp_path / "pull_request_event.json"
+    payload_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv("VIBESENSOR_CI_FORCE_FULL_STACK", "1")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(payload_path))
+    monkeypatch.setattr(
+        ci_changed_scope,
+        "_changed_files_for_merge_base",
+        lambda _base_sha, _head_sha: (_ for _ in ()).throw(
+            AssertionError("forced full-stack should not inspect changed files")
+        ),
+    )
+
+    assert (
+        ci_changed_scope._selection_for_github_event()
+        == ci_changed_scope.workflow_job_selection(()).github_outputs()
+    )
+
+
 def test_act_pull_request_event_helper_writes_non_empty_changed_scope_shas(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -125,3 +150,18 @@ def test_act_pull_request_event_helper_writes_non_empty_changed_scope_shas(
 
     ci_changed_scope._selection_for_github_event()
     assert merge_base_calls == [("base-sha", "head-sha")]
+
+
+def test_act_wrapper_distinguishes_changed_scope_and_full_stack_modes() -> None:
+    wrapper_text = (REPO_ROOT / "tools" / "tests" / "run_ci_with_act.sh").read_text(
+        encoding="utf-8"
+    )
+    docs_text = (REPO_ROOT / "docs" / "testing.md").read_text(encoding="utf-8")
+    ai_guidance = (REPO_ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8")
+
+    assert "run changed-scope CI jobs" in wrapper_text
+    assert "--full-stack # force all CI jobs through ci-scope" in wrapper_text
+    assert "VIBESENSOR_CI_FORCE_FULL_STACK=1" in wrapper_text
+    assert "changed-scope ACT run" in docs_text
+    assert "forced full-stack ACT run" in docs_text
+    assert "--full-stack" in ai_guidance

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,8 +142,8 @@ make test-all
 make benchmark-backend BENCHMARK_OPTS="--benchmark-save=baseline"
 make benchmark-compare-backend
 
-# Required pre-finalization gate — real GitHub workflow via act (requires Docker)
-act -W .github/workflows/ci.yml
+# GitHub workflow via act (requires Docker); default wrapper is changed-scope
+./tools/tests/run_ci_with_act.sh
 ```
 
 Focused feature-area and fuzzing runs:
@@ -308,10 +308,14 @@ Prerequisites: Docker and [`act`](https://nektosact.com/installation/index.html)
 # List available CI jobs
 act -l -W .github/workflows/ci.yml
 
-# Run all CI jobs for the current branch as a pull_request event.
+# Run changed-scope CI jobs for the current branch as a pull_request event.
 # Generate the event first so ci-scope sees real base/head SHAs.
 python3 tools/tests/act_event.py --output /tmp/vibesensor-act-event.json
 act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json
+
+# Force a full-stack workflow run through ci-scope.
+act pull_request -W .github/workflows/ci.yml -e /tmp/vibesensor-act-event.json \
+  --env VIBESENSOR_CI_FORCE_FULL_STACK=1
 
 # Run a single job
 act -j backend-lint -W .github/workflows/ci.yml
@@ -341,7 +345,8 @@ arguments through to `act`:
 
 ```bash
 ./tools/tests/run_ci_with_act.sh -l               # list jobs
-./tools/tests/run_ci_with_act.sh                   # run all CI jobs as pull_request
+./tools/tests/run_ci_with_act.sh                   # changed-scope ACT run as pull_request
+./tools/tests/run_ci_with_act.sh --full-stack      # forced full-stack ACT run
 ./tools/tests/run_ci_with_act.sh -j backend-lint  # run one job as pull_request
 ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 ```

--- a/tools/tests/ci_changed_scope.py
+++ b/tools/tests/ci_changed_scope.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from ci_path_rules import workflow_job_selection
 
 ROOT = Path(__file__).resolve().parents[2]
+_FORCE_FULL_STACK_ENV = "VIBESENSOR_CI_FORCE_FULL_STACK"
 
 
 def _git_output(*args: str) -> str:
@@ -36,6 +37,13 @@ def _safe_full_stack_outputs(reason: str) -> dict[str, str]:
 
 
 def _selection_for_github_event() -> dict[str, str]:
+    if os.environ.get(_FORCE_FULL_STACK_ENV, "").strip() == "1":
+        print(
+            f"[ci-scope] {_FORCE_FULL_STACK_ENV}=1; forcing full-stack scope",
+            file=sys.stderr,
+        )
+        return workflow_job_selection(()).github_outputs()
+
     event_name = os.environ.get("GITHUB_EVENT_NAME", "").strip()
     event_path = os.environ.get("GITHUB_EVENT_PATH", "").strip()
     if not event_name or not event_path:

--- a/tools/tests/run_ci_with_act.sh
+++ b/tools/tests/run_ci_with_act.sh
@@ -4,7 +4,8 @@
 # optional convenience only.
 #
 # Usage:
-#   ./tools/tests/run_ci_with_act.sh              # run all CI jobs (pull_request event)
+#   ./tools/tests/run_ci_with_act.sh              # run changed-scope CI jobs (pull_request event)
+#   ./tools/tests/run_ci_with_act.sh --full-stack # force all CI jobs through ci-scope
 #   ./tools/tests/run_ci_with_act.sh -l            # list available jobs
 #   ./tools/tests/run_ci_with_act.sh -j backend-lint      # run one job
 #   ./tools/tests/run_ci_with_act.sh -j backend-tests-1   # run one backend test shard
@@ -14,6 +15,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 BASE_REF=""
+FULL_STACK=0
 PASSTHROUGH_ARGS=()
 
 while [ "$#" -gt 0 ]; do
@@ -28,6 +30,14 @@ while [ "$#" -gt 0 ]; do
       ;;
     --base-ref=*)
       BASE_REF="${1#--base-ref=}"
+      shift
+      ;;
+    --scope-from-diff)
+      FULL_STACK=0
+      shift
+      ;;
+    --full-stack)
+      FULL_STACK=1
       shift
       ;;
     *)
@@ -70,6 +80,9 @@ fi
 "${PYTHON:-python3}" tools/tests/act_event.py "${GENERATE_ARGS[@]}"
 
 ACT_ARGS=(pull_request -W .github/workflows/ci.yml -e "$EVENT_FILE")
+if [ "$FULL_STACK" -eq 1 ]; then
+  ACT_ARGS+=(--env VIBESENSOR_CI_FORCE_FULL_STACK=1)
+fi
 if [ -f .secrets.act ]; then
   ACT_ARGS+=(--secret-file .secrets.act)
 fi


### PR DESCRIPTION
## What changed
- Added `VIBESENSOR_CI_FORCE_FULL_STACK=1` handling to `ci_changed_scope.py`.
- Added `run_ci_with_act.sh --full-stack` to force all gated CI jobs through `ci-scope`.
- Kept wrapper default as generated pull-request changed-scope parity.
- Updated docs and AI guidance to separate changed-scope ACT, forced full-stack ACT, and selected-job ACT.
- Added hygiene coverage for forced full-stack scope and wrapper/docs wording.

## Why
The wrapper default generates a realistic pull-request event, so `ci-scope` gates downstream jobs from the changed files. Calling that “all CI jobs” overstated validation coverage.

## Validation
- `ruff format` / `ruff check` on touched Python files
- `pytest apps/server/tests/hygiene/test_ci_changed_scope.py -q`
- `shellcheck --severity=warning -x -s bash tools/tests/run_ci_with_act.sh`
- `python tools/dev/docs_lint.py`
- `python tools/dev/check_hygiene.py`
- `python tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks and tradeoffs
- `--full-stack` uses an explicit local override intended for ACT/dev validation. GitHub’s normal changed-file gating remains unchanged.
- The wrapper still requires Docker and ACT; this only makes the chosen scope explicit.

Fixes #3621
