### PR TITLE
Defer post-analysis until raw finalize settles

### DIFF
--- a/apps/server/tests/use_cases/run/test_finalize_stages.py
+++ b/apps/server/tests/use_cases/run/test_finalize_stages.py
@@ -70,9 +70,9 @@ def test_finalize_active_run_reports_successful_stage_results() -> None:
     assert result.run_id_to_analyze == "run-1"
     assert [stage.stage_name for stage in result.stage_results] == [
         "FlushPendingRowsStage",
-        "ResolvePostAnalysisCandidateStage",
         "FinalizeRawCaptureStage",
         "FinalizePersistenceStage",
+        "ResolvePostAnalysisCandidateStage",
     ]
     assert [stage.status for stage in result.stage_results] == ["ok", "ok", "ok", "ok"]
 
@@ -116,9 +116,9 @@ def test_finalize_active_run_marks_skipped_and_degraded_stages(
 
     assert [stage.status for stage in result.stage_results] == [
         "skipped",
+        "degraded",
+        "degraded",
         "skipped",
-        "degraded",
-        "degraded",
     ]
     stage_logs = {
         getattr(record, "stage_name", ""): record
@@ -128,6 +128,85 @@ def test_finalize_active_run_marks_skipped_and_degraded_stages(
     assert stage_logs["FinalizeRawCaptureStage"].stage_status == "degraded"
     assert stage_logs["FinalizeRawCaptureStage"].diagnostic_context["queue_depth"] == 3
     assert stage_logs["FinalizePersistenceStage"].stage_status == "degraded"
+    assert result.stage_results[-1].diagnostic_context["reason"] == "raw_capture_finalize_unsettled"
+
+
+def test_finalize_active_run_resolves_analysis_after_finalize_stages() -> None:
+    events: list[str] = []
+    sample_flush = SimpleNamespace(pending_flush_snapshot=lambda: None)
+    persistence = SimpleNamespace(
+        status_snapshot=lambda: PersistenceStatusSnapshot(
+            write_error=None,
+            written_sample_count=1,
+            dropped_sample_count=0,
+        ),
+        ready_for_analysis=lambda run_id: (
+            events.append("resolve")
+            or (run_id if events == ["raw_finalize", "persistence_finalize", "resolve"] else None)
+        ),
+        history_run_created=True,
+        finalize_run=lambda run_id, start_time_utc, end_time_utc: (
+            events.append("persistence_finalize") or True
+        ),
+    )
+    raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: (
+            events.append("raw_finalize") or RawCaptureFinalizeResult(status="completed")
+        )
+    )
+
+    result = finalize_active_run(
+        run_id="run-ordered",
+        start_time_utc="2026-04-25T06:43:00Z",
+        stop_reason="manual",
+        ingest_drop_losses=None,
+        sample_flush=sample_flush,
+        persistence=persistence,
+        raw_capture=raw_capture,
+        record_raw_capture_finalize_result=lambda run_id, result: None,
+        logger=logging.getLogger("test.finalize.ordered"),
+    )
+
+    assert events == ["raw_finalize", "persistence_finalize", "resolve"]
+    assert result.run_id_to_analyze == "run-ordered"
+
+
+def test_finalize_active_run_defers_analysis_when_raw_capture_timeout_is_unsettled() -> None:
+    sample_flush = SimpleNamespace(pending_flush_snapshot=lambda: None)
+    persistence = SimpleNamespace(
+        status_snapshot=lambda: PersistenceStatusSnapshot(
+            write_error=None,
+            written_sample_count=1,
+            dropped_sample_count=0,
+        ),
+        ready_for_analysis=lambda run_id: run_id,
+        history_run_created=True,
+        finalize_run=lambda run_id, start_time_utc, end_time_utc: True,
+    )
+    raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="timeout",
+            error="raw capture finalize timed out",
+        )
+    )
+
+    result = finalize_active_run(
+        run_id="run-timeout",
+        start_time_utc="2026-04-25T06:44:00Z",
+        stop_reason="manual",
+        ingest_drop_losses=None,
+        sample_flush=sample_flush,
+        persistence=persistence,
+        raw_capture=raw_capture,
+        record_raw_capture_finalize_result=lambda run_id, result: None,
+        logger=logging.getLogger("test.finalize.timeout"),
+    )
+
+    assert result.run_id_to_analyze is None
+    resolve_stage = result.stage_results[-1]
+    assert resolve_stage.stage_name == "ResolvePostAnalysisCandidateStage"
+    assert resolve_stage.status == "skipped"
+    assert resolve_stage.diagnostic_context["reason"] == "raw_capture_finalize_unsettled"
 
 
 def test_finalize_active_run_logs_failed_stage_and_reraises(

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -602,6 +602,7 @@ def test_stop_recording_continues_when_raw_capture_finalize_degrades(
 ) -> None:
     from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
 
+    scheduled: list[str] = []
     logger = make_logger(history_db=fake_history_db)
     snapshot = _started_snapshot(logger)
     logger._sample_flush.append_records(
@@ -617,7 +618,7 @@ def test_stop_recording_continues_when_raw_capture_finalize_degrades(
         ),
         shutdown=lambda timeout_s=5.0: True,
     )
-    monkeypatch.setattr(logger, "schedule_post_analysis", lambda _run_id: None)
+    monkeypatch.setattr(logger, "schedule_post_analysis", scheduled.append)
 
     with caplog.at_level(logging.WARNING, logger="vibesensor.use_cases.run.logger"):
         status = logger.stop_recording()
@@ -630,7 +631,81 @@ def test_stop_recording_continues_when_raw_capture_finalize_degrades(
     assert metadata.raw_capture_finalize.status == "timeout"
     assert metadata.raw_capture_finalize.queue_depth == 3
     assert metadata.raw_capture_finalize.error_summary == "raw capture finalize timed out"
+    assert scheduled == []
     assert "raw_capture_finalize_degraded" in caplog.text
+
+
+def test_late_raw_capture_finalize_schedules_post_analysis_after_metadata_update(
+    make_logger,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
+    scheduled: list[str] = []
+    logger = make_logger(history_db=history_db.run_repository)
+    snapshot = _started_snapshot(logger)
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+    logger._raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="timeout",
+            error="raw capture finalize timed out",
+        ),
+        shutdown=lambda timeout_s=5.0: True,
+    )
+    monkeypatch.setattr(logger, "schedule_post_analysis", scheduled.append)
+
+    logger.stop_recording()
+    logger._handle_late_raw_capture_finalize_result(
+        snapshot.run_id,
+        RawCaptureFinalizeResult(status="completed"),
+    )
+
+    assert scheduled == [snapshot.run_id]
+    stored_metadata = history_db.run_repository.get_run_metadata(snapshot.run_id)
+    assert stored_metadata is not None
+    assert stored_metadata.raw_capture_finalize is not None
+    assert stored_metadata.raw_capture_finalize.status == "completed"
+
+
+def test_permanent_raw_capture_finalize_failure_schedules_with_degraded_metadata(
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+    scheduled: list[str] = []
+    logger = make_logger(history_db=fake_history_db)
+    snapshot = _started_snapshot(logger)
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+    logger._raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="failed",
+            error="raw capture finalize failed",
+            queue_depth=0,
+        ),
+        shutdown=lambda timeout_s=5.0: True,
+    )
+    monkeypatch.setattr(logger, "schedule_post_analysis", scheduled.append)
+
+    logger.stop_recording()
+
+    updated_run_id, metadata = fake_history_db.updated_metadata[-1]
+    assert updated_run_id == snapshot.run_id
+    assert metadata.raw_capture_finalize is not None
+    assert metadata.raw_capture_finalize.status == "failed"
+    assert metadata.raw_capture_finalize.error_summary == "raw capture finalize failed"
+    assert scheduled == [snapshot.run_id]
 
 
 def test_post_analysis_uses_run_language_from_metadata(

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -246,6 +246,48 @@ def test_raw_capture_writer_finalize_timeout_returns_degraded_result() -> None:
     assert writer.shutdown(timeout_s=1.0) is True
 
 
+def test_raw_capture_writer_notifies_late_finalize_after_timeout() -> None:
+    class HangingHistoryDb:
+        def __init__(self) -> None:
+            self.block_finalize = threading.Event()
+
+        async def aappend_raw_capture_chunk(self, _run_id: str, _chunk) -> None:
+            return None
+
+        async def afinalize_raw_capture(
+            self,
+            _run_id: str,
+            *,
+            run_start_monotonic_us: int | None = None,
+            sensor_clock_sync=None,
+            sensor_losses=None,
+        ):
+            del run_start_monotonic_us, sensor_clock_sync, sensor_losses
+            await asyncio.to_thread(self.block_finalize.wait)
+            return None
+
+    history_db = HangingHistoryDb()
+    completed = threading.Event()
+    late_results: list[tuple[str, str]] = []
+    writer = RunRawCaptureWriter(
+        history_db=history_db,
+        logger=logging.getLogger(__name__),
+        late_finalize_callback=lambda run_id, result: (
+            late_results.append((run_id, result.status)),
+            completed.set(),
+        ),
+    )
+    writer.start_run("run-timeout-late")
+
+    result = writer.finalize_run("run-timeout-late", timeout_s=0.1)
+    history_db.block_finalize.set()
+
+    assert result.status == "timeout"
+    assert completed.wait(timeout=2.0)
+    assert late_results == [("run-timeout-late", "completed")]
+    assert writer.shutdown(timeout_s=1.0) is True
+
+
 def test_raw_capture_writer_finalize_returns_enqueue_timeout_when_queue_stays_full() -> None:
     class SlowHistoryDb:
         def __init__(self) -> None:

--- a/apps/server/vibesensor/use_cases/run/finalize_stages.py
+++ b/apps/server/vibesensor/use_cases/run/finalize_stages.py
@@ -134,6 +134,41 @@ def _log_failed_stage_and_raise(
     raise exc
 
 
+def _resolve_post_analysis_candidate_stage(
+    *,
+    run_id: str | None,
+    raw_capture_finalize_status: str | None,
+    persistence: RunPersistenceWriter,
+    persistence_snapshot: PersistenceStatusSnapshot | None,
+    persistence_finalized: bool,
+) -> tuple[str | None, FinalizeStageResult]:
+    resolve_stage_start = time.monotonic()
+    run_id_to_analyze: str | None = None
+    if run_id is None:
+        resolve_reason = "no_active_run"
+    elif raw_capture_finalize_status == "timeout":
+        resolve_reason = "raw_capture_finalize_unsettled"
+    else:
+        run_id_to_analyze = persistence.ready_for_analysis(run_id)
+        resolve_reason = "ready" if run_id_to_analyze else "history_not_ready"
+    return run_id_to_analyze, _make_stage_result(
+        stage_name="ResolvePostAnalysisCandidateStage",
+        status="ok" if run_id_to_analyze else "skipped",
+        stage_start=resolve_stage_start,
+        artifacts_created=("post_analysis_candidate",) if run_id_to_analyze else (),
+        diagnostic_context={
+            "run_id": run_id or "",
+            "reason": resolve_reason,
+            "history_run_created": persistence.history_run_created,
+            "written_sample_count": (
+                0 if persistence_snapshot is None else persistence_snapshot.written_sample_count
+            ),
+            "raw_capture_status": raw_capture_finalize_status,
+            "persistence_finalized": persistence_finalized,
+        },
+    )
+
+
 def finalize_active_run(
     *,
     run_id: str | None,
@@ -193,29 +228,7 @@ def finalize_active_run(
     resolved_start_time_utc = start_time_utc or utc_now_iso()
     resolved_end_time_utc = utc_now_iso()
     persistence_snapshot = persistence.status_snapshot() if run_id is not None else None
-
-    resolve_stage_start = time.monotonic()
-    run_id_to_analyze = persistence.ready_for_analysis(run_id)
-    resolve_stage = _make_stage_result(
-        stage_name="ResolvePostAnalysisCandidateStage",
-        status="ok" if run_id_to_analyze else "skipped",
-        stage_start=resolve_stage_start,
-        artifacts_created=("post_analysis_candidate",) if run_id_to_analyze else (),
-        diagnostic_context={
-            "run_id": run_id or "",
-            "history_run_created": persistence.history_run_created,
-            "written_sample_count": (
-                0 if persistence_snapshot is None else persistence_snapshot.written_sample_count
-            ),
-        },
-    )
-    stage_results.append(resolve_stage)
-    _log_stage_result(
-        logger=logger,
-        run_id=run_id,
-        stop_reason=stop_reason,
-        stage_result=resolve_stage,
-    )
+    raw_capture_finalize_status: str | None = None
 
     raw_capture_stage_start = time.monotonic()
     if run_id is None:
@@ -242,6 +255,7 @@ def finalize_active_run(
                 diagnostic_context={"run_id": run_id},
             )
         record_raw_capture_finalize_result(run_id, finalize_result)
+        raw_capture_finalize_status = finalize_result.status
         raw_capture_status: FinalizeStageStatus
         raw_capture_warnings: tuple[str, ...] = ()
         raw_capture_artifacts: tuple[str, ...] = ()
@@ -276,6 +290,7 @@ def finalize_active_run(
     )
 
     persistence_stage_start = time.monotonic()
+    persistence_finalized = False
     if run_id is None:
         persistence_stage = _make_stage_result(
             stage_name="FinalizePersistenceStage",
@@ -285,7 +300,7 @@ def finalize_active_run(
         )
     else:
         try:
-            finalized = persistence.finalize_run(
+            persistence_finalized = persistence.finalize_run(
                 run_id,
                 resolved_start_time_utc,
                 resolved_end_time_utc,
@@ -302,13 +317,13 @@ def finalize_active_run(
             )
         persistence_stage = _make_stage_result(
             stage_name="FinalizePersistenceStage",
-            status="ok" if finalized else "degraded",
+            status="ok" if persistence_finalized else "degraded",
             stage_start=persistence_stage_start,
-            artifacts_created=("history_run_finalized",) if finalized else (),
-            warnings=() if finalized else ("history_finalize_failed",),
+            artifacts_created=("history_run_finalized",) if persistence_finalized else (),
+            warnings=() if persistence_finalized else ("history_finalize_failed",),
             diagnostic_context={
                 "run_id": run_id,
-                "post_analysis_candidate": bool(run_id_to_analyze),
+                "raw_capture_status": raw_capture_finalize_status,
             },
         )
     stage_results.append(persistence_stage)
@@ -317,6 +332,21 @@ def finalize_active_run(
         run_id=run_id,
         stop_reason=stop_reason,
         stage_result=persistence_stage,
+    )
+
+    run_id_to_analyze, resolve_stage = _resolve_post_analysis_candidate_stage(
+        run_id=run_id,
+        raw_capture_finalize_status=raw_capture_finalize_status,
+        persistence=persistence,
+        persistence_snapshot=persistence_snapshot,
+        persistence_finalized=persistence_finalized,
+    )
+    stage_results.append(resolve_stage)
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=resolve_stage,
     )
 
     return ActiveRunFinalizeResult(

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -156,6 +156,7 @@ class RunRecorder:
                 self.registry,
                 client_ids,
             ),
+            late_finalize_callback=self._handle_late_raw_capture_finalize_result,
         )
 
         self._sample_flush = SampleFlushOrchestrator(
@@ -582,6 +583,39 @@ class RunRecorder:
                 raw_capture_error=result.error,
             ),
         )
+
+    def _handle_late_raw_capture_finalize_result(
+        self,
+        run_id: str,
+        result: RawCaptureFinalizeResult,
+    ) -> None:
+        with self._lock:
+            previous = self._raw_capture_finalize_results.get(run_id)
+            if previous is not None and previous.status != "timeout":
+                return
+            self._record_raw_capture_finalize_result(run_id, result)
+            finalized = self._raw_capture_finalize_results[run_id]
+        if not self._persistence.update_raw_capture_finalize(run_id, finalized):
+            LOGGER.warning(
+                "late_raw_capture_finalize_metadata_update_failed",
+                extra=log_extra(
+                    event="late_raw_capture_finalize_metadata_update_failed",
+                    run_id=run_id,
+                    raw_capture_finalize_status=result.status,
+                    raw_capture_error=result.error,
+                ),
+            )
+            return
+        if self._history_db is not None:
+            LOGGER.info(
+                "late_raw_capture_finalize_scheduling_post_analysis",
+                extra=log_extra(
+                    event="late_raw_capture_finalize_scheduling_post_analysis",
+                    run_id=run_id,
+                    raw_capture_finalize_status=result.status,
+                ),
+            )
+            self.schedule_post_analysis(run_id)
 
     async def run(self) -> None:
         await _recorder_runtime.run_loop(self, logger=LOGGER)

--- a/apps/server/vibesensor/use_cases/run/persistence_writer.py
+++ b/apps/server/vibesensor/use_cases/run/persistence_writer.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from threading import RLock
 from typing import Any
 
 import aiosqlite
 
 from vibesensor.shared.ports import RunPersistence
-from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.run_schema import RunMetadata, RunRawCaptureFinalize
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
 
@@ -376,6 +376,50 @@ class RunPersistenceWriter:
             self.set_last_write_error(f"history finalize_run failed: {exc}")
             self._logger_provider().warning(
                 "Failed to finalize run in history DB",
+                exc_info=True,
+            )
+            return False
+
+    def update_raw_capture_finalize(
+        self,
+        run_id: str,
+        raw_capture_finalize: RunRawCaptureFinalize,
+    ) -> bool:
+        history_db = self._history_db
+        if history_db is None:
+            return False
+        try:
+            metadata = _sync_call(history_db, history_db.aget_run_metadata(run_id))
+            if metadata is None:
+                self.set_last_write_error(
+                    f"history metadata update failed: run {run_id} metadata not found"
+                )
+                self._logger_provider().warning(
+                    "History DB raw capture finalize metadata update skipped for missing run %s",
+                    run_id,
+                )
+                return False
+            updated = replace(metadata, raw_capture_finalize=raw_capture_finalize)
+            persisted = _sync_call(
+                history_db,
+                history_db.aupdate_run_metadata(run_id, updated),
+            )
+            if not persisted:
+                self.set_last_write_error(
+                    f"history metadata update skipped for missing run {run_id}"
+                )
+                self._logger_provider().warning(
+                    "History DB raw capture finalize metadata update skipped for run %s",
+                    run_id,
+                )
+                return False
+            self.clear_last_write_error()
+            return True
+        except (aiosqlite.Error, OSError) as exc:
+            self.set_last_write_error(f"history metadata update failed: {exc}")
+            self._logger_provider().warning(
+                "Failed to update raw capture finalize metadata for run %s",
+                run_id,
                 exc_info=True,
             )
             return False

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -59,6 +59,8 @@ class _FinalizeRequest:
     done: threading.Event = field(default_factory=threading.Event)
     manifest: RawCaptureManifest | None = None
     error: BaseException | None = None
+    timed_out: bool = False
+    late_callback_sent: bool = False
 
 
 @dataclass(slots=True)
@@ -126,6 +128,7 @@ class RunRawCaptureWriter:
         "_active_run_id",
         "_history_db",
         "_ingest_diagnostics",
+        "_late_finalize_callback",
         "_lock",
         "_logger",
         "_queue",
@@ -144,6 +147,7 @@ class RunRawCaptureWriter:
         sensor_sync_snapshotter: (
             Callable[[tuple[str, ...]], Mapping[str, RawCaptureSensorClockSync] | None] | None
         ) = None,
+        late_finalize_callback: Callable[[str, RawCaptureFinalizeResult], None] | None = None,
     ) -> None:
         self._history_db = (
             history_db
@@ -154,6 +158,7 @@ class RunRawCaptureWriter:
         )
         self._logger = logger
         self._ingest_diagnostics = ingest_diagnostics
+        self._late_finalize_callback = late_finalize_callback
         self._lock = threading.RLock()
         self._sensor_sync_snapshotter = sensor_sync_snapshotter
         self._queue: queue.Queue[
@@ -288,6 +293,9 @@ class RunRawCaptureWriter:
         finished = request.done.wait(timeout=_bounded_wait_timeout(timeout_s))
         if not finished:
             queue_depth = self._queue.qsize()
+            request.timed_out = True
+            if request.done.is_set():
+                self._notify_late_finalize(request)
             self._logger.error(
                 "Timed out waiting %.2fs for raw capture finalize for run %s; queue depth=%s",
                 max(0.0, float(timeout_s)),
@@ -387,6 +395,8 @@ class RunRawCaptureWriter:
                         )
                     finally:
                         item.done.set()
+                        if item.timed_out:
+                            self._notify_late_finalize(item)
                     continue
                 run_id, chunk, run_stats = item
                 try:
@@ -404,6 +414,33 @@ class RunRawCaptureWriter:
                     )
             finally:
                 self._queue.task_done()
+
+    def _notify_late_finalize(self, request: _FinalizeRequest) -> None:
+        callback = self._late_finalize_callback
+        if callback is None:
+            return
+        if request.late_callback_sent:
+            return
+        request.late_callback_sent = True
+        if request.error is not None:
+            result = RawCaptureFinalizeResult(
+                status="failed",
+                error=f"raw capture finalize failed for {request.run_id}: {request.error}",
+                queue_depth=self._queue.qsize(),
+            )
+        else:
+            result = RawCaptureFinalizeResult(
+                status="completed",
+                manifest=request.manifest,
+                queue_depth=self._queue.qsize(),
+            )
+        try:
+            callback(request.run_id, result)
+        except BaseException:  # noqa: BLE001
+            self._logger.exception(
+                "Late raw capture finalize callback failed for run %s",
+                request.run_id,
+            )
 
 
 def _merge_sensor_losses(


### PR DESCRIPTION
Fixes #3643.

## What changed
- Moved post-analysis candidate resolution after pending flush, raw-capture finalization, and persistence finalization.
- Treat raw-capture finalize `timeout` as unsettled, so stop/restart does not schedule post-analysis with a missing manifest.
- Added a late raw-finalize callback path. When the worker eventually completes, it records updated raw-capture finalize metadata and then schedules post-analysis.
- Kept permanent raw-finalize failures explicit: degraded metadata is recorded and post-analysis still runs as the fallback path.

## Why
Raw sidecars may finish moments after `stop_recording()` times out waiting for finalization. Scheduling immediately can permanently downgrade an otherwise raw-backed run to summary-only analysis.

## Validation
- `ruff format` / `ruff check` on touched files
- focused pytest for run finalization, raw capture writer, and recorder lifecycle tests
- `tools/dev/check_hygiene.py`
- `tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Timeout now defers analysis until the raw finalize worker reports a late result. If the worker never completes, analysis remains deferred rather than silently running without the sidecar.
- Full persistence and surfacing of every finalization stage result remains covered by follow-up #3649; this PR persists the raw-capture finalize state needed for the scheduling decision.
