### PR TITLE
Add watcher GitHub CLI timeouts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Commands
 - `act -l -W .github/workflows/ci.yml` (list CI jobs)
 - `./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-lint --job repo-hygiene --job backend-static-guards --job backend-preflight --job docs-lint --job backend-contract-drift --job backend-typecheck --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5` (faster backend-focused CI subset; direct local CI runners reject the wrong Python major/minor)
 - `pytest -q apps/server/tests/<module>/` (run tests for a single feature area)
-- `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` (compact state-change watcher; default `--interval 10`, `--heartbeat 120`; omit `--merge-on-green` for watch-only mode)
+- `./.venv/bin/python tools/watch_pr_checks.py --pr <PR_NUMBER> --repo Skamba/VibeSensor --merge-on-green` (compact state-change watcher; default `--interval 10`, `--heartbeat 120`, `--gh-timeout 30`, `--fetch-failure-limit 3`; omit `--merge-on-green` for watch-only mode)
 - `cd apps/ui && npm ci && npm run build` (bundle build after `make ui-typecheck`; raw `npm run typecheck` / `npm run build` only check contract freshness and fail if generated UI files are stale)
 - `cd apps/ui && npm run test:visual`
 - `cd firmware/esp && pio run`

--- a/apps/server/tests/hygiene/test_watch_pr_checks.py
+++ b/apps/server/tests/hygiene/test_watch_pr_checks.py
@@ -6,6 +6,8 @@ import importlib.util
 import subprocess
 import sys
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _WATCH_PR_CHECKS = REPO_ROOT / "tools" / "watch_pr_checks.py"
@@ -118,7 +120,11 @@ def test_main_emits_compact_state_changes_without_repeating_unchanged_pending_po
     )
     monotonic_times = iter([0.0, 10.0, 20.0])
 
-    monkeypatch.setattr(module, "_fetch_pr_status", lambda pr, repo: next(responses))
+    monkeypatch.setattr(
+        module,
+        "_fetch_pr_status",
+        lambda pr, repo, *, timeout_s: next(responses),
+    )
     monkeypatch.setattr(module, "_now_monotonic", lambda: next(monotonic_times))
     monkeypatch.setattr(module, "_now_utc", lambda: "12:00:00")
     monkeypatch.setattr(module, "_sleep", lambda seconds: None)
