### PR TITLE
Document ACT Pi image limitations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,7 @@ Validation chooser
 - Firmware code: `cd firmware/esp && pio run`.
 - Pi app artifact changes: `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh`.
 - Pi image-stage logic: `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`, then `./infra/pi-image/pi-gen/validate-image.sh [artifact]` when an artifact is available.
+- Do not use ACT for `.github/workflows/manual-pi-image-arm.yml` or `.github/workflows/weekly-pi-image.yml`; those workflows require GitHub's `ubuntu-24.04-arm` runner label, which is intentionally not mapped in `.actrc`. Use the Pi-image local build/validate commands above.
 - Docs or AI-instruction-only changes: `make docs-lint`.
 
 Command gotchas

--- a/apps/server/tests/hygiene/test_weekly_pi_image_workflow.py
+++ b/apps/server/tests/hygiene/test_weekly_pi_image_workflow.py
@@ -93,3 +93,20 @@ def test_manual_pi_image_workflow_reuses_shared_build_action_and_stays_artifact_
         if isinstance(step, dict) and isinstance(step.get("name"), str)
     }
     assert "Publish weekly Pi image release" not in step_names
+
+
+def test_arm_pi_image_act_limitation_stays_documented() -> None:
+    actrc = (REPO_ROOT / ".actrc").read_text(encoding="utf-8")
+    docs = (REPO_ROOT / "docs" / "testing.md").read_text(encoding="utf-8")
+    ai_guidance = (REPO_ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8")
+    pi_readme = (REPO_ROOT / "infra" / "pi-image" / "pi-gen" / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ubuntu-24.04-arm" not in actrc
+    for text in (docs, ai_guidance, pi_readme):
+        assert "ubuntu-24.04-arm" in text
+        assert "not mapped" in text
+        assert "BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh" in text
+        assert "BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh" in text
+        assert "./infra/pi-image/pi-gen/validate-image.sh" in text

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -369,6 +369,18 @@ No secrets are currently required. If needed in the future, copy
 
 ### Known limitations under `act`
 
+ACT parity is currently scoped to `.github/workflows/ci.yml`. Do not use ACT for
+the Pi-image workflows `manual-pi-image-arm.yml` or `weekly-pi-image.yml`: they
+run on GitHub's `ubuntu-24.04-arm` runner label, and `.actrc` intentionally does
+not map that ARM runner to a local container image. Validate Pi-image changes
+with the supported local path instead:
+
+```bash
+BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh
+BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh
+./infra/pi-image/pi-gen/validate-image.sh
+```
+
 | Job | Status | Notes |
 |---|---|---|
 | `backend-lint` | ✅ Fully supported | — |
@@ -384,6 +396,7 @@ No secrets are currently required. If needed in the future, copy
 | `release-smoke` | ✅ Fully supported | — |
 | `backend-tests` | ✅ Fully supported | This matrix job emits the `Backend tests (shard 1/5)` through `Backend tests (shard 5/5)` checks. Update-module workflow tests now patch tool lookup and privilege checks through shared fakes, so missing `nmcli` or non-root host state does not create `act`-only flakes. |
 | `e2e` | ✅ Fully supported | Runs isolated server subprocess shards directly; no Docker-in-Docker dependency. |
+| `manual-pi-image-arm.yml` / `weekly-pi-image.yml` | ❌ Not supported | ARM Pi-image workflows use `ubuntu-24.04-arm`, which is not mapped in `.actrc`; use `BUILD_MODE=app`, `BUILD_MODE=image`, and `validate-image.sh` instead. |
 
 ### Relationship to `run_ci_parallel.py`
 

--- a/infra/pi-image/pi-gen/README.md
+++ b/infra/pi-image/pi-gen/README.md
@@ -26,6 +26,12 @@ On Ubuntu runners, `qemu-user-binfmt` conflicts with `qemu-user-static`, so use
 
 ## Build
 
+ACT is not the supported local runner for Pi-image workflows. The GitHub
+workflows `manual-pi-image-arm.yml` and `weekly-pi-image.yml` use the
+`ubuntu-24.04-arm` runner label, which is intentionally not mapped in the repo
+`.actrc`. Use the local build and validation commands below for Pi-image
+changes.
+
 ```bash
 git clone https://github.com/Skamba/VibeSensor.git
 cd VibeSensor


### PR DESCRIPTION
Fixes #3625.

What changed:
- Documented that ACT parity is scoped to `.github/workflows/ci.yml`.
- Called out that `manual-pi-image-arm.yml` and `weekly-pi-image.yml` use `ubuntu-24.04-arm` and are not mapped in `.actrc`.
- Pointed Pi-image validation to `BUILD_MODE=app`, `BUILD_MODE=image`, and `validate-image.sh`.
- Added hygiene coverage so the ARM ACT limitation stays documented.

Why:
- Local ACT runs cannot represent the ARM Pi-image GitHub runner path.
- The supported local validation path should be explicit.

Validation:
- `ruff format apps/server/tests/hygiene/test_weekly_pi_image_workflow.py`
- `ruff check apps/server/tests/hygiene/test_weekly_pi_image_workflow.py`
- `pytest apps/server/tests/hygiene/test_weekly_pi_image_workflow.py -q`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

Risks / tradeoffs:
- Documentation-only behavior change.
- Keeps `ubuntu-24.04-arm` unmapped in `.actrc` instead of pretending ACT can run that workflow locally.

Follow-ups:
- None.
