### PR TITLE
Guard local CI Python runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_change_request.md
+++ b/.github/ISSUE_TEMPLATE/ai_change_request.md
@@ -26,7 +26,7 @@ make typecheck-backend
 pytest -q apps/server/tests/app/test_config.py -k my_case
 make test-all
 # (optional faster CI-parity subset)
-python3 tools/tests/run_ci_parallel.py --job backend-preflight --job backend-tests-1
+./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-preflight --job backend-tests-1
 ```
 
 ## Acceptance Criteria

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,20 +54,20 @@ Commands
 - `make ui-typecheck` (default frontend validation path: materialize generated UI contract artifacts, then run UI format drift, lint, and TypeScript checks)
 - `make docs-lint`
 - `make plan-validation` (primary AI/dev validation planner: changed-file CI plan, local command, ACT command, and JSON summary)
-- `python3 tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
+- `./.venv/bin/python tools/tests/plan_validation.py --run` (run the planned non-Docker local CI jobs)
 - `make doctor` (reports local prerequisites, including host `shellcheck` for local `shell-lint` parity)
 - `make test-changed` (heuristic changed-file runner vs `origin/main`, falling back to `main`)
 - `make test-ci-fast` (fast local CI gates: lint, docs, static guards, and type checks; no browser/release/firmware/e2e/backend test suites)
 - `make test-ci-lite` (non-Docker workflow jobs except e2e; includes backend shards, UI smoke, release smoke, and firmware native tests)
-- `make test-all` (CI-parity local suite: `python3 tools/tests/run_ci_parallel.py`)
+- `make test-all` (CI-parity local suite using the repo Python)
 - `./tools/tests/run_ci_with_act.sh` (changed-scope ACT/GitHub workflow parity with generated pull-request event data; requires Docker)
 - `./tools/tests/run_ci_with_act.sh --full-stack` (force all CI jobs through `ci-scope`; requires Docker)
 - `./tools/tests/run_ci_with_act.sh -j backend-lint` (run a selected CI job locally via `act`; requires Docker)
 - `./tools/tests/run_ci_with_act.sh -j backend-tests` (run the backend test matrix job via `act`; ACT uses raw GitHub job ids, not local logical shard ids like `backend-tests-1`)
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
-- `python3 tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset)
+- `./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset; direct local CI runners reject the wrong Python major/minor)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
-- `python3 tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` (compact state-change watcher; default `--interval 10`, `--heartbeat 120`; omit `--merge-on-green` for watch-only mode)
+- `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` (compact state-change watcher; default `--interval 10`, `--heartbeat 120`; omit `--merge-on-green` for watch-only mode)
 - `cd apps/ui && npm ci && npm run build` (bundle build after `make ui-typecheck`; raw `npm run typecheck` / `npm run build` only check contract freshness and fail if generated UI files are stale)
 - `cd apps/ui && npm run test:visual`
 - `cd firmware/esp && pio run`
@@ -77,7 +77,7 @@ Commands
 - `docker compose build --pull && docker compose up -d`
 
 Validation chooser
