### PR TITLE
Make update terminal states explicit

### DIFF
--- a/apps/server/tests/use_cases/updates/test_startup_recovery.py
+++ b/apps/server/tests/use_cases/updates/test_startup_recovery.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from vibesensor.use_cases.updates.models import UpdateJobStatus, UpdateState, UpdateTransport
+from vibesensor.use_cases.updates.models import (
+    UpdateJobStatus,
+    UpdateState,
+    UpdateTerminalState,
+    UpdateTransport,
+)
 from vibesensor.use_cases.updates.startup_recovery import UpdateStartupRecoveryCoordinator
 
 
@@ -76,3 +81,24 @@ async def test_recover_marks_interrupted_and_recovers_transport() -> None:
         ),
     )
     reporter.mark_interrupted.assert_called_once_with("Update interrupted by server restart")
+
+
+@pytest.mark.asyncio
+async def test_recover_repairs_cleanup_failed_terminal_state() -> None:
+    status = UpdateJobStatus(
+        state=UpdateState.failed,
+        finished_at=123.0,
+        terminal_state=UpdateTerminalState.timeout_cleanup_failed,
+    )
+    (
+        coordinator,
+        transport_coordinator,
+        recover,
+        reporter,
+        status_tracker,
+    ) = _make_recovery(status)
+
+    await coordinator.recover()
+
+    transport_coordinator.recover_interrupted.assert_awaited_once_with(status)
+    reporter.mark_interrupted.assert_not_called()

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -17,10 +17,14 @@ from _update_manager_test_helpers import (
     setup_update_env,
 )
 
-from vibesensor.shared.exceptions import UpdateCleanupError
 from vibesensor.use_cases.updates.finalization import UpdateWorkflowFinalizer
 from vibesensor.use_cases.updates.manager import UpdateManager
-from vibesensor.use_cases.updates.models import UpdateState, UpdateTransport, UsbInternetStatus
+from vibesensor.use_cases.updates.models import (
+    UpdateState,
+    UpdateTerminalState,
+    UpdateTransport,
+    UsbInternetStatus,
+)
 from vibesensor.use_cases.updates.run_models import PreparedUpdateRun
 from vibesensor.use_cases.updates.runtime_refresh import UpdateRuntimeDetailsRefresher
 from vibesensor.use_cases.updates.status import (
@@ -520,17 +524,15 @@ class TestUpdateManagerAsync:
         ):
             manager.start("TestNet", "pass123")
             assert manager.job_task is not None
-            with pytest.raises(
-                UpdateCleanupError,
-                match="Cleanup failed after cancellation: Runtime details refresh failed",
-            ):
-                await manager.job_task
+            await manager.job_task
 
         assert manager.status.finished_at is not None
         assert manager.status.state == UpdateState.failed
+        assert manager.status.terminal_state == UpdateTerminalState.cancelled_cleanup_failed
         persisted = state_store.load()
         assert persisted is not None
         assert persisted.state == UpdateState.failed