@@ -144,7 +150,7 @@ def test_main_reports_real_failures_with_details_url(monkeypatch, capsys) -> Non
     monkeypatch.setattr(
         module,
         "_fetch_pr_status",
-        lambda pr, repo: _pr_status(
+        lambda pr, repo, *, timeout_s: _pr_status(
             module,
             [
                 {
@@ -171,20 +177,84 @@ def test_main_reports_real_failures_with_details_url(monkeypatch, capsys) -> Non
     ]
 
 
-def test_merge_pr_uses_match_head_commit_and_deletes_branch(monkeypatch) -> None:
+def test_fetch_pr_status_uses_timeout_and_classifies_auth_failure(monkeypatch) -> None:
     module = _load_watch_pr_checks_module()
     observed: dict[str, object] = {}
 
-    def _fake_run(cmd, *, text, capture_output, check):
+    def _fake_run(cmd, *, text, capture_output, check, timeout):
         observed["cmd"] = cmd
         observed["text"] = text
         observed["capture_output"] = capture_output
         observed["check"] = check
+        observed["timeout"] = timeout
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            "",
+            "HTTP 401: authentication required",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    with pytest.raises(
+        module.GhCommandFailed,
+        match="auth: gh pr view exited 1: HTTP 401: authentication required",
+    ):
+        module._fetch_pr_status("2719", "Skamba/VibeSensor", timeout_s=42)
+
+    assert observed == {
+        "cmd": [
+            "gh",
+            "pr",
+            "view",
+            "2719",
+            "--json",
+            "statusCheckRollup,mergeStateStatus,mergeable,headRefOid",
+            "--repo",
+            "Skamba/VibeSensor",
+        ],
+        "text": True,
+        "capture_output": True,
+        "check": False,
+        "timeout": 42,
+    }
+
+
+def test_fetch_pr_status_reports_malformed_json(monkeypatch) -> None:
+    module = _load_watch_pr_checks_module()
+
+    def _fake_run(cmd, *, text, capture_output, check, timeout):
+        return subprocess.CompletedProcess(cmd, 0, "{", "")
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    with pytest.raises(
+        module.GhCommandFailed,
+        match="api: gh pr view returned malformed JSON",
+    ):
+        module._fetch_pr_status("2719", None)
+
+
+def test_merge_pr_uses_timeout_match_head_commit_and_deletes_branch(monkeypatch) -> None:
+    module = _load_watch_pr_checks_module()
+    observed: dict[str, object] = {}
+
+    def _fake_run(cmd, *, text, capture_output, check, timeout):
+        observed["cmd"] = cmd
+        observed["text"] = text
+        observed["capture_output"] = capture_output
+        observed["check"] = check
+        observed["timeout"] = timeout
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
     monkeypatch.setattr(module.subprocess, "run", _fake_run)
 
-    module._merge_pr("2719", "Skamba/VibeSensor", "abc123def4567890")
+    module._merge_pr(
+        "2719",
+        "Skamba/VibeSensor",
+        "abc123def4567890",
+        timeout_s=42,
+    )
 
     assert observed == {
         "cmd": [
@@ -202,7 +272,23 @@ def test_merge_pr_uses_match_head_commit_and_deletes_branch(monkeypatch) -> None
         "text": True,
         "capture_output": True,
         "check": False,
+        "timeout": 42,
     }
+
+
+def test_merge_pr_reports_timeout(monkeypatch) -> None:
+    module = _load_watch_pr_checks_module()
+
+    def _fake_run(cmd, *, text, capture_output, check, timeout):
+        raise subprocess.TimeoutExpired(cmd, timeout=timeout, stderr="network stall")
+
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    with pytest.raises(
+        module.MergeFailed,
+        match="timeout: gh pr merge timed out after 7s: network stall",
+    ):
+        module._merge_pr("2719", None, "abc123def4567890", timeout_s=7)
 
 
 def test_main_merges_on_green_when_requested(monkeypatch, capsys) -> None:
@@ -221,12 +307,16 @@ def test_main_merges_on_green_when_requested(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         module,
         "_fetch_pr_status",
-        lambda pr, repo: _pr_status(module, green_checks, head_sha="deadbeefcafebabe"),
+        lambda pr, repo, *, timeout_s: _pr_status(
+            module,
+            green_checks,
+            head_sha="deadbeefcafebabe",
+        ),
     )
     monkeypatch.setattr(
         module,
         "_merge_pr",
-        lambda pr, repo, head_sha: merged.append((pr, repo, head_sha)),
+        lambda pr, repo, head_sha, *, timeout_s: merged.append((pr, repo, head_sha)),
     )
     monkeypatch.setattr(module, "_now_monotonic", lambda: 0.0)
     monkeypatch.setattr(module, "_now_utc", lambda: "13:00:00")
@@ -258,12 +348,12 @@ def test_main_reports_merge_failure_when_merge_on_green_fails(monkeypatch, capsy
     monkeypatch.setattr(
         module,
         "_fetch_pr_status",
-        lambda pr, repo: _pr_status(module, green_checks),
+        lambda pr, repo, *, timeout_s: _pr_status(module, green_checks),
     )
     monkeypatch.setattr(
         module,
         "_merge_pr",
-        lambda pr, repo, head_sha: (_ for _ in ()).throw(
+        lambda pr, repo, head_sha, *, timeout_s: (_ for _ in ()).throw(
             module.MergeFailed("pull request is still a draft")
         ),
     )
@@ -277,4 +367,90 @@ def test_main_reports_merge_failure_when_merge_on_green_fails(monkeypatch, capsy
     assert output_lines == [
         "[13:05:00] PR 789 green ok=1 total=1",
         "RESULT=MERGE_FAILED (pull request is still a draft)",
+    ]
+
+
+def test_main_retries_transient_fetch_failure_then_reports_green(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_watch_pr_checks_module()
+    green_checks = [
+        {
+            "name": "Repo hygiene",
+            "workflowName": "CI",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "detailsUrl": "https://example.invalid/repo-hygiene",
+        }
+    ]
+    responses = iter(
+        [
+            module.GhCommandFailed("network: gh pr view exited 1: connection reset"),
+            _pr_status(module, green_checks),
+        ]
+    )
+    sleeps: list[int] = []
+
+    def _fake_fetch(pr, repo, *, timeout_s):
+        response = next(responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(module, "_fetch_pr_status", _fake_fetch)
+    monkeypatch.setattr(module, "_sleep", sleeps.append)
+    monkeypatch.setattr(module, "_now_monotonic", lambda: 0.0)
+    monkeypatch.setattr(module, "_now_utc", lambda: "13:10:00")
+
+    rc = module.main(["--pr", "123", "--interval", "2", "--fetch-failure-limit", "2"])
+    output_lines = capsys.readouterr().out.splitlines()
+
+    assert rc == 0
+    assert sleeps == [2]
+    assert output_lines == [
+        "[13:10:00] WARN gh pr view failed attempt 1/2: "
+        "network: gh pr view exited 1: connection reset",
+        "[13:10:00] PR 123 green ok=1 total=1",
+        "RESULT=ALL_GREEN",
+    ]
+
+
+def test_main_returns_fetch_failed_after_consecutive_fetch_failures(
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_watch_pr_checks_module()
+    sleeps: list[int] = []
+
+    monkeypatch.setattr(
+        module,
+        "_fetch_pr_status",
+        lambda pr, repo, *, timeout_s: (_ for _ in ()).throw(
+            module.GhCommandFailed("timeout: gh pr view timed out after 1s")
+        ),
+    )
+    monkeypatch.setattr(module, "_sleep", sleeps.append)
+    monkeypatch.setattr(module, "_now_utc", lambda: "13:15:00")
+
+    rc = module.main(
+        [
+            "--pr",
+            "123",
+            "--interval",
+            "2",
+            "--fetch-failure-limit",
+            "2",
+            "--gh-timeout",
+            "1",
+        ]
+    )
+    output_lines = capsys.readouterr().out.splitlines()
+
+    assert rc == 5
+    assert sleeps == [2]
+    assert output_lines == [
+        "[13:15:00] WARN gh pr view failed attempt 1/2: timeout: gh pr view timed out after 1s",
+        "[13:15:00] WARN gh pr view failed attempt 2/2: timeout: gh pr view timed out after 1s",
+        "RESULT=FETCH_FAILED (timeout: gh pr view timed out after 1s)",
     ]

--- a/tools/watch_pr_checks.py
+++ b/tools/watch_pr_checks.py
@@ -20,6 +20,8 @@ RUNNING_STATUSES = {"IN_PROGRESS"}
 QUEUED_STATUSES = {"EXPECTED", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
 SUCCESS_CONCLUSIONS = {"NEUTRAL", "SKIPPED", "SUCCESS"}
 ACTIONABLE_MERGE_STATES = {"DIRTY"}
+DEFAULT_GH_TIMEOUT_S = 30
+DEFAULT_FETCH_FAILURE_LIMIT = 3
 _REPO_TOOLING_SUPPORT_PATH = ROOT / "tools" / "repo_tooling_support.py"
 
 
@@ -63,6 +65,10 @@ class MergeFailed(RuntimeError):
     """Raised when merge-on-green cannot complete the PR merge."""
 
 
+class GhCommandFailed(RuntimeError):
+    """Raised when a bounded GitHub CLI call fails before producing usable data."""
+
+
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%H:%M:%S")
 
@@ -79,7 +85,126 @@ def _upper(value: object) -> str:
     return str(value or "").strip().upper()
 
 
-def _fetch_pr_status(pr: str, repo: str | None) -> PrStatusSnapshot:
+def _coerce_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
+def _compact_error_message(
+    text: str,
+    *,
+    limit: int = 200,
+    empty_message: str = "gh command failed without an error message",
+) -> str:
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return empty_message
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[: limit - 3]}..."
+
+
+def _gh_failure_category(text: str, *, timed_out: bool = False) -> str:
+    if timed_out:
+        return "timeout"
+    lowered = text.lower()
+    if any(
+        token in lowered
+        for token in (
+            "authentication",
+            "auth",
+            "login",
+            "oauth",
+            "permission",
+            "forbidden",
+            "401",
+            "403",
+        )
+    ):
+        return "auth"
+    if any(
+        token in lowered
+        for token in (
+            "api",
+            "graphql",
+            "rate limit",
+            "http 5",
+            "500",
+            "502",
+            "503",
+            "504",
+        )
+    ):
+        return "api"
+    if any(
+        token in lowered
+        for token in (
+            "network",
+            "connection",
+            "could not resolve",
+            "timed out",
+            "timeout",
+            "tls",
+            "temporary failure",
+        )
+    ):
+        return "network"
+    return "gh"
+
+
+def _format_gh_failure(
+    action: str,
+    *,
+    category: str,
+    detail: str,
+) -> str:
+    return f"{category}: {action} {detail}"
+
+
+def _run_gh(
+    cmd: Sequence[str],
+    *,
+    action: str,
+    timeout_s: int,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = "\n".join(
+            part
+            for part in (
+                _coerce_output(exc.stderr),
+                _coerce_output(exc.stdout),
+            )
+            if part
+        )
+        detail = f"timed out after {timeout_s}s"
+        if output:
+            detail = f"{detail}: {_compact_error_message(output)}"
+        raise GhCommandFailed(
+            _format_gh_failure(
+                action,
+                category="timeout",
+                detail=detail,
+            )
+        ) from exc
+
+
+def _fetch_pr_status(
+    pr: str,
+    repo: str | None,
+    *,
+    timeout_s: int = DEFAULT_GH_TIMEOUT_S,
+) -> PrStatusSnapshot:
     cmd = [
         "gh",
         "pr",
@@ -90,8 +215,28 @@ def _fetch_pr_status(pr: str, repo: str | None) -> PrStatusSnapshot:
     ]
     if repo:
         cmd.extend(["--repo", repo])
-    raw = subprocess.check_output(cmd, text=True)
-    payload = json.loads(raw)
+    proc = _run_gh(cmd, action="gh pr view", timeout_s=timeout_s)
+    if proc.returncode != 0:
+        output = "\n".join(part for part in (proc.stderr, proc.stdout) if part)
+        category = _gh_failure_category(output)
+        detail = (
+            f"exited {proc.returncode}: "
+            f"{_compact_error_message(output, empty_message='no stderr/stdout')}"
+        )
+        raise GhCommandFailed(
+            _format_gh_failure("gh pr view", category=category, detail=detail)
+        )
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise GhCommandFailed(
+            _format_gh_failure(
+                "gh pr view",
+                category="api",
+                detail=f"returned malformed JSON: {exc.msg}",
+            )
+        ) from exc
     checks_raw = payload.get("statusCheckRollup")
     return PrStatusSnapshot(
         checks=_snapshot_checks(checks_raw) if isinstance(checks_raw, list) else {},
@@ -259,16 +404,13 @@ def _short_sha(head_sha: str) -> str:
     return head_sha[:12] if head_sha else "unknown"
 
 
-def _compact_error_message(text: str, *, limit: int = 200) -> str:
-    collapsed = " ".join(text.split())
-    if not collapsed:
-        return "gh pr merge failed without an error message"
-    if len(collapsed) <= limit:
-        return collapsed
-    return f"{collapsed[: limit - 3]}..."
-
-
-def _merge_pr(pr: str, repo: str | None, head_sha: str) -> None:
+def _merge_pr(
+    pr: str,
+    repo: str | None,
+    head_sha: str,
+    *,
+    timeout_s: int = DEFAULT_GH_TIMEOUT_S,
+) -> None:
     cmd = ["gh", "pr", "merge", pr]
     if repo:
         cmd.extend(["--repo", repo])
@@ -276,16 +418,25 @@ def _merge_pr(pr: str, repo: str | None, head_sha: str) -> None:
     if head_sha:
         cmd.extend(["--match-head-commit", head_sha])
 
-    proc = subprocess.run(
-        cmd,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    try:
+        proc = _run_gh(cmd, action="gh pr merge", timeout_s=timeout_s)
+    except GhCommandFailed as exc:
+        raise MergeFailed(str(exc)) from exc
+
     if proc.returncode == 0:
         return
 
-    raise MergeFailed(_compact_error_message(proc.stderr or proc.stdout))
+    output = "\n".join(part for part in (proc.stderr, proc.stdout) if part)
+    raise MergeFailed(
+        _format_gh_failure(
+            "gh pr merge",
+            category=_gh_failure_category(output),
+            detail=(
+                f"exited {proc.returncode}: "
+                f"{_compact_error_message(output, empty_message='no stderr/stdout')}"
+            ),
+        )
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -313,6 +464,21 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Merge the PR via gh as soon as checks are green",
     )
+    parser.add_argument(
+        "--gh-timeout",
+        type=int,
+        default=DEFAULT_GH_TIMEOUT_S,
+        help=f"Timeout for each gh CLI call in seconds (default: {DEFAULT_GH_TIMEOUT_S})",
+    )
+    parser.add_argument(
+        "--fetch-failure-limit",
+        type=int,
+        default=DEFAULT_FETCH_FAILURE_LIMIT,
+        help=(
+            "Consecutive gh pr view failures to tolerate before RESULT=FETCH_FAILED "
+            f"(default: {DEFAULT_FETCH_FAILURE_LIMIT})"
+        ),
+    )
     return parser
 
 
@@ -326,13 +492,38 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.heartbeat < 0:
         print("heartbeat must be >= 0", file=sys.stderr)
         return 2
+    if args.gh_timeout <= 0:
+        print("gh-timeout must be > 0", file=sys.stderr)
+        return 2
+    if args.fetch_failure_limit <= 0:
+        print("fetch-failure-limit must be > 0", file=sys.stderr)
+        return 2
 
     previous_checks: dict[str, CheckSnapshot] | None = None
     previous_merge_issue: str | None = None
     last_summary_at = 0.0
+    consecutive_fetch_failures = 0
 
     while True:
-        snapshot = _fetch_pr_status(args.pr, args.repo)
+        try:
+            snapshot = _fetch_pr_status(
+                args.pr,
+                args.repo,
+                timeout_s=args.gh_timeout,
+            )
+        except GhCommandFailed as exc:
+            consecutive_fetch_failures += 1
+            print(
+                f"[{_now_utc()}] WARN gh pr view failed "
+                f"attempt {consecutive_fetch_failures}/{args.fetch_failure_limit}: {exc}"
+            )
+            if consecutive_fetch_failures >= args.fetch_failure_limit:
+                print(f"RESULT=FETCH_FAILED ({exc})")
+                return 5
+            _sleep(args.interval)
+            continue
+
+        consecutive_fetch_failures = 0
         current_checks = snapshot.checks
         current_merge_issue = _actionable_merge_issue(
             snapshot.merge_state, snapshot.mergeable
@@ -370,7 +561,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         if _all_green(current_checks):
             if args.merge_on_green:
                 try:
-                    _merge_pr(args.pr, args.repo, snapshot.head_sha)
+                    _merge_pr(
+                        args.pr,
+                        args.repo,
+                        snapshot.head_sha,
+                        timeout_s=args.gh_timeout,
+                    )
                 except MergeFailed as exc:
                     print(f"RESULT=MERGE_FAILED ({exc})")
                     return 4


### PR DESCRIPTION
Fixes #3626.

What changed:
- Added bounded `gh pr view` and `gh pr merge` subprocess calls to the PR check watcher.
- Added `--gh-timeout` and `--fetch-failure-limit`.
- Classified compact watcher diagnostics as auth, network, API, timeout, or generic `gh`.
- Retries transient `gh pr view` failures and emits `RESULT=FETCH_FAILED` after the failure limit.
- Keeps merge failures on `RESULT=MERGE_FAILED`, including merge timeouts.
- Updated AI command guidance with the new defaults.

Why:
- A hung or broken GitHub CLI call should not stall the AI merge-on-green loop forever.
- The watcher must always return an actionable `RESULT=` state.

Validation:
- `ruff format tools/watch_pr_checks.py apps/server/tests/hygiene/test_watch_pr_checks.py`
- `ruff check tools/watch_pr_checks.py apps/server/tests/hygiene/test_watch_pr_checks.py`
- `pytest apps/server/tests/hygiene/test_watch_pr_checks.py -q`
- `./.venv/bin/python tools/watch_pr_checks.py --help`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

Risks / tradeoffs:
- Default per-call timeout is 30s; slow GitHub CLI calls retry for view polling but merge returns a clear failure.
- Permanent fetch issues now stop after three consecutive failures instead of hanging forever.

Follow-ups:
- None.