-- Start with `make plan-validation` for changed-file CI scope; use `python3 tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
+- Start with `make plan-validation` for changed-file CI scope; use `./.venv/bin/python tools/tests/plan_validation.py --run` to execute planned non-Docker jobs, or `--act` when ACT/GitHub-workflow parity is required.
 - Use `make test-ci-fast` for a broad but fast local gate before heavier browser/release/backend suites; use `make test-ci-lite` only when you want the larger non-Docker workflow surface except e2e.
 - `run_ci_parallel.py` respects GitHub `needs` order among selected jobs, warns when you select a downstream job without its prerequisites, and reports workflow-only needs it substitutes locally.
 - Local `shell-lint` parity requires host `shellcheck`; use ACT when you need CI to install ShellCheck inside the workflow job.

--- a/apps/server/tests/hygiene/test_repo_tooling_support.py
+++ b/apps/server/tests/hygiene/test_repo_tooling_support.py
@@ -8,9 +8,19 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _REPO_TOOLING_SUPPORT = REPO_ROOT / "tools" / "repo_tooling_support.py"
+_DIRECT_LOCAL_CI_RUNNERS = (
+    REPO_ROOT / "tools" / "tests" / "run_ci_parallel.py",
+    REPO_ROOT / "tools" / "tests" / "run_changed.py",
+    REPO_ROOT / "tools" / "tests" / "run_backend_parallel.py",
+    REPO_ROOT / "tools" / "tests" / "run_e2e_parallel.py",
+    REPO_ROOT / "tools" / "tests" / "plan_validation.py",
+    REPO_ROOT / "tools" / "watch_pr_checks.py",
+)
 
 
 def _load_repo_tooling_support_module() -> ModuleType:
@@ -72,3 +82,42 @@ def test_tracked_files_prefers_git_listing(monkeypatch) -> None:
         "tools/dev/check_hygiene.py",
         "tools/tests/ci_workflow_manifest.py",
     ]
+
+
+def test_ensure_repo_python_version_accepts_configured_major_minor(tmp_path: Path) -> None:
+    module = _load_repo_tooling_support_module()
+    (tmp_path / ".python-version").write_text("3.13.5\n", encoding="utf-8")
+
+    module.ensure_repo_python_version(
+        tmp_path,
+        script_path=tmp_path / "tools" / "tests" / "run_ci_parallel.py",
+        actual_version_info=(3, 13, 13),
+        actual_version="3.13.13",
+        executable="/repo/.venv/bin/python",
+    )
+
+
+def test_ensure_repo_python_version_rejects_wrong_major_minor(tmp_path: Path) -> None:
+    module = _load_repo_tooling_support_module()
+    (tmp_path / ".python-version").write_text("3.13.5\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.ensure_repo_python_version(
+            tmp_path,
+            script_path=tmp_path / "tools" / "tests" / "run_ci_parallel.py",
+            actual_version_info=(3, 12, 10),
+            actual_version="3.12.10",
+            executable="/usr/bin/python3",
+        )
+
+    message = str(exc_info.value)
+    assert "tools/tests/run_ci_parallel.py must run with Python 3.13.x" in message
+    assert "current interpreter is Python 3.12.10 at /usr/bin/python3" in message
+    assert "Run `make setup`" in message
+    assert ".venv/bin/python tools/tests/run_ci_parallel.py" in message
+
+
+def test_direct_local_ci_runners_enforce_repo_python_version() -> None:
+    for runner_path in _DIRECT_LOCAL_CI_RUNNERS:
+        text = runner_path.read_text(encoding="utf-8")
+        assert "ensure_repo_python_version" in text, runner_path

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -37,9 +37,10 @@ def _install_main_fakes(module, monkeypatch, tmp_path: Path) -> tuple[dict[str, 
     monkeypatch.setattr(module, "_observed_durations_from_junit", lambda _path, _selected: {})
     monkeypatch.setattr(module, "_emit", emitted.append)
 
-    def _fake_run(cmd: list[str], *, log_path: Path) -> int:
+    def _fake_run(cmd: list[str], *, log_path: Path, timeout_s: int) -> int:
         captured["cmd"] = list(cmd)
         captured["log_path"] = log_path
+        captured["timeout_s"] = timeout_s
         log_path.write_text("$ fake pytest\n", encoding="utf-8")
         return 0
 
@@ -141,3 +142,33 @@ def test_main_cli_overrides_env_xdist_workers(monkeypatch, tmp_path: Path) -> No
     assert module.main(["--xdist-workers", "2"]) == 0
 
     assert captured["cmd"][4:6] == ["-n", "2"]
+
+
+def test_main_passes_configured_shard_timeout(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setenv(module._SHARD_TIMEOUT_ENV, "17")
+    captured, emitted = _install_main_fakes(module, monkeypatch, tmp_path)
+
+    assert module.main([]) == 0
+
+    assert captured["timeout_s"] == 17
+    assert any("timeout=17s" in line for line in emitted)
+
+
+def test_run_times_out_pytest_subprocess(monkeypatch, tmp_path: Path) -> None:
+    module = _load_run_backend_parallel_module()
+    log_path = tmp_path / "backend-tests.log"
+
+    def _fake_run(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise module.subprocess.TimeoutExpired(
+            cmd=["pytest"],
+            timeout=5,
+            output="partial pytest output\n",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    assert module._run(["pytest"], log_path=log_path, timeout_s=5) == 124
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "partial pytest output" in log_text
+    assert "timed out after 5s" in log_text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,15 +7,15 @@
 - Firmware build/flash guidance lives in `firmware/esp/README.md`.
 - Pi-image build/validation guidance lives in `infra/pi-image/pi-gen/README.md`.
 - `make format` is the canonical Python formatting command for backend and tooling files; no other Python formatter is supported in the repo workflow.
-- Use `make plan-validation` (`python3 tools/tests/plan_validation.py`) first to turn the current diff into the CI-backed validation plan.
-- Use `python3 tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
-- Use `python3 tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
+- Use `make plan-validation` first to turn the current diff into the CI-backed validation plan.
+- Use `./.venv/bin/python tools/tests/plan_validation.py --run` to run that plan through the non-Docker local runner.
+- Use `./.venv/bin/python tools/tests/plan_validation.py --act` when you need ACT/GitHub-workflow parity for the planned jobs.
 - Use `make test-ci-fast` for lint, docs, static guards, and type checks without browser, release, firmware, e2e, or backend test suites.
 - Use `make test-ci-lite` for the larger non-Docker workflow surface except e2e; it still includes backend shards, UI smoke, release smoke, and firmware native tests.
 - Local `shell-lint` parity requires host `shellcheck`; `make doctor` reports it, and ACT/GitHub CI install it inside the workflow job.
 - Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
 - Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
-- The full end-to-end verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
+- The full end-to-end verification runner is `make test-full-suite` (`./.venv/bin/python tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
 - `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time. It also accepts `--xdist-workers` / `VIBESENSOR_BACKEND_XDIST_WORKERS` for controlled intra-shard xdist; CI currently pins that to `3` because the current five-shard benchmark beat the nearby `5x2`, `4x3`, `4x2`, and `6x2` alternatives without changing shard count or the failure/JUnit surface. Retune only from fresh measurements, not guesswork.
 - `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
 - Python test configuration lives in `apps/server/pyproject.toml`.
