### PR TITLE
Add explicit report fallback reason codes

### DIFF
--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -13,11 +13,13 @@ from typing import Any, cast
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
+from vibesensor.adapters.history.projection import project_history_run_record
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_from_mapping
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.types.history_records import StoredHistoryRun
+from vibesensor.shared.types.run_lifecycle import RunArtifactLifecycle
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.report_cache import (
@@ -75,9 +77,55 @@ def _stored_run(run: dict[str, Any]) -> StoredHistoryRun:
         ),
         analysis_corrupt=bool(run.get("analysis_corrupt", False)),
         error_message=cast(str | None, run.get("error_message")),
+        lifecycle=cast(RunArtifactLifecycle | None, run.get("lifecycle")),
         analysis_started_at=cast(str | None, run.get("analysis_started_at")),
         analysis_completed_at=cast(str | None, run.get("analysis_completed_at")),
     )
+
+
+def test_project_history_run_record_exposes_pending_fallback_reason() -> None:
+    run = _stored_run(
+        {
+            "run_id": "pending-run",
+            "status": "analyzing",
+            "analysis": None,
+            "lifecycle": RunArtifactLifecycle(
+                stage="post_analysis_running",
+                raw_capture="ready",
+                whole_run_artifacts="pending",
+                post_analysis="running",
+                report="pending",
+            ),
+        }
+    )
+
+    payload = project_history_run_record(run)
+
+    assert payload["fallback_reasons"] == ["whole_run_analysis_pending"]
+
+
+def test_project_history_run_record_exposes_analysis_fallback_reasons() -> None:
+    run = _stored_run(
+        {
+            "run_id": "analysis-run",
+            "status": "complete",
+            "analysis": {
+                "run_id": "analysis-run",
+                "lang": "en",
+                "findings": [],
+                "top_causes": [],
+                "analysis_metadata": {
+                    "raw_capture_mode": "summary_only",
+                    "raw_backed_sample_count": 0,
+                },
+            },
+        }
+    )
+
+    payload = project_history_run_record(run)
+
+    assert payload["fallback_reasons"] == ["legacy_summary_only"]
+    assert payload["analysis"]["analysis_metadata"]["fallback_reasons"] == ["legacy_summary_only"]
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
@@ -116,7 +116,8 @@ def test_prepare_persisted_report_input_builds_summary_only_fallback_diagnosis_s
     assert len(diagnosis) == 1
     assert diagnosis[0].data_basis == "summary_only"
     assert diagnosis[0].uses_summary_fallback is True
-    assert diagnosis[0].fallback_reason == "summary-only legacy confidence"
+    assert diagnosis[0].fallback_reason == "legacy_summary_only"
+    assert prepared.report_facts.fallback_reasons == ("legacy_summary_only",)
     assert {factor.factor_key for factor in diagnosis[0].counterevidence_factors} >= {
         "summary_only",
         "close_alternative",
@@ -198,7 +199,11 @@ def test_prepare_persisted_report_input_uses_fatal_raw_capture_loss_policy_reaso
     diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
 
     assert len(diagnosis) == 1
-    assert diagnosis[0].fallback_reason == "raw_capture_queue_overflow_fatal"
+    assert diagnosis[0].fallback_reason == "raw_capture_loss_exceeded"
+    assert prepared.report_facts.fallback_reasons == (
+        "raw_capture_loss_exceeded",
+        "whole_run_evidence_missing",
+    )
 
 
 def test_prepare_persisted_report_input_builds_raw_backed_legacy_fallback_diagnosis_summary() -> (
@@ -216,10 +221,8 @@ def test_prepare_persisted_report_input_builds_raw_backed_legacy_fallback_diagno
     assert len(diagnosis) == 1
     assert diagnosis[0].data_basis == "raw_backed"
     assert diagnosis[0].uses_summary_fallback is True
-    assert (
-        diagnosis[0].fallback_reason
-        == "whole-run artifacts unavailable; replayed summary-era evidence"
-    )
+    assert diagnosis[0].fallback_reason == "whole_run_evidence_missing"
+    assert prepared.report_facts.fallback_reasons == ("whole_run_evidence_missing",)
     assert diagnosis[0].location_proof_basis == "supporting_windows_raw_backed"
     assert "summary_only" not in {
         factor.factor_key for factor in diagnosis[0].counterevidence_factors
@@ -267,10 +270,8 @@ def test_prepare_persisted_report_input_marks_partial_whole_run_inputs_as_incomp
 
     assert len(diagnosis) == 1
     assert diagnosis[0].uses_summary_fallback is True
-    assert (
-        diagnosis[0].fallback_reason
-        == "whole-run diagnosis inputs incomplete; replayed summary-era evidence"
-    )
+    assert diagnosis[0].fallback_reason == "whole_run_evidence_incomplete"
+    assert prepared.report_facts.fallback_reasons == ("whole_run_evidence_incomplete",)
     assert diagnosis[0].exemplar_references[0].kind == "whole_run_context_interval"
     assert diagnosis[0].exemplar_references[0].context_segment_index == 0
 
@@ -317,3 +318,22 @@ def test_prepare_persisted_report_input_keeps_persisted_whole_run_diagnosis_summ
     assert len(diagnosis) == 1
     assert diagnosis[0].diagnosis_key == "wheel_1x"
     assert diagnosis[0].uses_summary_fallback is False
+    assert prepared.report_facts.fallback_reasons == ()
+
+
+def test_prepare_persisted_report_input_marks_sidecar_summary_mismatch() -> None:
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 48,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_diagnosis_summaries_available": True,
+            "whole_run_diagnosis_summary_count": 1,
+        },
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].uses_summary_fallback is True
+    assert diagnosis[0].fallback_reason == "sidecar_summary_mismatch"
+    assert prepared.report_facts.fallback_reasons == ("sidecar_summary_mismatch",)

--- a/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
+++ b/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
@@ -79,7 +79,7 @@ def test_project_whole_run_diagnosis_factors_maps_counterevidence_signals_to_sta
                     rpm_gap_window_count=2,
                 )
             ),
