### PR TITLE
Redesign PDF page one as verdict surface

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_document_projection.py
+++ b/apps/server/tests/adapters/pdf/test_report_document_projection.py
@@ -187,7 +187,7 @@ def test_build_report_document_surfaces_evidence_snapshot_rows() -> None:
     ]
     assert "Medium (" in data.verdict_page.proof_snapshot_rows[0].value
     assert "Raw-backed replay" in data.verdict_page.proof_snapshot_rows[1].value
-    assert data.verdict_page.proof_snapshot_rows[2].value == "3 supporting windows across 1.5 s"
+    assert data.verdict_page.proof_snapshot_rows[2].value == "3 supporting windows"
     assert data.verdict_page.proof_snapshot_rows[3].value == "15.1-15.4 Hz matched band"
     assert [row.label for row in data.appendix_c.evidence_snapshot_rows] == [
         "Confidence",
@@ -1107,8 +1107,8 @@ def test_build_report_document_softens_same_corner_wheel_driveline_overlap_wordi
 
     data = build_report_document(prepare_report_input(summary))
 
-    assert data.verdict_page.also_consider is not None
-    assert "Driveline" in data.verdict_page.also_consider
+    assert data.verdict_page.also_consider == "Driveline"
+    assert data.verdict_page.fallback_path == "Inspect Driveline next"
     assert data.appendix_a.why_alternative_next is not None
     alternative_reason = data.appendix_a.why_alternative_next.lower()
     assert "wheel and driveline evidence overlap" in alternative_reason

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
@@ -290,7 +290,7 @@ def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> No
 
     assert "why this corner wins" in text
     assert "dominant corner" in text
-    assert "location confidence" in text
+    assert "coverage" in text
 
 
 def test_pdf_diagram_render_module_no_longer_reexports_layout_helpers() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
@@ -31,6 +31,8 @@ from vibesensor.shared.boundaries.reporting.document import (
     NextStep,
     RankedCandidateRow,
     ReportDocument,
+    TimelineGraphData,
+    TimelineGraphInterval,
     VerdictPageData,
 )
 from vibesensor.use_cases.history.report_document import build_report_document
@@ -213,7 +215,7 @@ def test_build_report_pdf_renders_data_trust_warning_detail() -> None:
 
     assert "inspect first — moderate confidence" in page_one_text
     assert "what to do next" in page_one_text
-    assert "potential saturation samples detected" in page_one_text
+    assert "potential saturation samples" in page_one_text
     assert "run quality and limits" in text
     assert "frame integrity" in text
 
@@ -274,7 +276,7 @@ def test_build_report_pdf_replaces_limited_run_context_with_concrete_reason() ->
     )
 
     assert "limited by run context" not in page_one_text
-    assert "speed was not steady during measurement" in page_one_text
+    assert "potential saturation samples" in page_one_text
 
 
 def test_build_report_pdf_rephrases_ambiguous_primary_location_on_page_one() -> None:
@@ -335,8 +337,95 @@ def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:
     text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").lower().split())
 
     assert "action-ready" in text
-    assert "location confidence strong" in text
+    assert "strong" in text
     assert "what to do next" in text
+
+
+def test_page_one_is_decision_first_without_timeline_or_long_caution() -> None:
+    pdf = build_report_pdf(
+        ReportDocument(
+            title="VibeSensor Diagnostic Report",
+            run_id="decision-first-page-one",
+            verdict_page=VerdictPageData(
+                suspected_source="Wheel / Tire",
+                inspect_first="Front-Left",
+                action_status="Inspect first — moderate confidence",
+                action_status_note="Alternative source still in scope",
+                reason_sentence="Wheel / Tire stayed strongest near Front-Left.",
+                dominant_corner="Front-Left",
+                runner_up_corner="Front-Right",
+                dominance_ratio_label="1.9x stronger",
+                location_confidence="Moderate",
+                coverage_label="4 of 4 expected positions stayed connected.",
+                fallback_path="Inspect Driveline next",
+                timeline_graph=TimelineGraphData(
+                    duration_s=10.0,
+                    speed_ceiling_kmh=80.0,
+                    intervals=(
+                        TimelineGraphInterval(
+                            phase_label="cruise",
+                            start_t_s=0.0,
+                            end_t_s=10.0,
+                            speed_min_kmh=60.0,
+                            speed_max_kmh=80.0,
+                            has_fault_evidence=True,
+                        ),
+                    ),
+                ),
+            ),
+            next_steps=[
+                NextStep(action="Check Front-Left for imbalance or radial/lateral runout.")
+            ],
+        )
+    )
+    page_one_text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+    page_one_lower = page_one_text.lower()
+
+    assert "wheel / tire" in page_one_lower
+    assert "inspect first" in page_one_lower
+    assert "front-left" in page_one_lower
+    assert "what to do next" in page_one_lower
+    assert "if clean" in page_one_lower
+    assert "inspect driveline next" in page_one_lower
+    assert "run timeline" not in page_one_lower
+    assert "detection windows" not in page_one_lower
+    assert "this run gives a sensible first inspection" not in page_one_lower
+    assert "alternative source still in scope" in page_one_lower
+
+
+def test_page_one_long_wheel_action_fits_primary_preview() -> None:
+    pdf = build_report_pdf(
+        ReportDocument(
+            title="VibeSensor Diagnostic Report",
+            run_id="long-action-page-one",
+            verdict_page=VerdictPageData(
+                suspected_source="Wheel / Tire",
+                inspect_first="Front-Left",
+                action_status="Inspect first — moderate confidence",
+                action_status_note="Alternative source still in scope",
+                reason_sentence="Wheel / Tire stayed strongest near Front-Left.",
+                dominant_corner="Front-Left",
+                runner_up_corner="Front-Right",
+                dominance_ratio_label="2.1x stronger",
+                location_confidence="Moderate",
+                coverage_label="4 of 4 expected positions stayed connected.",
+                fallback_path="Inspect Driveline next",
+            ),
+            next_steps=[
+                NextStep(
+                    action=(
+                        "Check Front-Left tire damage, belt shift, flat spots, uneven wear, "
+                        "and pressure mismatch."
+                    )
+                )
+            ],
+        )
+    )
+    text = " ".join((PdfReader(BytesIO(pdf)).pages[0].extract_text() or "").split())
+
+    assert "Check Front-Left tire damage" in text
+    assert "pressure mismatch" in text
+    assert "uneven wear, or" not in text
 
 
 def test_build_report_pdf_renders_medium_confidence_data_trust_summary_for_tier_b() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_summary_basics.py
