### PR TITLE
Make raw capture overflow policy visible

### DIFF
--- a/apps/server/tests/adapters/http/test_api_history_route_state.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_state.py
@@ -20,6 +20,12 @@ from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.adapters.http import create_router
 from vibesensor.domain import CarSnapshot
 from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureLossStats,
+    RawCaptureManifest,
+    RawCaptureSensorLossStats,
+    RawCaptureSensorManifest,
+)
 
 
 def _app_from_state(state: FakeState) -> FastAPI:
@@ -188,6 +194,52 @@ def test_history_run_includes_sample_count() -> None:
         response = client.get("/api/history/run-1")
 
     assert response.json()["sample_count"] == 3
+
+
+def test_history_run_detail_includes_raw_capture_quality() -> None:
+    @dataclass
+    class RawManifestDB(FakeHistoryDB):
+        async def aget_run(self, run_id: str) -> StoredHistoryRun | None:
+            run = await super().aget_run(run_id)
+            if run is None:
+                return None
+            losses = RawCaptureLossStats(queue_overflow_chunk_count=120)
+            sensor = RawCaptureSensorManifest(
+                client_id="sensor-a",
+                sample_rate_hz=800,
+                data_file="sensor-a.raw.i16le",
+                index_file="sensor-a.index.jsonl",
+                sample_count=64_000,
+                chunk_count=1000,
+                bytes_written=384_000,
+            )
+            return replace(
+                run,
+                raw_capture_manifest=RawCaptureManifest(
+                    run_id=run_id,
+                    relative_dir=f"raw-runs/{run_id}",
+                    sensors=(sensor,),
+                    total_samples=64_000,
+                    total_bytes=384_000,
+                    created_at="2026-01-01T00:00:00Z",
+                    sensor_losses=(RawCaptureSensorLossStats(client_id="sensor-a", losses=losses),),
+                    losses=losses,
+                ),
+            )
+
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(3)]
+    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    app = _app_from_state(FakeState(RawManifestDB(metadata, samples, analysis), FakeWsHub()))
+
+    with TestClient(app) as client:
+        response = client.get("/api/history/run-1")
+
+    quality = response.json()["raw_capture_quality"]
+    assert quality["severity"] == "fatal"
+    assert quality["reason"] == "raw_capture_queue_overflow_fatal"
+    assert quality["gate_whole_run"] is True
+    assert quality["queue_overflow_chunk_count"] == 120
 
 
 def test_history_list_includes_recorded_car_name() -> None:

--- a/apps/server/tests/shared/test_raw_capture_quality.py
+++ b/apps/server/tests/shared/test_raw_capture_quality.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from vibesensor.shared.raw_capture_quality import assess_raw_capture_loss_policy
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureLossStats,
+    RawCaptureManifest,
+    RawCaptureSensorLossStats,
+    RawCaptureSensorManifest,
+)
+
+
+def _manifest(*, queue_overflow: int, chunk_count: int = 1000) -> RawCaptureManifest:
+    sensor = RawCaptureSensorManifest(
+        client_id="sensor-a",
+        sample_rate_hz=800,
+        data_file="sensor-a.raw.i16le",
+        index_file="sensor-a.index.jsonl",
+        sample_count=chunk_count * 64,
+        chunk_count=chunk_count,
+        bytes_written=chunk_count * 64 * 3 * 2,
+    )
+    losses = RawCaptureLossStats(queue_overflow_chunk_count=queue_overflow)
+    return RawCaptureManifest(
+        run_id="run-quality",
+        relative_dir="raw-runs/run-quality",
+        sensors=(sensor,),
+        total_samples=sensor.sample_count,
+        total_bytes=sensor.bytes_written,
+        created_at="2026-01-01T00:00:00Z",
+        sensor_losses=(RawCaptureSensorLossStats(client_id="sensor-a", losses=losses),),
+        losses=losses,
+    )
+
+
+def test_raw_capture_loss_policy_warns_for_first_queue_overflow() -> None:
+    assessment = assess_raw_capture_loss_policy(_manifest(queue_overflow=1))
+
+    assert assessment.severity == "warn"
+    assert assessment.reason == "raw_capture_loss_warn"
+    assert assessment.gate_whole_run is False
+
+
+def test_raw_capture_loss_policy_gates_whole_run_for_fatal_queue_overflow() -> None:
+    assessment = assess_raw_capture_loss_policy(_manifest(queue_overflow=120))
+
+    assert assessment.severity == "fatal"
+    assert assessment.reason == "raw_capture_queue_overflow_fatal"
+    assert assessment.gate_whole_run is True
+    assert assessment.queue_overflow_chunk_count == 120
+
+
+def test_raw_capture_loss_policy_degrades_for_sensor_drop_ratio() -> None:
+    manifest = replace(_manifest(queue_overflow=0, chunk_count=100), losses=RawCaptureLossStats())
+    losses = RawCaptureLossStats(invalid_chunk_count=2)
+    manifest = replace(
+        manifest,
+        sensor_losses=(RawCaptureSensorLossStats(client_id="sensor-a", losses=losses),),
+        losses=losses,
+    )
+
+    assessment = assess_raw_capture_loss_policy(manifest)
+
+    assert assessment.severity == "degraded"
+    assert assessment.max_sensor_drop_ratio > 0.01

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
@@ -184,6 +184,23 @@ def test_prepare_persisted_report_input_uses_raw_not_configured_fallback_reason(
     assert diagnosis[0].fallback_reason == "raw_capture_not_configured"
 
 
+def test_prepare_persisted_report_input_uses_fatal_raw_capture_loss_policy_reason() -> None:
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 0,
+            "raw_capture_mode": "partial_raw_backed",
+            "raw_capture_loss_policy_severity": "fatal",
+            "raw_capture_loss_policy_reason": "raw_capture_queue_overflow_fatal",
+            "raw_capture_loss_policy_gate_whole_run": True,
+        }
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].fallback_reason == "raw_capture_queue_overflow_fatal"
+
+
 def test_prepare_persisted_report_input_builds_raw_backed_legacy_fallback_diagnosis_summary() -> (
     None
 ):

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_raw_capture_policy.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_raw_capture_policy.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureLossStats,
+    RawCaptureManifest,
+    RawRunCapture,
+)
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
+
+
+def _run_metadata(run_id: str, *, language: str = "en") -> RunMetadata:
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "language": language,
+        }
+    )
+
+
+def _samples() -> list:
+    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+
+
+def test_execute_post_analysis_skips_whole_run_artifacts_for_fatal_raw_capture_loss() -> None:
+    stored: dict[str, object] = {}
+    manifest = RawCaptureManifest(
+        run_id="run-loss-gated",
+        relative_dir="raw-runs/run-loss-gated",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+        losses=RawCaptureLossStats(queue_overflow_chunk_count=120),
+    )
+
+    class FakeDB:
+        async def astore_analysis(self, run_id, analysis):
+            stored["run_id"] = run_id
+            stored["analysis"] = analysis
+
+        async def astore_analysis_error(self, run_id, error):
+            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
+
+    def artifact_builder(**_kwargs):
+        raise AssertionError("fatal raw-capture loss must skip whole-run artifact build")
+
+    def context_builder(**_kwargs):
+        raise AssertionError("fatal raw-capture loss must skip whole-run context build")
+
+    def analysis_runner(run: PostAnalysisRunInput):
+        assert run.raw_replay.raw_capture_loss_policy_severity == "fatal"
+        assert run.raw_replay.raw_capture_loss_policy_reason == "raw_capture_queue_overflow_fatal"
+        assert run.raw_replay.raw_capture_loss_policy_gate_whole_run is True
+        return make_persisted_analysis(
+            {
+                "lang": "en",
+                "summary": {},
+                "analysis_metadata": {
+                    "raw_backed_sample_count": run.raw_backed_summary_row_count,
+                    "raw_capture_mode": run.raw_replay.raw_capture_mode,
+                    "raw_capture_loss_policy_severity": (
+                        run.raw_replay.raw_capture_loss_policy_severity
+                    ),
+                    "raw_capture_loss_policy_reason": (
+                        run.raw_replay.raw_capture_loss_policy_reason
+                    ),
+                    "raw_capture_loss_policy_gate_whole_run": (
+                        run.raw_replay.raw_capture_loss_policy_gate_whole_run
+                    ),
+                },
+            }
+        )
+
+    result = execute_post_analysis(
+        run_id="run-loss-gated",
+        db=FakeDB(),
+        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+            run_id=run_id,
+            metadata=_run_metadata(run_id, language="en"),
+            language="en",
+            samples=_samples(),
+            raw_capture=RawRunCapture(manifest=manifest, sensors=()),
+            total_summary_row_count=1,
+            stride=1,
+        ),
+        analysis_runner=analysis_runner,
+        whole_run_artifact_builder=artifact_builder,
+        whole_run_context_builder=context_builder,
+    )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    assert "whole_run_run_id" not in stored
+    assert (
+        stored["analysis"]["analysis_metadata"]["raw_capture_loss_policy_reason"]
+        == "raw_capture_queue_overflow_fatal"
+    )

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -339,6 +339,11 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_replay_stale_sync_sensor_count": 0,
         "raw_replay_high_rtt_sensor_count": 0,
         "raw_replay_confidence": "unavailable",
