### PR TITLE
Bound WebSocket broadcast backpressure

### DIFF
--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import time
 
+import anyio
 import pytest
 
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
@@ -82,3 +83,49 @@ async def test_prepare_replaces_non_finite_values_with_null() -> None:
         "selected_client_id": "sensor-a",
         "value": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_prepare_bounds_concurrent_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    active = 0
+    max_active = 0
+
+    async def _fake_run_sync(func, *args, **kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await anyio.sleep(0.01)
+        try:
+            return func(*args)
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
+        _fake_run_sync,
+    )
+    orchestrator = PayloadBuildOrchestrator(
+        _PayloadBuilder(),
+        capture_debug=False,
+        max_concurrent_serializations=2,
+    )
+
+    await orchestrator.prepare([f"sensor-{index}" for index in range(7)])
+
+    assert max_active == 2
+    assert orchestrator.serialized_payload_count == 7
+
+
+@pytest.mark.asyncio
+async def test_prepare_skips_payload_variants_over_budget() -> None:
+    orchestrator = PayloadBuildOrchestrator(
+        _PayloadBuilder(),
+        capture_debug=False,
+        max_payload_variants=2,
+    )
+
+    await orchestrator.prepare(["sensor-a", "sensor-b", "sensor-c"])
+
+    assert set(orchestrator.payload_cache) == {"sensor-a", "sensor-b", "sensor-c"}
+    assert orchestrator.skipped_client_ids == {"sensor-c"}
+    assert json.loads(orchestrator.payload_cache["sensor-c"]) == {"error": "payload_build_failed"}

--- a/apps/server/tests/adapters/websocket/test_ws_ingress_adversarial.py
+++ b/apps/server/tests/adapters/websocket/test_ws_ingress_adversarial.py
@@ -58,6 +58,67 @@ async def test_broadcast_pressure_builds_one_payload_per_unique_selection() -> N
 
 
 @pytest.mark.asyncio
+async def test_broadcast_bounds_concurrent_sends_under_many_clients() -> None:
+    hub = WebSocketHub()
+    websockets = []
+    active = 0
+    max_active = 0
+
+    async def _slow_send(_payload: str) -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await anyio.sleep(0.01)
+        active -= 1
+
+    for index in range(8):
+        ws = _make_ws()
+        ws.send_text.side_effect = _slow_send
+        await hub.add(ws, f"sensor-{index}")
+        websockets.append(ws)
+    hub._runner._max_concurrent_sends = 2
+    hub._runner._max_sends_per_tick = len(websockets)
+
+    await hub.broadcast(lambda selected: {"selected": selected})
+
+    assert max_active == 2
+    assert all(ws.send_text.await_count == 1 for ws in websockets)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_skips_sends_over_tick_budget(caplog) -> None:
+    hub = WebSocketHub()
+    websockets = []
+    for index in range(5):
+        ws = _make_ws()
+        await hub.add(ws, f"sensor-{index}")
+        websockets.append(ws)
+    hub._runner._max_sends_per_tick = 2
+
+    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"):
+        await hub.broadcast(lambda selected: {"selected": selected})
+
+    assert [_sent_json_sequence(ws) for ws in websockets] == [
+        [{"selected": "sensor-0"}],
+        [{"selected": "sensor-1"}],
+        [],
+        [],
+        [],
+    ]
+    assert hub.connection_count() == 5
+    backpressure_logs = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "ws_broadcast_backpressure"
+    ]
+    assert len(backpressure_logs) == 1
+    assert backpressure_logs[0].skipped_send_count == 3
+    assert backpressure_logs[0].payload_cache_bytes > 0
+    assert backpressure_logs[0].payload_serialization_count == 2
+    assert backpressure_logs[0].tick_duration_ms >= 0
+
+
+@pytest.mark.asyncio
 async def test_tick_controller_skips_negative_sleep_when_broadcast_lags() -> None:
     controller = BroadcastTickController(
         hz=100,

--- a/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
+++ b/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from collections.abc import Callable
 
 import anyio
@@ -28,6 +29,10 @@ LOGGER = logging.getLogger(__name__)
 __all__ = ["BroadcastRunner"]
 
 _SEND_FAILURE_EXCEPTIONS = (OSError, RuntimeError)
+_DEFAULT_MAX_CONCURRENT_SENDS = 16
+_DEFAULT_MAX_SENDS_PER_TICK = 128
+_DEFAULT_MAX_CONCURRENT_PAYLOAD_SERIALIZATIONS = 4
+_DEFAULT_MAX_PAYLOAD_VARIANTS_PER_TICK = 32
 
 
 class BroadcastRunner:
@@ -39,10 +44,23 @@ class BroadcastRunner:
         *,
         send_timeout_s: float,
         send_error_log_interval_s: float,
+        max_concurrent_sends: int = _DEFAULT_MAX_CONCURRENT_SENDS,
+        max_sends_per_tick: int = _DEFAULT_MAX_SENDS_PER_TICK,
+        max_concurrent_payload_serializations: int = (
+            _DEFAULT_MAX_CONCURRENT_PAYLOAD_SERIALIZATIONS
+        ),
+        max_payload_variants_per_tick: int = _DEFAULT_MAX_PAYLOAD_VARIANTS_PER_TICK,
     ) -> None:
         self._tracker = tracker
         self._send_timeout_s = send_timeout_s
         self._send_error_log_interval_s = send_error_log_interval_s
