### PR TITLE
Refresh live processing docs paths

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -12,9 +12,10 @@ FastAPI backend for VibeSensor. It ingests UDP telemetry from ESP32 sensor nodes
 ## Current architecture
 
 ```text
-ESP32 nodes -> adapters/udp/ -> infra/processing/ + use_cases/diagnostics/
-                             -> infra/runtime/ -> adapters/http/ + adapters/websocket/ -> apps/ui
-                             -> use_cases/run/ + adapters/persistence/history_db/ -> use_cases/history/ -> adapters/pdf/
+ESP32 nodes -> apps/server/vibesensor/adapters/udp/
+             -> live-processing layer + apps/server/vibesensor/use_cases/diagnostics/
+             -> apps/server/vibesensor/infra/runtime/ -> apps/server/vibesensor/adapters/http/ + apps/server/vibesensor/adapters/websocket/ -> apps/ui
+             -> apps/server/vibesensor/use_cases/run/ + apps/server/vibesensor/adapters/persistence/history_db/ -> apps/server/vibesensor/use_cases/history/ -> apps/server/vibesensor/adapters/pdf/
 ```
 
 Backend ownership boundaries:

--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -40,3 +40,25 @@ def test_make_command_target_lint_rejects_stale_documented_targets(
     assert module._check_make_command_targets(["docs/testing.md"], tmp_path) == [
         "docs/testing.md: documented make target does not exist: coverage-html"
     ]
+
+
+def test_docs_lint_rejects_removed_processing_path_references(tmp_path: Path) -> None:
+    module = _load_docs_lint_module()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    docs_path = docs_dir / "intake_buffering.md"
+    docs_path.write_text(
+        "Old path: `infra/processing/fft.py`.\n",
+        encoding="utf-8",
+    )
+
+    original_repo_root = module.REPO_ROOT
+    module.REPO_ROOT = tmp_path
+    try:
+        assert module._check_stale_repo_path_references(["docs/intake_buffering.md"]) == [
+            "docs/intake_buffering.md: stale repo path reference: "
+            "infra/processing/fft.py "
+            "(use apps/server/vibesensor/shared/fft_analysis.py)"
+        ]
+    finally:
+        module.REPO_ROOT = original_repo_root

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -37,11 +37,12 @@ Scope: architecture and data flow for the post-stop diagnostics pipeline in
 | **Stateless?** | Yes — each tick processes the current rolling window | Yes — processes all stored samples in one pass |
 
 Mathematical primitives (e.g. `compute_vibration_strength_db`,
-`noise_floor_amp_p20_g`) live in the `vibesensor` top-level package and the
-live-processing owners under `apps/server/vibesensor/infra/processing/`; the
-canonical windowing, frequency-bin, and peak-detection steps are SciPy-backed
-and the same persisted peak/floor outputs are then reused by
-diagnostics/reporting.
+`noise_floor_amp_p20_g`) live in
+`apps/server/vibesensor/vibration_strength.py`; canonical windowing,
+frequency-bin, and peak-detection steps live in
+`apps/server/vibesensor/shared/fft_analysis.py`; and live snapshot/metric
+coordination stays under `apps/server/vibesensor/infra/processing/`. The same
+persisted peak/floor outputs are then reused by diagnostics/reporting.
 
 ## Related deep dives
 

--- a/docs/dataflows.md
+++ b/docs/dataflows.md
@@ -9,7 +9,7 @@ who consumes it?" Then follow the linked deep dives for step-by-step details.
 | Field | Value |
 |------|-------------|
 | Source | UDP sensor datagrams from the ESP32 fleet |
-| Main path | `adapters/udp/udp_data_rx.py` -> registry + `apps/server/vibesensor/infra/processing/` -> `apps/server/vibesensor/infra/runtime/ws_payload_projection.py` -> `apps/server/vibesensor/infra/runtime/ws_broadcast.py` |
+| Main path | `apps/server/vibesensor/adapters/udp/udp_data_rx.py` -> registry + `apps/server/vibesensor/infra/processing/` -> `apps/server/vibesensor/infra/runtime/ws_payload_projection.py` -> `apps/server/vibesensor/infra/runtime/ws_broadcast.py` |
 | Boundary | Live WebSocket payload projection only; no history DB or post-stop analysis in this path |
 | Final consumer | Dashboard live UI |
 | Data shape | Live and transient, not replayable |