+        "raw_capture_loss_policy_severity": "ok",
+        "raw_capture_loss_policy_reason": "raw_capture_loss_ok",
+        "raw_capture_loss_policy_gate_whole_run": False,
+        "raw_capture_loss_policy_max_sensor_drop_ratio": 0.0,
+        "raw_capture_loss_policy_max_events_per_minute": 0.0,
     }
 
 
@@ -453,6 +458,12 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
     assert summary["analysis_metadata"]["raw_replay_queue_overflow_chunk_count"] == 2
     assert summary["analysis_metadata"]["raw_replay_invalid_chunk_count"] == 0
     assert summary["analysis_metadata"]["raw_replay_write_error_chunk_count"] == 1
+    assert summary["analysis_metadata"]["raw_capture_loss_policy_severity"] == "fatal"
+    assert (
+        summary["analysis_metadata"]["raw_capture_loss_policy_reason"]
+        == "raw_capture_queue_overflow_fatal"
+    )
+    assert summary["analysis_metadata"]["raw_capture_loss_policy_gate_whole_run"] is True
     assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
         warning["code"] for warning in summary["warnings"]
     ]

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -8,6 +8,7 @@ import numpy as np
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
 from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_CAPTURE_LOSS_POLICY,
     WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
     WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
 )
@@ -223,6 +224,47 @@ def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> 
     assert result.raw_replay.replay_confidence == "partial"
     assert result.raw_replay.raw_capture_mode == "partial_raw_backed"
     assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
+        warning.code for warning in result.raw_replay.warnings
+    ]
+
+
+def test_build_post_analysis_input_marks_fatal_raw_capture_loss_policy() -> None:
+    raw_capture = _raw_capture("run-fatal-drops")
+    loss_stats = RawCaptureLossStats(queue_overflow_chunk_count=120)
+    raw_capture = RawRunCapture(
+        manifest=replace(
+            raw_capture.manifest,
+            sensor_losses=(RawCaptureSensorLossStats(client_id="sensor-a", losses=loss_stats),),
+            losses=loss_stats,
+        ),
+        sensors=raw_capture.sensors,
+    )
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-fatal-drops",
+        metadata=_metadata("run-fatal-drops"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": 64 / 800,
+                    "sample_rate_hz": 800,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                }
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_summary_row_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    assert result.raw_replay.raw_capture_loss_policy_severity == "fatal"
+    assert result.raw_replay.raw_capture_loss_policy_reason == "raw_capture_queue_overflow_fatal"
+    assert result.raw_replay.raw_capture_loss_policy_gate_whole_run is True
+    assert WARNING_CODE_RAW_CAPTURE_LOSS_POLICY in [
         warning.code for warning in result.raw_replay.warnings
     ]
 

--- a/apps/server/tests/use_cases/test_system_health.py
+++ b/apps/server/tests/use_cases/test_system_health.py
@@ -204,6 +204,7 @@ class TestBuildSystemHealthSnapshotOk:
 
         assert result["ingest"]["udp"]["max_packet_queue_age_ms"] == 20.0
         assert result["ingest"]["raw_capture"]["queue_max_depth"] == 3