+++ b/apps/server/tests/adapters/pdf/test_report_summary_basics.py
@@ -54,7 +54,7 @@ def test_complete_run_has_speed_bins_findings_and_plots(tmp_path: Path) -> None:
     for text in (
         "VibeSensor Diagnostic Report",
         "Most likely source",
-        "Action status",
+        "Recapture before acting",
         "What to do next",
         "Recapture Guidance",
         "Traceability",

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -166,8 +166,12 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
     assert prepared.report_facts.confidence.signal_keys == ("raw_backed",)
     assert prepared.report_facts.confidence.caveat_keys == ("close_alternative",)
     assert any(
-        "12" in row.value and "6.0" in row.value
+        "12" in row.value and "6.0" not in row.value
         for row in document.verdict_page.proof_snapshot_rows
+    )
+    assert any(
+        "12" in row.value and "6.0" in row.value
+        for row in document.appendix_c.evidence_snapshot_rows
     )
     assert any(
         "18.2" in row.value and "18.6" in row.value

--- a/apps/server/vibesensor/adapters/pdf/action_cards.py
+++ b/apps/server/vibesensor/adapters/pdf/action_cards.py
@@ -45,7 +45,7 @@ def estimate_compact_action_card_height(*, title: str, why: str | None, width: f
     """Return the compact page-1 preview card height."""
 
     text_w = width - 14 * mm
-    title_lines = _wrap_lines(title, text_w, FS_BODY)[:2]
+    title_lines = _wrap_lines(title, text_w, FS_BODY)[:3]
     why_lines = _wrap_lines(why or "", text_w, FS_SMALL)[:2] if why else []
     return float(
         max(
@@ -96,7 +96,7 @@ def draw_compact_action_card(
             size=FS_SMALL,
             color=SUB_CLR,
             leading=FS_SMALL + 1.0,
-            max_lines=2,
+            max_lines=3,
         )
     return float(y_top - card_h - 2.5 * mm)
 

--- a/apps/server/vibesensor/adapters/pdf/page1_actions.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_actions.py
@@ -12,8 +12,15 @@ from vibesensor.adapters.pdf.action_cards import (
     draw_compact_action_card,
     estimate_compact_action_card_height,
 )
-from vibesensor.adapters.pdf.pdf_drawing import _draw_panel
-from vibesensor.adapters.pdf.pdf_style import FS_BODY, FS_SMALL, PANEL_HEADER_H, SUB_CLR
+from vibesensor.adapters.pdf.pdf_drawing import _draw_panel, _hex
+from vibesensor.adapters.pdf.pdf_style import (
+    FONT_B,
+    FS_BODY,
+    FS_SMALL,
+    PANEL_HEADER_H,
+    SUB_CLR,
+    TEXT_CLR,
+)
 from vibesensor.adapters.pdf.pdf_text import _draw_text, _measure_text_height
 
 if TYPE_CHECKING:
@@ -32,27 +39,24 @@ def estimate_actions_block_height(
 
     content_w = w - 8 * mm
     content_h = 0.0
+    fallback = plan.verdict_page.fallback_path
     if not plan.next_steps:
         content_h += _measure_text_height(tr("NO_NEXT_STEPS"), w=content_w, size=FS_BODY)
     else:
-        shown_steps = plan.next_steps[:2]
-        for index, step in enumerate(shown_steps):
-            content_h += estimate_compact_action_card_height(
-                title=step.action,
-                why=None,
-                width=content_w,
-            )
-            if index < len(shown_steps) - 1:
-                content_h += 2.5 * mm
-        if len(plan.next_steps) > len(shown_steps):
-            content_h += 0.5 * mm + _measure_text_height(
-                tr("REPORT_ACTIONS_PAGE1_MORE"),
+        content_h += estimate_compact_action_card_height(
+            title=plan.next_steps[0].action,
+            why=None,
+            width=content_w,
+        )
+        if fallback:
+            content_h += 7.0 * mm + _measure_text_height(
+                fallback,
                 w=content_w,
-                size=FS_SMALL,
-                leading=FS_SMALL + 1.0,
+                size=FS_BODY,
+                leading=FS_BODY + 1.0,
                 max_lines=2,
             )
-    return float(max(38 * mm, PANEL_HEADER_H + 2 * mm + content_h + 4 * mm))
+    return float(max(30 * mm, PANEL_HEADER_H + 2 * mm + content_h + 4 * mm))
 
 
 def draw_actions_block(
@@ -76,34 +80,31 @@ def draw_actions_block(
         )
         return
 
-    row_y = inner_y
-    shown_steps = plan.next_steps[:2]
-    for index, step in enumerate(shown_steps, start=1):
-        estimated_h = estimate_compact_action_card_height(
-            title=step.action,
-            why=None,
-            width=w - 8 * mm,
-        )
-        if row_y - estimated_h < y + 4 * mm:
-            break
-        row_y = draw_compact_action_card(
-            c,
-            index=index,
-            title=step.action,
-            why=None,
-            x=inner_x,
-            y_top=row_y,
-            w=w - 8 * mm,
-        )
-    if len(plan.next_steps) > len(shown_steps) and row_y > y + 10 * mm:
+    row_y = draw_compact_action_card(
+        c,
+        index=1,
+        title=plan.next_steps[0].action,
+        why=None,
+        x=inner_x,
+        y_top=inner_y,
+        w=w - 8 * mm,
+    )
+    fallback = plan.verdict_page.fallback_path
+    if fallback and row_y > y + 7 * mm:
+        c.setStrokeColor(_hex("#dcdfe6"))
+        c.line(inner_x, row_y - 0.8 * mm, inner_x + w - 8 * mm, row_y - 0.8 * mm)
+        c.setFillColor(_hex(TEXT_CLR))
+        c.setFont(FONT_B, FS_SMALL)
+        c.drawString(inner_x, row_y - 4.1 * mm, tr("REPORT_PAGE1_IF_CLEAN_LABEL"))
         _draw_text(
             c,
             inner_x,
-            row_y - 0.5 * mm,
+            row_y - 8.1 * mm,
             w - 8 * mm,
-            tr("REPORT_ACTIONS_PAGE1_MORE"),
-            size=FS_SMALL,
-            color=SUB_CLR,
-            leading=FS_SMALL + 1.0,
+            fallback,
+            font=FONT_B,
+            size=FS_BODY,
+            color=TEXT_CLR,
+            leading=FS_BODY + 1.0,
             max_lines=2,
         )

--- a/apps/server/vibesensor/adapters/pdf/page1_header.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_header.py
@@ -24,6 +24,7 @@ from vibesensor.adapters.pdf.pdf_text import _draw_text, _measure_text_height, _
 
 if TYPE_CHECKING:
     from vibesensor.adapters.pdf.report_types import Page1RenderPlan
+    from vibesensor.shared.boundaries.reporting.document import VerdictPageData
 
 __all__ = ["draw_header_strip", "draw_hero_block"]
 
@@ -42,8 +43,8 @@ def draw_header_strip(
         c, x, y, w, h, fill=REPORT_COLORS["brand_surface"], border=REPORT_COLORS["brand_surface"]
     )
     c.setFillColor(_hex(REPORT_COLORS["brand"]))
-    c.setFont(FONT_B, FS_H2)
-    c.drawString(x + 4 * mm, y + h - 5.5 * mm, plan.title or tr("REPORT_FOOTER_TITLE"))
+    c.setFont(FONT_B, FS_BODY)
+    c.drawString(x + 3 * mm, y + h - 4.2 * mm, plan.title or tr("REPORT_FOOTER_TITLE"))
 
     values = [
         (tr("RUN_DATE"), plan.run_datetime or tr("UNKNOWN")),
@@ -55,31 +56,30 @@ def draw_header_strip(
         (tr("SENSORS_LABEL"), str(plan.sensor_count or 0)),
         (tr("SPEED_BAND"), plan.verdict_page.speed_window_label or tr("UNKNOWN")),
     ]
-    inner_x = x + 4 * mm
-    top_y = y + h - 12.0 * mm
-    col_gap = 2 * mm
-    col_w = (w - 8 * mm - (2 * col_gap)) / 3
+    inner_x = x + 3 * mm
+    top_y = y + h - 9.0 * mm
+    col_gap = 1.5 * mm
+    col_w = (w - 6 * mm - (4 * col_gap)) / 5
     for index, (label, value) in enumerate(values):
-        row = index // 3
-        col = index % 3
+        col = index
         col_x = inner_x + (col * (col_w + col_gap))
-        row_y = top_y - (row * 8.2 * mm)
-        value_text = _truncate_single_line(str(value), col_w, FS_BODY)
+        row_y = top_y
+        value_text = _truncate_single_line(str(value), col_w, FS_SMALL)
         c.setFillColor(_hex(SUB_CLR))
         c.setFont(FONT, FS_SMALL)
         c.drawString(col_x, row_y, label)
         c.setFillColor(_hex(TEXT_CLR))
-        c.setFont(FONT_B, FS_BODY)
+        c.setFont(FONT_B, FS_SMALL)
         _draw_text(
             c,
             col_x,
-            row_y - 4.0 * mm,
+            row_y - 3.5 * mm,
             col_w,
             value_text,
             font=FONT_B,
-            size=FS_BODY,
+            size=FS_SMALL,
             color=TEXT_CLR,
-            leading=FS_BODY + 1.0,
+            leading=FS_SMALL + 1.0,
             max_lines=1,
         )
 
@@ -167,18 +167,16 @@ def draw_hero_block(
     _draw_panel(c, x, y, w, h, fill="#ffffff")
     inner_x = x + 5 * mm
     inner_y = y + h - 6.0 * mm
-    left_w = w * 0.58
-    left_content_w = left_w - 10 * mm
-    right_x = x + left_w + 8 * mm
-    right_w = w - (left_w + 13 * mm)
+    content_w = w - 10 * mm
 
     next_y = draw_label_value(
         c,
         x=inner_x,
         y=inner_y,
-        width=left_content_w,
+        width=content_w,
         label=tr("REPORT_SUSPECTED_SOURCE_LABEL"),
         value=verdict.suspected_source or tr("UNKNOWN"),
+        value_size=FS_H2,
     )
     if verdict.inspect_first:
         next_y = (
@@ -186,7 +184,7 @@ def draw_hero_block(
                 c,
                 inner_x,
                 next_y - 0.2 * mm,
-                left_content_w,
+                content_w,
                 f"{tr('REPORT_INSPECT_FIRST_LABEL')}: {verdict.inspect_first}",
                 font=FONT_B,
                 size=FS_BODY,
@@ -201,23 +199,71 @@ def draw_hero_block(
             c,
             inner_x,
             next_y - 0.2 * mm,
-            left_content_w,
+            content_w,
             verdict.reason_sentence,
             size=FS_SMALL,
             color=SUB_CLR,
             leading=FS_SMALL + 1.1,
-            max_lines=4,
+            max_lines=2,
         )
 
-    c.setFillColor(_hex(SUB_CLR))
-    c.setFont(FONT, FS_SMALL)
-    c.drawString(right_x, inner_y + 1.2 * mm, tr("REPORT_ACTION_STATUS_LABEL"))
-    _draw_action_status_callout(
-        c,
-        status=verdict.action_status or tr("UNKNOWN"),
-        note=verdict.action_status_note,
-        tr=tr,
-        x=right_x,
-        y_top=inner_y - 1.5 * mm,
-        w=right_w,
-    )
+    _draw_verdict_cues(c, verdict=verdict, tr=tr, x=inner_x, y=y + 22 * mm, w=content_w)
+    if verdict.action_status_note:
+        _draw_text(
+            c,
+            inner_x,
+            y + 13.0 * mm,
+            content_w,
+            f"{tr('REPORT_PAGE1_MAIN_CAVEAT_LABEL')}: {verdict.action_status_note}",
+            size=FS_SMALL,
+            color=SUB_CLR,
+            leading=FS_SMALL + 1.0,
+            max_lines=1,
+        )
+
+
+def _draw_verdict_cues(
+    c: Canvas,
+    *,
+    verdict: VerdictPageData,
+    tr: Callable[..., str],
+    x: float,
+    y: float,
+    w: float,
+) -> None:
+    status = str(verdict.action_status or tr("UNKNOWN")).strip()
+    cue_texts = [status]
+    if status == tr("REPORT_ACTION_STATUS_READY"):
+        cue_texts.append(str(verdict.location_confidence or "").strip())
+    cue_texts = [text for text in cue_texts if text]
+    if not cue_texts:
+        return
+
+    row_gap = 1.2 * mm
+    chip_h = 7.0 * mm
+    cursor_x = x
+    cursor_y = y + chip_h
+    for index, text in enumerate(cue_texts[:3]):
+        fill, border = _status_palette(text if index == 0 else "", tr=tr)
+        chip_w = min(
+            w, max(36 * mm, c.stringWidth(text, FONT_B if index == 0 else FONT, FS_SMALL) + 7 * mm)
+        )
+        if cursor_x != x and cursor_x + chip_w > x + w:
+            cursor_x = x
+            cursor_y -= chip_h + row_gap
+        c.setFillColor(_hex(fill))
+        c.setStrokeColor(_hex(border))
+        c.roundRect(cursor_x, cursor_y - chip_h, chip_w, chip_h, 2.5 * mm, stroke=1, fill=1)
+        _draw_text(
+            c,
+            cursor_x + 3 * mm,
+            cursor_y - 2.2 * mm,
+            chip_w - 6 * mm,
+            text,
+            font=FONT_B if index == 0 else FONT,
+            size=FS_SMALL,
+            color=TEXT_CLR,
+            leading=FS_SMALL + 1.0,
+            max_lines=1,
+        )
+        cursor_x += chip_w + 1.8 * mm

--- a/apps/server/vibesensor/adapters/pdf/page1_proof.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_proof.py
@@ -12,15 +12,10 @@ from vibesensor.adapters.pdf.page1_common import draw_label_value
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 from vibesensor.adapters.pdf.pdf_drawing import _draw_panel
 from vibesensor.adapters.pdf.pdf_style import (
-    FONT_B,
     FS_BODY,
     FS_H2,
-    FS_SMALL,
     PANEL_HEADER_H,
-    SUB_CLR,
-    TEXT_CLR,
 )
-from vibesensor.adapters.pdf.pdf_text import _draw_text, _wrap_lines
 from vibesensor.adapters.pdf.pdf_timeline_render import run_timeline_graph
 
 if TYPE_CHECKING:
@@ -43,7 +38,7 @@ def draw_proof_block(
     _draw_panel(c, x, y, w, h, verdict.proof_panel_title or tr("REPORT_PROOF_PANEL_TITLE"))
     inner_x = x + 4 * mm
     inner_y = y + h - PANEL_HEADER_H - 2 * mm
-    diagram_w = w * 0.44
+    diagram_w = w * 0.38
     left_x = inner_x
     left_w = diagram_w - 2 * mm
     left_bottom = y + 7 * mm
@@ -69,32 +64,6 @@ def draw_proof_block(
     text_x = x + diagram_w + 5 * mm
     text_w = w - diagram_w - 9 * mm
     text_y = inner_y
-    text_y = (
-        _draw_text(
-            c,
-            text_x,
-            text_y,
-            text_w,
-            verdict.proof_summary or tr("UNKNOWN"),
-            font=FONT_B,
-            size=FS_BODY,
-            color=TEXT_CLR,
-            leading=FS_BODY + 1.4,
-            max_lines=4,
-        )
-        - 1.5 * mm
-    )
-    for snapshot in verdict.proof_snapshot_rows[:3]:
-        text_y = draw_label_value(
-            c,
-            x=text_x,
-            y=text_y,
-            width=text_w,
-            label=snapshot.label,
-            value=snapshot.value or tr("UNKNOWN"),
-            value_size=FS_BODY,
-            max_lines=3,
-        )
     text_y = draw_label_value(
         c,
         x=text_x,
@@ -114,21 +83,16 @@ def draw_proof_block(
             value=verdict.runner_up_corner,
             value_size=FS_BODY,
         )
-    location_confidence = verdict.location_confidence or tr("UNKNOWN")
-    confidence_value_size = (
-        FS_BODY if len(_wrap_lines(location_confidence, text_w, FS_H2)) > 1 else FS_H2
-    )
-    confidence_max_lines = 3 if confidence_value_size == FS_BODY else 2
-    text_y = draw_label_value(
-        c,
-        x=text_x,
-        y=text_y,
-        width=text_w,
-        label=tr("REPORT_LOCATION_CONFIDENCE_LABEL"),
-        value=location_confidence,
-        value_size=confidence_value_size,
-        max_lines=confidence_max_lines,
-    )
+    if verdict.dominance_ratio_label:
+        text_y = draw_label_value(
+            c,
+            x=text_x,
+            y=text_y,
+            width=text_w,
+            label=tr("REPORT_DOMINANCE_RATIO_LABEL"),
+            value=verdict.dominance_ratio_label,
+            value_size=FS_BODY,
+        )
     text_y = draw_label_value(
         c,
         x=text_x,
@@ -139,27 +103,6 @@ def draw_proof_block(
         value_size=FS_BODY,
         max_lines=3,
     )
-    if verdict.also_consider:
-        text_y = draw_label_value(
-            c,
-            x=text_x,
-            y=text_y,
-            width=text_w,
-            label=tr("REPORT_ALTERNATIVE_SOURCE_LABEL"),
-            value=verdict.also_consider,
-            value_size=FS_BODY,
-        )
-    if verdict.proof_caveat:
-        _draw_text(
-            c,
-            text_x,
-            text_y - 1.5 * mm,
-            text_w,
-            verdict.proof_caveat,
-            size=FS_SMALL,
-            color=SUB_CLR,
-            leading=FS_SMALL + 1.2,
-        )
 
 
 def draw_timeline_block(

--- a/apps/server/vibesensor/adapters/pdf/pdf_page1.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_page1.py
@@ -9,7 +9,7 @@ from reportlab.pdfgen.canvas import Canvas
 
 from vibesensor.adapters.pdf.page1_actions import draw_actions_block, estimate_actions_block_height
 from vibesensor.adapters.pdf.page1_header import draw_header_strip, draw_hero_block
-from vibesensor.adapters.pdf.page1_proof import draw_proof_block, draw_timeline_block
+from vibesensor.adapters.pdf.page1_proof import draw_proof_block
 from vibesensor.adapters.pdf.pdf_style import GAP, MARGIN, PAGE_H, PAGE_W
 from vibesensor.report_i18n import tr as _tr
 from vibesensor.shared.types.json_types import JsonValue
@@ -29,31 +29,24 @@ def _page1(
     def tr(key: str, **kw: JsonValue) -> str:
         return _tr(plan.lang, key, **kw)
 
-    header_h = 26 * mm
-    hero_h = 40 * mm
+    header_h = 18 * mm
+    hero_h = 54 * mm
     content_bottom = MARGIN + 8 * mm
     main_h = page_top - content_bottom - header_h - hero_h - (2 * GAP)
-    proof_w = width * 0.58
+    lower_h = min(main_h, 118 * mm)
+    lower_y = content_bottom + main_h - lower_h
+    proof_w = width * 0.52
     actions_w = width - proof_w - GAP
 
     header_y = page_top - header_h
     hero_y = header_y - GAP - hero_h
-    middle_y = content_bottom
 
-    timeline_graph = plan.verdict_page.timeline_graph
-    timeline_gap = GAP if timeline_graph is not None else 0.0
-    timeline_h = (
-        float(min(48 * mm, max(42 * mm, main_h * 0.22))) if timeline_graph is not None else 0.0
-    )
-    upper_content_y = middle_y + timeline_h + timeline_gap
-    upper_content_h = main_h - timeline_h - timeline_gap
-
-    actions_h = min(upper_content_h, estimate_actions_block_height(plan, tr=tr, w=actions_w))
-    actions_y = upper_content_y + upper_content_h - actions_h
+    actions_h = min(lower_h, estimate_actions_block_height(plan, tr=tr, w=actions_w))
+    actions_y = lower_y + lower_h - actions_h
 
     draw_header_strip(c, plan, tr=tr, x=MARGIN, y=header_y, w=width, h=header_h)
     draw_hero_block(c, plan, tr=tr, x=MARGIN, y=hero_y, w=width, h=hero_h)
-    draw_proof_block(c, plan, tr=tr, x=MARGIN, y=upper_content_y, w=proof_w, h=upper_content_h)
+    draw_proof_block(c, plan, tr=tr, x=MARGIN, y=lower_y, w=proof_w, h=lower_h)
     draw_actions_block(
         c,
         plan,
@@ -63,5 +56,3 @@ def _page1(
         w=actions_w,
         h=actions_h,
     )
-    if timeline_graph is not None:
-        draw_timeline_block(c, plan, tr=tr, x=MARGIN, y=middle_y, w=width, h=timeline_h)

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1907,6 +1907,26 @@
     "en": "Recapture before acting",
     "nl": "Eerst opnieuw meten"
   },
+  "REPORT_PAGE1_CAVEAT_ALTERNATIVE": {
+    "en": "Alternative source still in scope",
+    "nl": "Alternatieve bron blijft in beeld"
+  },
+  "REPORT_PAGE1_CAVEAT_LIMITED_RUN": {
+    "en": "Run limits affect confidence",
+    "nl": "Runbeperkingen beïnvloeden de zekerheid"
+  },
+  "REPORT_PAGE1_FALLBACK_ALTERNATIVE": {
+    "en": "Inspect {source} next",
+    "nl": "Controleer daarna {source}"
+  },
+  "REPORT_PAGE1_IF_CLEAN_LABEL": {
+    "en": "If clean",
+    "nl": "Als dit schoon is"
+  },
+  "REPORT_PAGE1_MAIN_CAVEAT_LABEL": {
+    "en": "Main caveat",
+    "nl": "Belangrijkste kanttekening"
+  },
   "REPORT_ALSO_CONSIDER_LABEL": {
     "en": "Also consider",
     "nl": "Overweeg ook"
@@ -2190,6 +2210,14 @@
   "REPORT_LOCATION_CONFIDENCE_LABEL": {
     "en": "Location confidence",
     "nl": "Locatievertrouwen"
+  },
+  "REPORT_DOMINANCE_RATIO_LABEL": {
+    "en": "Dominance ratio",
+    "nl": "Dominantieverhouding"
+  },
+  "REPORT_DOMINANCE_RATIO_VALUE": {
+    "en": "{ratio}x stronger",
+    "nl": "{ratio}x sterker"
   },
   "REPORT_LOCATION_CONFIDENCE_MIXED": {
     "en": "Mixed",

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
@@ -71,8 +71,10 @@ class VerdictPageData:
     reason_sentence: str | None = None
     dominant_corner: str | None = None
     runner_up_corner: str | None = None
+    dominance_ratio_label: str | None = None
     location_confidence: str | None = None
     coverage_label: str | None = None
+    fallback_path: str | None = None
     also_consider: str | None = None
     proof_summary: str | None = None
     proof_caveat: str | None = None

--- a/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
@@ -76,6 +76,7 @@ def build_report_document_sections(
             tr=context.tr,
         )
     )
+    verdict_page = build_verdict_page(context=context, appendix_a=appendix_a)
     return ReportDocumentSections(
         system_cards=tuple(
             build_system_cards(
@@ -106,7 +107,7 @@ def build_report_document_sections(
                 tr=context.tr,
             )
         ),
-        verdict_page=build_verdict_page(context=context),
+        verdict_page=verdict_page,
         appendix_a=appendix_a,
         appendix_b=appendix_b,
         appendix_c=build_appendix_c_data(

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -39,7 +39,7 @@ def build_evidence_snapshot_rows(
         ),
         ReportLabelValueRow(
             label=tr("REPORT_SUPPORT_WINDOW_SUMMARY_LABEL"),
-            value=_support_window_text(report_facts, tr=tr),
+            value=_support_window_text(report_facts, compact=compact, tr=tr),
         ),
         ReportLabelValueRow(
             label=tr("REPORT_STABLE_FREQUENCY_LABEL"),
@@ -95,14 +95,19 @@ def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str
     return tr("REPORT_EVIDENCE_BASIS_SUMMARY")
 
 
-def _support_window_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+def _support_window_text(
+    report_facts: PreparedReportFacts,
+    *,
+    compact: bool,
+    tr: Callable[..., str],
+) -> str:
     diagnosis = report_facts.primary_diagnosis
     if diagnosis is not None:
         count = diagnosis.supporting_window_count
         duration_s = diagnosis.supporting_duration_s
         if count is None or count <= 0:
             return tr("REPORT_SUPPORT_WINDOW_SUMMARY_NONE")
-        if duration_s is not None and duration_s > 0:
+        if not compact and duration_s is not None and duration_s > 0:
             return tr(
                 "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
                 count=str(count),
@@ -114,7 +119,7 @@ def _support_window_text(report_facts: PreparedReportFacts, *, tr: Callable[...,
     duration_s = evidence.supporting_duration_s
     if count is None or count <= 0:
         return tr("REPORT_SUPPORT_WINDOW_SUMMARY_NONE")
-    if duration_s is not None and duration_s > 0:
+    if not compact and duration_s is not None and duration_s > 0:
         return tr(
             "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
             count=str(count),

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 
 from vibesensor.domain import SuitabilityCheck, TestRun
 from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
-from vibesensor.shared.boundaries.reporting.document import PatternEvidence, VerdictPageData
+from vibesensor.shared.boundaries.reporting.document import (
+    AppendixAData,
+    PatternEvidence,
+    VerdictPageData,
+)
 from vibesensor.shared.report_diagnostics import first_nonpass_detail
 from vibesensor.shared.report_presentation import (
     action_status_text,
@@ -98,6 +102,7 @@ def build_verdict_page_data(
         ),
         dominant_corner=display_location(primary.primary_location, tr=tr),
         runner_up_corner=verdict_context.runner_up_corner,
+        dominance_ratio_label=_dominance_ratio_label(primary.dominance_ratio, tr=tr),
         location_confidence=_location_confidence_display_text(
             primary=primary,
             action_status_key=verdict_context.action_status_key,
@@ -140,7 +145,11 @@ def build_verdict_page_data(
     )
 
 
-def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
+def build_verdict_page(
+    *,
+    context: ReportDocumentContext,
+    appendix_a: AppendixAData,
+) -> VerdictPageData:
     """Build the fully assembled verdict page from shared document context."""
 
     verdict_page = build_verdict_page_data(
@@ -164,7 +173,9 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
     )
     return replace(
         verdict_page,
+        reason_sentence=_page1_reason_sentence(verdict_page.reason_sentence, proof_summary),
         proof_summary=proof_summary,
+        fallback_path=_page1_fallback_path(verdict_page, appendix_a=appendix_a, tr=context.tr),
         proof_snapshot_rows=build_evidence_snapshot_rows(
             context.report_facts,
             compact=True,
@@ -175,6 +186,35 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
             duration_s=context.run_facts.duration_s,
         ),
     )
+
+
+def _page1_reason_sentence(current: str | None, proof_summary: str | None) -> str | None:
+    summary = str(proof_summary or "").strip()
+    if "No single corner" in summary or "Geen enkele hoek" in summary:
+        return summary
+    return current
+
+
+def _dominance_ratio_label(
+    dominance_ratio: float | None,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    if dominance_ratio is None or dominance_ratio <= 0:
+        return None
+    return tr("REPORT_DOMINANCE_RATIO_VALUE", ratio=f"{dominance_ratio:.1f}")
+
+
+def _page1_fallback_path(
+    verdict_page: VerdictPageData,
+    *,
+    appendix_a: AppendixAData,
+    tr: Callable[..., str],
+) -> str | None:
+    alternative = str(verdict_page.also_consider or appendix_a.alternative_source or "").strip()
+    if not alternative:
+        return None
+    return tr("REPORT_PAGE1_FALLBACK_ALTERNATIVE", source=alternative)
 
 
 def _build_primary_reason_sentence(
@@ -220,25 +260,7 @@ def _location_confidence_display_text(
         action_status_key=action_status_key,
         location_confidence_key=location_confidence_key,
     )
-    if action_status_key != "action_ready_caution":
-        return location_confidence_text(presented_key, tr=tr)
-
-    reason = str(primary.certainty_reason or "").strip().split(";")[0].rstrip(".")
-    if reason:
-        return reason
-    if alternative_source_visible:
-        return tr("REPORT_LOCATION_CONFIDENCE_CLOSE_SCORES")
-    issue = first_nonpass_detail(
-        suitability_checks=suitability_checks,
-        warnings=warnings,
-        lang=lang,
-        tr=tr,
-    )
-    if issue:
-        return issue.rstrip(".")
-    if dominance_ratio is not None:
-        return tr("REPORT_LOCATION_CONFIDENCE_RATIO_REASON", ratio=f"{dominance_ratio:.1f}")
-    return tr("REPORT_LOCATION_CONFIDENCE_MODERATE_DETAIL")
+    return location_confidence_text(presented_key, tr=tr)
 
 
 def _action_status_note_text(
@@ -262,18 +284,9 @@ def _action_status_note_text(
         lang=lang,
         tr=tr,
     )
-    score_note: str | None = None
     if action_status_key == "action_ready_caution" and alternative_source_visible:
-        ranked_candidates = list(aggregate.effective_top_causes()[:2])
-        if len(ranked_candidates) > 1:
-            score_note = tr(
-                "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_ALTERNATIVE",
-                primary=human_source(ranked_candidates[0].suspected_source, tr=tr),
-                alternative=human_source(ranked_candidates[1].suspected_source, tr=tr),
-            )
-        else:
-            score_note = tr("REPORT_ACTION_STATUS_NOTE_GATE_CAUTION")
-    reason = score_note or proof_caveat_text(
+        return tr("REPORT_PAGE1_CAVEAT_ALTERNATIVE")
+    reason = proof_caveat_text(
         confidence_facts=report_confidence,
         action_status_key=action_status_key,
         location_confidence_key=location_confidence_key,
@@ -288,5 +301,15 @@ def _action_status_note_text(
                 issue=issue_norm,
                 reason=reason_norm,
             )
-        return issue
-    return issue or reason
+        return _brief_page1_note(issue, tr=tr)
+    return _brief_page1_note(issue or reason, tr=tr)
+
+
+def _brief_page1_note(note: str | None, *, tr: Callable[..., str]) -> str | None:
+    text = str(note or "").strip()
+    if not text:
+        return None
+    first_sentence = text.split(". ", 1)[0].rstrip(".")
+    if len(first_sentence) <= 96:
+        return first_sentence
+    return tr("REPORT_PAGE1_CAVEAT_LIMITED_RUN")

--- a/docs/design_language.md
+++ b/docs/design_language.md
@@ -75,11 +75,12 @@ Automatic on touch/coarse-pointer tablet-ish viewports (`pointer: coarse` + `max
 
 ## PDF Report Layout
 
-The generated PDF uses A4 portrait and is structured as a **diagnostic worksheet**:
+The generated PDF uses A4 portrait and starts with a **one-glance verdict page**:
 
 ### Page structure
-1. **Diagnostic Worksheet** (page 1) — header bar with date/car metadata, observed signature block (primary system, strength, certainty + reason), system finding cards, single next-steps section, data trust quality bar.
+1. **Verdict page** (page 1) — compact date/car/run metadata, primary source, inspect-first target, short reason, confidence/caveat cues, concise corner proof, and the first action plus fallback path. Page 1 intentionally omits the run timeline and support-duration phrasing that can be confused with elapsed runtime.
 2. **Evidence & Diagnostics** (page 2) — left column: car hotspot heat-map diagram (42 % width, aspect-ratio preserved); right column: compact pattern evidence panel + diagnostic peaks table (system-relevance oriented).
+3. **Inspection path** — full action-card detail, alternatives, confirm/falsify guidance, and longer evidence/context that does not belong on the glanceable verdict page.
 
 ### Primitives
 | Primitive | File | Purpose |


### PR DESCRIPTION
Closes #3678

## What changed
- Compressed the page-1 metadata strip so context no longer dominates the verdict.
- Moved the hero into a decision-first surface: source, inspect-first target, short reason, status cue, and one caveat.
- Removed the run timeline from page 1.
- Reduced page-1 proof to corner, runner-up, dominance ratio, and coverage.
- Changed page-1 actions to primary step plus fallback path.
- Changed page-1 support wording to count-only; full support-duration detail stays in Appendix C.
- Added short i18n strings, rendered-output/data-contract/layout tests, and design docs.

## Why
Page 1 was acting like a dense mini worksheet. It mixed verdict, proof, caveat, action, timeline, and support-duration detail, which made the first inspection decision harder to scan and made long action/caution text fragile.

## Validation
- `make typecheck-backend`
- `pytest -q apps/server/tests/adapters/pdf/ apps/server/tests/integration/test_report_pipeline.py apps/server/tests/use_cases/history/`
- `make docs-lint`
- `tools/dev/check_hygiene.py`
- `tools/tests/plan_validation.py --json-only`
- `make lint`
- `git diff --check`

## Risks / tradeoffs / edge cases
- Page 1 intentionally shows less proof detail. The detailed evidence remains in later pages.
- The timeline is no longer rendered on page 1. Existing timeline renderer tests stay because the renderer still exists.
- Support duration is not shown on page 1 to avoid confusing aggregate support with elapsed runtime; Appendix C still carries the richer value.
- Related clipping/support wording issues #3679 and #3680 may be affected by this redesign, but this PR only closes #3678.

## Follow-ups
- Reconcile #3679 and #3680 after merge to decide whether this redesign already resolves them or whether narrower follow-up work remains.