-            fallback_reason="summary-only legacy confidence",
+            fallback_reason="legacy_summary_only",
         )
     )
 
@@ -98,7 +98,7 @@ def test_project_whole_run_diagnosis_factors_maps_counterevidence_signals_to_sta
         "close_alternative",
         "incomplete_reference",
     ]
-    assert counter_factors[0]["details"]["fallback_reason"] == "summary-only legacy confidence"
+    assert counter_factors[0]["details"]["fallback_reason"] == "legacy_summary_only"
     assert counter_factors[1]["details"]["speed_gap_window_count"] == 3
     assert counter_factors[5]["details"]["frequency_span_hz"] == pytest.approx(2.2)
     assert counter_factors[10]["details"]["alternative_source"] == "driveshaft"

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -344,6 +344,7 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_capture_loss_policy_gate_whole_run": False,
         "raw_capture_loss_policy_max_sensor_drop_ratio": 0.0,
         "raw_capture_loss_policy_max_events_per_minute": 0.0,
+        "fallback_reasons": ["raw_capture_not_configured", "legacy_summary_only"],
     }
 
 
@@ -464,6 +465,10 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
         == "raw_capture_queue_overflow_fatal"
     )
     assert summary["analysis_metadata"]["raw_capture_loss_policy_gate_whole_run"] is True
+    assert summary["analysis_metadata"]["fallback_reasons"] == [
+        "raw_capture_loss_exceeded",
+        "legacy_summary_only",
+    ]
     assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
         warning["code"] for warning in summary["warnings"]
     ]

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
@@ -11,6 +11,7 @@ from vibesensor.shared.types.whole_run_analysis import (
 from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
     append_run_context_warnings,
     append_whole_run_analysis_metadata,
+    refresh_report_fallback_metadata,
 )
 
 
@@ -108,3 +109,39 @@ def test_append_run_context_warnings_preserves_existing_warning_rows() -> None:
             "detail": "Incomplete alignment",
         },
     ]
+
+
+def test_refresh_report_fallback_metadata_clears_reason_when_diagnosis_summary_exists() -> None:
+    summary = make_persisted_analysis(
+        {
+            "run_id": "run-1",
+            "analysis_metadata": {
+                "raw_capture_mode": "raw_backed",
+                "raw_backed_sample_count": 24,
+                "fallback_reasons": ["whole_run_evidence_missing"],
+                "whole_run_diagnosis_summaries_available": True,
+                "whole_run_diagnosis_summary_count": 1,
+            },
+            "whole_run_diagnosis_summaries": [
+                {
+                    "diagnosis_key": "wheel_1x",
+                    "suspected_source": "wheel/tire",
+                    "rank": 1,
+                    "data_basis": "raw_backed",
+                    "ambiguous_diagnosis": False,
+                    "ambiguous_location": False,
+                    "suspicious": False,
+                    "weak_spatial_separation": False,
+                    "has_reference_gap": False,
+                    "uses_summary_fallback": False,
+                    "exemplar_references": [],
+                    "support_factors": [],
+                    "counterevidence_factors": [],
+                }
+            ],
+        }
+    )
+
+    result = refresh_report_fallback_metadata(summary).to_json_object()
+
+    assert "fallback_reasons" not in result["analysis_metadata"]

--- a/apps/server/vibesensor/adapters/history/projection.py
+++ b/apps/server/vibesensor/adapters/history/projection.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import cast
 
+from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.analysis_payloads import (
     project_analysis_summary,
     project_persisted_analysis,
 )