+        assert result["ingest"]["raw_capture"]["pressure_state"] == "warn"
         assert result["ingest"]["ws_publish"]["active_connections"] == 1
         assert result["ingest"]["ws_publish"]["max_publish_duration_ms"] == 12.0
         assert result["ingest"]["clients"] == [
@@ -314,6 +315,26 @@ class TestBuildSystemHealthSnapshotDegraded:
         assert result["db_engine_unhealthy"] is True
         assert result["db_engine_unhealthy_reason"] == "shutdown_timeout"
         assert "db_engine_unhealthy" in result["degradation_reasons"]
+
+    def test_raw_capture_queue_overflow_is_degraded(self) -> None:
+        loop_state = ProcessingLoopState()
+        health_state = _ready_health_state()
+        registry, run_recorder = _make_deps()
+        ingest_diagnostics = IngestDiagnosticsCollector()
+        ingest_diagnostics.note_raw_capture_drop(depth=0)
+
+        result = _snapshot(
+            loop_state,
+            health_state,
+            registry,
+            run_recorder,
+            ingest_diagnostics=ingest_diagnostics,
+        )
+
+        assert result["status"] == "warn"
+        assert result["ingest"]["raw_capture"]["pressure_state"] == "warn"
+        assert result["ingest"]["raw_capture"]["dropped_chunks"] == 1
+        assert "raw_capture_dropped_chunks" in result["degradation_reasons"]
 
 
 class TestBuildSystemHealthSnapshotWarn:

--- a/apps/server/vibesensor/adapters/history/projection.py
+++ b/apps/server/vibesensor/adapters/history/projection.py
@@ -14,6 +14,7 @@ from vibesensor.shared.boundaries.runs.metadata import (
     run_metadata_from_mapping,
     run_metadata_to_json_object,
 )
+from vibesensor.shared.raw_capture_quality import assess_raw_capture_loss_policy
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
@@ -109,6 +110,10 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
         payload["artifact_availability"] = run.artifact_availability.to_json_object()
     if run.raw_capture_finalize is not None:
         payload["raw_capture_finalize"] = run.raw_capture_finalize.to_json_object()
+    if run.raw_capture_manifest is not None:
+        payload["raw_capture_quality"] = assess_raw_capture_loss_policy(
+            run.raw_capture_manifest
+        ).to_json_object()
     return _apply_projected_run_fields(
         payload,
         metadata=run.metadata,

--- a/apps/server/vibesensor/adapters/http/models/health.py
+++ b/apps/server/vibesensor/adapters/http/models/health.py
@@ -65,6 +65,7 @@ class HealthRawCaptureResponse(BaseModel):
     queue_max_depth: int
     dropped_chunks: int
     write_error_chunks: int
+    pressure_state: Literal["ok", "warn", "degraded"] = "ok"
 
 
 class HealthWsPublishResponse(BaseModel):

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -142,6 +142,22 @@ class HistoryFinalizationStageResponse(BaseModel):
     diagnostic_context: ApiPayloadObject = Field(default_factory=dict)
 
 
+class HistoryRawCaptureQualityResponse(BaseModel):
+    """Response body describing raw-capture loss policy for one run."""
+
+    severity: Literal["ok", "warn", "degraded", "fatal"]
+    reason: str
+    gate_whole_run: bool
+    affected_sensor_count: int = 0
+    queue_overflow_sensor_count: int = 0
+    total_chunk_count: int = 0
+    total_loss_event_count: int = 0
+    total_dropped_chunk_count: int = 0
+    queue_overflow_chunk_count: int = 0
+    max_sensor_drop_ratio: float = 0.0
+    max_sensor_loss_events_per_minute: float = 0.0
+
+
 class HistoryListEntryResponse(BaseModel):
     """Response body for a single history-run list row."""
 
@@ -184,6 +200,7 @@ class HistoryRunResponse(_StrictBase):
     artifact_availability: HistoryArtifactAvailabilityResponse | None = None
     raw_capture_finalize: HistoryRawCaptureFinalizeResponse | None = None
     finalization_stages: list[HistoryFinalizationStageResponse] | None = None
+    raw_capture_quality: HistoryRawCaptureQualityResponse | None = None
 
 
 class HistoryInsightWarningResponse(BaseModel):

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1807,6 +1807,14 @@
     "en": "Raw capture timing could not be proven against the recorder clock for {sensors} sensor(s), so affected metrics used persisted summary samples. Missing sync proof: {missing_sync}, stale sync snapshots: {stale}, high-RTT sync snapshots: {high_rtt}.",
     "nl": "Raw-capturetiming kon voor {sensors} sensor(en) niet tegen de recorderklok worden bewezen, dus getroffen metrieken gebruikten persistente samenvattingssamples. Ontbrekend sync-bewijs: {missing_sync}, verouderde sync-snapshots: {stale}, sync-snapshots met hoge RTT: {high_rtt}."
   },
+  "RUN_CONTEXT_WARNING_RAW_CAPTURE_LOSS_POLICY_TITLE": {
+    "en": "Raw capture loss exceeded the run-quality policy",
+    "nl": "Raw-captureverlies overschreed het kwaliteitsbeleid voor de run"
+  },
+  "RUN_CONTEXT_WARNING_RAW_CAPTURE_LOSS_POLICY_DETAIL": {
+    "en": "Raw capture loss policy is {severity} ({reason}). Affected sensors: {sensors}, raw-capture queue overflows: {queue_overflow}, dropped chunks: {dropped}, worst sensor drop ratio: {max_drop_percent}%, worst sensor loss rate: {max_events_per_minute}/min. Fatal loss disables whole-run raw-backed sidecar analysis for this run.",
+    "nl": "Het raw-captureverliesbeleid is {severity} ({reason}). Getroffen sensoren: {sensors}, raw-capture-wachtrijoverlopen: {queue_overflow}, gedropte chunks: {dropped}, slechtste sensor-dropverhouding: {max_drop_percent}%, slechtste sensor-verliesfrequentie: {max_events_per_minute}/min. Fataal verlies schakelt whole-run raw-backed sidecaranalyse uit voor deze run."
+  },
   "RUN_CONTEXT_WARNING_RAW_CAPTURE_FINALIZE_TITLE": {
     "en": "Raw capture finalization degraded before the run closed",
     "nl": "De raw-capturefinalisatie degradeerde voordat de run werd gesloten"

--- a/apps/server/vibesensor/infra/runtime/health_snapshot.py
+++ b/apps/server/vibesensor/infra/runtime/health_snapshot.py
@@ -120,13 +120,20 @@ def build_system_health_snapshot(
         degradation_reasons.append("analyzing_runs_present")
     if persistence["last_completed_run_error"]:
         degradation_reasons.append("last_analysis_failed")
-    status: Literal["ok", "warn", "degraded"] = "ok"
-    if degradation_reasons:
-        status = "degraded" if has_error else "warn"
     runtime_clients = ingest_diagnostics.client_snapshots()
     udp_snapshot = ingest_diagnostics.udp_snapshot()
     raw_capture_snapshot = ingest_diagnostics.raw_capture_snapshot()
+    if raw_capture_snapshot.dropped_chunks > 0:
+        degradation_reasons.append("raw_capture_dropped_chunks")
+    if raw_capture_snapshot.write_error_chunks > 0:
+        degradation_reasons.append("raw_capture_write_errors")
+        has_error = True
+    if raw_capture_snapshot.pressure_state != "ok":
+        degradation_reasons.append(f"raw_capture_pressure:{raw_capture_snapshot.pressure_state}")
     ws_publish_snapshot = ingest_diagnostics.ws_publish_snapshot()
+    status: Literal["ok", "warn", "degraded"] = "ok"
+    if degradation_reasons:
+        status = "degraded" if has_error else "warn"
     ingest_clients: list[IngestClientHealthSnapshot] = []
     seen_client_ids: set[str] = set()
     for client_id in registry.active_client_ids():
@@ -221,6 +228,7 @@ def build_system_health_snapshot(
                 "queue_max_depth": raw_capture_snapshot.queue_max_depth,
                 "dropped_chunks": raw_capture_snapshot.dropped_chunks,
                 "write_error_chunks": raw_capture_snapshot.write_error_chunks,
+                "pressure_state": raw_capture_snapshot.pressure_state,
             },
             "ws_publish": {
                 "active_connections": ws_publish_snapshot.active_connections,

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -477,6 +477,12 @@ def _whole_run_diagnosis_fallback_reason(
     analysis_metadata = payload.get("analysis_metadata")
     if not isinstance(analysis_metadata, Mapping):
         return "analysis metadata missing; replayed summary-era evidence"
+    loss_policy_severity = text_or_none(analysis_metadata.get("raw_capture_loss_policy_severity"))
+    if loss_policy_severity == "fatal":
+        return (
+            text_or_none(analysis_metadata.get("raw_capture_loss_policy_reason"))
+            or "raw_capture_loss_policy_fatal"
+        )
     raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
     raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
     if raw_capture_mode == "summary_only" or raw_backed_sample_count <= 0:

--- a/apps/server/vibesensor/shared/ingest_diagnostics.py
+++ b/apps/server/vibesensor/shared/ingest_diagnostics.py
@@ -45,6 +45,7 @@ class RawCaptureRuntimeSnapshot:
     queue_max_depth: int = 0
     dropped_chunks: int = 0
     write_error_chunks: int = 0
+    pressure_state: str = "ok"
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,6 +226,12 @@ class IngestDiagnosticsCollector:
                 queue_max_depth=self._raw_capture_max_depth,
                 dropped_chunks=self._raw_capture_dropped_chunks,
                 write_error_chunks=self._raw_capture_write_error_chunks,
+                pressure_state=_raw_capture_pressure_state(
+                    queue_depth=self._raw_capture_current_depth,
+                    queue_max_depth=self._raw_capture_max_depth,
+                    dropped_chunks=self._raw_capture_dropped_chunks,
+                    write_error_chunks=self._raw_capture_write_error_chunks,
+                ),
             )
 
     def ws_publish_snapshot(self) -> WsPublishRuntimeSnapshot:
@@ -249,3 +256,17 @@ class IngestDiagnosticsCollector:
                 )
                 for client_id, state in self._clients.items()
             }
+
+
+def _raw_capture_pressure_state(
+    *,
+    queue_depth: int,
+    queue_max_depth: int,
+    dropped_chunks: int,
+    write_error_chunks: int,
+) -> str:
+    if write_error_chunks > 0 or dropped_chunks >= 10:
+        return "degraded"
+    if dropped_chunks > 0 or queue_depth > 0 or queue_max_depth >= 1024:
+        return "warn"
+    return "ok"

--- a/apps/server/vibesensor/shared/ingest_diagnostics.py
+++ b/apps/server/vibesensor/shared/ingest_diagnostics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from threading import RLock
+from typing import Literal
 
 __all__ = [
     "ClientIngestRuntimeSnapshot",
@@ -10,6 +11,8 @@ __all__ = [
     "UdpIngestRuntimeSnapshot",
     "WsPublishRuntimeSnapshot",
 ]
+
+type RawCapturePressureState = Literal["ok", "warn", "degraded"]
 
 
 def _ms(value_s: float) -> float:
@@ -45,7 +48,7 @@ class RawCaptureRuntimeSnapshot:
     queue_max_depth: int = 0
     dropped_chunks: int = 0
     write_error_chunks: int = 0
-    pressure_state: str = "ok"
+    pressure_state: RawCapturePressureState = "ok"
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,7 +267,7 @@ def _raw_capture_pressure_state(
     queue_max_depth: int,
     dropped_chunks: int,
     write_error_chunks: int,
-) -> str:
+) -> RawCapturePressureState:
     if write_error_chunks > 0 or dropped_chunks >= 10:
         return "degraded"
     if dropped_chunks > 0 or queue_depth > 0 or queue_max_depth >= 1024:

--- a/apps/server/vibesensor/shared/raw_capture_quality.py
+++ b/apps/server/vibesensor/shared/raw_capture_quality.py
@@ -1,0 +1,188 @@
+"""Raw-capture loss policy used by history, reports, and post-analysis gating."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureManifest,
+    RawCaptureSensorLossStats,
+)
+
+type RawCaptureLossPolicySeverity = Literal["ok", "warn", "degraded", "fatal"]
+
+_DEGRADED_SENSOR_DROP_RATIO = 0.01
+_FATAL_SENSOR_DROP_RATIO = 0.05
+_DEGRADED_LOSS_EVENTS_PER_MINUTE = 3.0
+_FATAL_LOSS_EVENTS_PER_MINUTE = 30.0
+_DEGRADED_QUEUE_OVERFLOW_CHUNKS = 10
+_FATAL_QUEUE_OVERFLOW_CHUNKS = 100
+_MIN_LOSS_RATE_DURATION_S = 60.0
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureLossPolicyAssessment:
+    """Compact policy result for persisted raw-capture loss counters."""
+
+    severity: RawCaptureLossPolicySeverity
+    reason: str
+    gate_whole_run: bool
+    affected_sensor_count: int
+    queue_overflow_sensor_count: int
+    total_chunk_count: int
+    total_loss_event_count: int
+    total_dropped_chunk_count: int
+    queue_overflow_chunk_count: int
+    max_sensor_drop_ratio: float
+    max_sensor_loss_events_per_minute: float
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "severity": self.severity,
+            "reason": self.reason,
+            "gate_whole_run": self.gate_whole_run,
+            "affected_sensor_count": self.affected_sensor_count,
+            "queue_overflow_sensor_count": self.queue_overflow_sensor_count,
+            "total_chunk_count": self.total_chunk_count,
+            "total_loss_event_count": self.total_loss_event_count,
+            "total_dropped_chunk_count": self.total_dropped_chunk_count,
+            "queue_overflow_chunk_count": self.queue_overflow_chunk_count,
+            "max_sensor_drop_ratio": round(self.max_sensor_drop_ratio, 6),
+            "max_sensor_loss_events_per_minute": round(
+                self.max_sensor_loss_events_per_minute,
+                3,
+            ),
+        }
+
+
+def assess_raw_capture_loss_policy(
+    manifest: RawCaptureManifest | None,
+) -> RawCaptureLossPolicyAssessment:
+    """Classify raw-capture loss against stable per-sensor/run-duration thresholds."""
+    if manifest is None:
+        return RawCaptureLossPolicyAssessment(
+            severity="ok",
+            reason="raw_capture_not_available",
+            gate_whole_run=False,
+            affected_sensor_count=0,
+            queue_overflow_sensor_count=0,
+            total_chunk_count=0,
+            total_loss_event_count=0,
+            total_dropped_chunk_count=0,
+            queue_overflow_chunk_count=0,
+            max_sensor_drop_ratio=0.0,
+            max_sensor_loss_events_per_minute=0.0,
+        )
+    sensor_durations = {
+        sensor.client_id: _sensor_duration_s(
+            sample_count=sensor.sample_count,
+            sample_rate_hz=sensor.sample_rate_hz,
+            first_t0_us=sensor.first_t0_us,
+            last_t0_us=sensor.last_t0_us,
+        )
+        for sensor in manifest.sensors
+    }
+    sensor_chunk_counts = {
+        sensor.client_id: max(0, int(sensor.chunk_count)) for sensor in manifest.sensors
+    }
+    affected_sensor_count = 0
+    queue_overflow_sensor_count = 0
+    max_sensor_drop_ratio = 0.0
+    max_sensor_loss_events_per_minute = 0.0
+    for sensor_loss in manifest.sensor_losses:
+        if sensor_loss.total_loss_event_count <= 0:
+            continue
+        affected_sensor_count += 1
+        if sensor_loss.losses.queue_overflow_chunk_count > 0:
+            queue_overflow_sensor_count += 1
+        max_sensor_drop_ratio = max(
+            max_sensor_drop_ratio,
+            _sensor_drop_ratio(sensor_loss, sensor_chunk_counts.get(sensor_loss.client_id, 0)),
+        )
+        max_sensor_loss_events_per_minute = max(
+            max_sensor_loss_events_per_minute,
+            _loss_events_per_minute(
+                sensor_loss.total_loss_event_count,
+                sensor_durations.get(sensor_loss.client_id),
+            ),
+        )
+    total_chunk_count = manifest.total_chunk_count
+    total_loss_event_count = manifest.total_loss_event_count
+    total_dropped_chunk_count = manifest.total_dropped_chunk_count
+    queue_overflow_chunk_count = manifest.losses.queue_overflow_chunk_count
+    severity, reason = _classify_loss(
+        total_loss_event_count=total_loss_event_count,
+        queue_overflow_chunk_count=queue_overflow_chunk_count,
+        write_error_chunk_count=manifest.losses.write_error_chunk_count,
+        max_sensor_drop_ratio=max_sensor_drop_ratio,
+        max_sensor_loss_events_per_minute=max_sensor_loss_events_per_minute,
+    )
+    return RawCaptureLossPolicyAssessment(
+        severity=severity,
+        reason=reason,
+        gate_whole_run=severity == "fatal",
+        affected_sensor_count=affected_sensor_count,
+        queue_overflow_sensor_count=queue_overflow_sensor_count,
+        total_chunk_count=total_chunk_count,
+        total_loss_event_count=total_loss_event_count,
+        total_dropped_chunk_count=total_dropped_chunk_count,
+        queue_overflow_chunk_count=queue_overflow_chunk_count,
+        max_sensor_drop_ratio=max_sensor_drop_ratio,
+        max_sensor_loss_events_per_minute=max_sensor_loss_events_per_minute,
+    )
+
+
+def _classify_loss(
+    *,
+    total_loss_event_count: int,
+    queue_overflow_chunk_count: int,
+    write_error_chunk_count: int,
+    max_sensor_drop_ratio: float,
+    max_sensor_loss_events_per_minute: float,
+) -> tuple[RawCaptureLossPolicySeverity, str]:
+    if total_loss_event_count <= 0:
+        return "ok", "raw_capture_loss_ok"
+    if (
+        max_sensor_drop_ratio >= _FATAL_SENSOR_DROP_RATIO
+        or max_sensor_loss_events_per_minute >= _FATAL_LOSS_EVENTS_PER_MINUTE
+        or queue_overflow_chunk_count >= _FATAL_QUEUE_OVERFLOW_CHUNKS
+    ):
+        return "fatal", "raw_capture_queue_overflow_fatal"
+    if (
+        max_sensor_drop_ratio >= _DEGRADED_SENSOR_DROP_RATIO
+        or max_sensor_loss_events_per_minute >= _DEGRADED_LOSS_EVENTS_PER_MINUTE
+        or queue_overflow_chunk_count >= _DEGRADED_QUEUE_OVERFLOW_CHUNKS
+        or write_error_chunk_count > 0
+    ):
+        return "degraded", "raw_capture_loss_degraded"
+    return "warn", "raw_capture_loss_warn"
+
+
+def _sensor_drop_ratio(sensor_loss: RawCaptureSensorLossStats, chunk_count: int) -> float:
+    dropped = max(0, int(sensor_loss.total_dropped_chunk_count))
+    denominator = max(0, int(chunk_count)) + dropped
+    if denominator <= 0:
+        return 0.0
+    return dropped / float(denominator)
+
+
+def _loss_events_per_minute(loss_event_count: int, duration_s: float | None) -> float:
+    if duration_s is None or duration_s < _MIN_LOSS_RATE_DURATION_S:
+        return 0.0
+    return max(0, int(loss_event_count)) / (duration_s / 60.0)
+
+
+def _sensor_duration_s(
+    *,
+    sample_count: int,
+    sample_rate_hz: int,
+    first_t0_us: int | None,
+    last_t0_us: int | None,
+) -> float | None:
+    if sample_count > 0 and sample_rate_hz > 0:
+        return max(0.0, float(sample_count) / float(sample_rate_hz))
+    if first_t0_us is not None and last_t0_us is not None and last_t0_us >= first_t0_us:
+        return max(0.0, (last_t0_us - first_t0_us) / 1_000_000.0)
+    return None

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -21,6 +21,7 @@ WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS = "raw_replay_dropped_chunks"
 WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK = "raw_replay_timing_fallback"
 WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE = "raw_replay_fft_unusable"
 WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED = "raw_replay_sync_unverified"
+WARNING_CODE_RAW_CAPTURE_LOSS_POLICY = "raw_capture_loss_policy"
 WARNING_CODE_RAW_CAPTURE_FINALIZE_DEGRADED = "raw_capture_finalize_degraded"
 WarningSeverity = Literal["warn", "error"]
 

--- a/apps/server/vibesensor/shared/types/health_snapshot.py
+++ b/apps/server/vibesensor/shared/types/health_snapshot.py
@@ -43,6 +43,7 @@ class RawCaptureQueueHealthSnapshot(TypedDict):
     queue_max_depth: int
     dropped_chunks: int
     write_error_chunks: int
+    pressure_state: Literal["ok", "warn", "degraded"]
 
 
 class WsPublishHealthSnapshot(TypedDict):

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -69,6 +69,9 @@ from vibesensor.use_cases.run.post_analysis_outcomes import (
     PostAnalysisExecutionSuccess,
     is_retryable_post_analysis_error,
 )
+from vibesensor.use_cases.run.post_analysis_raw_capture_policy import (
+    assess_whole_run_raw_capture_policy,
+)
 from vibesensor.use_cases.run.post_analysis_whole_run_builders import (
     build_whole_run_artifacts,
     build_whole_run_context_artifacts,
@@ -663,6 +666,7 @@ def run_whole_run_pipeline_stages(
     order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
     spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
     stored_artifact_manifest: WholeRunArtifactManifest | None = None
+    raw_capture_policy = assess_whole_run_raw_capture_policy(loaded)
 
     def record_stage[ResultT](
         *,
@@ -721,7 +725,7 @@ def run_whole_run_pipeline_stages(
         )
 
     def build_context_stage() -> WholeRunStageExecution[WholeRunContextArtifactBundle | None]:
-        raw_capture_manifest = loaded.raw_capture_manifest
+        raw_capture_manifest = raw_capture_policy.manifest
         assert raw_capture_manifest is not None
         if spectral_result is not None and spectral_result.window_plan is not None:
             bundle = builders.context_builder(
@@ -748,16 +752,15 @@ def run_whole_run_pipeline_stages(
 
     spectral_result = record_stage(
         stage_name="BuildWholeRunSpectraStage",
-        prerequisites_met=loaded.raw_capture is not None,
-        prerequisite_reason="raw_capture_missing",
+        prerequisites_met=raw_capture_policy.spectra_prerequisites_met(loaded.raw_capture),
+        prerequisite_reason=raw_capture_policy.spectra_prerequisite_reason(loaded.raw_capture),
         runner=build_spectral_stage,
     )
     spectral_bundle = spectral_result.bundle if spectral_result is not None else None
-
     context_bundle = record_stage(
         stage_name="BuildWholeRunContextStage",
-        prerequisites_met=loaded.raw_capture_manifest is not None,
-        prerequisite_reason="raw_capture_manifest_missing",
+        prerequisites_met=raw_capture_policy.context_prerequisites_met(),
+        prerequisite_reason=raw_capture_policy.context_prerequisite_reason(),
         runner=build_context_stage,
     )
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_raw_capture_policy.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_raw_capture_policy.py
@@ -1,0 +1,53 @@
+"""Raw-capture quality helpers for post-analysis whole-run stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.shared.raw_capture_quality import (
+    RawCaptureLossPolicyAssessment,
+    assess_raw_capture_loss_policy,
+)
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+
+from .post_analysis_loader import LoadedPostAnalysisRun
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunRawCapturePolicy:
+    manifest: RawCaptureManifest | None
+    loss_policy: RawCaptureLossPolicyAssessment
+
+    @property
+    def whole_run_allowed(self) -> bool:
+        return not self.loss_policy.gate_whole_run
+
+    @property
+    def prerequisite_reason(self) -> str:
+        return (
+            self.loss_policy.reason if self.loss_policy.gate_whole_run else "missing_prerequisites"
+        )
+
+    def spectra_prerequisites_met(self, raw_capture: RawRunCapture | None) -> bool:
+        return raw_capture is not None and self.whole_run_allowed
+
+    def spectra_prerequisite_reason(self, raw_capture: RawRunCapture | None) -> str:
+        return "raw_capture_missing" if raw_capture is None else self.prerequisite_reason
+
+    def context_prerequisites_met(self) -> bool:
+        return self.manifest is not None and self.whole_run_allowed
+
+    def context_prerequisite_reason(self) -> str:
+        return "raw_capture_manifest_missing" if self.manifest is None else self.prerequisite_reason
+
+
+def assess_whole_run_raw_capture_policy(
+    loaded: LoadedPostAnalysisRun,
+) -> WholeRunRawCapturePolicy:
+    manifest = loaded.raw_capture_manifest or (
+        loaded.raw_capture.manifest if loaded.raw_capture is not None else None
+    )
+    return WholeRunRawCapturePolicy(
+        manifest=manifest,
+        loss_policy=assess_raw_capture_loss_policy(manifest),
+    )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -97,6 +97,17 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_queue_overflow_chunk_count": run.raw_replay.queue_overflow_chunk_count,
         "raw_replay_invalid_chunk_count": run.raw_replay.invalid_chunk_count,
         "raw_replay_write_error_chunk_count": run.raw_replay.write_error_chunk_count,
+        "raw_capture_loss_policy_severity": run.raw_replay.raw_capture_loss_policy_severity,
+        "raw_capture_loss_policy_reason": run.raw_replay.raw_capture_loss_policy_reason,
+        "raw_capture_loss_policy_gate_whole_run": (
+            run.raw_replay.raw_capture_loss_policy_gate_whole_run
+        ),
+        "raw_capture_loss_policy_max_sensor_drop_ratio": (
+            run.raw_replay.raw_capture_loss_policy_max_sensor_drop_ratio
+        ),
+        "raw_capture_loss_policy_max_events_per_minute": (
+            run.raw_replay.raw_capture_loss_policy_max_events_per_minute
+        ),
         "raw_replay_timing_fallback_count": run.raw_replay.timing_fallback_count,
         "raw_replay_sample_rate_mismatch_count": run.raw_replay.sample_rate_mismatch_count,
         "raw_replay_fft_unusable_window_count": run.raw_replay.fft_unusable_window_count,

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -13,6 +13,10 @@ from vibesensor.shared.boundaries.codecs import strength_metrics_from_mapping
 from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
 from vibesensor.shared.fft_analysis import SpectralAnalysisComputer, medfilt3
 from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.raw_capture_quality import (
+    RawCaptureLossPolicyAssessment,
+    assess_raw_capture_loss_policy,
+)
 from vibesensor.shared.raw_capture_timeline import (
     RawSensorTimeline,
     RawWindowSegment,
@@ -23,6 +27,7 @@ from vibesensor.shared.raw_capture_timeline import (
     resolve_raw_window_end_time,
 )
 from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_CAPTURE_LOSS_POLICY,
     WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
     WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
@@ -85,6 +90,11 @@ class RawReplaySummary:
     high_rtt_sensor_count: int
     replay_confidence: RawReplayConfidence
     raw_capture_mode: str
+    raw_capture_loss_policy_severity: str = "ok"
+    raw_capture_loss_policy_reason: str = "raw_capture_loss_ok"
+    raw_capture_loss_policy_gate_whole_run: bool = False
+    raw_capture_loss_policy_max_sensor_drop_ratio: float = 0.0
+    raw_capture_loss_policy_max_events_per_minute: float = 0.0
     udp_ingest_queue_drop_count: int = 0
     warnings: tuple[RunContextWarning, ...] = ()
 
@@ -164,46 +174,7 @@ def build_raw_backed_samples(
         )
     fft_n = int(metadata.fft_window_size_samples or 0)
     if fft_n <= 0:
-        return RawReplayResult(
-            samples=samples,
-            summary=RawReplaySummary(
-                raw_capture_available=True,
-                raw_backed_summary_row_count=0,
-                replay_window_count=len(samples),
-                complete_window_count=0,
-                partial_window_count=0,
-                missing_window_count=len(samples),
-                gap_count=0,
-                overlap_count=0,
-                dropped_chunk_count=0,
-                late_packet_chunk_count=0,
-                queue_overflow_chunk_count=0,
-                invalid_chunk_count=0,
-                write_error_chunk_count=0,
-                timing_fallback_count=0,
-                sample_rate_mismatch_count=0,
-                fft_unusable_window_count=0,
-                sample_rate_unverified_sensor_count=0,
-                unanchored_sensor_count=0,
-                legacy_sensor_count=0,
-                sync_unverified_sensor_count=0,
-                stale_sync_sensor_count=0,
-                high_rtt_sensor_count=0,
-                replay_confidence="fallback",
-                raw_capture_mode="summary_only",
-                udp_ingest_queue_drop_count=0,
-            ),
-            window_coverages=tuple(
-                RawReplayWindowCoverage(
-                    client_id=sample.client_id,
-                    t_s=sample.t_s,
-                    coverage_state="missing",
-                    raw_backed=False,
-                    reason="fft_window_missing",
-                )
-                for sample in samples
-            ),
-        )
+        return _build_fft_unavailable_replay_result(samples=samples, raw_capture=raw_capture)
     timelines = {
         sensor.manifest.client_id: _build_sensor_timeline(
             raw_capture, sensor_id=sensor.manifest.client_id
@@ -270,6 +241,7 @@ def build_raw_backed_samples(
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
     late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
+    loss_policy = assess_raw_capture_loss_policy(raw_capture.manifest)
     udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
@@ -321,6 +293,13 @@ def build_raw_backed_samples(
             high_rtt_sensor_count=high_rtt_sensor_count,
             replay_confidence=replay_confidence,
             raw_capture_mode=raw_capture_mode,
+            raw_capture_loss_policy_severity=loss_policy.severity,
+            raw_capture_loss_policy_reason=loss_policy.reason,
+            raw_capture_loss_policy_gate_whole_run=loss_policy.gate_whole_run,
+            raw_capture_loss_policy_max_sensor_drop_ratio=(loss_policy.max_sensor_drop_ratio),
+            raw_capture_loss_policy_max_events_per_minute=(
+                loss_policy.max_sensor_loss_events_per_minute
+            ),
             udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
             warnings=_build_replay_warnings(
                 raw_backed_summary_row_count=raw_backed_count,
@@ -343,6 +322,7 @@ def build_raw_backed_samples(
                 sync_unverified_sensor_count=sync_unverified_sensor_count,
                 stale_sync_sensor_count=stale_sync_sensor_count,
                 high_rtt_sensor_count=high_rtt_sensor_count,
+                loss_policy=loss_policy,
             ),
         ),
         window_coverages=tuple(coverages),
@@ -507,6 +487,90 @@ def _rebuild_sample(
     )
 
 
+def _build_fft_unavailable_replay_result(
+    *,
+    samples: tuple[SensorFrame, ...],
+    raw_capture: RawRunCapture,
+) -> RawReplayResult:
+    loss_policy = assess_raw_capture_loss_policy(raw_capture.manifest)
+    dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
+    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
+    queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
+    invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
+    write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
+    return RawReplayResult(
+        samples=samples,
+        summary=RawReplaySummary(
+            raw_capture_available=True,
+            raw_backed_summary_row_count=0,
+            replay_window_count=len(samples),
+            complete_window_count=0,
+            partial_window_count=0,
+            missing_window_count=len(samples),
+            gap_count=0,
+            overlap_count=0,
+            dropped_chunk_count=dropped_chunk_count,
+            late_packet_chunk_count=late_packet_chunk_count,
+            queue_overflow_chunk_count=queue_overflow_chunk_count,
+            invalid_chunk_count=invalid_chunk_count,
+            write_error_chunk_count=write_error_chunk_count,
+            timing_fallback_count=0,
+            sample_rate_mismatch_count=0,
+            fft_unusable_window_count=0,
+            sample_rate_unverified_sensor_count=0,
+            unanchored_sensor_count=0,
+            legacy_sensor_count=0,
+            sync_unverified_sensor_count=0,
+            stale_sync_sensor_count=0,
+            high_rtt_sensor_count=0,
+            replay_confidence="fallback",
+            raw_capture_mode="summary_only",
+            raw_capture_loss_policy_severity=loss_policy.severity,
+            raw_capture_loss_policy_reason=loss_policy.reason,
+            raw_capture_loss_policy_gate_whole_run=loss_policy.gate_whole_run,
+            raw_capture_loss_policy_max_sensor_drop_ratio=loss_policy.max_sensor_drop_ratio,
+            raw_capture_loss_policy_max_events_per_minute=(
+                loss_policy.max_sensor_loss_events_per_minute
+            ),
+            udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
+            warnings=_build_replay_warnings(
+                raw_backed_summary_row_count=0,
+                timing_fallback_count=0,
+                partial_window_count=0,
+                missing_window_count=len(samples),
+                gap_count=0,
+                overlap_count=0,
+                dropped_chunk_count=dropped_chunk_count,
+                late_packet_chunk_count=late_packet_chunk_count,
+                udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
+                queue_overflow_chunk_count=queue_overflow_chunk_count,
+                invalid_chunk_count=invalid_chunk_count,
+                write_error_chunk_count=write_error_chunk_count,
+                sample_rate_mismatch_count=0,
+                fft_unusable_window_count=0,
+                sample_rate_unverified_sensor_count=0,
+                legacy_sensor_count=0,
+                unanchored_sensor_count=0,
+                sync_unverified_sensor_count=0,
+                stale_sync_sensor_count=0,
+                high_rtt_sensor_count=0,
+                loss_policy=loss_policy,
+            ),
+        ),
+        window_coverages=tuple(
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="fft_window_missing",
+            )
+            for sample in samples
+        ),
+    )
+
+
 def _build_fft_computer(metadata: RunMetadata) -> SpectralAnalysisComputer:
     return SpectralAnalysisComputer(
         fft_n=int(metadata.fft_window_size_samples or 0),
@@ -627,6 +691,7 @@ def _build_replay_warnings(
     sync_unverified_sensor_count: int,
     stale_sync_sensor_count: int,
     high_rtt_sensor_count: int,
+    loss_policy: RawCaptureLossPolicyAssessment | None = None,
 ) -> tuple[RunContextWarning, ...]:
     if legacy_sensor_count > 0 and raw_backed_summary_row_count <= 0:
         return (
@@ -712,6 +777,27 @@ def _build_replay_warnings(
                     queue_overflow=str(max(0, queue_overflow_chunk_count)),
                     invalid=str(max(0, invalid_chunk_count)),
                     write_errors=str(max(0, write_error_chunk_count)),
+                ),
+            )
+        )
+    if loss_policy is not None and loss_policy.severity in {"degraded", "fatal"}:
+        max_drop_percent = max(0.0, loss_policy.max_sensor_drop_ratio) * 100.0
+        max_events_per_minute = max(0.0, loss_policy.max_sensor_loss_events_per_minute)
+        warnings.append(
+            RunContextWarning(
+                code=WARNING_CODE_RAW_CAPTURE_LOSS_POLICY,
+                severity="error" if loss_policy.severity == "fatal" else "warn",
+                applies_to="raw_capture",
+                title=i18n_ref("RUN_CONTEXT_WARNING_RAW_CAPTURE_LOSS_POLICY_TITLE"),
+                detail=i18n_ref(
+                    "RUN_CONTEXT_WARNING_RAW_CAPTURE_LOSS_POLICY_DETAIL",
+                    severity=loss_policy.severity,
+                    reason=loss_policy.reason,
+                    sensors=str(max(0, int(loss_policy.affected_sensor_count))),
+                    queue_overflow=str(max(0, queue_overflow_chunk_count)),
+                    dropped=str(max(0, dropped_chunk_count)),
+                    max_drop_percent=f"{max_drop_percent:.2f}",
+                    max_events_per_minute=f"{max_events_per_minute:.2f}",
                 ),
             )
         )

--- a/apps/ui/src/api/update_validators.ts
+++ b/apps/ui/src/api/update_validators.ts
@@ -16,6 +16,7 @@ const nullableFiniteNumberSchema = v.nullable(finiteNumberSchema);
 const updateStateSchema = v.picklist(["idle", "running", "success", "failed"]);
 const updateTransportSchema = v.picklist(["wifi", "usb_internet"]);
 const healthStatusSchema = v.picklist(["ok", "warn", "degraded"]);
+const rawCapturePressureStateSchema = v.picklist(["ok", "warn", "degraded"]);
 
 const stringMapSchema = v.record(v.string(), v.string());
 const integerMapSchema = v.record(v.string(), integerSchema);
@@ -116,6 +117,7 @@ const healthUdpIngestSchema = v.looseObject({
 
 const healthRawCaptureSchema = v.looseObject({
   dropped_chunks: integerSchema,
+  pressure_state: rawCapturePressureStateSchema,
   queue_depth: integerSchema,
   queue_max_depth: integerSchema,
   write_error_chunks: integerSchema,

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -3808,6 +3808,16 @@
             "title": "Dropped Chunks",
             "type": "integer"
           },
+          "pressure_state": {
+            "default": "ok",
+            "enum": [
+              "ok",
+              "warn",
+              "degraded"
+            ],
+            "title": "Pressure State",
+            "type": "string"
+          },
           "queue_depth": {
             "title": "Queue Depth",
             "type": "integer"
@@ -4789,6 +4799,76 @@
         "title": "HistoryRawCaptureFinalizeResponse",
         "type": "object"
       },
+      "HistoryRawCaptureQualityResponse": {
+        "description": "Response body describing raw-capture loss policy for one run.",
+        "properties": {
+          "affected_sensor_count": {
+            "default": 0,
+            "title": "Affected Sensor Count",
+            "type": "integer"
+          },
+          "gate_whole_run": {
+            "title": "Gate Whole Run",
+            "type": "boolean"
+          },
+          "max_sensor_drop_ratio": {
+            "default": 0.0,
+            "title": "Max Sensor Drop Ratio",
+            "type": "number"
+          },
+          "max_sensor_loss_events_per_minute": {
+            "default": 0.0,
+            "title": "Max Sensor Loss Events Per Minute",
+            "type": "number"
+          },
+          "queue_overflow_chunk_count": {
+            "default": 0,
+            "title": "Queue Overflow Chunk Count",
+            "type": "integer"
+          },
+          "queue_overflow_sensor_count": {
+            "default": 0,
+            "title": "Queue Overflow Sensor Count",
+            "type": "integer"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "ok",
+              "warn",
+              "degraded",
+              "fatal"
+            ],
+            "title": "Severity",
+            "type": "string"
+          },
+          "total_chunk_count": {
+            "default": 0,
+            "title": "Total Chunk Count",
+            "type": "integer"
+          },
+          "total_dropped_chunk_count": {
+            "default": 0,
+            "title": "Total Dropped Chunk Count",
+            "type": "integer"
+          },
+          "total_loss_event_count": {
+            "default": 0,
+            "title": "Total Loss Event Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "severity",
+          "reason",
+          "gate_whole_run"
+        ],
+        "title": "HistoryRawCaptureQualityResponse",
+        "type": "object"
+      },
       "HistoryRunLifecycleResponse": {
         "description": "Response body describing the canonical derived lifecycle for a history run.",
         "properties": {
@@ -4921,6 +5001,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/HistoryRawCaptureFinalizeResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "raw_capture_quality": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HistoryRawCaptureQualityResponse"
               },
               {
                 "type": "null"

--- a/apps/ui/tests/maintenance_payload_test_support.ts
+++ b/apps/ui/tests/maintenance_payload_test_support.ts
@@ -98,6 +98,7 @@ export function createHealthyUpdateStatus(
         queue_depth: 0,
         queue_max_depth: 0,
         dropped_chunks: 0,
+        pressure_state: "ok",
         write_error_chunks: 0,
       },
       ws_publish: {

--- a/tools/dev/maintainability_allowlist.yml
+++ b/tools/dev/maintainability_allowlist.yml
@@ -8,8 +8,8 @@ files:
     max_lines: 2612
     reason: Static guard collection retained as one entrypoint until guard modules are split.
   apps/server/vibesensor/use_cases/run/post_analysis_executor.py:
-    max_lines: 1246
-    reason: Whole-run post-analysis orchestration retained until stage runner extraction.
+    max_lines: 1250
+    reason: Whole-run post-analysis orchestration retained until stage runner extraction; raw-capture quality gating is centralized but still adds stage wiring.
   apps/server/tests/adapters/pdf/test_report_document_projection.py:
     max_lines: 1217
     reason: High-density report projection regression matrix kept together by document-output seam.
@@ -24,8 +24,8 @@ functions:
     max_lines: 281
     reason: Contract sync and UI validation entrypoint guards stay together until workflow/config checks are split.
   apps/server/vibesensor/use_cases/run/post_analysis_executor.py::run_whole_run_pipeline_stages:
-    max_lines: 228
-    reason: Whole-run stage orchestration retained until table-driven stage runner extraction.
+    max_lines: 229
+    reason: Whole-run stage orchestration retained until table-driven stage runner extraction; raw-capture quality gating is kept at the stage prerequisite seam.
   apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py::_appendix_c_page:
     max_lines: 367
     reason: Dense appendix drawing routine retained until PDF rendering is split into smaller layout helpers.


### PR DESCRIPTION
Fixes #3650.

What changed:
- Added shared raw-capture loss policy with warn/degraded/fatal classification.
- Persisted policy facts into raw replay and post-analysis metadata.
- Gate whole-run sidecar stages on fatal raw-capture loss.
- Surface raw-capture quality in history details, reports, and health pressure state.
- Updated HTTP contract and frontend health validator fixture.

Why:
- Queue overflow and raw-capture loss were counted, but not first-class enough for analysis gating, history, health, or report fallback decisions.

Validation:
- make ui-typecheck
- pytest: raw-capture policy/replay/summary/executor/report/health/history focused suite, 80 passed
- tools/dev/check_hygiene.py
- tools/tests/plan_validation.py --json-only
- make lint
- git diff --check

Risks / tradeoffs / edge cases:
- Thresholds are compact policy defaults: fatal at >=100 queue-overflow chunks, degraded at >=10, plus sensor drop ratio and sustained loss-rate checks.
- Loss-rate checks ignore runs shorter than 60 seconds so tiny runs do not become fatal from small absolute counts.
- History list stays unchanged; raw_capture_quality is detail-only because detail records have the manifest.

Follow-ups:
- Tune thresholds later if real capture data shows different operational bands.