### PR TITLE
Extend docs lint command guards

### DIFF
--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -109,6 +109,37 @@ def test_ci_job_example_lint_separates_act_and_local_job_ids(tmp_path: Path) -> 
     ]
 
 
+def test_local_logical_ci_job_id_loader_expands_matrix_names(tmp_path: Path) -> None:
+    module = _load_docs_lint_module()
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "ci.yml").write_text(
+        "\n".join(
+            [
+                "jobs:",
+                "  ci-scope:",
+                "    steps: []",
+                "  backend-tests:",
+                "    strategy:",
+                "      matrix:",
+                "        include:",
+                '          - logical_job_name: "backend-tests-1"',
+                '          - logical_job_name: "backend-tests-2"',
+                "    steps: []",
+                "  docs-lint:",
+                "    steps: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module._local_logical_ci_job_ids(tmp_path) == {
+        "backend-tests-1",
+        "backend-tests-2",
+        "docs-lint",
+    }
+
+
 def test_direct_shell_script_command_lint_requires_executable_script(
     tmp_path: Path,
 ) -> None:

--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -52,13 +52,80 @@ def test_docs_lint_rejects_removed_processing_path_references(tmp_path: Path) ->
         encoding="utf-8",
     )
 
-    original_repo_root = module.REPO_ROOT
-    module.REPO_ROOT = tmp_path
-    try:
-        assert module._check_stale_repo_path_references(["docs/intake_buffering.md"]) == [
-            "docs/intake_buffering.md: stale repo path reference: "
-            "infra/processing/fft.py "
-            "(use apps/server/vibesensor/shared/fft_analysis.py)"
-        ]
-    finally:
-        module.REPO_ROOT = original_repo_root
+    assert module._check_stale_repo_path_references(
+        ["docs/intake_buffering.md"],
+        tmp_path,
+    ) == [
+        "docs/intake_buffering.md: stale repo path reference: "
+        "infra/processing/fft.py "
+        "(use apps/server/vibesensor/shared/fft_analysis.py)"
+    ]
+
+
+def test_npm_run_script_lint_rejects_missing_ui_scripts(tmp_path: Path) -> None:
+    module = _load_docs_lint_module()
+    ui_dir = tmp_path / "apps" / "ui"
+    ui_dir.mkdir(parents=True)
+    (ui_dir / "package.json").write_text(
+        '{"scripts": {"build": "vite build", "test:unit": "vitest run"}}',
+        encoding="utf-8",
+    )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "testing.md").write_text(
+        "Good: `npm run build`.\nBad: `npm run test:visual`.\n",
+        encoding="utf-8",
+    )
+
+    assert module._check_npm_run_scripts(["docs/testing.md"], tmp_path) == [
+        "docs/testing.md: documented npm script does not exist in apps/ui/package.json: test:visual"
+    ]
+
+
+def test_ci_job_example_lint_separates_act_and_local_job_ids(tmp_path: Path) -> None:
+    module = _load_docs_lint_module()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "testing.md").write_text(
+        "\n".join(
+            [
+                "`act -j backend-tests -W .github/workflows/ci.yml`",
+                "`act -j backend-tests-1 -W .github/workflows/ci.yml`",
+                "`./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-tests-1`",
+                "`./.venv/bin/python tools/tests/run_ci_parallel.py --job backend-tests`",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module._check_ci_job_examples(
+        ["docs/testing.md"],
+        tmp_path,
+        raw_workflow_job_ids={"backend-tests"},
+        local_logical_job_ids={"backend-tests-1"},
+    ) == [
+        "docs/testing.md: ACT job example must use raw workflow job id: backend-tests-1",
+        "docs/testing.md: local CI job example must use logical job id: backend-tests",
+    ]
+
+
+def test_direct_shell_script_command_lint_requires_executable_script(
+    tmp_path: Path,
+) -> None:
+    module = _load_docs_lint_module()
+    script_dir = tmp_path / "tools" / "tests"
+    script_dir.mkdir(parents=True)
+    script_path = script_dir / "run_ci_with_act.sh"
+    script_path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    script_path.chmod(0o644)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "testing.md").write_text(
+        "`./tools/tests/run_ci_with_act.sh -j backend-lint`\n",
+        encoding="utf-8",
+    )
+
+    assert module._check_direct_shell_script_commands(["docs/testing.md"], tmp_path) == [
+        "docs/testing.md: documented script command is not executable: "
+        "tools/tests/run_ci_with_act.sh"
+    ]

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -257,16 +257,30 @@ def _raw_workflow_job_ids(repo_root: Path) -> set[str]:
 
 
 def _local_logical_ci_job_ids(repo_root: Path) -> set[str]:
-    manifest_path = repo_root / "tools" / "tests" / "ci_workflow_manifest.py"
-    spec = importlib.util.spec_from_file_location(
-        "ci_workflow_manifest_docs_lint", manifest_path
-    )
-    if spec is None or spec.loader is None:
+    workflow_text = _read_text(repo_root, ".github/workflows/ci.yml")
+    if workflow_text is None:
         return set()
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return set(module.ci_workflow_jobs())
+
+    raw_job_ids = _raw_workflow_job_ids(repo_root)
+    local_job_ids = set(raw_job_ids) - {"ci-scope", "ui-build-artifact"}
+    matrix_parent_jobs: set[str] = set()
+    current_job: str | None = None
+    job_re = re.compile(r"^  (?P<job>[A-Za-z0-9_-]+):(?:\s+#.*)?$")
+    logical_job_re = re.compile(
+        r"^\s+-?\s*logical_job_name:\s*[\"']?(?P<job>[A-Za-z0-9_-]+)"
+        r"[\"']?(?:\s+#.*)?$"
+    )
+    for line in workflow_text.splitlines():
+        job_match = job_re.match(line)
+        if job_match:
+            current_job = job_match.group("job")
+            continue
+        logical_job_match = logical_job_re.match(line)
+        if current_job and logical_job_match:
+            local_job_ids.add(logical_job_match.group("job"))
+            matrix_parent_jobs.add(current_job)
+
+    return local_job_ids - matrix_parent_jobs
 
 
 def _markdown_code_snippets(text: str) -> list[str]:

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -17,8 +17,6 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
-
 LARGE_BLOCK_THRESHOLD = 30  # lines
 EXCLUDED_DIRS = {
     ".git",
@@ -240,10 +238,22 @@ def _raw_workflow_job_ids(repo_root: Path) -> set[str]:
     workflow_text = _read_text(repo_root, ".github/workflows/ci.yml")
     if workflow_text is None:
         return set()
-    workflow = yaml.safe_load(workflow_text)
-    if not isinstance(workflow, dict) or not isinstance(workflow.get("jobs"), dict):
-        return set()
-    return {str(job_id) for job_id in workflow["jobs"]}
+    job_ids: set[str] = set()
+    in_jobs = False
+    job_re = re.compile(r"^  (?P<job>[A-Za-z0-9_-]+):(?:\s+#.*)?$")
+    for line in workflow_text.splitlines():
+        stripped = line.strip()
+        if stripped == "jobs:":
+            in_jobs = True
+            continue
+        if not in_jobs or not stripped or stripped.startswith("#"):
+            continue
+        if not line.startswith(" "):
+            break
+        match = job_re.match(line)
+        if match:
+            job_ids.add(match.group("job"))
+    return job_ids
 
 
 def _local_logical_ci_job_ids(repo_root: Path) -> set[str]:

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -12,9 +12,12 @@ Exit 0 if clean, 1 if violations found.
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import sys
 from pathlib import Path
+
+import yaml
 
 LARGE_BLOCK_THRESHOLD = 30  # lines
 EXCLUDED_DIRS = {
@@ -68,6 +71,12 @@ STALE_REPO_PATH_REFERENCES = {
 MAKE_COMMAND_RE = re.compile(r"(?<![\w./-])make\s+(?P<args>[^`#\n]*)")
 MAKE_TARGET_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 MAKE_OPTION_ARGS = {"-C", "-f", "--file", "--directory"}
+NPM_RUN_RE = re.compile(r"(?<![\w./-])npm\s+run\s+(?P<script>[A-Za-z0-9:._-]+)")
+CI_JOB_ARG_RE = re.compile(r"(?<!\S)(?:-j|--job)\s+(?P<job>[A-Za-z0-9_-]+)")
+DIRECT_SHELL_SCRIPT_RE = re.compile(
+    r"(?:^|[`;\s])(?:[A-Z_][A-Z0-9_]*=[^`\s]+\s+)*(?:sudo\s+)?\./"
+    r"(?P<path>(?:apps/server/scripts/|infra/|tools/)[A-Za-z0-9._~/-]+\.sh)\b"
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -213,6 +222,43 @@ def _makefile_targets(repo_root: Path) -> set[str]:
     return targets
 
 
+def _ui_npm_scripts(repo_root: Path) -> set[str]:
+    package_json_text = _read_text(repo_root, "apps/ui/package.json")
+    if package_json_text is None:
+        return set()
+    try:
+        payload = json.loads(package_json_text)
+    except json.JSONDecodeError:
+        return set()
+    scripts = payload.get("scripts")
+    if not isinstance(scripts, dict):
+        return set()
+    return {name for name in scripts if isinstance(name, str)}
+
+
+def _raw_workflow_job_ids(repo_root: Path) -> set[str]:
+    workflow_text = _read_text(repo_root, ".github/workflows/ci.yml")
+    if workflow_text is None:
+        return set()
+    workflow = yaml.safe_load(workflow_text)
+    if not isinstance(workflow, dict) or not isinstance(workflow.get("jobs"), dict):
+        return set()
+    return {str(job_id) for job_id in workflow["jobs"]}
+
+
+def _local_logical_ci_job_ids(repo_root: Path) -> set[str]:
+    manifest_path = repo_root / "tools" / "tests" / "ci_workflow_manifest.py"
+    spec = importlib.util.spec_from_file_location(
+        "ci_workflow_manifest_docs_lint", manifest_path
+    )
+    if spec is None or spec.loader is None:
+        return set()
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return set(module.ci_workflow_jobs())
+
+
 def _markdown_code_snippets(text: str) -> list[str]:
     snippets: list[str] = []
     in_fence = False
@@ -269,6 +315,67 @@ def _check_make_command_targets(
                     issues.append(
                         f"{path}: documented make target does not exist: {target}"
                     )
+    return issues
+
+
+def _check_npm_run_scripts(markdown_files: list[str], repo_root: Path) -> list[str]:
+    """Flag documented UI npm scripts that do not exist in apps/ui/package.json."""
+    scripts = _ui_npm_scripts(repo_root)
+    if not scripts:
+        return [
+            "apps/ui/package.json scripts could not be loaded for docs command lint"
+        ]
+
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        for snippet in _markdown_code_snippets(text):
+            for match in NPM_RUN_RE.finditer(snippet):
+                script = match.group("script")
+                if script not in scripts:
+                    issues.append(
+                        f"{path}: documented npm script does not exist in apps/ui/package.json: {script}"
+                    )
+    return issues
+
+
+def _check_ci_job_examples(
+    markdown_files: list[str],
+    repo_root: Path,
+    *,
+    raw_workflow_job_ids: set[str] | None = None,
+    local_logical_job_ids: set[str] | None = None,
+) -> list[str]:
+    """Flag ACT/local runner job examples that use the wrong job-id namespace."""
+    raw_job_ids = raw_workflow_job_ids or _raw_workflow_job_ids(repo_root)
+    local_job_ids = local_logical_job_ids or _local_logical_ci_job_ids(repo_root)
+    if not raw_job_ids:
+        return ["CI workflow job ids could not be loaded for docs command lint"]
+    if not local_job_ids:
+        return ["local CI logical job ids could not be loaded for docs command lint"]
+
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        for snippet in _markdown_code_snippets(text):
+            if "act " in snippet or "run_ci_with_act.sh" in snippet:
+                for match in CI_JOB_ARG_RE.finditer(snippet):
+                    job = match.group("job")
+                    if job not in raw_job_ids:
+                        issues.append(
+                            f"{path}: ACT job example must use raw workflow job id: {job}"
+                        )
+            if "run_ci_parallel.py" in snippet:
+                for match in CI_JOB_ARG_RE.finditer(snippet):
+                    job = match.group("job")
+                    if job not in local_job_ids:
+                        issues.append(
+                            f"{path}: local CI job example must use logical job id: {job}"
+                        )
     return issues
 
 
@@ -354,7 +461,11 @@ def _check_guidance_script_references(
     guidance_files = sorted(
         path
         for path in markdown_files
-        if path.startswith(".github/instructions/")
+        if path in {"README.md", "CONTRIBUTING.md", "SECURITY.md"}
+        or path.startswith("docs/")
+        or path.startswith(".github/ISSUE_TEMPLATE/")
+        or path.startswith(".github/instructions/")
+        or path == ".github/copilot-instructions.md"
         or path == "AGENTS.md"
         or path.endswith("/AGENTS.md")
     )
@@ -379,6 +490,29 @@ def _check_guidance_script_references(
                     f"{path}: missing repo-local script reference: {candidate}"
                 )
 
+    return issues
+
+
+def _check_direct_shell_script_commands(
+    markdown_files: list[str], repo_root: Path
+) -> list[str]:
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        for snippet in _markdown_code_snippets(text):
+            for match in DIRECT_SHELL_SCRIPT_RE.finditer(snippet):
+                candidate = match.group("path")
+                script_path = repo_root / candidate
+                if not script_path.is_file():
+                    issues.append(
+                        f"{path}: missing executable script command: {candidate}"
+                    )
+                elif script_path.stat().st_mode & 0o111 == 0:
+                    issues.append(
+                        f"{path}: documented script command is not executable: {candidate}"
+                    )
     return issues
 
 
@@ -417,10 +551,12 @@ def _check_backticked_repo_paths(
     return issues
 
 
-def _check_stale_repo_path_references(markdown_files: list[str]) -> list[str]:
+def _check_stale_repo_path_references(
+    markdown_files: list[str], repo_root: Path
+) -> list[str]:
     issues: list[str] = []
     for path in sorted(markdown_files):
-        text = _read_text(REPO_ROOT, path)
+        text = _read_text(repo_root, path)
         if text is None:
             continue
         for stale_path, replacement in STALE_REPO_PATH_REFERENCES.items():
@@ -447,9 +583,12 @@ def main() -> int:
     issues.extend(_check_markdown_links(markdown_files, repo_root))
     issues.extend(_check_ai_guidance_stack(markdown_files, repo_root))
     issues.extend(_check_guidance_script_references(markdown_files, repo_root))
+    issues.extend(_check_direct_shell_script_commands(markdown_files, repo_root))
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))
-    issues.extend(_check_stale_repo_path_references(markdown_files))
+    issues.extend(_check_stale_repo_path_references(markdown_files, repo_root))
     issues.extend(_check_make_command_targets(markdown_files, repo_root))
+    issues.extend(_check_npm_run_scripts(markdown_files, repo_root))
+    issues.extend(_check_ci_job_examples(markdown_files, repo_root))
 
     if issues:
         print(f"❌ {len(issues)} docs issue(s):")
@@ -458,7 +597,7 @@ def main() -> int:
         return 1
 
     print(
-        "✅ No docs misuse, runtime docs access, broken local markdown links, stale make commands, or AI guidance stack drift detected."
+        "✅ No docs misuse, runtime docs access, broken local markdown links, stale commands, missing repo paths, or AI guidance stack drift detected."
     )
     return 0
 


### PR DESCRIPTION
Fixes #3634.

What changed:
- Extended `tools/dev/docs_lint.py` beyond make/path checks.
- Validates documented `npm run ...` scripts against `apps/ui/package.json`.
- Validates ACT `-j` examples against raw GitHub workflow job ids.
- Validates `run_ci_parallel.py --job` examples against local logical job ids.
- Checks direct documented shell-script commands for existing executable files.
- Broadens repo-local script reference checks across docs, AI guidance, AGENTS files, and issue templates.
- Added focused hygiene tests for each new guard.

Why:
- AI/dev docs should fail fast when commands or navigation targets drift.
- ACT and local runner job ids are different namespaces and need lint coverage.

Validation:
- `ruff format tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `ruff check tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

Risks / tradeoffs:
- Docs lint is stricter. Existing docs pass with the new checks.
- Script executable checks are limited to direct `./.../*.sh` command examples.

Follow-ups:
- None.