@@ -115,15 +115,15 @@ and complete in under 5 seconds.
 
 ## Running tests
 
-Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `python3 tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-fast` for lint/docs/static/typecheck gates without heavy suites, `make test-ci-lite` for non-Docker workflow jobs except e2e, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. `make ui-typecheck` includes the UI Biome formatter drift check before lint/dependency/type gates. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
+Backend/local CI tiers: `make plan-validation` for the CI-backed changed-file plan, `./.venv/bin/python tools/tests/plan_validation.py --run` to execute that plan through the non-Docker local runner, `make test` for backend iteration, `make test-ci-fast` for lint/docs/static/typecheck gates without heavy suites, `make test-ci-lite` for non-Docker workflow jobs except e2e, `make test-all` for the broader local runner, and `./tools/tests/run_ci_with_act.sh` when you need ACT/GitHub-workflow parity. `make ui-typecheck` includes the UI Biome formatter drift check before lint/dependency/type gates. Local `shell-lint` runs need host `shellcheck`; use ACT if you need the workflow-managed install path.
 
 Main local tiers:
 
 ```bash
 # CI-backed changed-file validation plan
 make plan-validation
-python3 tools/tests/plan_validation.py --run
-python3 tools/tests/plan_validation.py --act
+./.venv/bin/python tools/tests/plan_validation.py --run
+./.venv/bin/python tools/tests/plan_validation.py --act
 
 # Changed-file heuristic (current branch vs origin/main, fallback to main)
 make test-changed
@@ -164,11 +164,16 @@ for later runs with `make benchmark-backend` / `make benchmark-compare-backend`.
 Focused CI job groups and full-stack validation:
 
 ```bash
