### PR TITLE
Keep docs index complete

### DIFF
--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -184,3 +184,29 @@ def test_design_doc_status_lint_requires_explicit_status(tmp_path: Path) -> None
     ) == [
         "docs/designs/missing.md: design doc must declare Status: Active, Historical, or Superseded"
     ]
+
+
+def test_docs_index_lint_requires_every_docs_markdown_file(
+    tmp_path: Path,
+) -> None:
+    module = _load_docs_lint_module()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "README.md").write_text(
+        "| File | Description |\n|---|---|\n| `docs/README.md` | Index. |\n",
+        encoding="utf-8",
+    )
+    (docs_dir / "listed.md").write_text("# Listed\n", encoding="utf-8")
+    (docs_dir / "missing.md").write_text("# Missing\n", encoding="utf-8")
+
+    assert module._check_docs_index_complete(
+        [
+            "docs/README.md",
+            "docs/listed.md",
+            "docs/missing.md",
+        ],
+        tmp_path,
+    ) == [
+        "docs/README.md must list docs/listed.md",
+        "docs/README.md must list docs/missing.md",
+    ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # Documentation Index
 
-Every documentation file in the repository and a short description of what it covers.
+Every user-facing documentation file in the repository and a short description
+of what it covers.
 
 ## AI Guidance
 
@@ -29,12 +30,18 @@ links onward to the scoped instruction files and repo map below.
 | `docs/order_tracking.md` | Order-reference math, tolerance bands, and order-finding flow. |
 | `docs/report_pipeline.md` | Report generation flow from analysis to PDF. |
 | `docs/design_language.md` | Visual design decisions for report layout and UI. |
-| `docs/designs/final-report-redesign.md` | Active report/PDF design guidance for the verdict page and appendices. |
-| `docs/designs/whole-run-post-analysis-program.md` | Active whole-run post-analysis architecture guidance. |
-| `docs/designs/whole-run-post-analysis-history.md` | Historical whole-run post-analysis issue plan, branch notes, and benchmark snapshots. |
+| `docs/anti_alias_characterization.md` | Anti-alias filter characterization data and interpretation notes. |
 | `docs/metrics.md` | Vibration metric definitions and unit rules. |
 | `docs/metrics_to_report_mapping.md` | How metrics map to report sections. |
 | `docs/protocol.md` | UDP and WebSocket protocol details between ESP32 and server. |
+
+## Design records
+
+| File | Status | Description |
+|------|--------|-------------|
+| `docs/designs/final-report-redesign.md` | Active | Report/PDF design guidance for the verdict page and appendices. |
+| `docs/designs/whole-run-post-analysis-program.md` | Active | Whole-run post-analysis architecture guidance. |
+| `docs/designs/whole-run-post-analysis-history.md` | Historical | Whole-run post-analysis issue plan, branch notes, and benchmark snapshots. |
 
 ## Infrastructure & Operations
 
@@ -69,6 +76,7 @@ HTTP/WebSocket error semantics. Pair it with `apps/ui/README.md` §
 | File | Description |
 |------|-------------|
 | `README.md` | Project overview and quickstart. |
+| `docs/README.md` | This documentation inventory. |
 | `CONTRIBUTING.md` | Development workflow and setup paths. |
 | `CHANGELOG.md` | Release history. |
 | `apps/server/README.md` | Backend setup, deployment, and CLI usage. |

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -611,6 +611,22 @@ def _check_design_doc_status(markdown_files: list[str], repo_root: Path) -> list
     return issues
 
 
+def _check_docs_index_complete(markdown_files: list[str], repo_root: Path) -> list[str]:
+    docs_index_text = _read_text(repo_root, "docs/README.md")
+    if docs_index_text is None:
+        return ["missing docs/README.md"]
+
+    issues: list[str] = []
+    for path in sorted(
+        path
+        for path in markdown_files
+        if path.startswith("docs/") and path.endswith(".md")
+    ):
+        if f"`{path}`" not in docs_index_text:
+            issues.append(f"docs/README.md must list {path}")
+    return issues
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     all_files = _tracked_files(repo_root)
@@ -630,6 +646,7 @@ def main() -> int:
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))
     issues.extend(_check_stale_repo_path_references(markdown_files, repo_root))
     issues.extend(_check_design_doc_status(markdown_files, repo_root))
+    issues.extend(_check_docs_index_complete(markdown_files, repo_root))
     issues.extend(_check_make_command_targets(markdown_files, repo_root))
     issues.extend(_check_npm_run_scripts(markdown_files, repo_root))
     issues.extend(_check_ci_job_examples(markdown_files, repo_root))


### PR DESCRIPTION
Fixes #3636.

## What changed
- Added missing docs index entries for `docs/README.md` and `docs/anti_alias_characterization.md`.
- Split design docs into a status-aware `Design records` table.
- Added docs-lint coverage that requires every tracked `docs/**/*.md` file to be listed in `docs/README.md`.

## Why
The index claimed broad coverage but could drift silently. Humans and agents need the inventory to be complete enough to find active guidance versus design history.

## Validation
- `ruff format tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `ruff check tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python3 tools/dev/docs_lint.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- The guard covers tracked markdown under `docs/`; root READMEs and area AGENTS files stay under existing guidance checks.
- Future docs additions must update the index in the same change.

## Follow-ups / out of scope
- No source behavior changes.