+        self._max_concurrent_sends = max(1, int(max_concurrent_sends))
+        self._max_sends_per_tick = max(1, int(max_sends_per_tick))
+        self._max_concurrent_payload_serializations = max(
+            1,
+            int(max_concurrent_payload_serializations),
+        )
+        self._max_payload_variants_per_tick = max(1, int(max_payload_variants_per_tick))
         self._last_send_error_log_ts = 0.0
 
     async def broadcast(
@@ -64,36 +82,63 @@ class BroadcastRunner:
                 "vibesensor.capture_debug": capture_debug,
             },
         ) as span:
+            tick_started = time.monotonic()
+            send_conns = conns[: self._max_sends_per_tick]
+            skipped_send_count = len(conns) - len(send_conns)
             payloads = PayloadBuildOrchestrator(
                 payload_builder,
                 capture_debug=capture_debug,
+                max_concurrent_serializations=self._max_concurrent_payload_serializations,
+                max_payload_variants=self._max_payload_variants_per_tick,
             )
             try:
-                await payloads.prepare(conn.selected_client_id for conn in conns)
+                await payloads.prepare(conn.selected_client_id for conn in send_conns)
                 sent_selected_client_ids: dict[int, str | None] = {}
 
-                dead_ws: list[WSConnectionSnapshot | None] = [None] * len(conns)
-                async with anyio.create_task_group() as task_group:
-                    for index, conn in enumerate(conns):
-                        task_group.start_soon(
-                            self._send_current_conn_into_slot,
-                            index,
-                            conn,
-                            payloads,
-                            sent_selected_client_ids,
-                            dead_ws,
-                        )
+                dead_ws: list[WSConnectionSnapshot | None] = [None] * len(send_conns)
+                for start in range(0, len(send_conns), self._max_concurrent_sends):
+                    async with anyio.create_task_group() as task_group:
+                        for index, conn in enumerate(
+                            send_conns[start : start + self._max_concurrent_sends],
+                            start=start,
+                        ):
+                            task_group.start_soon(
+                                self._send_current_conn_into_slot,
+                                index,
+                                conn,
+                                payloads,
+                                sent_selected_client_ids,
+                                dead_ws,
+                            )
                 await self._cleanup_dead(dead_ws)
             except Exception as exc:
                 mark_span_error(span, exc)
                 raise
             span.set_attribute("vibesensor.payload_variant_count", len(payloads.payload_cache))
+            span.set_attribute("vibesensor.payload_cache_bytes", payloads.payload_cache_bytes)
+            span.set_attribute(
+                "vibesensor.payload_serialization_count",
+                payloads.serialized_payload_count,
+            )
+            tick_duration_ms = max(0, int(round((time.monotonic() - tick_started) * 1000)))
+            span.set_attribute("vibesensor.tick_duration_ms", tick_duration_ms)
             span.set_attribute("vibesensor.failed_client_count", len(payloads.failed_client_ids))
+            span.set_attribute("vibesensor.skipped_send_count", skipped_send_count)
+            span.set_attribute(
+                "vibesensor.skipped_payload_variant_count",
+                len(payloads.skipped_client_ids),
+            )
             span.set_attribute(
                 "vibesensor.removed_connection_count", sum(1 for ws in dead_ws if ws)
             )
+            self._log_backpressure(
+                connection_count=len(conns),
+                skipped_send_count=skipped_send_count,
+                tick_duration_ms=tick_duration_ms,
+                payloads=payloads,
+            )
             self._log_build_failures(payloads, sent_selected_client_ids)
-            self._log_debug(payloads, conns, dead_ws)
+            self._log_debug(payloads, send_conns, dead_ws)
 
     async def _send_conn(
         self,
@@ -195,6 +240,36 @@ class BroadcastRunner:
                     "None" if cid is None else cid for cid in payloads.failed_client_ids
                 ),
                 affected_connection_count=affected,