-from vibesensor.shared.boundaries.reporting.summary import has_projectable_report_payload
+from vibesensor.shared.boundaries.reporting.fallback_reasons import (
+    REPORT_FALLBACK_REASONS_METADATA_KEY,
+    dedupe_report_fallback_reasons,
+    derive_report_fallback_reasons,
+    finalization_stage_fallback_reasons,
+)
+from vibesensor.shared.boundaries.reporting.summary import (
+    has_projectable_report_payload,
+    report_summary_from_mapping,
+)
 from vibesensor.shared.boundaries.runs.metadata import (
     run_metadata_from_mapping,
     run_metadata_to_json_object,
@@ -50,6 +60,7 @@ def _project_persisted_history_analysis(
     )
     if strip_internal:
         projected = strip_internal_fields(projected)
+    _apply_projected_analysis_fallback_reasons(projected)
     _remove_history_metadata_only_fields(projected)
     return projected
 
@@ -60,6 +71,7 @@ def _project_summary_analysis(analysis: Mapping[str, object]) -> JsonObject:
         project_projectable=lambda: project_analysis_summary(cast(JsonObject, dict(analysis)))[0],
     )
     projected = strip_internal_fields(projected)
+    _apply_projected_analysis_fallback_reasons(projected)
     _remove_history_metadata_only_fields(projected)
     return projected
 
@@ -114,6 +126,8 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
         payload["raw_capture_quality"] = assess_raw_capture_loss_policy(
             run.raw_capture_manifest
         ).to_json_object()