@@ -26,7 +26,7 @@ Deep dive: `docs/intake_buffering.md`
 | Field | Value |
 |------|-------------|
 | Source | The same UDP stream while a run is active |
-| Main path | registry + `apps/server/vibesensor/infra/processing/` -> `use_cases/run/sample_flush.py` -> `use_cases/run/persistence_writer.py` -> history DB |
+| Main path | registry + `apps/server/vibesensor/infra/processing/` -> `apps/server/vibesensor/use_cases/run/sample_flush.py` -> `apps/server/vibesensor/use_cases/run/persistence_writer.py` -> history DB |
 | Boundary | `SampleFlushOrchestrator` owns row building/flush timing; `RunPersistenceWriter` owns the history DB boundary |
 | Final consumer | Persisted run samples, run metadata, and post-stop queueing |
 | Data shape | Persisted summary/sample rows, not replayable raw sensor capture |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -12,10 +12,11 @@ shared contracts that must settle early, and the recommended execution order.
 ### Live path
 
 - Raw UDP samples enter through `apps/server/vibesensor/adapters/udp/udp_data_rx.py`.
-- Live FFT/strength computation lives in `apps/server/vibesensor/infra/processing/`.
-- The canonical spectrum window is `FFT_N = 2048` with a Hann window from
-  `apps/server/vibesensor/shared/constants/dsp.py` and
+- Live FFT/strength coordination lives in
   `apps/server/vibesensor/infra/processing/compute.py`.
+- The canonical spectrum window is `FFT_N = 2048`; shared spectral primitives
+  live in `apps/server/vibesensor/shared/fft_analysis.py` with DSP constants in
+  `apps/server/vibesensor/shared/constants/dsp.py`.
 - Live feature cadence is derived from `feature_interval_s`, which is currently
   written as `1 / metrics_log_hz` by
   `apps/server/vibesensor/use_cases/run/run_metadata_builder.py`.