+            ),
+        )
+
+    def _log_backpressure(
+        self,
+        *,
+        connection_count: int,
+        skipped_send_count: int,
+        tick_duration_ms: int,
+        payloads: PayloadBuildOrchestrator,
+    ) -> None:
+        skipped_payload_variant_count = len(payloads.skipped_client_ids)
+        if skipped_send_count <= 0 and skipped_payload_variant_count <= 0:
+            return
+        LOGGER.warning(
+            "WebSocket broadcast backpressure skipped sends=%d payload_variants=%d",
+            skipped_send_count,
+            skipped_payload_variant_count,
+            extra=log_extra(
+                event="ws_broadcast_backpressure",
+                connection_count=connection_count,
+                max_sends_per_tick=self._max_sends_per_tick,
+                max_concurrent_sends=self._max_concurrent_sends,
+                skipped_send_count=skipped_send_count,
+                max_payload_variants_per_tick=self._max_payload_variants_per_tick,
+                max_concurrent_payload_serializations=(self._max_concurrent_payload_serializations),
+                skipped_payload_variant_count=skipped_payload_variant_count,
+                payload_cache_bytes=payloads.payload_cache_bytes,
+                payload_serialization_count=payloads.serialized_payload_count,
+                tick_duration_ms=tick_duration_ms,
             ),
         )
 

--- a/apps/server/vibesensor/adapters/websocket/hub.py
+++ b/apps/server/vibesensor/adapters/websocket/hub.py
@@ -40,6 +40,18 @@ _SEND_TIMEOUT_S: float = 0.5
 _SEND_ERROR_LOG_INTERVAL_S: float = 10.0
 """Minimum interval between logged send-error warnings to avoid log spam."""
 
+_MAX_CONCURRENT_SENDS: int = 16
+"""Maximum concurrent WebSocket send operations in one broadcast tick."""
+
+_MAX_SENDS_PER_TICK: int = 128
+"""Maximum connection snapshots attempted in one broadcast tick."""
+
+_MAX_CONCURRENT_PAYLOAD_SERIALIZATIONS: int = 4
+"""Maximum concurrent payload serializations in one broadcast tick."""
+
+_MAX_PAYLOAD_VARIANTS_PER_TICK: int = 32
+"""Maximum unique selected-client payload variants built in one broadcast tick."""
+
 
 class WebSocketHub:
     """Fan-out broadcaster: sends live metric payloads to all connected WebSocket clients."""
@@ -51,6 +63,10 @@ class WebSocketHub:
             self._tracker,
             send_timeout_s=_SEND_TIMEOUT_S,
             send_error_log_interval_s=_SEND_ERROR_LOG_INTERVAL_S,
+            max_concurrent_sends=_MAX_CONCURRENT_SENDS,
+            max_sends_per_tick=_MAX_SENDS_PER_TICK,
+            max_concurrent_payload_serializations=_MAX_CONCURRENT_PAYLOAD_SERIALIZATIONS,
+            max_payload_variants_per_tick=_MAX_PAYLOAD_VARIANTS_PER_TICK,
         )
 
     async def add(self, websocket: WebSocket, selected_client_id: str | None) -> None:

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -18,6 +18,8 @@ __all__ = ["PayloadBuildOrchestrator"]
 _ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
 _ERROR_PAYLOAD: str = json_text_dumps(_ERROR_PAYLOAD_BODY)
 _SELECTED_CLIENT_ID_NULL_JSON = '"selected_client_id":null'
+_DEFAULT_MAX_CONCURRENT_SERIALIZATIONS = 4
+_DEFAULT_MAX_PAYLOAD_VARIANTS = 64
 
 
 def _dump_json_text(value: object) -> str:
@@ -32,13 +34,19 @@ class PayloadBuildOrchestrator:
         payload_builder: Callable[[str | None], LiveWsPayload],
         *,
         capture_debug: bool,
+        max_concurrent_serializations: int = _DEFAULT_MAX_CONCURRENT_SERIALIZATIONS,
+        max_payload_variants: int = _DEFAULT_MAX_PAYLOAD_VARIANTS,
     ) -> None:
         self._payload_builder = payload_builder
+        self._max_concurrent_serializations = max(1, int(max_concurrent_serializations))
+        self._max_payload_variants = max(1, int(max_payload_variants))
         self._payload_cache: dict[str | None, str] = {}
         self._payload_template_cache: dict[tuple[tuple[str, object], ...], str] = {}
         self._pending_payload_events: dict[str | None, anyio.Event] = {}
         self._failed_client_ids: set[str | None] = set()