-python3 tools/tests/run_ci_parallel.py --ci-lite
-python3 tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-smoke
-python3 tools/tests/run_ci_parallel.py --job release-smoke
+./.venv/bin/python tools/tests/run_ci_parallel.py --ci-lite
+./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-smoke
+./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
 make test-full-suite
 ```
+
+Prefer the Makefile targets after `make setup`; they resolve the repo virtualenv
+Python automatically. Direct local CI runner scripts also self-check the
+`.python-version` major/minor and stop with a targeted setup hint if an ambient
+Python such as system `python3` is wrong.
 
 When multiple selected local jobs have GitHub `needs` relationships,
 `run_ci_parallel.py` runs them in dependency waves and skips selected downstream
@@ -200,7 +205,7 @@ cd apps/ui && npm run test:unit
 cd apps/ui && npm run build
 cd apps/ui && npm run test:visual
 cd apps/ui && npm run test:visual:audit   # optional broader visual sweep
-python3 tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
+./.venv/bin/python tools/tests/run_ci_parallel.py --job frontend-quality --job frontend-typecheck --job ui-unit --job ui-smoke
 ```
 
 The UI has three test layers; pick the one that matches the seam under test:
@@ -238,7 +243,7 @@ cd firmware/esp && pio run
 BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh
 BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
 ./infra/pi-image/pi-gen/validate-image.sh
