### PR TITLE
Guard mutating local API requests by origin

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,20 @@ needed for Raspberry Pi or firmware users.
 | Latest GitHub release | Supported when a fix needs a release artifact |
 | Older releases, branches, forks, or local deployments | Not supported |
 
+## Local appliance HTTP boundary
+
+VibeSensor is designed as an offline/local Raspberry Pi appliance, often served
+from its own hotspot. Read-only dashboard endpoints are open to devices that can
+reach the local server. Mutating HTTP endpoints (`POST`, `PUT`, `PATCH`, and
+`DELETE`) reject browser-style requests with an `Origin` or `Referer` header that
+does not match the request host. This is a same-origin/CSRF boundary for local UI
+use, not user authentication.
+
+Direct local clients such as `curl`, scripts, or same-origin UI requests can still
+call mutating endpoints. Secure deployments should still set a hotspot PSK,
+limit who can join the local network, and avoid exposing the server outside the
+trusted appliance network.
+
 ## Reporting a vulnerability
 
 Use GitHub private vulnerability reporting from this repository's Security tab

--- a/apps/server/tests/adapters/http/test_local_mutation_safety.py
+++ b/apps/server/tests/adapters/http/test_local_mutation_safety.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.http import create_router
+from vibesensor.adapters.http.middleware import install_local_mutation_safety_middleware
+
+_UNSAFE_METHODS = {"DELETE", "PATCH", "POST", "PUT"}
+
+
+def _test_client() -> TestClient:
+    app = FastAPI()
+    install_local_mutation_safety_middleware(app)
+
+    @app.get("/state")
+    async def read_state() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/state")
+    async def mutate_state() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.put("/state")
+    async def replace_state() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.patch("/state")
+    async def patch_state() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.delete("/state")
+    async def delete_state() -> dict[str, bool]:
+        return {"ok": True}
+
+    return TestClient(app, base_url="http://vibesensor.local")
+
+
+@pytest.mark.parametrize("method", sorted(_UNSAFE_METHODS))
+def test_local_mutation_safety_blocks_cross_origin_browser_mutations(method: str) -> None:
+    with _test_client() as client:
+        response = client.request(method, "/state", headers={"Origin": "http://evil.local"})
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Mutating local API requests must be same-origin.",
+    }
+
+
+@pytest.mark.parametrize(
+    ("header_name", "header_value"),
+    [
+        ("Origin", "http://vibesensor.local"),
+        ("Referer", "http://vibesensor.local/settings"),
+    ],
+)
+def test_local_mutation_safety_allows_same_origin_mutations(
+    header_name: str,
+    header_value: str,
+) -> None:
+    with _test_client() as client:
+        response = client.post(
+            "/state",
+            headers={header_name: header_value},
+        )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("header_value", ["not a url", "ftp://vibesensor.local"])
+def test_local_mutation_safety_rejects_malformed_browser_origin(header_value: str) -> None:
+    with _test_client() as client:
+        response = client.post("/state", headers={"Origin": header_value})
+
+    assert response.status_code == 403
+
+
+def test_local_mutation_safety_allows_non_browser_local_clients() -> None:
+    with _test_client() as client:
+        response = client.post("/state")
+
+    assert response.status_code == 200
+
+
+def test_local_mutation_safety_allows_cross_origin_read_only_requests() -> None:
+    with _test_client() as client:
+        response = client.get("/state", headers={"Origin": "http://evil.local"})
+
+    assert response.status_code == 200
+
+
+def test_all_mutating_http_routes_are_classified_by_method(fake_state) -> None:
+    router = create_router(fake_state.router)
+    unsafe_routes = {
+        (
+            next(method for method in sorted(route.methods) if method in _UNSAFE_METHODS),
+            route.path,
+        )
+        for route in router.routes
+        if isinstance(route, APIRoute)
+        and route.methods is not None
+        and route.methods.intersection(_UNSAFE_METHODS)
+    }
+
+    assert unsafe_routes == {
+        ("DELETE", "/api/clients/{client_id}"),
+        ("DELETE", "/api/history/{run_id}"),
+        ("DELETE", "/api/settings/cars/{car_id}"),
+        ("POST", "/api/clients/{client_id}/identify"),
+        ("POST", "/api/clients/{client_id}/location"),
+        ("POST", "/api/esp-flash/cancel"),
+        ("POST", "/api/esp-flash/start"),
+        ("POST", "/api/recording/start"),
+        ("POST", "/api/recording/stop"),
+        ("POST", "/api/settings/cars"),
+        ("POST", "/api/settings/obd/pair"),
+        ("POST", "/api/settings/obd/scan"),
+        ("POST", "/api/update/cancel"),
+        ("POST", "/api/update/start"),
+        ("PUT", "/api/settings/analysis"),
+        ("PUT", "/api/settings/cars/active"),
+        ("PUT", "/api/settings/cars/{car_id}"),
+        ("PUT", "/api/settings/language"),
+        ("PUT", "/api/settings/speed-source"),
+        ("PUT", "/api/settings/speed-unit"),
+    }

--- a/apps/server/vibesensor/adapters/http/middleware.py
+++ b/apps/server/vibesensor/adapters/http/middleware.py
@@ -4,10 +4,12 @@ import asyncio
 import logging
 import sys
 from time import perf_counter
+from urllib.parse import urlsplit
 
 from fastapi import FastAPI
 from opentelemetry.trace import SpanKind
 from starlette.datastructures import Headers, MutableHeaders
