### PR TITLE
Remove stale uPlot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Sensors connect to the Pi's Wi-Fi AP, stream accelerometer data via UDP, and the
 ```
 apps/
   server/      Python backend (FastAPI + signal processing + reports)
-  ui/          TypeScript frontend (Vite + uPlot)
+  ui/          TypeScript/Vite frontend dashboard
 firmware/
   esp/         ESP32 firmware (PlatformIO, C++)
 infra/

--- a/apps/server/tests/hygiene/test_docs_lint.py
+++ b/apps/server/tests/hygiene/test_docs_lint.py
@@ -303,3 +303,39 @@ def test_ai_guidance_lint_rejects_unsupported_uv_run_commands(
         ],
         tmp_path,
     ) == [".github/instructions/tests.instructions.md: unsupported AI guidance command: uv run"]
+
+
+def test_frontend_stack_lint_rejects_docs_for_missing_ui_dependencies(
+    tmp_path: Path,
+) -> None:
+    module = _load_docs_lint_module()
+    ui_dir = tmp_path / "apps" / "ui"
+    ui_dir.mkdir(parents=True)
+    (ui_dir / "package.json").write_text(
+        '{"dependencies": {"preact": "^10.0.0"}, "devDependencies": {"vite": "^8.0.0"}}',
+        encoding="utf-8",
+    )
+    (tmp_path / "README.md").write_text(
+        "apps/ui is a TypeScript frontend (Vite + uPlot).\n",
+        encoding="utf-8",
+    )
+    (ui_dir / "README.md").write_text(
+        "- **Preact** — UI rendering\n",
+        encoding="utf-8",
+    )
+
+    assert module._check_stale_frontend_stack_references(
+        ["README.md", "apps/ui/README.md"],
+        tmp_path,
+    ) == ["README.md: stale frontend stack reference: uPlot is not an apps/ui dependency"]
+
+    package_json = '{"dependencies": {"uplot": "^1.0.0"}, "devDependencies": {}}'
+    (ui_dir / "package.json").write_text(package_json, encoding="utf-8")
+
+    assert (
+        module._check_stale_frontend_stack_references(
+            ["README.md", "apps/ui/README.md"],
+            tmp_path,
+        )
+        == []
+    )

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -11,7 +11,7 @@ server over HTTP (REST) and WebSocket (live data).
 - **@tanstack/query-core** — canonical server-state fetch, cache, polling, and invalidation ownership
 - **comlink** — typed Web Worker bridge for off-main-thread spectrum frame preparation
 - **Vite** — build tool and dev server
-- **uPlot** — high-performance spectrum charts
+- **Canvas chart renderer** — custom live spectrum visualization
 - **Vitest + happy-dom** — canonical fast unit/integration test runner
 - **Playwright** — browser, visual regression, and smoke testing
 - **CSS custom properties** — Material Design 3 inspired theming
@@ -144,7 +144,7 @@ frame preparation does not.
   contract plus the pure preparation core reused by the worker and focused
   tests.
 - `src/app/runtime/spectrum_canvas_renderer.ts` no longer prepares frames from
-  raw AppState. It only composes chart-band metadata, owns uPlot/canvas
+  raw AppState. It only composes chart-band metadata, owns the canvas chart
   lifecycle, and renders already prepared frames.
 - Worker responses may return transferable typed arrays (`Float64Array`) for the
   prepared frequency/series payloads. Treat those series as read-only numeric
@@ -252,7 +252,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that owns Comlink worker lifecycle for heavy spectrum frame preparation, splits data refreshes from lighter settings-driven decoration refreshes, and wires overlay, canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
-| `app/runtime/spectrum_canvas_renderer.ts` | Prepared-frame chart-band composition, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_canvas_renderer.ts` | Prepared-frame chart-band composition, plot lifecycle, cadence-aware tween scheduling, stable chart buffer reuse for same-shape frames, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_frame_preparer.ts` | Typed spectrum frame-prep contract plus pure interpolation/dB conversion core shared by worker and focused tests |
 | `app/runtime/spectrum_frame_preparer_worker.ts` | Canonical Comlink worker entrypoint for off-main-thread spectrum frame preparation plus transferable response packing |
 | `app/runtime/spectrum_frame_preparer_worker_client.ts` | Runtime-owned worker client wrapper that creates, proxies, and disposes the spectrum frame-prep worker |
@@ -323,7 +323,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `config.ts` | Centralized UI tuning constants for polling intervals, spectrum ranges, and history heatmap positions |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | Shared spectrum math helpers such as amplitude-to-dB conversion that stay safe to import on the startup path |
-| `spectrum_chart.ts` | Lazy-loaded uPlot chart wrapper, explicit `setData`/`redraw` bridge, and stylesheet entry for interactive spectrum visualization |
+| `spectrum_chart.ts` | Lazy-loaded canvas chart wrapper, explicit `setData`/`redraw` bridge, and stylesheet entry for interactive spectrum visualization |
 | `spectrum_css_vars.ts` | Shared cached spectrum CSS-variable snapshot for chart and canvas renderer colors |
 | `server_payload.ts` | Transport-boundary WebSocket payload adaptation and schema-version guardrails around the generated WS types |
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
@@ -374,7 +374,7 @@ individual page/settings panel islands own their local chrome plus typed
 bridges. The remaining
 imperative paths are deliberate runtime integrations rather than alternate UI
 renderers: the shell controller still owns app-level status/preference state,
-the spectrum controller still owns the uPlot/canvas lifecycle through
+the spectrum controller still owns the canvas chart lifecycle through
 island-owned chart refs, and a few focused bridges still move typed wizard or
 status models into island-owned hosts. Those seams should use semantic methods
 like `setModel()` / `setDiagnostics()` rather than generic `render(model)`
@@ -423,7 +423,7 @@ instead of controller-side variant class interpolation.
   prefer `useSignalProperties()` from `app/ui_signals.ts` over repeating
   property access or per-property `useComputed(...)` adapters.
 - Use `effect()` only for narrow imperative integrations such as timers,
-  persistence, canvas/uPlot bridges, or other external-library coordination.
+  persistence, canvas chart bridges, or other external-library coordination.
 - Preact-rendered copy should come from `getUiText()` or `useUiText()`.
   Do not leave `data-i18n` attributes in JSX unless a non-Preact consumer still
   reads them.
@@ -445,7 +445,7 @@ instead of controller-side variant class interpolation.
   and its failure text now points at the exact replacement seam to use.
 - Normal UI rendering belongs in Preact owner surfaces. If code outside an
   island needs imperative DOM work, keep it narrowly scoped to non-render
-  integrations such as download anchors, canvas/uPlot lifecycles, observers, or
+  integrations such as download anchors, canvas chart lifecycles, observers, or
   external-library mount points instead of generic HTML/string builder helpers.
 - Expected feature shape is thin facade + focused workflow/transport/presenter
   or derived view-state modules. Workflow modules stay DOM-free, render-state

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -270,8 +270,7 @@ export function createSpectrumCanvasRenderer(
     currentFreqAxis.value = frame.freq;
     syncChartDataBuffer(frame.freq, frame.values);
     plot.setData(chartData.value, options.resetScales);
-    // uPlot does not commit a paint when setData() skips scale recalculation.
-    // Tween frames reuse fixed axes, so explicitly rebuild paths and redraw.
+    // Same-scale tween frames reuse fixed axes, so explicitly redraw the canvas.
     if (!options.resetScales) {
       plot.redraw(true, false);
     }

--- a/apps/ui/take-screenshot.mjs
+++ b/apps/ui/take-screenshot.mjs
@@ -90,7 +90,7 @@ async function main() {
       { timeout: PAGE_TIMEOUT_MS },
     );
 
-    // Verify spectrum canvas has rendered data (uPlot creates a canvas element)
+    // Verify spectrum canvas has rendered data.
     const hasCanvas = await page.evaluate(() => {
       const canvas = document.querySelector("#specChart canvas");
       if (!canvas) return false;

--- a/tools/dev/docs_lint.py
+++ b/tools/dev/docs_lint.py
@@ -238,6 +238,22 @@ def _ui_npm_scripts(repo_root: Path) -> set[str]:
     return {name for name in scripts if isinstance(name, str)}
 
 
+def _ui_dependency_names(repo_root: Path) -> set[str]:
+    package_json_text = _read_text(repo_root, "apps/ui/package.json")
+    if package_json_text is None:
+        return set()
+    try:
+        payload = json.loads(package_json_text)
+    except json.JSONDecodeError:
+        return set()
+    dependency_names: set[str] = set()
+    for section_name in ("dependencies", "devDependencies"):
+        section = payload.get(section_name)
+        if isinstance(section, dict):
+            dependency_names.update(name for name in section if isinstance(name, str))
+    return dependency_names
+
+
 def _raw_workflow_job_ids(repo_root: Path) -> set[str]:
     workflow_text = _read_text(repo_root, ".github/workflows/ci.yml")
     if workflow_text is None:
@@ -541,6 +557,35 @@ def _check_unsupported_ai_toolchain_commands(
     return issues
 
 
+def _check_stale_frontend_stack_references(
+    markdown_files: list[str], repo_root: Path
+) -> list[str]:
+    if "uplot" in _ui_dependency_names(repo_root):
+        return []
+
+    issues: list[str] = []
+    guidance_files = sorted(
+        path
+        for path in markdown_files
+        if path in {"README.md", "CONTRIBUTING.md"}
+        or path.startswith("docs/")
+        or path.startswith(".github/instructions/")
+        or path == ".github/copilot-instructions.md"
+        or path == "AGENTS.md"
+        or path.endswith("/AGENTS.md")
+        or path == "apps/ui/README.md"
+    )
+    for path in guidance_files:
+        text = _read_text(repo_root, path)
+        if text is None:
+            continue
+        if "uplot" in text.lower():
+            issues.append(
+                f"{path}: stale frontend stack reference: uPlot is not an apps/ui dependency"
+            )
+    return issues
+
+
 def _check_guidance_script_references(
     markdown_files: list[str], repo_root: Path
 ) -> list[str]:
@@ -704,6 +749,7 @@ def main() -> int:
     issues.extend(_check_frontend_guidance_validation(repo_root))
     issues.extend(_check_firmware_guidance_validation(repo_root))
     issues.extend(_check_unsupported_ai_toolchain_commands(markdown_files, repo_root))
+    issues.extend(_check_stale_frontend_stack_references(markdown_files, repo_root))
     issues.extend(_check_guidance_script_references(markdown_files, repo_root))
     issues.extend(_check_direct_shell_script_commands(markdown_files, repo_root))
     issues.extend(_check_backticked_repo_paths(markdown_files, repo_root))


### PR DESCRIPTION
Fixes #3640.

## What changed
- Removed stale uPlot wording from the root project layout.
- Updated UI docs to describe the current Vite/Preact/custom canvas chart stack.
- Removed stale uPlot comments from spectrum-related UI source/test helper code.
- Added docs-lint coverage that rejects uPlot stack references in docs/AI guidance while `uplot` is not declared in `apps/ui/package.json`.

## Why
The UI no longer ships `uplot`. Docs that name it as an active frontend technology mislead contributors and agents.

## Validation
- `rg "uPlot|uplot" README.md apps/ui/README.md docs .github AGENTS.md apps/server/AGENTS.md apps/server/tests/AGENTS.md`
- `ruff format tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `ruff check tools/dev/docs_lint.py apps/server/tests/hygiene/test_docs_lint.py`
- `./.venv/bin/python -m pytest apps/server/tests/hygiene/test_docs_lint.py -q`
- `python3 tools/dev/docs_lint.py`
- `./.venv/bin/python tools/dev/check_hygiene.py`
- `./.venv/bin/python tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Documentation and comments only for UI source behavior.
- The lint guard intentionally allows uPlot docs again only if `uplot` becomes a declared UI dependency.

## Follow-ups / out of scope
- No UI runtime behavior changes.