+        assert persisted.terminal_state == UpdateTerminalState.cancelled_cleanup_failed
         assert any(
             issue.message == "Cleanup failed after cancellation: Runtime details refresh failed"
             and issue.detail == ""

--- a/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
@@ -15,6 +15,7 @@ from vibesensor.use_cases.updates.models import (
     UpdatePhase,
     UpdateRequest,
     UpdateState,
+    UpdateTerminalState,
     UpdateTransport,
 )
 from vibesensor.use_cases.updates.status import (
@@ -95,6 +96,7 @@ async def test_start_rejects_concurrent_job_and_keeps_secret_redacted(
 
     final_status = _load_status(state_store)
     assert final_status.state == UpdateState.failed
+    assert final_status.terminal_state == UpdateTerminalState.cancelled_cleanly
     assert final_status.finished_at is not None
     assert any(issue.message == "Update was cancelled" for issue in final_status.issues)
     _assert_secret_not_persisted(state_store, request.password)
@@ -116,6 +118,7 @@ async def test_timeout_marks_failure_and_persists_cleanup_state(tmp_path: Path) 
 
     status = _load_status(state_store)
     assert status.state == UpdateState.failed
+    assert status.terminal_state == UpdateTerminalState.timeout
     assert status.finished_at is not None
     assert any(issue.message == "Update timed out after 0.01s" for issue in status.issues)
     _assert_secret_not_persisted(state_store, request.password)
@@ -134,6 +137,7 @@ async def test_update_error_marks_failure_without_propagating(tmp_path: Path) ->
 
     status = _load_status(state_store)
     assert status.state == UpdateState.failed
+    assert status.terminal_state == UpdateTerminalState.workflow_failed
     assert status.finished_at is not None
     assert any(issue.message == "transport failed" for issue in status.issues)
     _assert_secret_not_persisted(state_store, request.password)
@@ -154,6 +158,7 @@ async def test_cleanup_error_propagates_explicitly_and_persists_failure(tmp_path
 
     status = _load_status(state_store)
     assert status.state == UpdateState.failed
+    assert status.terminal_state == UpdateTerminalState.cleanup_failed
     assert status.finished_at is not None
     assert any(issue.message == "transport cleanup failed" for issue in status.issues)
     _assert_secret_not_persisted(state_store, request.password)
@@ -185,3 +190,61 @@ async def test_start_exports_update_workflow_trace_span(tmp_path: Path) -> None:
     span = next(item for item in read_trace_output(trace_path) if item["name"] == "update.workflow")
     assert span["attributes"]["vibesensor.transport"] == "wifi"
     assert span["attributes"]["vibesensor.final_state"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_timeout_cleanup_failure_preserves_timeout_as_primary_state(tmp_path: Path) -> None:
+    manager, state_store, _tracker, workflow_run = _build_manager(tmp_path, timeout_s=0.01)
+
+    async def cleanup_fails_after_timeout(*, request: UpdateRequest) -> None:
+        assert request == _wifi_request()
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError as exc:
+            raise UpdateCleanupError("cleanup failed after timeout") from exc
+
+    workflow_run.side_effect = cleanup_fails_after_timeout
+    request = _wifi_request()
+    manager.start(request.ssid, request.password, transport=request.transport)
+    task = manager.job_task
+    assert task is not None
+    await task
+
+    status = _load_status(state_store)
+    assert status.state == UpdateState.failed
+    assert status.terminal_state == UpdateTerminalState.timeout_cleanup_failed
+    assert [issue.phase for issue in status.issues] == ["timeout", "cleanup"]
+    assert status.issues[0].message == "Update timed out after 0.01s"
+    assert status.issues[1].message == "cleanup failed after timeout"
+
+
+@pytest.mark.asyncio
+async def test_cancel_cleanup_failure_preserves_cancelled_as_primary_state(tmp_path: Path) -> None:
+    manager, state_store, _tracker, workflow_run = _build_manager(tmp_path)
+    started = asyncio.Event()
+
+    async def cleanup_fails_after_cancel(*, request: UpdateRequest) -> None:
+        assert request == _wifi_request()
+        started.set()
+        try:
+            await asyncio.sleep(1.0)
+        except asyncio.CancelledError as exc:
+            raise UpdateCleanupError("cleanup failed after cancellation") from exc
+
+    workflow_run.side_effect = cleanup_fails_after_cancel
+    request = _wifi_request()
+    manager.start(request.ssid, request.password, transport=request.transport)
+    task = manager.job_task
+    assert task is not None
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    assert manager.cancel() is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    status = _load_status(state_store)
+    assert status.state == UpdateState.failed
+    assert status.terminal_state == UpdateTerminalState.cancelled_cleanup_failed
+    assert [issue.phase for issue in status.issues] == ["cancelled", "cleanup"]
+    assert status.issues[0].message == "Update was cancelled"
+    assert status.issues[1].message == "cleanup failed after cancellation"

--- a/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
+++ b/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
@@ -11,6 +11,7 @@ from vibesensor.use_cases.updates.models import (
     UpdatePhase,
     UpdateRuntimeDetails,
     UpdateState,
+    UpdateTerminalState,
     UpdateTransport,
 )
 from vibesensor.use_cases.updates.status import (
@@ -34,6 +35,7 @@ class TestUpdateJobStatusRoundTrip:
             issues=[UpdateIssue(phase="installing", message="slow pip", detail="took 90s")],
             log_tail=["line1", "line2", "line3"],
             exit_code=0,
+            terminal_state=UpdateTerminalState.success,
             runtime=UpdateRuntimeDetails(version="1.2.3"),
         )
         restored = update_status_from_builtins(update_status_to_builtins(original))
@@ -45,6 +47,7 @@ class TestUpdateJobStatusRoundTrip:
         assert restored.last_success_at == original.last_success_at
         assert restored.ssid == original.ssid
         assert restored.exit_code == original.exit_code
+        assert restored.terminal_state == UpdateTerminalState.success
         assert restored.runtime == UpdateRuntimeDetails(version="1.2.3")
         assert len(restored.issues) == 1
         assert restored.issues[0].phase == "installing"
@@ -65,6 +68,7 @@ class TestUpdateJobStatusRoundTrip:
         assert status.issues == []
         assert status.log_tail == []
         assert status.exit_code is None
+        assert status.terminal_state is None
         assert status.runtime == UpdateRuntimeDetails()
 
     def test_from_payload_truncates_log_tail_to_50_lines(self) -> None:

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -99,14 +99,21 @@ class UpdateManager:
             kind=SpanKind.INTERNAL,
             attributes={"vibesensor.transport": request.transport.value},
         ) as span:
+            workflow_task = asyncio.create_task(
+                self._workflow.run(request=request),
+                name=f"{self._task_name}-workflow",
+            )
             try:
                 await asyncio.wait_for(
-                    self._workflow.run(request=request),
+                    asyncio.shield(workflow_task),
                     timeout=self._timeout_s,
                 )
             except UpdateCleanupError as exc:
                 mark_span_error(span, exc)
-                self._reporter.fail(exc, default_phase="cleanup")
+                if str(exc).startswith("Cleanup failed after cancellation:"):
+                    self._reporter.fail_cancelled_cleanup_failed(exc)
+                    return
+                self._reporter.fail_cleanup_failed(exc)
                 raise
             except UpdateError as exc:
                 mark_span_error(span, exc)
@@ -114,12 +121,39 @@ class UpdateManager:
                 return
             except TimeoutError as exc:
                 mark_span_error(span, exc)
-                self._reporter.fail_timeout(timeout_s=self._timeout_s)
+                workflow_task.cancel()
+                cleanup_error = await _await_cancelled_workflow_cleanup(workflow_task)
+                if cleanup_error is not None:
+                    mark_span_error(span, cleanup_error)
+                    self._reporter.fail_timeout_cleanup_failed(
+                        cleanup_error,
+                        timeout_s=self._timeout_s,
+                    )
+                else:
+                    self._reporter.fail_timeout(timeout_s=self._timeout_s)
             except asyncio.CancelledError:
                 span.set_attribute("vibesensor.cancelled", True)
-                self._reporter.fail_cancelled()
+                workflow_task.cancel()
+                cleanup_error = await _await_cancelled_workflow_cleanup(workflow_task)
+                if cleanup_error is not None:
+                    mark_span_error(span, cleanup_error)
+                    self._reporter.fail_cancelled_cleanup_failed(cleanup_error)
+                else:
+                    self._reporter.fail_cancelled()
                 raise
             finally:
                 span.set_attribute("vibesensor.final_state", self._status.status.state.value)
                 self._status.clear_secrets()
                 self._status.finish_cleanup()
+
+
+async def _await_cancelled_workflow_cleanup(
+    workflow_task: asyncio.Task[None],
+) -> UpdateCleanupError | None:
+    try:
+        await workflow_task
+    except UpdateCleanupError as exc:
+        return exc
+    except asyncio.CancelledError:
+        return None
+    return None

--- a/apps/server/vibesensor/use_cases/updates/models.py
+++ b/apps/server/vibesensor/use_cases/updates/models.py
@@ -30,6 +30,18 @@ class UpdateState(enum.StrEnum):
     failed = "failed"
 
 
+class UpdateTerminalState(enum.StrEnum):
+    """Explicit terminal outcome for the most recent update job."""
+
+    success = "success"
+    workflow_failed = "workflow_failed"
+    cleanup_failed = "cleanup_failed"
+    cancelled_cleanly = "cancelled_cleanly"
+    cancelled_cleanup_failed = "cancelled_cleanup_failed"
+    timeout = "timeout"
+    timeout_cleanup_failed = "timeout_cleanup_failed"
+
+
 class UpdatePhase(enum.StrEnum):
     """Granular phase within an OTA update job."""
 
@@ -139,6 +151,7 @@ class UpdateJobStatus:
     issues: list[UpdateIssue] = field(default_factory=list)
     log_tail: list[str] = field(default_factory=list)
     exit_code: int | None = None
+    terminal_state: UpdateTerminalState | None = None
     runtime: UpdateRuntimeDetails = field(default_factory=lambda: UpdateRuntimeDetails())
 
     def __post_init__(self) -> None:

--- a/apps/server/vibesensor/use_cases/updates/startup_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/startup_recovery.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from vibesensor.use_cases.updates.models import UpdateState
+from vibesensor.use_cases.updates.models import UpdateState, UpdateTerminalState
 from vibesensor.use_cases.updates.status import (
     UpdateStatusTracker,
     UpdateTerminalStateReporter,
@@ -10,6 +10,14 @@ from vibesensor.use_cases.updates.status import (
 from vibesensor.use_cases.updates.transport.coordinator import UpdateTransportCoordinator
 
 __all__ = ["UpdateStartupRecoveryCoordinator"]
+
+_CLEANUP_FAILED_TERMINAL_STATES = frozenset(
+    {
+        UpdateTerminalState.cleanup_failed,
+        UpdateTerminalState.cancelled_cleanup_failed,
+        UpdateTerminalState.timeout_cleanup_failed,
+    }
+)
 
 
 class UpdateStartupRecoveryCoordinator:
@@ -30,6 +38,9 @@ class UpdateStartupRecoveryCoordinator:
 
     async def recover(self) -> None:
         status = self._status.status
+        if status.terminal_state in _CLEANUP_FAILED_TERMINAL_STATES:
+            await self._transport_coordinator.recover_interrupted(status)
+            return
         if status.state != UpdateState.running or status.finished_at is not None:
             return
         self._reporter.mark_interrupted("Update interrupted by server restart")

--- a/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
+++ b/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
@@ -15,6 +15,7 @@ from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdatePhase,
     UpdateState,
+    UpdateTerminalState,
     UpdateTransport,
 )
 
@@ -68,6 +69,7 @@ class UpdateJobStatusPayload(msgspec.Struct, kw_only=True):
     issues: list[UpdateIssuePayload] = msgspec.field(default_factory=list)
     log_tail: list[str] = msgspec.field(default_factory=list)
     exit_code: int | None = None
+    terminal_state: UpdateTerminalState | None = None
     runtime: UpdateRuntimeDetailsPayload = msgspec.field(
         default_factory=UpdateRuntimeDetailsPayload
     )

--- a/apps/server/vibesensor/use_cases/updates/status/reporter.py
+++ b/apps/server/vibesensor/use_cases/updates/status/reporter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from vibesensor.shared.exceptions import UpdateError
-from vibesensor.use_cases.updates.models import UpdateState
+from vibesensor.use_cases.updates.models import UpdateState, UpdateTerminalState
 
 from .tracker import UpdateStatusTracker
 
@@ -18,7 +18,13 @@ class UpdateTerminalStateReporter:
     def __init__(self, *, status: UpdateStatusTracker) -> None:
         self._status = status
 
-    def fail(self, error: UpdateError, *, default_phase: str) -> None:
+    def fail(
+        self,
+        error: UpdateError,
+        *,
+        default_phase: str,
+        terminal_state: UpdateTerminalState = UpdateTerminalState.workflow_failed,
+    ) -> None:
         if self._status.status.state is UpdateState.idle:
             return
         phase = error.phase or self._status.status.phase.value or default_phase
@@ -27,18 +33,75 @@ class UpdateTerminalStateReporter:
             str(error),
             error.detail,
             log_message=error.log_message,
+            terminal_state=terminal_state,
         )
+        for note in getattr(error, "__notes__", ()):
+            if str(note).startswith("Cleanup also failed:"):
+                self._status.add_issue("cleanup", str(note))
 
     def fail_timeout(self, *, timeout_s: float) -> None:
         if self._status.status.state is UpdateState.idle:
             return
         message = f"Update timed out after {timeout_s}s"
-        self._status.fail("timeout", message, log_message=message)
+        self._status.fail(
+            "timeout",
+            message,
+            log_message=message,
+            terminal_state=UpdateTerminalState.timeout,
+        )
+
+    def fail_timeout_cleanup_failed(
+        self,
+        cleanup_error: UpdateError,
+        *,
+        timeout_s: float,
+    ) -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        message = f"Update timed out after {timeout_s}s"
+        self._status.add_issue("timeout", message)
+        self._status.log(message)
+        self._status.fail(
+            "cleanup",
+            str(cleanup_error),
+            cleanup_error.detail,
+            log_message=cleanup_error.log_message,
+            terminal_state=UpdateTerminalState.timeout_cleanup_failed,
+        )
 
     def fail_cancelled(self, *, message: str = "Update was cancelled") -> None:
         if self._status.status.state is UpdateState.idle:
             return
-        self._status.fail("cancelled", message, log_message="Update cancelled")
+        self._status.fail(
+            "cancelled",
+            message,
+            log_message="Update cancelled",
+            terminal_state=UpdateTerminalState.cancelled_cleanly,
+        )
+
+    def fail_cancelled_cleanup_failed(self, cleanup_error: UpdateError) -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        self._status.add_issue("cancelled", "Update was cancelled")
+        self._status.log("Update cancelled")
+        self._status.fail(
+            "cleanup",
+            str(cleanup_error),
+            cleanup_error.detail,
+            log_message=cleanup_error.log_message,
+            terminal_state=UpdateTerminalState.cancelled_cleanup_failed,
+        )
+
+    def fail_cleanup_failed(self, cleanup_error: UpdateError) -> None:
+        if self._status.status.state is UpdateState.idle:
+            return
+        self._status.fail(
+            cleanup_error.phase or "cleanup",
+            str(cleanup_error),
+            cleanup_error.detail,
+            log_message=cleanup_error.log_message,
+            terminal_state=UpdateTerminalState.cleanup_failed,
+        )
 
     def mark_interrupted(self, message: str, detail: str = "") -> None:
         self._status.mark_interrupted(message, detail)

--- a/apps/server/vibesensor/use_cases/updates/status/session.py
+++ b/apps/server/vibesensor/use_cases/updates/status/session.py
@@ -10,6 +10,7 @@ from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateRuntimeDetails,
     UpdateState,
+    UpdateTerminalState,
 )
 
 from .state_store import UpdateStateStore
@@ -58,6 +59,7 @@ class UpdateStatusSession:
             ssid=request.ssid,
             uplink_interface=None,
             last_success_at=self._status.last_success_at,
+            terminal_state=None,
             runtime=previous_runtime,
         )
         self.persist()
@@ -76,8 +78,9 @@ class UpdateStatusSession:
         self.touch()
         self.persist()
 
-    def mark_failed(self) -> None:
+    def mark_failed(self, terminal_state: UpdateTerminalState | None = None) -> None:
         self._status.state = UpdateState.failed
+        self._status.terminal_state = terminal_state
         self.touch()
         self.persist()
 
@@ -93,6 +96,7 @@ class UpdateStatusSession:
         self._status.phase = UpdatePhase.done
         self._status.last_success_at = now
         self._status.exit_code = 0
+        self._status.terminal_state = UpdateTerminalState.success
         self._status.phase_started_at = now
         self._status.updated_at = now
 

--- a/apps/server/vibesensor/use_cases/updates/status/tracker.py
+++ b/apps/server/vibesensor/use_cases/updates/status/tracker.py
@@ -11,6 +11,7 @@ from vibesensor.use_cases.updates.models import (
     UpdateRequest,
     UpdateRuntimeDetails,
     UpdateState,
+    UpdateTerminalState,
 )
 from vibesensor.use_cases.updates.runner import sanitize_log_line
 
@@ -112,8 +113,8 @@ class UpdateStatusTracker:
             self._log_buffer.extend_issues(self.status, rewritten)
             self._session.touch()
 
-    def mark_failed(self) -> None:
-        self._session.mark_failed()
+    def mark_failed(self, terminal_state: UpdateTerminalState | None = None) -> None:
+        self._session.mark_failed(terminal_state)
 
     def fail(
         self,
@@ -122,11 +123,12 @@ class UpdateStatusTracker:
         detail: str = "",
         *,
         log_message: str | None = None,
+        terminal_state: UpdateTerminalState | None = None,
     ) -> None:
         self.add_issue(phase, message, detail)
         if log_message:
             self.log(log_message)
-        self.mark_failed()
+        self.mark_failed(terminal_state)
 
     def mark_interrupted(self, message: str, detail: str = "") -> None:
         self.add_issue("startup", message, detail)


### PR DESCRIPTION
## What changed
- Added explicit update terminal states for success, workflow failure, cleanup failure, clean cancellation, cancellation with cleanup failure, timeout, and timeout with cleanup failure.
- Await workflow cleanup after manager timeout/cancel so cleanup failures are recorded in status instead of leaking as unobserved task exceptions.
- Preserve cancellation/timeout as the primary outcome while recording cleanup as the secondary failed phase.
- Make startup recovery repair cleanup-failed terminal states.

## Why
Update failure handling controls whether Pi network/service state returns to a safe mode. Ambiguous terminal states made cancellation, timeout, and cleanup failure hard to reason about.

## Validation/tests
- `ruff format` / `ruff check` on touched update files and tests
- Focused update pytest for manager lifecycle, async manager, finalization, model roundtrip, startup recovery
- `./.venv/bin/python tools/dev/check_hygiene.py`
- `./.venv/bin/python tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks, tradeoffs, edge cases
- Normal cleanup failure still propagates as an explicit failure.
- Cancellation cleanup failure is reported as failed status without surfacing cleanup as the primary exception.
- Startup recovery now retries cleanup repair for cleanup-failed terminal states even when the job already has `finished_at`.

Closes #3646