### PR TITLE
Separate active design docs from history

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ Guidance stack
 - `docs/ai/repo-map.md` is the repo map for layout, entry points, and stable ownership boundaries; it is not a second workflow or policy guide.
 - Do not create additional guidance files in `docs/ai/`.
 - Paths below are repo-relative unless a bullet is explicitly talking about a Python import namespace such as `vibesensor.domain` or `vibesensor.shared.*`.
+- Design docs under `docs/designs/` must declare `Status: Active`, `Status: Historical`, or `Status: Superseded`; follow Active docs as guidance, and treat Historical/Superseded docs as reference only.
 
 Execution philosophy
 - Be decisive, direct, and completion-oriented. Default to completing the user's requested change end to end.

--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -160,3 +160,27 @@ def test_direct_shell_script_command_lint_requires_executable_script(
         "docs/testing.md: documented script command is not executable: "
         "tools/tests/run_ci_with_act.sh"
     ]
+
+
+def test_design_doc_status_lint_requires_explicit_status(tmp_path: Path) -> None:
+    module = _load_docs_lint_module()
+    design_dir = tmp_path / "docs" / "designs"
+    design_dir.mkdir(parents=True)
+    (design_dir / "active.md").write_text(
+        "# Active design\n\n> **Status:** Active\n",
+        encoding="utf-8",
+    )
+    (design_dir / "missing.md").write_text(
+        "# Missing status\n",
+        encoding="utf-8",
+    )
+
+    assert module._check_design_doc_status(
+        [
+            "docs/designs/active.md",
+            "docs/designs/missing.md",
+        ],
+        tmp_path,
+    ) == [
+        "docs/designs/missing.md: design doc must declare Status: Active, Historical, or Superseded"
+    ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ links onward to the scoped instruction files and repo map below.
 | `docs/order_tracking.md` | Order-reference math, tolerance bands, and order-finding flow. |
 | `docs/report_pipeline.md` | Report generation flow from analysis to PDF. |
 | `docs/design_language.md` | Visual design decisions for report layout and UI. |
+| `docs/designs/final-report-redesign.md` | Active report/PDF design guidance for the verdict page and appendices. |
+| `docs/designs/whole-run-post-analysis-program.md` | Active whole-run post-analysis architecture guidance. |
+| `docs/designs/whole-run-post-analysis-history.md` | Historical whole-run post-analysis issue plan, branch notes, and benchmark snapshots. |
 | `docs/metrics.md` | Vibration metric definitions and unit rules. |
 | `docs/metrics_to_report_mapping.md` | How metrics map to report sections. |
 | `docs/protocol.md` | UDP and WebSocket protocol details between ESP32 and server. |

--- a/docs/designs/final-report-redesign.md
+++ b/docs/designs/final-report-redesign.md
@@ -1,5 +1,9 @@
 # Final report redesign: Verdict + Workbook
 
+> **Status:** Active
+> **Use:** Current report/PDF design guidance for the verdict page, appendices,
+> vocabulary, and history-side preparation responsibilities.
+
 ## Baseline design being extended
 
 This design explicitly extends the last-selected **“Verdict + Workbook”** direction rather than replacing it.

--- a/docs/designs/whole-run-post-analysis-history.md
+++ b/docs/designs/whole-run-post-analysis-history.md
@@ -1,0 +1,79 @@
+# Whole-run post-analysis history and execution notes
+
+> **Status:** Historical
+> **Use:** Historical record only. Do not treat this file as current
+> implementation guidance. Current architecture and constraints live in
+> `docs/designs/whole-run-post-analysis-program.md`.
+
+This file preserves old planning context, benchmark snapshots, and branch notes
+that are useful for archaeology but should not steer new implementation work.
+
+## Original scope record
+
+The original execution design covered parent issues #3075, #3076, #3077, #3078,
+and #3079, using the completed raw-capture work from #3065 as the foundation.
+
+## Benchmark snapshot
+
+Historical #3085 baseline:
+
+- `benchmark_whole_run_spectra.py` used a 5-minute, 4-sensor, 800 Hz raw-capture
+  fixture with `FFT_N=2048` and `feature_interval_s=1.0`.
+- The validated `make benchmark-backend` sweep showed the executor fastest in
+  sequential mode with `max_workers=1` and `chunk_window_count=32` (mean
+  ~547 ms) versus slower 4-worker runs at chunk sizes 64 (~586 ms), 32
+  (~622 ms), and 16 (~668 ms).
+- The raw range-reader baseline for one full window sweep over one sensor was
+  ~371 ms.
+
+Treat these numbers as historical snapshots. Rerun explicit benchmarks on the
+target hardware before changing current executor defaults.
+
+## Planned sub-issue breakdown
+
+### Parent #3075 -- whole-run engine
+
+1. #3080 Define deterministic whole-run window contracts and artifact manifest
+2. #3081 Add indexed raw-capture range reads for offline window analysis
+3. #3082 Build the canonical whole-run window planner from run metadata
+4. #3083 Add a file-backed whole-run analysis artifact store and manifest plumbing
+5. #3084 Implement the raw-window spectral executor with deterministic chunk scheduling
+   - Historical branch note: work landed locally on branch
+     `issue-3084-spectral-executor` with deterministic chunk ordering, shared
+     FFT primitive extraction into `vibesensor.shared.fft_analysis`, per-sensor
+     `.npy` grid/matrix artifacts, per-window `.jsonl` summaries with explicit
+     coverage states, and post-analysis manifest persistence plumbing.
+6. #3085 Benchmark the whole-run engine on Pi-sized runs
+
+### Parent #3076 -- phase segmentation and context timelines
+
+1. #3086 Define whole-run context timeline and segment contracts
+2. #3087 Normalize full-run speed and RPM context onto the window grid
+3. #3088 Implement whole-run phase segmentation over normalized timelines
+4. #3089 Persist segment timelines and per-window context labels
+5. #3090 Surface context completeness and fallback signals to history and report consumers
+
+### Parent #3077 -- order tracking and harmonic stability
+
+1. #3091 Define whole-run order-trace and harmonic evidence contracts
+2. #3092 Build per-candidate order traces from window spectra and context labels
+3. #3093 Add harmonic stability and order-lock scoring across the full run
+4. #3094 Summarize order traces by source family, phase, and support intervals
+5. #3095 Persist ranked order-trace summaries and exemplars for downstream fusion
+
+### Parent #3078 -- multi-sensor coherence and spatial evidence
+
+1. #3096 Define multi-sensor coherence and spatial evidence contracts
+2. #3097 Join aligned per-window sensor outputs with coverage and missing-data rules
+3. #3098 Implement candidate-level coherence and cross-sensor agreement metrics
+4. #3099 Implement spatial separation and supporting-window hotspot summaries
+5. #3100 Persist spatial evidence and proof-basis summaries for downstream fusion
+
+### Parent #3079 -- fusion, counterevidence, and diagnosis ranking
+
+1. #3101 Define persisted whole-run evidence fusion and diagnosis summary contracts
+2. #3102 Model support factors and counterevidence factors with stable keys
+3. #3103 Implement the diagnosis ranker over context, order, and spatial evidence
+4. #3104 Add summary-only and partial-artifact fallback scoring for legacy runs
+5. #3105 Expose fused diagnosis evidence through history and report preparation and PDF surfaces
+6. #3106 Add cross-scenario regression coverage for clear, mixed, and ambiguous whole-run diagnoses

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -1,11 +1,16 @@
 # Whole-run post-analysis program
 
-Scope: execution design for parent issues #3075, #3076, #3077, #3078, and
-#3079, using the completed raw-capture work from #3065 as the foundation.
+> **Status:** Active
+> **Use:** Current source-of-truth architecture guidance for whole-run
+> post-analysis. Follow this document for current owners, contracts, and design
+> constraints.
+> **Historical record:**
+> `docs/designs/whole-run-post-analysis-history.md` keeps old issue plans,
+> branch notes, and benchmark snapshots for reference only.
 
-This document is a design and decomposition artifact, not an implementation
-status log. It records the current architecture, the target architecture, the
-shared contracts that must settle early, and the recommended execution order.
+This document records the current architecture, the target architecture, the
+shared contracts that must stay stable, and the recommended execution order. It
+does not track implementation status or old branch plans.
 
 ## Current state
 
@@ -422,7 +427,7 @@ Current foundation:
    `StoredHistoryRun` exposes that manifest as
    `whole_run_artifact_manifest`.
 
-Recommended follow-on behavior:
+Current persistence guidance:
 
 1. Keep `PersistedAnalysis` as the stable history/report summary boundary.
 2. Store only compact summaries and exemplars in `PersistedAnalysis`.
@@ -521,13 +526,6 @@ Add opt-in benchmarks for:
 - spatial/coherence cost by sensor count
 - end-to-end whole-run analysis memory peak on long runs
 
-Current #3085 baseline:
-
-- `benchmark_whole_run_spectra.py` uses a 5-minute, 4-sensor, 800 Hz raw-capture fixture with `FFT_N=2048` and `feature_interval_s=1.0`.
-- The validated `make benchmark-backend` sweep showed the executor fastest in sequential mode with `max_workers=1` and `chunk_window_count=32` (mean ~547 ms) versus slower 4-worker runs at chunk sizes 64 (~586 ms), 32 (~622 ms), and 16 (~668 ms).
-- The raw range-reader baseline for one full window sweep over one sensor was ~371 ms.
-- Keep the default executor settings at `max_workers=1`, `chunk_window_count=32`, and rerun the explicit benchmark on target hardware before raising worker count.
-
 ## Summary-only and legacy fallback policy
 
 - If raw capture is absent, preserve the current summary-only diagnostics/report
@@ -565,48 +563,3 @@ Current #3085 baseline:
    spectral/context artifacts.
 6. Build fusion, counterevidence, persisted diagnosis summaries, and report
    wiring last.
-
-## Planned sub-issue breakdown
-
-### Parent #3075 — whole-run engine
-
-1. #3080 Define deterministic whole-run window contracts and artifact manifest
-2. #3081 Add indexed raw-capture range reads for offline window analysis
-3. #3082 Build the canonical whole-run window planner from run metadata
-4. #3083 Add a file-backed whole-run analysis artifact store and manifest plumbing
-5. #3084 Implement the raw-window spectral executor with deterministic chunk scheduling
-   - Landed locally on branch `issue-3084-spectral-executor`: deterministic chunk ordering, shared FFT primitive extraction into `vibesensor.shared.fft_analysis`, per-sensor `.npy` grid/matrix artifacts, per-window `.jsonl` summaries with explicit coverage states, and post-analysis manifest persistence plumbing.
-6. #3085 Benchmark the whole-run engine on Pi-sized runs
-
-### Parent #3076 — phase segmentation and context timelines
-
-1. #3086 Define whole-run context timeline and segment contracts
-2. #3087 Normalize full-run speed and RPM context onto the window grid
-3. #3088 Implement whole-run phase segmentation over normalized timelines
-4. #3089 Persist segment timelines and per-window context labels
-5. #3090 Surface context completeness and fallback signals to history and report consumers
-
-### Parent #3077 — order tracking and harmonic stability
-
-1. #3091 Define whole-run order-trace and harmonic evidence contracts
-2. #3092 Build per-candidate order traces from window spectra and context labels
-3. #3093 Add harmonic stability and order-lock scoring across the full run
-4. #3094 Summarize order traces by source family, phase, and support intervals
-5. #3095 Persist ranked order-trace summaries and exemplars for downstream fusion
-
-### Parent #3078 — multi-sensor coherence and spatial evidence
-
-1. #3096 Define multi-sensor coherence and spatial evidence contracts
-2. #3097 Join aligned per-window sensor outputs with coverage and missing-data rules
-3. #3098 Implement candidate-level coherence and cross-sensor agreement metrics
-4. #3099 Implement spatial separation and supporting-window hotspot summaries
-5. #3100 Persist spatial evidence and proof-basis summaries for downstream fusion
-
-### Parent #3079 — fusion, counterevidence, and diagnosis ranking
-
-1. #3101 Define persisted whole-run evidence fusion and diagnosis summary contracts
-2. #3102 Model support factors and counterevidence factors with stable keys
-3. #3103 Implement the diagnosis ranker over context, order, and spatial evidence
-4. #3104 Add summary-only and partial-artifact fallback scoring for legacy runs
-5. #3105 Expose fused diagnosis evidence through history and report preparation and PDF surfaces
-6. #3106 Add cross-scenario regression coverage for clear, mixed, and ambiguous whole-run diagnoses

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -75,6 +75,10 @@ DIRECT_SHELL_SCRIPT_RE = re.compile(
     r"(?:^|[`;\s])(?:[A-Z_][A-Z0-9_]*=[^`\s]+\s+)*(?:sudo\s+)?\./"
     r"(?P<path>(?:apps/server/scripts/|infra/|tools/)[A-Za-z0-9._~/-]+\.sh)\b"
 )
+DESIGN_DOC_STATUS_RE = re.compile(
+    r"^\s*>?\s*\*\*Status:\*\*\s*(Active|Historical|Superseded)\s*$",
+    re.MULTILINE,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -592,6 +596,21 @@ def _check_stale_repo_path_references(
     return issues
 
 
+def _check_design_doc_status(markdown_files: list[str], repo_root: Path) -> list[str]:
+    issues: list[str] = []
+    for path in sorted(markdown_files):
+        if not (path.startswith("docs/designs/") and path.endswith(".md")):
+            continue
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        if not DESIGN_DOC_STATUS_RE.search(text):
+            issues.append(
+                f"{path}: design doc must declare Status: Active, Historical, or Superseded"
+            )
+    return issues
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     all_files = _tracked_files(repo_root)
@@ -610,6 +629,7 @@ def main() -> int:
     issues.extend(_check_direct_shell_script_commands(markdown_files, repo_root))
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))
     issues.extend(_check_stale_repo_path_references(markdown_files, repo_root))
+    issues.extend(_check_design_doc_status(markdown_files, repo_root))
     issues.extend(_check_make_command_targets(markdown_files, repo_root))
     issues.extend(_check_npm_run_scripts(markdown_files, repo_root))
     issues.extend(_check_ci_job_examples(markdown_files, repo_root))


### PR DESCRIPTION
Fixes #3635.

## What changed
- Marked every `docs/designs/*.md` file as `Active` or `Historical`.
- Kept the whole-run architecture doc active and moved old issue plans, branch notes, and benchmark snapshots into `docs/designs/whole-run-post-analysis-history.md`.
- Listed the design docs in `docs/README.md`.
- Added AI guidance for design-doc status meaning.
- Added docs-lint enforcement for design-doc status markers.

## Why
Active architecture guidance was mixed with stale execution history. Agents could treat old issue plans or branch notes as current instructions.

## Validation
- `ruff format tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `ruff check tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check --cached`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Historical details stay available, but are no longer in the active architecture path.
- Status enforcement is limited to `docs/designs/*.md`.
- The lint accepts exactly `Active`, `Historical`, or `Superseded`.

## Follow-ups / out of scope
- No source behavior changes.