+    if fallback_reasons := _history_run_fallback_reasons(run):
+        payload["fallback_reasons"] = list(fallback_reasons)
     return _apply_projected_run_fields(
         payload,
         metadata=run.metadata,
@@ -125,6 +139,55 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
 def project_history_insights(analysis: Mapping[str, object]) -> JsonObject:
     """Project persisted insights payloads for HTTP responses."""
     return _project_summary_analysis(analysis)
+
+
+def _apply_projected_analysis_fallback_reasons(payload: JsonObject) -> None:
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        return
+    normalized = report_summary_from_mapping(payload)
+    reasons = derive_report_fallback_reasons(
+        analysis_metadata,
+        has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
+        has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
+        has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),
+        has_whole_run_diagnosis_summaries=bool(normalized.whole_run_diagnosis_summaries),
+    )
+    if reasons:
+        analysis_metadata[REPORT_FALLBACK_REASONS_METADATA_KEY] = list(reasons)
+    else:
+        analysis_metadata.pop(REPORT_FALLBACK_REASONS_METADATA_KEY, None)
+
+
+def _history_run_fallback_reasons(run: StoredHistoryRun) -> tuple[str, ...]:
+    reasons: list[str] = []
+    reasons.extend(finalization_stage_fallback_reasons(run.metadata.finalization_stages))
+    if run.analysis is None:
+        if run.lifecycle is not None and run.lifecycle.post_analysis in {"pending", "running"}:
+            reasons.append("whole_run_analysis_pending")
+        elif run.status in {RunStatus.RECORDING, RunStatus.ANALYZING}:
+            reasons.append("whole_run_analysis_pending")
+        elif run.status == RunStatus.ERROR or run.error_message:
+            reasons.append("whole_run_analysis_failed")
+        elif run.lifecycle is not None and run.lifecycle.post_analysis == "degraded":
+            reasons.append("whole_run_analysis_failed")
+    else:
+        payload = run.analysis.to_json_object()
+        analysis_metadata = payload.get("analysis_metadata")
+        if isinstance(analysis_metadata, dict):
+            normalized = report_summary_from_mapping(payload)
+            reasons.extend(
+                derive_report_fallback_reasons(
+                    analysis_metadata,
+                    has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
+                    has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
+                    has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),
+                    has_whole_run_diagnosis_summaries=bool(
+                        normalized.whole_run_diagnosis_summaries
+                    ),
+                )
+            )
+    return tuple(dedupe_report_fallback_reasons(reasons))
 
 
 def build_projected_run_details_json(

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -201,6 +201,7 @@ class HistoryRunResponse(_StrictBase):
     raw_capture_finalize: HistoryRawCaptureFinalizeResponse | None = None
     finalization_stages: list[HistoryFinalizationStageResponse] | None = None
     raw_capture_quality: HistoryRawCaptureQualityResponse | None = None
+    fallback_reasons: list[str] | None = None
 
 
 class HistoryInsightWarningResponse(BaseModel):

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -12,6 +12,11 @@ from .facts import (
     ReportRunFacts,
     prepare_report_facts,
 )
+from .fallback_reasons import (
+    REPORT_FALLBACK_REASON_VALUES,
+    REPORT_FALLBACK_REASONS_METADATA_KEY,
+    ReportFallbackReason,
+)
 from .findings import FindingPresentation, PreparedReportFindings
 from .input import PreparedReportInput, validate_prepared_report_input
 
@@ -48,10 +53,13 @@ __all__ = [
     "PreparedReportFindings",
     "PreparedReportInput",
     "PrimaryReportFacts",
+    "REPORT_FALLBACK_REASONS_METADATA_KEY",
+    "REPORT_FALLBACK_REASON_VALUES",
     "ReportConfidenceFacts",
     "ReportContextFacts",
     "ReportCoverageSummary",
     "ReportDecisionFacts",
+    "ReportFallbackReason",
     "ReportOrderHarmonicEvidenceSummary",
     "ReportOrderTracePhaseSupport",
     "ReportOrderTraceSupportInterval",

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -45,6 +45,12 @@ from vibesensor.shared.boundaries.reporting.decision_facts import (
     build_report_decision_facts,
 )
 from vibesensor.shared.boundaries.reporting.evidence_facts import build_report_evidence_facts
+from vibesensor.shared.boundaries.reporting.fallback_reasons import (
+    ReportFallbackReason,
+    dedupe_report_fallback_reasons,
+    derive_report_fallback_reasons,
+    finalization_stage_fallback_reasons,
+)
 from vibesensor.shared.boundaries.reporting.findings import (
     PreparedReportFindings,
     prepare_report_findings,
@@ -149,6 +155,7 @@ class PreparedReportFacts:
     """Canonical grouped report facts for run, sensor, and decision concerns."""
 
     run: ReportRunFacts
+    fallback_reasons: tuple[ReportFallbackReason, ...]
     context: ReportContextFacts
     sensor: ReportSensorFacts
     decision: ReportDecisionFacts
@@ -186,6 +193,7 @@ def prepare_report_facts(
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
     config_snap = test_run.capture.setup.configuration_snapshot
+    fallback_reasons = _report_fallback_reasons(payload, summary=summary)
     context_facts = _build_report_context_facts(payload, summary=summary)
     sensor_facts = build_report_sensor_facts(
         test_run=test_run,
@@ -226,6 +234,7 @@ def prepare_report_facts(
         evidence_facts=evidence_facts,
         confidence_facts=provisional_confidence_facts,
         context_facts=context_facts,
+        fallback_reasons=fallback_reasons,
     )
     confidence_facts = _report_surface_confidence_facts(
         whole_run_diagnosis_summaries,
@@ -267,6 +276,7 @@ def prepare_report_facts(
             timeline_intervals=summary.timeline_intervals,
             peak_table_rows=summary.peak_table_rows,
         ),
+        fallback_reasons=fallback_reasons,
         context=context_facts,
         sensor=sensor_facts,
         decision=decision_facts,
@@ -395,13 +405,18 @@ def _report_whole_run_diagnosis_summaries(
     evidence_facts: ReportEvidenceFacts,
     confidence_facts: ReportConfidenceFacts,
     context_facts: ReportContextFacts,
+    fallback_reasons: tuple[ReportFallbackReason, ...],
 ) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
     if summary.whole_run_diagnosis_summaries:
         return summary.whole_run_diagnosis_summaries
     primary_candidate = decision_facts.primary_candidate
     if primary_candidate.domain_primary is None or primary_candidate.primary_source is None:
         return ()
-    fallback_reason = _whole_run_diagnosis_fallback_reason(payload, summary=summary)
+    fallback_reason = _whole_run_diagnosis_fallback_reason(
+        payload,
+        summary=summary,
+        fallback_reasons=fallback_reasons,
+    )
     if fallback_reason is None:
         return ()
     fallback_confidence = apply_report_confidence_fallback(
@@ -471,22 +486,20 @@ def _whole_run_diagnosis_fallback_reason(
     payload: Mapping[str, object],
     *,
     summary: NormalizedReportSummary,
+    fallback_reasons: tuple[ReportFallbackReason, ...],
 ) -> str | None:
-    if (finalization_reason := _finalization_stage_fallback_reason(summary)) is not None:
-        return finalization_reason
+    if fallback_reasons:
+        return fallback_reasons[0]
     analysis_metadata = payload.get("analysis_metadata")
     if not isinstance(analysis_metadata, Mapping):
-        return "analysis metadata missing; replayed summary-era evidence"
+        return "legacy_summary_only"
     loss_policy_severity = text_or_none(analysis_metadata.get("raw_capture_loss_policy_severity"))
     if loss_policy_severity == "fatal":
-        return (
-            text_or_none(analysis_metadata.get("raw_capture_loss_policy_reason"))
-            or "raw_capture_loss_policy_fatal"
-        )
+        return "raw_capture_loss_exceeded"
     raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
     raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
     if raw_capture_mode == "summary_only" or raw_backed_sample_count <= 0:
-        return "summary-only legacy confidence"
+        return "legacy_summary_only"
     has_partial_whole_run_inputs = bool(
         summary.whole_run_context_intervals
         or summary.whole_run_order_summaries
@@ -497,40 +510,33 @@ def _whole_run_diagnosis_fallback_reason(
         or analysis_metadata.get("whole_run_spatial_coherence_available")
     )
     if has_partial_whole_run_inputs:
-        return "whole-run diagnosis inputs incomplete; replayed summary-era evidence"
-    return "whole-run artifacts unavailable; replayed summary-era evidence"
+        return "whole_run_evidence_incomplete"
+    return "whole_run_evidence_missing"
 
 
-def _finalization_stage_fallback_reason(summary: NormalizedReportSummary) -> str | None:
+def _report_fallback_reasons(
+    payload: Mapping[str, object],
+    *,
+    summary: NormalizedReportSummary,
+) -> tuple[ReportFallbackReason, ...]:
+    reasons: list[str] = []
     metadata = summary.metadata
-    if metadata is None or not metadata.finalization_stages:
-        return None
-    stages = {stage.stage_name: stage for stage in metadata.finalization_stages}
-    raw_stage = stages.get("FinalizeRawCaptureStage")
-    resolve_stage = stages.get("ResolvePostAnalysisCandidateStage")
-    raw_status = (
-        text_or_none(raw_stage.diagnostic_context.get("raw_capture_status"))
-        if raw_stage is not None
-        else None
-    )
-    resolve_reason = (
-        text_or_none(resolve_stage.diagnostic_context.get("reason"))
-        if resolve_stage is not None
-        else None
-    )
-    if resolve_reason == "persistence_finalize_unsettled":
-        return "persistence_finalize_unsettled"
-    if raw_status == "not_configured":
-        return "raw_capture_not_configured"
-    if resolve_reason == "raw_capture_finalize_unsettled" or (
-        raw_stage is not None and raw_stage.status == "degraded"
-    ):
-        if raw_status in {"enqueue_timeout", "timeout", "failed"}:
-            return f"raw_capture_finalize_{raw_status}"
-        return "raw_capture_finalize_unsettled"
-    if resolve_reason == "history_not_ready":
-        return "history_not_ready"
-    return None
+    if metadata is not None:
+        reasons.extend(finalization_stage_fallback_reasons(metadata.finalization_stages))
+    analysis_metadata = payload.get("analysis_metadata")
+    if isinstance(analysis_metadata, Mapping):
+        reasons.extend(
+            derive_report_fallback_reasons(
+                analysis_metadata,
+                has_whole_run_context_intervals=bool(summary.whole_run_context_intervals),
+                has_whole_run_order_summaries=bool(summary.whole_run_order_summaries),
+                has_whole_run_spatial_summaries=bool(summary.whole_run_spatial_summaries),
+                has_whole_run_diagnosis_summaries=bool(summary.whole_run_diagnosis_summaries),
+            )
+        )
+    else:
+        reasons.append("legacy_summary_only")
+    return dedupe_report_fallback_reasons(reasons)
 
 
 def _report_surface_confidence_facts(

--- a/apps/server/vibesensor/shared/boundaries/reporting/fallback_reasons.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/fallback_reasons.py
@@ -1,0 +1,221 @@
+"""Stable report/history fallback reason codes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Literal
+
+from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+
+__all__ = [
+    "REPORT_FALLBACK_REASONS_METADATA_KEY",
+    "REPORT_FALLBACK_REASON_VALUES",
+    "ReportFallbackReason",
+    "dedupe_report_fallback_reasons",
+    "derive_report_fallback_reasons",
+    "finalization_stage_fallback_reasons",
+    "normalize_report_fallback_reasons",
+]
+
+REPORT_FALLBACK_REASONS_METADATA_KEY = "fallback_reasons"
+
+type ReportFallbackReason = Literal[
+    "raw_capture_not_configured",
+    "raw_capture_loss_exceeded",
+    "raw_capture_finalize_timeout",
+    "raw_capture_finalize_failed",
+    "raw_capture_finalize_unsettled",
+    "persistence_finalize_unsettled",
+    "history_not_ready",
+    "whole_run_analysis_pending",
+    "whole_run_analysis_failed",
+    "legacy_summary_only",
+    "sidecar_summary_mismatch",
+    "whole_run_evidence_missing",
+    "whole_run_evidence_incomplete",
+]
+
+REPORT_FALLBACK_REASON_VALUES: frozenset[ReportFallbackReason] = frozenset(
+    {
+        "raw_capture_not_configured",
+        "raw_capture_loss_exceeded",
+        "raw_capture_finalize_timeout",
+        "raw_capture_finalize_failed",
+        "raw_capture_finalize_unsettled",
+        "persistence_finalize_unsettled",
+        "history_not_ready",
+        "whole_run_analysis_pending",
+        "whole_run_analysis_failed",
+        "legacy_summary_only",
+        "sidecar_summary_mismatch",
+        "whole_run_evidence_missing",
+        "whole_run_evidence_incomplete",
+    }
+)
+
+
+def normalize_report_fallback_reasons(raw_reasons: object) -> tuple[ReportFallbackReason, ...]:
+    if not isinstance(raw_reasons, list | tuple):
+        return ()
+    return dedupe_report_fallback_reasons(
+        reason
+        for raw_reason in raw_reasons
+        if (reason := text_or_none(raw_reason)) in REPORT_FALLBACK_REASON_VALUES
+    )
+
+
+def dedupe_report_fallback_reasons(
+    reasons: Iterable[str],
+) -> tuple[ReportFallbackReason, ...]:
+    result: list[ReportFallbackReason] = []
+    seen: set[str] = set()
+    for reason in reasons:
+        if reason in seen or reason not in REPORT_FALLBACK_REASON_VALUES:
+            continue
+        seen.add(reason)
+        result.append(reason)
+    return tuple(result)
+
+
+def finalization_stage_fallback_reasons(
+    finalization_stages: Iterable[object],
+) -> tuple[ReportFallbackReason, ...]:
+    stages = {str(getattr(stage, "stage_name", "")): stage for stage in finalization_stages}
+    raw_stage = stages.get("FinalizeRawCaptureStage")
+    resolve_stage = stages.get("ResolvePostAnalysisCandidateStage")
+    raw_context = getattr(raw_stage, "diagnostic_context", {}) if raw_stage is not None else {}
+    resolve_context = (
+        getattr(resolve_stage, "diagnostic_context", {}) if resolve_stage is not None else {}
+    )
+    raw_status = (
+        text_or_none(raw_context.get("raw_capture_status"))
+        if isinstance(raw_context, Mapping)
+        else None
+    )
+    resolve_reason = (
+        text_or_none(resolve_context.get("reason"))
+        if isinstance(resolve_context, Mapping)
+        else None
+    )
+    reasons: list[str] = []
+    if resolve_reason == "persistence_finalize_unsettled":
+        reasons.append("persistence_finalize_unsettled")
+    if raw_status == "not_configured":
+        reasons.append("raw_capture_not_configured")
+    if resolve_reason == "raw_capture_finalize_unsettled" or (
+        raw_stage is not None and getattr(raw_stage, "status", "") == "degraded"
+    ):
+        if raw_status in {"timeout", "enqueue_timeout"}:
+            reasons.append("raw_capture_finalize_timeout")
+        elif raw_status == "failed":
+            reasons.append("raw_capture_finalize_failed")
+        else:
+            reasons.append("raw_capture_finalize_unsettled")
+    if resolve_reason == "history_not_ready":
+        reasons.append("history_not_ready")
+    return dedupe_report_fallback_reasons(reasons)
+
+
+def derive_report_fallback_reasons(
+    analysis_metadata: Mapping[str, object],
+    *,
+    has_whole_run_context_intervals: bool,
+    has_whole_run_order_summaries: bool,
+    has_whole_run_spatial_summaries: bool,
+    has_whole_run_diagnosis_summaries: bool,
+) -> tuple[ReportFallbackReason, ...]:
+    reasons: list[str] = []
+    reasons.extend(_raw_capture_fallback_reasons(analysis_metadata))
+    reasons.extend(
+        _whole_run_fallback_reasons(
+            analysis_metadata,
+            has_whole_run_context_intervals=has_whole_run_context_intervals,
+            has_whole_run_order_summaries=has_whole_run_order_summaries,
+            has_whole_run_spatial_summaries=has_whole_run_spatial_summaries,
+            has_whole_run_diagnosis_summaries=has_whole_run_diagnosis_summaries,
+        )
+    )
+    return dedupe_report_fallback_reasons(reasons)
+
+
+def _raw_capture_fallback_reasons(
+    analysis_metadata: Mapping[str, object],
+) -> tuple[ReportFallbackReason, ...]:
+    reasons: list[str] = []
+    if analysis_metadata.get("raw_capture_available") is False:
+        reasons.append("raw_capture_not_configured")
+    finalize_status = text_or_none(analysis_metadata.get("raw_capture_finalize_status"))
+    if finalize_status == "timeout":
+        reasons.append("raw_capture_finalize_timeout")
+    elif finalize_status == "failed":
+        reasons.append("raw_capture_finalize_failed")
+    loss_policy_severity = text_or_none(analysis_metadata.get("raw_capture_loss_policy_severity"))
+    if loss_policy_severity == "fatal" or bool(
+        analysis_metadata.get("raw_capture_loss_policy_gate_whole_run")
+    ):
+        reasons.append("raw_capture_loss_exceeded")
+    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
+    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
+    if raw_capture_mode == "summary_only" or (
+        raw_capture_mode is None and raw_backed_sample_count <= 0
+    ):
+        reasons.append("legacy_summary_only")
+    return dedupe_report_fallback_reasons(reasons)
+
+
+def _whole_run_fallback_reasons(
+    analysis_metadata: Mapping[str, object],
+    *,
+    has_whole_run_context_intervals: bool,
+    has_whole_run_order_summaries: bool,
+    has_whole_run_spatial_summaries: bool,
+    has_whole_run_diagnosis_summaries: bool,
+) -> tuple[ReportFallbackReason, ...]:
+    if has_whole_run_diagnosis_summaries:
+        return ()
+    if _has_sidecar_summary_mismatch(
+        analysis_metadata,
+        has_whole_run_order_summaries=has_whole_run_order_summaries,
+        has_whole_run_spatial_summaries=has_whole_run_spatial_summaries,
+    ):
+        return ("sidecar_summary_mismatch",)
+    has_partial_whole_run_inputs = bool(
+        has_whole_run_context_intervals
+        or has_whole_run_order_summaries
+        or has_whole_run_spatial_summaries
+        or analysis_metadata.get("whole_run_artifacts_available")
+        or analysis_metadata.get("whole_run_context_available")
+        or analysis_metadata.get("whole_run_order_family_summaries_available")
+        or analysis_metadata.get("whole_run_spatial_coherence_available")
+    )
+    if has_partial_whole_run_inputs:
+        return ("whole_run_evidence_incomplete",)
+    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
+    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
+    if raw_capture_mode in {"raw_backed", "partial_raw_backed"} or raw_backed_sample_count > 0:
+        return ("whole_run_evidence_missing",)
+    return ()
+
+
+def _has_sidecar_summary_mismatch(
+    analysis_metadata: Mapping[str, object],
+    *,
+    has_whole_run_order_summaries: bool,
+    has_whole_run_spatial_summaries: bool,
+) -> bool:
+    if (
+        bool(analysis_metadata.get("whole_run_diagnosis_summaries_available"))
+        and coerce_count(analysis_metadata.get("whole_run_diagnosis_summary_count")) > 0
+    ):
+        return True
+    if (
+        bool(analysis_metadata.get("whole_run_order_family_summaries_available"))
+        and coerce_count(analysis_metadata.get("whole_run_order_family_summary_count")) > 0
+        and not has_whole_run_order_summaries
+    ):
+        return True
+    return bool(
+        bool(analysis_metadata.get("whole_run_spatial_coherence_available"))
+        and coerce_count(analysis_metadata.get("whole_run_spatial_coherence_summary_count")) > 0
+        and not has_whole_run_spatial_summaries
+    )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -98,6 +98,7 @@ from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
     build_diagnosis_summary_rows,
     ranked_whole_run_order_summaries,
     ranked_whole_run_spatial_summaries,
+    refresh_report_fallback_metadata,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -968,7 +969,7 @@ def run_build_report_facts_stage(
     if stored_artifact_manifest is not None:
         summary = append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
 
-    return summary, _make_stage_result(
+    return refresh_report_fallback_metadata(summary), _make_stage_result(
         stage_name=stage_name,
         status="ok",
         stage_start=stage_start,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -7,6 +7,10 @@ from math import ceil
 from typing import TYPE_CHECKING
 
 from vibesensor.shared.boundaries.analysis_payloads import analysis_result_to_summary
+from vibesensor.shared.boundaries.reporting.fallback_reasons import (
+    REPORT_FALLBACK_REASONS_METADATA_KEY,
+    derive_report_fallback_reasons,
+)
 from vibesensor.shared.boundaries.summary_fields.warnings import summary_warning_payloads
 from vibesensor.shared.boundaries.summary_serialization._location_intensity import (
     serialize_location_intensity_rows,
@@ -169,6 +173,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         analysis_metadata["sampling_event_sample_count"] = run.event_sample_count
         analysis_metadata["sampling_evenly_spaced_row_count"] = run.evenly_spaced_sample_count
         analysis_metadata["sampling_event_row_count"] = run.event_sample_count
+    _set_initial_report_fallback_reasons(analysis_metadata)
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)
     summary_warnings: list[RunContextWarning] = list(run.raw_replay.warnings)
     finalize_warning = _raw_capture_finalize_warning(raw_capture_finalize)
@@ -225,6 +230,18 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         )
 
     return PersistedAnalysis.from_json_object(summary_payload)
+
+
+def _set_initial_report_fallback_reasons(analysis_metadata: JsonObject) -> None:
+    fallback_reasons = derive_report_fallback_reasons(
+        analysis_metadata,
+        has_whole_run_context_intervals=False,
+        has_whole_run_order_summaries=False,
+        has_whole_run_spatial_summaries=False,
+        has_whole_run_diagnosis_summaries=False,
+    )
+    if fallback_reasons:
+        analysis_metadata[REPORT_FALLBACK_REASONS_METADATA_KEY] = list(fallback_reasons)
 
 
 def _raw_capture_finalize_warning(

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from vibesensor.domain import CarOrderReferenceStatus
+from vibesensor.shared.boundaries.reporting.fallback_reasons import (
+    REPORT_FALLBACK_REASONS_METADATA_KEY,
+    derive_report_fallback_reasons,
+)
+from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
 from vibesensor.shared.run_context_warning import (
     RunContextWarningsInput,
     normalize_run_context_warnings,
@@ -323,6 +328,27 @@ def append_whole_run_diagnosis_summary_metadata(
         payload["analysis_metadata"] = analysis_metadata
     analysis_metadata["whole_run_diagnosis_summaries_available"] = True
     analysis_metadata["whole_run_diagnosis_summary_count"] = len(diagnosis_summaries)
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def refresh_report_fallback_metadata(summary: PersistedAnalysis) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    normalized = report_summary_from_mapping(payload)
+    fallback_reasons = derive_report_fallback_reasons(
+        analysis_metadata,
+        has_whole_run_context_intervals=bool(normalized.whole_run_context_intervals),
+        has_whole_run_order_summaries=bool(normalized.whole_run_order_summaries),
+        has_whole_run_spatial_summaries=bool(normalized.whole_run_spatial_summaries),
+        has_whole_run_diagnosis_summaries=bool(normalized.whole_run_diagnosis_summaries),
+    )
+    if fallback_reasons:
+        analysis_metadata[REPORT_FALLBACK_REASONS_METADATA_KEY] = list(fallback_reasons)
+    else:
+        analysis_metadata.pop(REPORT_FALLBACK_REASONS_METADATA_KEY, None)
     return PersistedAnalysis.from_json_object(payload)
 
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -5004,6 +5004,20 @@
             ],
             "title": "Error Message"
           },
+          "fallback_reasons": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Reasons"
+          },
           "finalization_stages": {
             "anyOf": [
               {

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -75,7 +75,8 @@ Canonical report preparation now lives in
 `NormalizedReportSummary` decoding, domain reconstruction, filename/language
 normalization, and grouped semantic fact assembly:
 
-- `facts.py` builds `PreparedReportFacts(run=..., sensor=..., decision=..., evidence=..., confidence=..., findings=...)`
+- `facts.py` builds `PreparedReportFacts(run=..., fallback_reasons=..., sensor=..., decision=..., evidence=..., confidence=..., findings=...)`
+- `fallback_reasons.py` owns stable machine-readable fallback reason codes for history/report consumers (`raw_capture_not_configured`, `raw_capture_loss_exceeded`, `raw_capture_finalize_timeout`, `whole_run_analysis_pending`, `whole_run_analysis_failed`, `legacy_summary_only`, `sidecar_summary_mismatch`, `whole_run_evidence_missing`, and `whole_run_evidence_incomplete`)
 - `evidence_facts.py` builds explicit proof facts (data basis, supporting-window count/duration, stable frequency band, strongest supporting sensors, and caveats) from persisted analysis + reconstructed domain findings
 - `confidence_facts.py` converts persisted evidence quality signals into bounded report confidence (raw-backed vs summary-only basis, support count/duration, frequency stability, order-lock quality, spatial concentration, counterevidence, and reference gaps)
 - `findings.py` owns report-facing finding/top-cause presentation shaping
@@ -106,6 +107,7 @@ needs:
 - **Pattern evidence**: matched systems, certainty label, interpretation
 - **Evidence snapshots**: concise page-1 proof rows plus Appendix-C proof rows built from prepared evidence facts, not renderer-time DSP
 - **Confidence surfaces**: observed certainty, page-1 confidence row, and proof caveats come from prepared `ReportConfidenceFacts`, not renderer-only heuristics
+- **Fallback reasons**: history and report preparation expose explicit `fallback_reasons` instead of inferring from missing fields; report confidence/caveats use the same stable codes carried in `analysis_metadata.fallback_reasons`
 - **Appendix-C proof pack**: a diagnosis-focused evidence chain plus retained supporting-window exemplars for the selected diagnosis; the older ranked-measurement table is fallback-only when exemplar windows are unavailable
 - **Location proof surfaces**: page-1 and Appendix-B location diagrams/hotspot summaries should use diagnosis-supporting window location facts when they exist, with explicit summary-only / whole-run fallback notes instead of silently reusing whole-run intensity
 - **Peak rows**: top diagnostic peaks with classification


### PR DESCRIPTION
Closes #3655

## What changed
- Added stable report/history fallback reason codes and exported the contract from the reporting boundary.
- Persist and refresh `analysis_metadata.fallback_reasons` during post-analysis/report fact assembly.
- Expose fallback reasons through prepared report facts and projected history run details.
- Replace legacy human fallback strings with machine-readable codes.
- Detect dense sidecar metadata without matching compact summaries as `sidecar_summary_mismatch`.
- Document the fallback reason contract in the report pipeline docs.

## Why
Reports and history should not infer missing evidence from absent fields. Raw not configured, raw loss, finalization problems, legacy summaries, pending/failed whole-run analysis, and sidecar summary mismatches need separate stable codes.

## Validation
- `make typecheck-backend`
- `pytest apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py apps/server/tests/use_cases/history/test_history_service_edges.py -q`
- `tools/dev/check_hygiene.py`
- `tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Existing fallback reason strings in generated fallback diagnosis summaries change to stable codes. This is intentional contract cleanup.
- Existing raw-capture loss policy detail remains available separately as `raw_capture_loss_policy_reason`; report fallback uses the broader `raw_capture_loss_exceeded` code.
- Stale persisted fallback reason lists are recomputed during report/history projection so compact summary state wins.

## Follow-ups
None.