@@ -105,7 +106,7 @@ raw capture manifest/files (#3065)
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata |
-| Whole-run spectra | `use_cases/diagnostics/`, `shared/fft_analysis.py`, `apps/server/vibesensor/infra/processing/` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling |
+| Whole-run spectra | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |

--- a/docs/intake_buffering.md
+++ b/docs/intake_buffering.md
@@ -21,19 +21,24 @@ them, updates the client registry, writes samples into the ring buffer
 (`SignalProcessor.ingest()`), and sends a UDP ACK. This runs on the main
 event loop but each call is lightweight (microseconds per packet).
 
-### 3. Live compute (`runtime/processing_loop.py` + `processing/processor.py`)
+### 3. Live compute
 
-The async processing loop in `runtime/processing_loop.py` runs on a timer,
-filters to active clients with fresh data, and calls `SignalProcessor.compute_all()`
-via `asyncio.to_thread()` so the event loop never performs FFT work directly.
+Owner files:
+
+- `apps/server/vibesensor/infra/runtime/processing_loop.py`
+- `apps/server/vibesensor/infra/processing/processor.py`
+
+The async processing loop runs on a timer, filters to active clients with fresh
+data, and calls `SignalProcessor.compute_all()` via `asyncio.to_thread()` so the
+event loop never performs FFT work directly.
 
 `SignalProcessor` is now a facade over three explicit subsystems:
 
-- `processing/buffer_store.py`: coordinator over ingest, snapshot capture, stats, and shared buffer queries
-- `processing/buffer_registry.py`: per-client buffers, epochs, eviction, and lock ordering
-- `processing/buffer_mutations.py` + `processing/ingest_preparation.py`: buffer mutation policy plus chunk normalization/overflow trimming
-- `processing/compute.py`: FFT cache ownership plus metric computation from snapshots
-- `processing/processor.py`: facade class with payload shaping, debug output, and time-alignment views
+- `apps/server/vibesensor/infra/processing/buffer_store.py`: coordinator over ingest, snapshot capture, stats, and shared buffer queries
+- `apps/server/vibesensor/infra/processing/buffer_registry.py`: per-client buffers, epochs, eviction, and lock ordering
+- `apps/server/vibesensor/infra/processing/buffer_mutations.py` + `apps/server/vibesensor/infra/processing/ingest_preparation.py`: buffer mutation policy plus chunk normalization/overflow trimming
+- `apps/server/vibesensor/infra/processing/compute.py`: FFT cache ownership plus metric computation from snapshots
+- `apps/server/vibesensor/infra/processing/processor.py`: facade class with payload shaping, debug output, and time-alignment views
 
 Inside `SignalProcessor.compute_all()`, per-client FFT work is dispatched through
 the shared `WorkerPool` when multiple clients are active. `compute_metrics()` now
@@ -74,7 +79,9 @@ then analyzes that one block.
 
 ### FFT pipeline
 
-`apps/server/vibesensor/infra/processing/compute.py` owns the cached FFT setup:
+`apps/server/vibesensor/infra/processing/compute.py` owns the live cached FFT
+setup through `SignalMetricsComputer`, which extends the shared
+`apps/server/vibesensor/shared/fft_analysis.py` spectral-analysis primitive:
 
 - `SignalMetricsComputer` precomputes a Hann window with
   `scipy.signal.windows.hann(config.fft_n)`.
@@ -83,21 +90,21 @@ then analyzes that one block.
 - `fft_params(sample_rate_hz)` caches the frequency slice and valid FFT indices
   per sample rate so repeated ticks do not rebuild them.
 
-`apps/server/vibesensor/infra/processing/compute.py` coordinates the pure DSP
-steps with shared FFT/strength helpers:
+`apps/server/vibesensor/infra/processing/compute.py` coordinates live snapshot
+handling and metric commits, while the pure DSP steps stay in shared helpers:
 
 1. `medfilt3()` applies a 3-point median filter per axis before FFT work. This
    removes isolated transport/I2C spikes without blurring normal vibration
    content.
 2. `SignalMetricsComputer.compute()` detrends the captured windows by removing
    the per-axis mean before RMS/P2P and FFT computation.
-3. `compute_fft_spectrum()` applies the SciPy-backed Hann window, runs the
-   planned pyFFTW RFFT backend, slices the configured frequency range via
-   SciPy FFT frequency bins, and produces both per-axis spectra and a combined
-   amplitude curve.
-4. `compute_vibration_strength_db()` uses SciPy peak finding to select dominant
-   candidate bins, estimates a P20/median noise floor, and converts the
-   dominant peak band into the
+3. `apps/server/vibesensor/shared/fft_analysis.py` applies the SciPy-backed
+   Hann window, runs the planned pyFFTW RFFT backend, slices the configured
+   frequency range via SciPy FFT frequency bins, and produces both per-axis
+   spectra and a combined amplitude curve.
+4. `apps/server/vibesensor/vibration_strength.py` uses SciPy peak finding to
+   select dominant candidate bins, estimates a P20/median noise floor, and
+   converts the dominant peak band into the
    shared dB metric used by both live telemetry and post-stop analysis:
 
    ```text
@@ -112,8 +119,9 @@ steps with shared FFT/strength helpers:
 - Generation counters decide freshness. If the ingest generation has not moved,
   the compute side can reuse the cached metrics/spectrum instead of rebuilding
   them.
-- The combined vibration-strength formula lives in `vibration_strength.py`; the
-  live path does not carry a second dB implementation.
+- The combined vibration-strength formula lives in
+  `apps/server/vibesensor/vibration_strength.py`; the live path does not carry a
+  second dB implementation.
 - Payload serialization stays downstream of computation. The processing layer
   stores structured metrics and spectrum arrays first, and only later surfaces
   them to HTTP/WebSocket payload builders.

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -126,8 +126,10 @@ The same reference math serves both runtime and diagnostics:
 
 The saved per-sample peak/floor inputs consumed by order matching come from the
 same canonical live-processing FFT/strength pipeline
-(`apps/server/vibesensor/infra/processing/` plus `vibration_strength.py`), so
-order analysis does not maintain a second independent DSP stack.
+(`apps/server/vibesensor/infra/processing/compute.py`,
+`apps/server/vibesensor/shared/fft_analysis.py`, and
+`apps/server/vibesensor/vibration_strength.py`), so order analysis does not
+maintain a second independent DSP stack.
 
 That shared ownership is why `shared/order_bands.py` exists outside
 `use_cases/diagnostics/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -450,10 +450,11 @@ cd apps/server && python -m pytest -q --cov=vibesensor --cov-report=term-missing
 Coverage guidance:
 
 - Treat coverage as a risk-finding tool, not the only quality signal.
-- High-risk backend areas such as `use_cases/diagnostics/`,
+- High-risk backend areas such as `apps/server/vibesensor/use_cases/diagnostics/`,
   `apps/server/vibesensor/infra/processing/`,
-  `adapters/persistence/history_db/`, and `use_cases/updates/` should stay above the repo-wide baseline whenever
-  practical.
+  `apps/server/vibesensor/adapters/persistence/history_db/`, and
+  `apps/server/vibesensor/use_cases/updates/` should stay above the repo-wide
+  baseline whenever practical.
 
 The default CI-parity suite now derives these blocking GitHub checks from the
 workflow-backed CI manifest:

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -62,6 +62,9 @@ REPO_PATH_PREFIXES = (
 GENERATED_REPO_PATH_REFERENCES = {
     "apps/ui/src/constants.ts",
 }
+STALE_REPO_PATH_REFERENCES = {
+    "infra/processing/fft.py": "apps/server/vibesensor/shared/fft_analysis.py",
+}
 MAKE_COMMAND_RE = re.compile(r"(?<![\w./-])make\s+(?P<args>[^`#\n]*)")
 MAKE_TARGET_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 MAKE_OPTION_ARGS = {"-C", "-f", "--file", "--directory"}
@@ -414,6 +417,21 @@ def _check_backticked_repo_paths(
     return issues
 
 
+def _check_stale_repo_path_references(markdown_files: list[str]) -> list[str]:
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        text = _read_text(REPO_ROOT, path)
+        if text is None:
+            continue
+        for stale_path, replacement in STALE_REPO_PATH_REFERENCES.items():
+            if stale_path in text:
+                issues.append(
+                    f"{path}: stale repo path reference: {stale_path} "
+                    f"(use {replacement})"
+                )
+    return issues
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     all_files = _tracked_files(repo_root)
@@ -430,6 +448,7 @@ def main() -> int:
     issues.extend(_check_ai_guidance_stack(markdown_files, repo_root))
     issues.extend(_check_guidance_script_references(markdown_files, repo_root))
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))
+    issues.extend(_check_stale_repo_path_references(markdown_files))
     issues.extend(_check_make_command_targets(markdown_files, repo_root))
 
     if issues:


### PR DESCRIPTION
Fixes #3632.

What changed:
- Refreshed live-processing docs to use current repo-relative paths.
- Pointed FFT ownership to `apps/server/vibesensor/infra/processing/compute.py`, `apps/server/vibesensor/shared/fft_analysis.py`, and `apps/server/vibesensor/vibration_strength.py`.
- Replaced nearby backend shorthand paths in the touched docs with repo-relative paths where they were acting as navigation targets.
- Added a docs-lint guard for the removed `infra/processing/fft.py` path.

Why:
- The old path mix made AI/dev navigation brittle.
- Removed processing-module paths should fail docs lint instead of surviving in prose.

Validation:
- `ruff format tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `ruff check tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

Risks / tradeoffs:
- Documentation and lint-only change.
- Keeps conceptual "live-processing layer" wording where the text is not pointing to a file.

Follow-ups:
- None.