+        self._skipped_client_ids: set[str | None] = set()
         self._debug_info: dict[str | None, bool] | None = {} if capture_debug else None
+        self._serialized_payload_count = 0
 
     @property
     def payload_cache(self) -> Mapping[str | None, str]:
@@ -49,8 +57,20 @@ class PayloadBuildOrchestrator:
         return self._failed_client_ids
 
     @property
+    def skipped_client_ids(self) -> set[str | None]:
+        return self._skipped_client_ids
+
+    @property
     def debug_info(self) -> dict[str | None, bool] | None:
         return self._debug_info
+
+    @property
+    def serialized_payload_count(self) -> int:
+        return self._serialized_payload_count
+
+    @property
+    def payload_cache_bytes(self) -> int:
+        return sum(len(text.encode("utf-8")) for text in self._payload_cache.values())
 
     def _build_raw_payload(self, selected_client_id: str | None) -> LiveWsPayload | None:
         """Build the raw payload for *selected_client_id* on the event-loop thread."""
@@ -183,9 +203,14 @@ class PayloadBuildOrchestrator:
         """Prime cached payloads for the current snapshot's unique client selections."""
 
         unique_selected_ids = list(dict.fromkeys(selected_client_ids))
+        selected_ids_to_build = unique_selected_ids[: self._max_payload_variants]
+        for selected_client_id in unique_selected_ids[self._max_payload_variants :]:
+            self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
+            self._skipped_client_ids.add(selected_client_id)
+
         raw_payloads: dict[str | None, LiveWsPayload] = {}
 
-        for selected_client_id in unique_selected_ids:
+        for selected_client_id in selected_ids_to_build:
             raw_payload = self._build_raw_payload(selected_client_id)
             if raw_payload is None:
                 self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
@@ -206,10 +231,15 @@ class PayloadBuildOrchestrator:
                 selected_client_id,
                 raw_payload,
             )
+            self._serialized_payload_count += 1
 
-        async with anyio.create_task_group() as task_group:
-            for selected_client_id, raw_payload in raw_payloads.items():
-                task_group.start_soon(_serialize_one, selected_client_id, raw_payload)
+        raw_payload_items = list(raw_payloads.items())
+        for start in range(0, len(raw_payload_items), self._max_concurrent_serializations):
+            async with anyio.create_task_group() as task_group:
+                for selected_client_id, raw_payload in raw_payload_items[
+                    start : start + self._max_concurrent_serializations
+                ]:
+                    task_group.start_soon(_serialize_one, selected_client_id, raw_payload)
 
         for selected_client_id in raw_payloads:
             text, failed, has_freq = serialized_payloads[selected_client_id]
@@ -222,6 +252,10 @@ class PayloadBuildOrchestrator:
     async def _build_payload_text(self, selected_client_id: str | None) -> str:
         """Build and serialize payload text for *selected_client_id* once for the tick."""
 
+        if len(self._payload_cache) >= self._max_payload_variants:
+            self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
+            self._skipped_client_ids.add(selected_client_id)
+            return _ERROR_PAYLOAD
         raw_payload = self._build_raw_payload(selected_client_id)
         if raw_payload is None:
             self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
@@ -231,6 +265,7 @@ class PayloadBuildOrchestrator:
             selected_client_id,
             raw_payload,
         )
+        self._serialized_payload_count += 1
         self._payload_cache[selected_client_id] = text
         if failed:
             self._failed_client_ids.add(selected_client_id)


### PR DESCRIPTION
Fixes #3645.

## What changed
- Bounded WebSocket send fan-out per tick.
- Added a per-tick send attempt budget so excess stale work is skipped instead of queued.
- Bounded payload serialization concurrency and per-tick selected-client payload variants.
- Added backpressure diagnostics for skipped sends, skipped payload variants, payload cache bytes, serialization count, and tick duration.
- Added adversarial tests for many clients, slow sends, per-tick send budget, serialization concurrency, and payload variant budget.

## Why
The live dashboard runs on constrained hardware. Reconnect storms, many browser tabs, or many distinct selected-client ids should not create unbounded task fan-out or serialization pressure.

## Validation
- `ruff format` / `ruff check` on touched files
- focused WebSocket pytest
- `tools/dev/check_hygiene.py`
- `tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Over-budget connections keep their socket and simply miss that tick. The next tick can serve them if they are still active.
- The send budget is internal for now. No config surface was added to avoid unnecessary deployment/config churn.