-python3 tools/tests/run_ci_parallel.py --job release-smoke
+./.venv/bin/python tools/tests/run_ci_parallel.py --job release-smoke
 ```
 
 - Use `pio run -t upload` and `pio device monitor` only when hardware-backed

--- a/tools/repo_tooling_support.py
+++ b/tools/repo_tooling_support.py
@@ -15,6 +15,51 @@ from types import ModuleType
 CommandTokenNormalizer = Callable[[str], str]
 
 
+def _repo_python_major_minor(repo_root: Path) -> tuple[int, int]:
+    version_path = repo_root / ".python-version"
+    raw_version = version_path.read_text(encoding="utf-8").strip()
+    parts = raw_version.split(".")
+    if len(parts) < 2:
+        raise SystemExit(
+            f"{version_path} must contain at least a major.minor Python version."
+        )
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise SystemExit(
+            f"{version_path} contains an invalid Python version: {raw_version!r}"
+        ) from exc
+
+
+def ensure_repo_python_version(
+    repo_root: Path,
+    *,
+    script_path: Path | None = None,
+    actual_version_info: Sequence[int] | None = None,
+    actual_version: str | None = None,
+    executable: str | None = None,
+) -> None:
+    """Stop direct repo tooling runs that use the wrong Python major.minor."""
+
+    expected_major, expected_minor = _repo_python_major_minor(repo_root)
+    observed = actual_version_info or sys.version_info
+    actual_major_minor = int(observed[0]), int(observed[1])
+    if actual_major_minor == (expected_major, expected_minor):
+        return
+
+    label = (
+        script_path.relative_to(repo_root).as_posix() if script_path else "this command"
+    )
+    current_version = (actual_version or sys.version).split()[0]
+    current_executable = executable or sys.executable
+    raise SystemExit(
+        f"{label} must run with Python {expected_major}.{expected_minor}.x from .python-version; "
+        f"current interpreter is Python {current_version} at {current_executable}. "
+        "Run `make setup`, then use a Makefile target or "
+        f"`{repo_root / '.venv' / 'bin' / 'python'} {label}`."
+    )
+
+
 def walk_files(repo_root: Path, excluded_dirs: Iterable[str]) -> list[str]:
     excluded = set(excluded_dirs)
     files: list[str] = []

--- a/tools/tests/plan_validation.py
+++ b/tools/tests/plan_validation.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
+_REPO_TOOLING_SUPPORT_PATH = ROOT / "tools" / "repo_tooling_support.py"
 _CI_PATH_RULES_PATH = Path(__file__).with_name("ci_path_rules.py")
 _CI_MANIFEST_PATH = Path(__file__).with_name("ci_workflow_manifest.py")
 _RUN_CHANGED_PATH = Path(__file__).with_name("run_changed.py")
@@ -29,6 +30,13 @@ def _load_module(name: str, path: Path):
     return module
 
 
+_REPO_TOOLING_SUPPORT = _load_module(
+    "repo_tooling_support_for_plan_validation",
+    _REPO_TOOLING_SUPPORT_PATH,
+)
+_REPO_TOOLING_SUPPORT.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
 _CI_PATH_RULES = _load_module("ci_path_rules_for_plan_validation", _CI_PATH_RULES_PATH)
 _CI_MANIFEST = _load_module("ci_manifest_for_plan_validation", _CI_MANIFEST_PATH)
 _RUN_CHANGED = _load_module("run_changed_for_plan_validation", _RUN_CHANGED_PATH)

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -18,9 +18,11 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[2]
+
 
 def _load_repo_tooling_support():
-    helper_path = Path(__file__).resolve().parents[1] / "repo_tooling_support.py"
+    helper_path = ROOT / "tools" / "repo_tooling_support.py"
     spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
@@ -30,6 +32,9 @@ def _load_repo_tooling_support():
 
 
 _repo_tooling_support = _load_repo_tooling_support()
+_repo_tooling_support.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
 _parallel_runner_support = _repo_tooling_support.load_parallel_runner_support(__file__)
 resolve_duration_cache_path = _parallel_runner_support.duration_cache_path
 read_duration_cache = _parallel_runner_support.load_duration_cache
@@ -40,7 +45,6 @@ read_observed_durations_from_junit = (
 collect_normalized_test_ids = _parallel_runner_support.parse_collected_test_ids
 
 
-ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci"
 _DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
 _XDIST_WORKERS_ENV = "VIBESENSOR_BACKEND_XDIST_WORKERS"

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -48,8 +48,10 @@ collect_normalized_test_ids = _parallel_runner_support.parse_collected_test_ids
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci"
 _DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
 _XDIST_WORKERS_ENV = "VIBESENSOR_BACKEND_XDIST_WORKERS"
+_SHARD_TIMEOUT_ENV = "VIBESENSOR_BACKEND_SHARD_TIMEOUT_S"
 _DEFAULT_DURATION = 1.0
 _DEFAULT_XDIST_WORKERS = 3
+_DEFAULT_SHARD_TIMEOUT_S = 900
 
 
 def _emit(line: str) -> None:
@@ -79,6 +81,20 @@ def _xdist_workers_default(env: Mapping[str, str] | None = None) -> int:
         raise SystemExit(f"{_XDIST_WORKERS_ENV} must be an integer >= 0") from exc
     if value < 0:
         raise SystemExit(f"{_XDIST_WORKERS_ENV} must be >= 0")
+    return value
+
+
+def _shard_timeout_default(env: Mapping[str, str] | None = None) -> int:
+    source = os.environ if env is None else env
+    raw = source.get(_SHARD_TIMEOUT_ENV)
+    if raw is None or raw == "":
+        return _DEFAULT_SHARD_TIMEOUT_S
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{_SHARD_TIMEOUT_ENV} must be an integer > 0") from exc
+    if value <= 0:
+        raise SystemExit(f"{_SHARD_TIMEOUT_ENV} must be > 0")
     return value
 
 
@@ -206,16 +222,35 @@ def _selected_test_ids(
     return selected
 
 
-def _run(cmd: list[str], *, log_path: Path) -> int:
+def _timeout_output(exc: subprocess.TimeoutExpired) -> str:
+    output = exc.stdout or exc.output or ""
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return output
+
+
+def _run(cmd: list[str], *, log_path: Path, timeout_s: int) -> int:
     with log_path.open("w", encoding="utf-8") as log_file:
         log_file.write(f"$ {shlex.join(cmd)}\n")
-        proc = subprocess.run(
-            cmd,
-            cwd=str(ROOT),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(ROOT),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            output = _timeout_output(exc)
+            if output:
+                log_file.write(output)
+                if not output.endswith("\n"):
+                    log_file.write("\n")
+            log_file.write(
+                f"[backend-parallel] timed out after {timeout_s}s; pytest process was terminated.\n"
+            )
+            return 124
         output = proc.stdout or ""
         if output:
             log_file.write(output)
@@ -266,6 +301,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             f"{_XDIST_WORKERS_ENV} or {_DEFAULT_XDIST_WORKERS}."
         ),
     )
+    parser.add_argument(
+        "--timeout-s",
+        type=int,
+        default=_shard_timeout_default(),
+        help=(
+            "Maximum wall-clock seconds for the shard pytest subprocess; defaults to "
+            f"{_SHARD_TIMEOUT_ENV} or {_DEFAULT_SHARD_TIMEOUT_S}."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
@@ -273,6 +317,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         raise SystemExit("--shard-index must be between 1 and --shards")
     if args.xdist_workers < 0:
         raise SystemExit("--xdist-workers must be >= 0")
+    if args.timeout_s <= 0:
+        raise SystemExit("--timeout-s must be > 0")
     return args
 
 
@@ -307,7 +353,7 @@ def main(argv: list[str] | None = None) -> int:
         f"[backend-parallel] collected {len(collected)} test cases across "
         f"{len(grouped_tests)} test files; running shard {args.shard_index}/{args.shards} "
         f"with {len(selected_targets)} files and {len(selected_tests)} test cases "
-        f"using pytest -n {args.xdist_workers}"
+        f"using pytest -n {args.xdist_workers} timeout={args.timeout_s}s"
     )
 
     if not selected_targets:
@@ -330,7 +376,7 @@ def main(argv: list[str] | None = None) -> int:
         *selected_targets,
     ]
     started = time.monotonic()
-    rc = _run(pytest_cmd, log_path=log_path)
+    rc = _run(pytest_cmd, log_path=log_path, timeout_s=args.timeout_s)
     elapsed = time.monotonic() - started
 
     observed_durations = _observed_durations_from_junit(junit_path, selected_tests)

--- a/tools/tests/run_changed.py
+++ b/tools/tests/run_changed.py
@@ -12,7 +12,21 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 ROOT = Path(__file__).resolve().parents[2]
+_REPO_TOOLING_SUPPORT_PATH = ROOT / "tools" / "repo_tooling_support.py"
 _CI_PATH_RULES_PATH = Path(__file__).with_name("ci_path_rules.py")
+
+
+def _load_repo_tooling_support_module():
+    spec = importlib.util.spec_from_file_location(
+        "repo_tooling_support_for_run_changed",
+        _REPO_TOOLING_SUPPORT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {_REPO_TOOLING_SUPPORT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_ci_path_rules_module():
@@ -27,6 +41,10 @@ def _load_ci_path_rules_module():
     return module
 
 
+_REPO_TOOLING_SUPPORT = _load_repo_tooling_support_module()
+_REPO_TOOLING_SUPPORT.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
 _CI_PATH_RULES = _load_ci_path_rules_module()
 FULL_STACK_TRIGGER_FILES = _CI_PATH_RULES.FULL_STACK_TRIGGER_FILES
 FULL_STACK_TRIGGER_PREFIXES = _CI_PATH_RULES.FULL_STACK_TRIGGER_PREFIXES

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -23,7 +23,21 @@ UI_NODE_MODULES = UI_DIR / "node_modules"
 UI_BOOTSTRAP_HELPER = ROOT / "tools" / "ui" / "ensure_ui_bootstrap.mjs"
 PRINT_LOCK = threading.Lock()
 RESULT_LOCK = threading.Lock()
+_REPO_TOOLING_SUPPORT_PATH = ROOT / "tools" / "repo_tooling_support.py"
 _CI_MANIFEST_PATH = Path(__file__).with_name("ci_workflow_manifest.py")
+
+
+def _load_repo_tooling_support_module():
+    spec = importlib.util.spec_from_file_location(
+        "repo_tooling_support_for_run_ci_parallel",
+        _REPO_TOOLING_SUPPORT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {_REPO_TOOLING_SUPPORT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _load_ci_workflow_manifest_module():
@@ -38,6 +52,10 @@ def _load_ci_workflow_manifest_module():
     return module
 
 
+_REPO_TOOLING_SUPPORT = _load_repo_tooling_support_module()
+_REPO_TOOLING_SUPPORT.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
 _CI_MANIFEST = _load_ci_workflow_manifest_module()
 ALL_JOB_NAMES = _CI_MANIFEST.all_job_names()
 CI_FAST_JOB_NAMES = _CI_MANIFEST.ci_fast_job_names()

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -22,18 +22,11 @@ from pathlib import Path
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
-from vibesensor.use_cases.isolated_server_runtime import (
-    IsolatedRuntimePaths,
-    build_isolated_server_config,
-    build_isolated_server_env,
-    build_server_subprocess_cmd,
-    start_server_subprocess,
-    terminate_subprocess,
-)
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def _load_repo_tooling_support():
-    helper_path = Path(__file__).resolve().parents[1] / "repo_tooling_support.py"
+    helper_path = ROOT / "tools" / "repo_tooling_support.py"
     spec = importlib.util.spec_from_file_location("repo_tooling_support", helper_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Unable to load repo tooling helpers from {helper_path}")
@@ -43,6 +36,21 @@ def _load_repo_tooling_support():
 
 
 _repo_tooling_support = _load_repo_tooling_support()
+_repo_tooling_support.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
+
+# Keep the repo Python check above the first import from the installed backend package.
+from vibesensor.use_cases.isolated_server_runtime import (  # noqa: E402
+    IsolatedRuntimePaths,
+    build_isolated_server_config,
+    build_isolated_server_env,
+    build_server_subprocess_cmd,
+    start_server_subprocess,
+    terminate_subprocess,
+)
+
+
 _parallel_runner_support = _repo_tooling_support.load_parallel_runner_support(__file__)
 resolve_duration_cache_path = _parallel_runner_support.duration_cache_path
 read_duration_cache = _parallel_runner_support.load_duration_cache
@@ -108,7 +116,6 @@ def collect_test_ids(pytest_args: list[str]) -> list[str]:
     return _parse_collected_test_ids(result.stdout or "")
 
 
-ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "e2e_parallel"
 PRINT_LOCK = threading.Lock()
 _DURATION_CACHE_ENV = "VIBESENSOR_E2E_DURATION_CACHE"

--- a/tools/watch_pr_checks.py
+++ b/tools/watch_pr_checks.py
@@ -4,19 +4,42 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Sequence
 
+ROOT = Path(__file__).resolve().parents[1]
 COMPLETED_STATUS = "COMPLETED"
 RUNNING_STATUSES = {"IN_PROGRESS"}
 QUEUED_STATUSES = {"EXPECTED", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
 SUCCESS_CONCLUSIONS = {"NEUTRAL", "SKIPPED", "SUCCESS"}
 ACTIONABLE_MERGE_STATES = {"DIRTY"}
+_REPO_TOOLING_SUPPORT_PATH = ROOT / "tools" / "repo_tooling_support.py"
+
+
+def _load_repo_tooling_support_module():
+    spec = importlib.util.spec_from_file_location(
+        "repo_tooling_support_for_watch_pr_checks",
+        _REPO_TOOLING_SUPPORT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {_REPO_TOOLING_SUPPORT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_REPO_TOOLING_SUPPORT = _load_repo_tooling_support_module()
+_REPO_TOOLING_SUPPORT.ensure_repo_python_version(
+    ROOT, script_path=Path(__file__).resolve()
+)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixes #3623

## What changed
- Added a shared `.python-version` major/minor guard for direct repo tooling runs.
- Wired the guard into direct local CI runner/planner/watch scripts:
  - `run_ci_parallel.py`
  - `run_changed.py`
  - `run_backend_parallel.py`
  - `run_e2e_parallel.py`
  - `plan_validation.py`
  - `watch_pr_checks.py`
- Updated AI/dev docs and templates to prefer Makefile targets or `./.venv/bin/python` for direct local CI commands.
- Added hygiene coverage for the guard, error message, and runner wiring.
- Added a wall-clock timeout to backend shard subprocesses so a stuck/flaky shard fails with log context instead of blocking CI indefinitely.

## Why
Ambient `python3` can point at the wrong runtime. Local CI should not silently run under a Python major/minor that differs from `.python-version`.

## Validation
- `ruff format` / `ruff check` on touched Python files
- `pytest apps/server/tests/hygiene/test_repo_tooling_support.py apps/server/tests/hygiene/test_run_changed.py apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_run_e2e_parallel.py apps/server/tests/hygiene/test_watch_pr_checks.py apps/server/tests/hygiene/test_ai_issue_template_commands.py -q`
- Direct runner smoke checks through `./.venv/bin/python`
- `./.venv/bin/python tools/tests/run_backend_parallel.py --shards 5 --shard-index 2 --timeout-s 90`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs
Small tooling behavior change. Direct scripts now fail early when run with the wrong Python major/minor. Backend shards now fail after the configured timeout instead of hanging forever. Patch-level Python differences remain allowed because local and hosted setup can resolve newer patch releases within the configured Python line.

## Follow-ups
None.