+from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from vibesensor.shared.exceptions import VibeSensorError
@@ -22,6 +24,57 @@ from vibesensor.shared.structured_logging import (
 from vibesensor.shared.tracing import mark_span_error, start_span
 
 LOGGER = logging.getLogger(__name__)
+_UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _same_origin_header_matches_host(value: str, host: str | None) -> bool:
+    if not value or not host:
+        return False
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return False
+    return parsed.netloc.lower() == host.lower()
+
+
+class LocalMutationSafetyMiddleware:
+    """Reject browser-triggered cross-origin mutating HTTP requests."""
+
+    __slots__ = ("app",)
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        method = str(scope.get("method") or "").upper()
+        if method not in _UNSAFE_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        host = headers.get("host")
+        origin = headers.get("origin")
+        referer = headers.get("referer")
+        if origin is not None:
+            allowed = _same_origin_header_matches_host(origin, host)
+        elif referer is not None:
+            allowed = _same_origin_header_matches_host(referer, host)
+        else:
+            allowed = True
+        if allowed:
+            await self.app(scope, receive, send)
+            return
+
+        response = JSONResponse(
+            {"detail": "Mutating local API requests must be same-origin."},
+            status_code=403,
+        )
+        await response(scope, receive, send)
 
 
 def _failure_kind_for_request_error(exc: BaseException) -> str:
@@ -137,3 +190,7 @@ class RequestLoggingMiddleware:
 
 def install_request_logging_middleware(app: FastAPI) -> None:
     app.add_middleware(RequestLoggingMiddleware)
+
+
+def install_local_mutation_safety_middleware(app: FastAPI) -> None:
+    app.add_middleware(LocalMutationSafetyMiddleware)

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -24,7 +24,10 @@ from granian.log import LogLevels
 
 from vibesensor.adapters.http import create_router
 from vibesensor.adapters.http.error_boundary import install_http_exception_handlers
-from vibesensor.adapters.http.middleware import install_request_logging_middleware
+from vibesensor.adapters.http.middleware import (
+    install_local_mutation_safety_middleware,
+    install_request_logging_middleware,
+)
 from vibesensor.adapters.udp.udp_data_rx import start_udp_data_receiver
 from vibesensor.app.config_loader import load_config
 from vibesensor.app.container import build_runtime
@@ -93,6 +96,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     app = FastAPI(title="VibeSensor", lifespan=lifespan)
     app.state.runtime = runtime
     install_http_exception_handlers(app)
+    install_local_mutation_safety_middleware(app)
     install_request_logging_middleware(app)
     app.include_router(create_router(runtime.router))
     if bootstrap_settings.serve_static:

--- a/docs/configuration_reference.md
+++ b/docs/configuration_reference.md
@@ -53,6 +53,16 @@ For local development examples, see `apps/server/config.dev.yaml`,
 | `server.host` | `0.0.0.0` | Bind host for the FastAPI server. |
 | `server.port` | `80` | TCP port for HTTP/UI traffic. Must stay within `1`-`65535`. Dev configs typically override this to `8000`. |
 
+### Local mutation safety
+
+There is no YAML switch for the local HTTP safety boundary. The server always
+keeps read-only dashboard/API requests open, and it rejects mutating methods
+(`POST`, `PUT`, `PATCH`, `DELETE`) when a browser sends an `Origin` or `Referer`
+header for a different host than the request `Host`. Same-origin UI requests and
+non-browser local clients without those headers remain allowed. Treat this as a
+CSRF/trusted-origin guard, not login/authentication; secure deployments should
+still set `ap.psk` and restrict who can join the local appliance network.
+
 ## `udp`
 
 | Key | Default | Notes |

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -36,6 +36,13 @@ If raw waveform storage should expire earlier, set
 startup maintenance removes raw sidecars first while keeping the run summaries
 available in history.
 
+Mutating local HTTP calls (`POST`, `PUT`, `PATCH`, `DELETE`) are protected by a
+same-origin guard. Browser requests with an `Origin` or `Referer` for a different
+host than the request `Host` return `403`; same-origin UI requests and local
+tools such as `curl` without browser origin headers continue to work. If an
+operator reports a blocked settings/update/history action, compare the browser
+URL, proxy host, and request `Host` header before changing server config.
+
 ## Enable and inspect backend traces
 
 Tracing is disabled by default. When you need end-to-end backend traces, enable


### PR DESCRIPTION
Closes #3648

## What changed
- Added global middleware for unsafe HTTP methods: `POST`, `PUT`, `PATCH`, `DELETE`.
- Browser requests with mismatched or malformed `Origin`/`Referer` now return `403`.
- Same-origin UI requests, read-only requests, and non-browser local clients without browser origin headers still work.
- Added tests for the guard and a route inventory check for mutating endpoints.
- Documented the local appliance trust boundary in security/config/runbook docs.

## Why
Local-network mutating actions needed an explicit safety boundary. This keeps the appliance usable on a trusted local network while blocking drive-by browser mutations from another origin.

## Validation
- `ruff check --fix apps/server/vibesensor/adapters/http/middleware.py apps/server/vibesensor/app/bootstrap.py apps/server/tests/adapters/http/test_local_mutation_safety.py`
- `ruff format apps/server/vibesensor/adapters/http/middleware.py apps/server/vibesensor/app/bootstrap.py apps/server/tests/adapters/http/test_local_mutation_safety.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/http/test_local_mutation_safety.py apps/server/tests/adapters/http/test_request_observability.py apps/server/tests/app/test_app_composition.py -q`
- `./.venv/bin/python tools/dev/check_hygiene.py`
- `./.venv/bin/python tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- This is same-origin protection, not login/auth. Devices on the trusted local network can still use direct clients.
- Deployments behind a proxy must preserve the browser-visible host in the request `Host` header.
- Requests with malformed browser origin headers are rejected instead of guessed safe.

## Follow-ups
None for this issue.