### PR TITLE
Fix ACT job id docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,7 @@ Commands
 - `./tools/tests/run_ci_with_act.sh` (changed-scope ACT/GitHub workflow parity with generated pull-request event data; requires Docker)
 - `./tools/tests/run_ci_with_act.sh --full-stack` (force all CI jobs through `ci-scope`; requires Docker)
 - `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a selected CI job locally via `act`; requires Docker)
+- `./tools/tests/run_ci_with_act.sh -j backend-tests` (run the backend test matrix job via `act`; ACT uses raw GitHub job ids, not local logical shard ids like `backend-tests-1`)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
 - `python3 tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)

--- a/apps/server/tests/hygiene/test_ci_changed_scope.py
+++ b/apps/server/tests/hygiene/test_ci_changed_scope.py
@@ -4,17 +4,28 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
+import shlex
 import sys
 from pathlib import Path
 from types import ModuleType
 
 import pytest
+import yaml
 
 from tests._paths import REPO_ROOT
 
 _CI_PATH_RULES = REPO_ROOT / "tools" / "tests" / "ci_path_rules.py"
 _CI_CHANGED_SCOPE = REPO_ROOT / "tools" / "tests" / "ci_changed_scope.py"
 _ACT_EVENT = REPO_ROOT / "tools" / "tests" / "act_event.py"
+_CI_MANIFEST = REPO_ROOT / "tools" / "tests" / "ci_workflow_manifest.py"
+_CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_COMMAND_EXAMPLE_PATHS = (
+    REPO_ROOT / "tools" / "tests" / "run_ci_with_act.sh",
+    REPO_ROOT / "docs" / "testing.md",
+    REPO_ROOT / ".github" / "copilot-instructions.md",
+    REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "ai_change_request.md",
+)
 
 
 def _load_module(name: str, path: Path) -> ModuleType:
@@ -24,6 +35,48 @@ def _load_module(name: str, path: Path) -> ModuleType:
     sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _command_snippets(text: str, command_name: str) -> list[str]:
+    snippets: list[str] = []
+    command_pattern = re.escape(command_name)
+    for line in text.splitlines():
+        if command_name not in line:
+            continue
+        snippets.extend(re.findall(rf"`([^`]*{command_pattern}[^`]*)`", line))
+        if snippets and snippets[-1] in line:
+            continue
+        stripped = re.sub(r"^\s*(?:#\s*)?", "", line).strip()
+        snippets.append(stripped)
+    return snippets
+
+
+def _job_args_from_snippets(snippets: list[str], flags: set[str]) -> list[str]:
+    job_args: list[str] = []
+    for snippet in snippets:
+        command_text = snippet.split("#", 1)[0].strip()
+        if not command_text:
+            continue
+        tokens = shlex.split(command_text)
+        for index, token in enumerate(tokens):
+            if token in flags and index + 1 < len(tokens):
+                job_args.append(tokens[index + 1])
+            for flag in flags:
+                if token.startswith(f"{flag}="):
+                    job_args.append(token.split("=", 1)[1])
+    return job_args
+
+
+def _documented_job_args(command_name: str, flags: set[str]) -> set[str]:
+    job_args: set[str] = set()
+    for path in _COMMAND_EXAMPLE_PATHS:
+        job_args.update(
+            _job_args_from_snippets(
+                _command_snippets(path.read_text(encoding="utf-8"), command_name),
+                flags,
+            )
+        )
+    return job_args
 
 
 @pytest.fixture
@@ -165,3 +218,24 @@ def test_act_wrapper_distinguishes_changed_scope_and_full_stack_modes() -> None:
     assert "changed-scope ACT run" in docs_text
     assert "forced full-stack ACT run" in docs_text
     assert "--full-stack" in ai_guidance
+
+
+def test_documented_act_job_examples_use_raw_workflow_job_ids() -> None:
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    raw_workflow_job_ids = set(workflow["jobs"])
+
+    act_job_examples = _documented_job_args("run_ci_with_act.sh", {"-j"})
+
+    assert "backend-tests" in act_job_examples
+    assert "backend-tests-1" not in act_job_examples
+    assert not sorted(act_job_examples - raw_workflow_job_ids)
+
+
+def test_documented_local_runner_job_examples_use_logical_job_ids() -> None:
+    manifest = _load_module("ci_workflow_manifest_for_command_docs_test", _CI_MANIFEST)
+    local_logical_job_ids = set(manifest.ci_workflow_jobs())
+
+    local_runner_examples = _documented_job_args("run_ci_parallel.py", {"--job"})
+
+    assert "backend-tests-1" in local_runner_examples
+    assert not sorted(local_runner_examples - local_logical_job_ids)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -348,8 +348,13 @@ arguments through to `act`:
 ./tools/tests/run_ci_with_act.sh                   # changed-scope ACT run as pull_request
 ./tools/tests/run_ci_with_act.sh --full-stack      # forced full-stack ACT run
 ./tools/tests/run_ci_with_act.sh -j backend-lint  # run one job as pull_request
+./tools/tests/run_ci_with_act.sh -j backend-tests # run backend test matrix job
 ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 ```
+
+For ACT `-j`, use raw GitHub workflow job ids from `.github/workflows/ci.yml`
+such as `backend-tests`. Do not use the local logical backend shard ids
+`backend-tests-1` through `backend-tests-5` with ACT.
 
 ### Secrets
 

--- a/tools/tests/run_ci_with_act.sh
+++ b/tools/tests/run_ci_with_act.sh
@@ -8,9 +8,12 @@
 #   ./tools/tests/run_ci_with_act.sh --full-stack # force all CI jobs through ci-scope
 #   ./tools/tests/run_ci_with_act.sh -l            # list available jobs
 #   ./tools/tests/run_ci_with_act.sh -j backend-lint      # run one job
-#   ./tools/tests/run_ci_with_act.sh -j backend-tests-1   # run one backend test shard
+#   ./tools/tests/run_ci_with_act.sh -j backend-tests     # run backend test matrix job
 #   ./tools/tests/run_ci_with_act.sh --base-ref main -j backend-lint
 #   ./tools/tests/run_ci_with_act.sh <extra act args>     # pass-through
+#
+# ACT selects raw GitHub workflow job ids. Use backend-tests here; the
+# backend-tests-1..5 logical shard ids are only for run_ci_parallel.py.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"


### PR DESCRIPTION
Fixes #3622

## What changed
- Replaced the ACT backend shard example with the raw workflow job id: `backend-tests`.
- Documented that ACT `-j` uses GitHub workflow job ids, while `run_ci_parallel.py --job` uses local logical shard ids such as `backend-tests-1`.
- Added hygiene coverage that validates documented ACT job examples against `.github/workflows/ci.yml` job ids and local runner examples against the local manifest job ids.

## Why
`act -j` does not select local logical shard names. The old `backend-tests-1` example failed because only `backend-tests` exists as the GitHub workflow job id.

## Validation
- `ruff format apps/server/tests/hygiene/test_ci_changed_scope.py`
- `ruff check apps/server/tests/hygiene/test_ci_changed_scope.py`
- `pytest apps/server/tests/hygiene/test_ci_changed_scope.py -q`
- `shellcheck --severity=warning -x -s bash tools/tests/run_ci_with_act.sh`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs
Tiny docs/test change. No runtime behavior changes. ACT still cannot select one backend matrix shard with a local logical shard id; use the local runner for that.

## Follow-ups
None.
