### PR TITLE
Add post-run raw window iterator

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+from test_support.history_db_lifecycle import build_history_db, create_recording_run
+
+from vibesensor.shared.types.raw_capture import RawCaptureChunk
+from vibesensor.shared.types.run_schema import RunMetadata, RunSensorMetadata
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawWindowIteratorConfig,
+    prepare_post_run_raw_window_iterator,
+)
+
+
+def _append_chunk(
+    db,
+    *,
+    run_id: str,
+    client_id: str,
+    t0_us: int,
+    samples: np.ndarray,
+    sample_rate_hz: int = 4,
+) -> None:
+    chunk = RawCaptureChunk(
+        client_id=client_id,
+        sample_rate_hz=sample_rate_hz,
+        t0_us=t0_us,
+        sample_count=int(samples.shape[0]),
+        samples_i16le=np.ascontiguousarray(samples, dtype=np.int16).tobytes(order="C"),
+    )
+    db.run_repository._run_sync(db.run_repository.aappend_raw_capture_chunk(run_id, chunk))
+
+
+def _finalize_raw_capture(db, run_id: str):
+    return db.run_repository._run_sync(db.run_repository.afinalize_raw_capture(run_id))
+
+
+async def _collect_windows(iterator) -> list:
+    return [window async for window in iterator.iter_windows()]
+
+
+def _samples(rows: int, *, offset: int = 0) -> np.ndarray:
+    x = np.arange(offset, offset + rows, dtype=np.int16)
+    y = x + 100
+    z = x + 200
+    return np.stack([x, y, z], axis=1)
+
+
+def _create_run_with_sensor_metadata(db, run_id: str) -> None:
+    metadata = RunMetadata.create(
+        run_id=run_id,
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="ADXL345",
+        raw_sample_rate_hz=4,
+        configured_raw_sample_rate_hz=4,
+        feature_interval_s=0.5,
+        fft_window_size_samples=4,
+        accel_scale_g_per_lsb=0.001,
+        sensor_snapshots=(
+            RunSensorMetadata(sensor_id="sensor-a", location_code="front_left"),
+            RunSensorMetadata(sensor_id="sensor-b", location_code="rear_right"),
+        ),
+    )
+    create_recording_run(
+        db,
+        run_id,
+        metadata=metadata,
+    )
+
+
+def test_post_run_raw_window_iterator_streams_configured_sensor_ranges(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-windows")
+    _append_chunk(db, run_id="run-windows", client_id="sensor-a", t0_us=0, samples=_samples(6))
+    _append_chunk(
+        db,
+        run_id="run-windows",
+        client_id="sensor-b",
+        t0_us=0,
+        samples=_samples(4, offset=20),
+    )
+    assert _finalize_raw_capture(db, "run-windows") is not None
+
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(
+            db.run_repository,
+            "run-windows",
+            config=PostRunRawWindowIteratorConfig(
+                window_size_s=1.0,
+                overlap_pct=0.5,
+                min_valid_samples_pct=0.5,
+            ),
+        )
+    )
+    windows = db.run_repository._run_sync(_collect_windows(iterator))
+
+    assert iterator.plan is not None
+    assert [window.window.sample_start for window in windows] == [0, 2, 4]
+    assert [window.window.sample_end for window in windows] == [4, 6, 8]
+    assert [sensor.client_id for sensor in windows[0].sensors] == ["sensor-a", "sensor-b"]
+    assert windows[0].sensors[0].location == "front_left"
+    assert windows[0].sensors[0].axis_x_i16.tolist() == [0, 1, 2, 3]
+    assert windows[1].sensors[0].axis_y_i16.tolist() == [102, 103, 104, 105]
+    assert "partial_window" in windows[2].sensors[0].data_quality_flags
+    assert "missing_samples" in windows[2].sensors[0].data_quality_flags
+    assert "low_sample_count" in windows[2].sensors[1].data_quality_flags
+
+
+def test_post_run_raw_window_iterator_uses_manifest_range_reads_not_full_capture(
+    tmp_path: Path,
+) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-stream")
+    _append_chunk(db, run_id="run-stream", client_id="sensor-a", t0_us=0, samples=_samples(6))
+    assert _finalize_raw_capture(db, "run-stream") is not None
+
+    class CountingRepository:
+        def __init__(self, wrapped) -> None:
+            self.wrapped = wrapped
+            self.range_reads: list[tuple[str, int, int]] = []
+
+        async def aget_run_metadata(self, run_id: str):
+            return await self.wrapped.aget_run_metadata(run_id)
+
+        async def aget_raw_capture_manifest(self, run_id: str):
+            return await self.wrapped.aget_raw_capture_manifest(run_id)
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            run_id: str,
+            client_id: str,
+            *,
+            sample_start: int,
+            sample_count: int,
+        ):
+            self.range_reads.append((client_id, sample_start, sample_count))
+            return await self.wrapped.aload_raw_capture_sensor_range(
+                run_id,
+                client_id,
+                sample_start=sample_start,
+                sample_count=sample_count,
+            )
+
+    repository = CountingRepository(db.run_repository)
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(
+            repository,
+            "run-stream",
+            config=PostRunRawWindowIteratorConfig(
+                window_size_s=1.0,
+                overlap_pct=0.5,
+                min_valid_samples_pct=0.5,
+                sensor_ids=("sensor-a",),
+            ),
+        )
+    )
+    db.run_repository._run_sync(_collect_windows(iterator))
+
+    assert repository.range_reads == [
+        ("sensor-a", 0, 4),
+        ("sensor-a", 2, 4),
+        ("sensor-a", 4, 4),
+    ]
+
+
+def test_post_run_raw_window_iterator_returns_warning_for_missing_artifact(
+    tmp_path: Path,
+) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-missing")
+
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(db.run_repository, "run-missing")
+    )
+    windows = db.run_repository._run_sync(_collect_windows(iterator))
+
+    assert windows == []
+    assert [warning.code for warning in iterator.warnings] == ["missing_raw_capture_manifest"]
+
+
+def test_post_run_raw_window_iterator_flags_timestamp_gaps(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-gap")
+    _append_chunk(db, run_id="run-gap", client_id="sensor-a", t0_us=0, samples=_samples(4))
+    _append_chunk(
+        db,
+        run_id="run-gap",
+        client_id="sensor-a",
+        t0_us=1_000_000,
+        samples=_samples(4, offset=4),
+    )
+    assert _finalize_raw_capture(db, "run-gap") is not None
+
+    class GapRangeRepository:
+        async def aget_run_metadata(self, run_id: str):
+            return await db.run_repository.aget_run_metadata(run_id)
+
+        async def aget_raw_capture_manifest(self, run_id: str):
+            return await db.run_repository.aget_raw_capture_manifest(run_id)
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            run_id: str,
+            client_id: str,
+            *,
+            sample_start: int,
+            sample_count: int,
+        ):
+            raw_range = await db.run_repository.aload_raw_capture_sensor_range(
+                run_id,
+                client_id,
+                sample_start=sample_start,
+                sample_count=sample_count,
+            )
+            if raw_range is None or len(raw_range.chunks) < 2:
+                return raw_range
+            shifted_chunk = replace(raw_range.chunks[1], t0_us=2_000_000)
+            return replace(raw_range, chunks=(raw_range.chunks[0], shifted_chunk))
+
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(
+            GapRangeRepository(),
+            "run-gap",
+            config=PostRunRawWindowIteratorConfig(
+                window_size_s=1.0,
+                overlap_pct=0.5,
+                min_valid_samples_pct=0.5,
+            ),
+        )
+    )
+    windows = db.run_repository._run_sync(_collect_windows(iterator))
+
+    assert "timestamp_gap" in windows[1].sensors[0].data_quality_flags
+    assert "timestamp_gap" in {warning.code for warning in windows[1].warnings}
+
+
+def test_post_run_raw_window_iterator_rejects_unsupported_manifest_schema(
+    tmp_path: Path,
+) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-schema")
+    _append_chunk(db, run_id="run-schema", client_id="sensor-a", t0_us=0, samples=_samples(4))
+    manifest = _finalize_raw_capture(db, "run-schema")
+    assert manifest is not None
+
+    class UnsupportedSchemaRepository:
+        async def aget_run_metadata(self, run_id: str):
+            return await db.run_repository.aget_run_metadata(run_id)
+
+        async def aget_raw_capture_manifest(self, run_id: str):
+            loaded = await db.run_repository.aget_raw_capture_manifest(run_id)
+            assert loaded is not None
+            return replace(loaded, schema_version=loaded.schema_version + 1)
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            run_id: str,
+            client_id: str,
+            *,
+            sample_start: int,
+            sample_count: int,
+        ):
+            raise AssertionError("unsupported manifests must not read sidecar ranges")
+
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(UnsupportedSchemaRepository(), "run-schema")
+    )
+
+    assert iterator.plan is None
+    assert "unsupported_schema_version" in {warning.code for warning in iterator.warnings}
+
+
+def test_post_run_raw_window_iterator_validates_config() -> None:
+    with pytest.raises(ValueError, match="0 <= overlap_pct < 1"):
+        asyncio.run(
+            prepare_post_run_raw_window_iterator(  # type: ignore[arg-type]
+                object(),
+                "run-invalid",
+                config=PostRunRawWindowIteratorConfig(overlap_pct=1.0),
+            )
+        )

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
@@ -1,0 +1,721 @@
+"""Streaming raw waveform window access for post-run diagnostics."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+import numpy as np
+import numpy.typing as npt
+
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorManifest,
+    RawCaptureSensorRange,
+)
+from vibesensor.shared.types.run_schema import RunMetadata, RunSensorMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+
+_SUPPORTED_RAW_CAPTURE_SCHEMA_VERSION = 7
+_SUPPORTED_RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
+_SUPPORTED_RAW_CAPTURE_MODE = "full_run"
+_AXIS_COUNT = 3
+
+type PostRunRawWindowWarningCode = Literal[
+    "missing_run_metadata",
+    "missing_raw_capture_manifest",
+    "manifest_run_id_mismatch",
+    "unsupported_schema_version",
+    "unsupported_storage_type",
+    "unsupported_capture_mode",
+    "missing_sensor_identity",
+    "missing_sensor_location",
+    "missing_requested_sensor",
+    "missing_sidecar",
+    "invalid_sample_rate",
+    "sample_rate_mismatch",
+    "sample_rate_unverified",
+    "timestamp_gap",
+    "invalid_axis_data",
+    "low_sample_count",
+]
+
+type PostRunRawWindowDataQualityFlag = Literal[
+    "partial_window",
+    "timestamp_gap",
+    "missing_samples",
+    "low_sample_count",
+    "invalid_axis_data",
+    "sample_rate_mismatch",
+    "sample_rate_unverified",
+    "missing_sensor_location",
+    "missing_sidecar",
+]
+
+
+class PostRunRawWindowRepository(Protocol):
+    async def aget_run_metadata(self, run_id: str) -> RunMetadata | None: ...
+
+    async def aget_raw_capture_manifest(self, run_id: str) -> RawCaptureManifest | None: ...
+
+    async def aload_raw_capture_sensor_range(
+        self,
+        run_id: str,
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawWindowWarning:
+    """Structured non-fatal warning from raw post-run window access."""
+
+    code: PostRunRawWindowWarningCode
+    message: str
+    sensor_id: str | None = None
+    window_index: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawWindowIteratorConfig:
+    """Configurable post-run window policy.
+
+    If ``window_size_s`` or ``overlap_pct`` is omitted, the persisted run metadata
+    supplies the canonical FFT window size and feature stride.
+    """
+
+    window_size_s: float | None = None
+    overlap_pct: float | None = None
+    min_valid_samples_pct: float = 1.0
+    sensor_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawWindowPlan:
+    """Deterministic raw-window graph over one raw-capture artifact bundle."""
+
+    policy: WholeRunWindowPolicy
+    coverage_sample_start: int
+    coverage_sample_end: int
+    windows: tuple[WholeRunWindowDescriptor, ...]
+    min_valid_samples_pct: float
+
+    @property
+    def total_sample_count(self) -> int:
+        return max(0, self.coverage_sample_end - self.coverage_sample_start)
+
+    @property
+    def total_window_count(self) -> int:
+        return len(self.windows)
+
+    @property
+    def min_valid_samples(self) -> int:
+        return max(
+            1,
+            int(math.ceil(self.policy.window_size_samples * self.min_valid_samples_pct)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawSensorWindow:
+    """One sensor's raw axis arrays for one post-run analysis window."""
+
+    run_id: str
+    client_id: str
+    location: str
+    window: WholeRunWindowDescriptor
+    sample_rate_hz: int
+    axis_x_i16: npt.NDArray[np.int16]
+    axis_y_i16: npt.NDArray[np.int16]
+    axis_z_i16: npt.NDArray[np.int16]
+    requested_sample_start: int
+    requested_sample_count: int
+    returned_sample_start: int | None
+    returned_sample_count: int
+    data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
+
+    @property
+    def start_t_s(self) -> float:
+        return self.window.start_t_s
+
+    @property
+    def end_t_s(self) -> float:
+        return self.window.end_t_s
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawWindow:
+    """Run-level DTO for one deterministic window across selected sensors."""
+
+    run_id: str
+    window: WholeRunWindowDescriptor
+    sensors: tuple[PostRunRawSensorWindow, ...]
+    warnings: tuple[PostRunRawWindowWarning, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunRawWindowIterator:
+    """Prepared streaming iterator over raw-capture window ranges."""
+
+    repository: PostRunRawWindowRepository
+    run_id: str
+    metadata: RunMetadata | None
+    manifest: RawCaptureManifest | None
+    plan: PostRunRawWindowPlan | None
+    sensors: tuple[RawCaptureSensorManifest, ...]
+    warnings: tuple[PostRunRawWindowWarning, ...]
+    config: PostRunRawWindowIteratorConfig
+
+    async def iter_windows(self) -> AsyncIterator[PostRunRawWindow]:
+        """Yield raw windows by reading only the needed sensor ranges."""
+
+        if self.plan is None:
+            return
+        for window in self.plan.windows:
+            sensor_windows: list[PostRunRawSensorWindow] = []
+            window_warnings: list[PostRunRawWindowWarning] = []
+            for sensor in self.sensors:
+                raw_range = await self.repository.aload_raw_capture_sensor_range(
+                    self.run_id,
+                    sensor.client_id,
+                    sample_start=window.sample_start,
+                    sample_count=window.sample_count,
+                )
+                sensor_window, sensor_warnings = _build_sensor_window(
+                    run_id=self.run_id,
+                    metadata=self.metadata,
+                    window=window,
+                    plan=self.plan,
+                    sensor=sensor,
+                    raw_range=raw_range,
+                )
+                sensor_windows.append(sensor_window)
+                window_warnings.extend(sensor_warnings)
+            yield PostRunRawWindow(
+                run_id=self.run_id,
+                window=window,
+                sensors=tuple(sensor_windows),
+                warnings=tuple(window_warnings),
+            )
+
+
+async def prepare_post_run_raw_window_iterator(
+    repository: PostRunRawWindowRepository,
+    run_id: str,
+    *,
+    config: PostRunRawWindowIteratorConfig | None = None,
+) -> PostRunRawWindowIterator:
+    """Prepare manifest validation and window planning for one post-run raw capture."""
+
+    effective_config = config or PostRunRawWindowIteratorConfig()
+    _validate_config(effective_config)
+    metadata = await repository.aget_run_metadata(run_id)
+    warnings: list[PostRunRawWindowWarning] = []
+    if metadata is None:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="missing_run_metadata",
+                message=f"run {run_id} has no metadata row",
+            )
+        )
+        return _empty_iterator(repository, run_id, effective_config, warnings)
+
+    manifest = await repository.aget_raw_capture_manifest(run_id)
+    if manifest is None:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="missing_raw_capture_manifest",
+                message=f"run {run_id} has no raw-capture manifest",
+            )
+        )
+        return _empty_iterator(
+            repository,
+            run_id,
+            effective_config,
+            warnings,
+            metadata=metadata,
+        )
+
+    warnings.extend(_validate_manifest(run_id=run_id, manifest=manifest))
+    if any(_fatal_manifest_warning(warning) for warning in warnings):
+        return _empty_iterator(
+            repository,
+            run_id,
+            effective_config,
+            warnings,
+            metadata=metadata,
+            manifest=manifest,
+        )
+
+    sensors = _select_sensors(manifest, effective_config.sensor_ids, warnings)
+    warnings.extend(_validate_sensors(metadata=metadata, sensors=sensors))
+    plan = _build_plan(
+        metadata=metadata,
+        sensors=sensors,
+        config=effective_config,
+        warnings=warnings,
+    )
+    return PostRunRawWindowIterator(
+        repository=repository,
+        run_id=run_id,
+        metadata=metadata,
+        manifest=manifest,
+        plan=plan,
+        sensors=sensors,
+        warnings=tuple(warnings),
+        config=effective_config,
+    )
+
+
+def _empty_iterator(
+    repository: PostRunRawWindowRepository,
+    run_id: str,
+    config: PostRunRawWindowIteratorConfig,
+    warnings: Sequence[PostRunRawWindowWarning],
+    *,
+    metadata: RunMetadata | None = None,
+    manifest: RawCaptureManifest | None = None,
+) -> PostRunRawWindowIterator:
+    return PostRunRawWindowIterator(
+        repository=repository,
+        run_id=run_id,
+        metadata=metadata,
+        manifest=manifest,
+        plan=None,
+        sensors=(),
+        warnings=tuple(warnings),
+        config=config,
+    )
+
+
+def _validate_manifest(
+    *,
+    run_id: str,
+    manifest: RawCaptureManifest,
+) -> tuple[PostRunRawWindowWarning, ...]:
+    warnings: list[PostRunRawWindowWarning] = []
+    if manifest.run_id != run_id:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="manifest_run_id_mismatch",
+                message=(
+                    f"raw-capture manifest run_id {manifest.run_id!r} does not match {run_id!r}"
+                ),
+            )
+        )
+    if manifest.schema_version != _SUPPORTED_RAW_CAPTURE_SCHEMA_VERSION:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="unsupported_schema_version",
+                message=(
+                    f"raw-capture schema {manifest.schema_version} is not supported; "
+                    f"expected {_SUPPORTED_RAW_CAPTURE_SCHEMA_VERSION}"
+                ),
+            )
+        )
+    if manifest.storage_type != _SUPPORTED_RAW_CAPTURE_STORAGE_TYPE:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="unsupported_storage_type",
+                message=f"raw-capture storage type {manifest.storage_type!r} is not supported",
+            )
+        )
+    if manifest.capture_mode != _SUPPORTED_RAW_CAPTURE_MODE:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="unsupported_capture_mode",
+                message=f"raw-capture mode {manifest.capture_mode!r} is not supported",
+            )
+        )
+    return tuple(warnings)
+
+
+def _fatal_manifest_warning(warning: PostRunRawWindowWarning) -> bool:
+    return warning.code in {
+        "manifest_run_id_mismatch",
+        "unsupported_schema_version",
+        "unsupported_storage_type",
+        "unsupported_capture_mode",
+    }
+
+
+def _select_sensors(
+    manifest: RawCaptureManifest,
+    requested_sensor_ids: tuple[str, ...],
+    warnings: list[PostRunRawWindowWarning],
+) -> tuple[RawCaptureSensorManifest, ...]:
+    sensors_by_id = {
+        sensor.client_id: sensor for sensor in manifest.sensors if sensor.client_id.strip()
+    }
+    if not requested_sensor_ids:
+        return tuple(sorted(sensors_by_id.values(), key=lambda sensor: sensor.client_id))
+
+    selected: list[RawCaptureSensorManifest] = []
+    for sensor_id in requested_sensor_ids:
+        sensor = sensors_by_id.get(sensor_id)
+        if sensor is None:
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="missing_requested_sensor",
+                    message=f"requested raw-capture sensor {sensor_id!r} is not in the manifest",
+                    sensor_id=sensor_id,
+                )
+            )
+            continue
+        selected.append(sensor)
+    return tuple(selected)
+
+
+def _validate_sensors(
+    *,
+    metadata: RunMetadata,
+    sensors: Sequence[RawCaptureSensorManifest],
+) -> tuple[PostRunRawWindowWarning, ...]:
+    warnings: list[PostRunRawWindowWarning] = []
+    metadata_sample_rate_hz = int(metadata.raw_sample_rate_hz or 0)
+    for sensor in sensors:
+        if not sensor.client_id.strip():
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="missing_sensor_identity",
+                    message="raw-capture manifest contains a sensor without an identity",
+                )
+            )
+        if sensor.sample_rate_hz <= 0:
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="invalid_sample_rate",
+                    message=(
+                        f"sensor {sensor.client_id} has invalid "
+                        f"sample_rate_hz={sensor.sample_rate_hz}"
+                    ),
+                    sensor_id=sensor.client_id,
+                )
+            )
+        if metadata_sample_rate_hz > 0 and sensor.sample_rate_hz != metadata_sample_rate_hz:
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="sample_rate_mismatch",
+                    message=(
+                        f"sensor {sensor.client_id} sample rate {sensor.sample_rate_hz} "
+                        f"does not match run metadata {metadata_sample_rate_hz}"
+                    ),
+                    sensor_id=sensor.client_id,
+                )
+            )
+        if sensor.sample_rate_unverified:
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="sample_rate_unverified",
+                    message=(
+                        f"sensor {sensor.client_id} sample rate proof is "
+                        f"{sensor.sample_rate_proof_state}"
+                    ),
+                    sensor_id=sensor.client_id,
+                )
+            )
+        snapshot = metadata.sensor_snapshot_for(sensor.client_id)
+        if snapshot is None or not snapshot.location_code.strip():
+            warnings.append(
+                PostRunRawWindowWarning(
+                    code="missing_sensor_location",
+                    message=f"sensor {sensor.client_id} has no run metadata location snapshot",
+                    sensor_id=sensor.client_id,
+                )
+            )
+    return tuple(warnings)
+
+
+def _build_plan(
+    *,
+    metadata: RunMetadata,
+    sensors: Sequence[RawCaptureSensorManifest],
+    config: PostRunRawWindowIteratorConfig,
+    warnings: list[PostRunRawWindowWarning],
+) -> PostRunRawWindowPlan | None:
+    if not sensors:
+        return None
+    policy = _resolve_policy(metadata=metadata, config=config)
+    total_sample_count = max(max(0, sensor.sample_count) for sensor in sensors)
+    if total_sample_count <= 0:
+        return PostRunRawWindowPlan(
+            policy=policy,
+            coverage_sample_start=0,
+            coverage_sample_end=0,
+            windows=(),
+            min_valid_samples_pct=config.min_valid_samples_pct,
+        )
+    min_valid_samples = max(
+        1,
+        int(math.ceil(policy.window_size_samples * config.min_valid_samples_pct)),
+    )
+    windows: list[WholeRunWindowDescriptor] = []
+    for sample_start in range(0, total_sample_count, policy.stride_samples):
+        remaining_samples = total_sample_count - sample_start
+        if remaining_samples < min_valid_samples:
+            break
+        windows.append(
+            WholeRunWindowDescriptor.from_policy(
+                window_index=len(windows),
+                sample_start=sample_start,
+                policy=policy,
+            )
+        )
+    if not windows and total_sample_count > 0:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="low_sample_count",
+                message=(
+                    f"run has {total_sample_count} raw sample(s), below the "
+                    f"{min_valid_samples} sample minimum for one window"
+                ),
+            )
+        )
+    return PostRunRawWindowPlan(
+        policy=policy,
+        coverage_sample_start=0,
+        coverage_sample_end=total_sample_count,
+        windows=tuple(windows),
+        min_valid_samples_pct=config.min_valid_samples_pct,
+    )
+
+
+def _resolve_policy(
+    *,
+    metadata: RunMetadata,
+    config: PostRunRawWindowIteratorConfig,
+) -> WholeRunWindowPolicy:
+    _validate_config(config)
+    sample_rate_hz = int(metadata.raw_sample_rate_hz or 0)
+    if sample_rate_hz <= 0:
+        raise ValueError("post-run raw window iterator requires raw_sample_rate_hz")
+
+    if config.window_size_s is None:
+        window_size_samples = int(metadata.fft_window_size_samples or 0)
+        if window_size_samples <= 0:
+            raise ValueError("post-run raw window iterator requires fft_window_size_samples")
+    else:
+        raw_window_samples = config.window_size_s * float(sample_rate_hz)
+        window_size_samples = int(round(raw_window_samples))
+        if window_size_samples <= 0 or not math.isclose(
+            raw_window_samples,
+            float(window_size_samples),
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(
+                "post-run raw window iterator requires window_size_s * raw_sample_rate_hz "
+                "to resolve to an integral sample count"
+            )
+
+    if config.overlap_pct is None:
+        feature_interval_s = float(metadata.feature_interval_s or 0.0)
+        if feature_interval_s <= 0.0:
+            raise ValueError("post-run raw window iterator requires feature_interval_s")
+        raw_stride_samples = feature_interval_s * float(sample_rate_hz)
+        stride_samples = int(round(raw_stride_samples))
+        if stride_samples <= 0 or not math.isclose(
+            raw_stride_samples,
+            float(stride_samples),
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(
+                "post-run raw window iterator requires feature_interval_s * raw_sample_rate_hz "
+                "to resolve to an integral sample stride"
+            )
+    else:
+        stride_samples = int(round(window_size_samples * (1.0 - config.overlap_pct)))
+        feature_interval_s = float(stride_samples) / float(sample_rate_hz)
+
+    if stride_samples <= 0 or stride_samples > window_size_samples:
+        raise ValueError("post-run raw window iterator requires 0 < stride <= window size")
+    return WholeRunWindowPolicy(
+        sample_rate_hz=sample_rate_hz,
+        window_size_samples=window_size_samples,
+        stride_samples=stride_samples,
+        overlap_samples=window_size_samples - stride_samples,
+        feature_interval_s=feature_interval_s,
+    )
+
+
+def _validate_config(config: PostRunRawWindowIteratorConfig) -> None:
+    if config.window_size_s is not None and config.window_size_s <= 0.0:
+        raise ValueError("post-run raw window iterator requires window_size_s > 0")
+    if config.overlap_pct is not None and not 0.0 <= config.overlap_pct < 1.0:
+        raise ValueError("post-run raw window iterator requires 0 <= overlap_pct < 1")
+    if not 0.0 < config.min_valid_samples_pct <= 1.0:
+        raise ValueError("post-run raw window iterator requires 0 < min_valid_samples_pct <= 1")
+
+
+def _build_sensor_window(
+    *,
+    run_id: str,
+    metadata: RunMetadata | None,
+    window: WholeRunWindowDescriptor,
+    plan: PostRunRawWindowPlan,
+    sensor: RawCaptureSensorManifest,
+    raw_range: RawCaptureSensorRange | None,
+) -> tuple[PostRunRawSensorWindow, tuple[PostRunRawWindowWarning, ...]]:
+    warnings: list[PostRunRawWindowWarning] = []
+    if raw_range is None:
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="missing_sidecar",
+                message=f"raw sidecar for sensor {sensor.client_id} is missing",
+                sensor_id=sensor.client_id,
+                window_index=window.window_index,
+            )
+        )
+        samples = np.empty((0, _AXIS_COUNT), dtype=np.int16)
+        flags: list[PostRunRawWindowDataQualityFlag] = [
+            "missing_sidecar",
+            "missing_samples",
+            "low_sample_count",
+        ]
+        returned_sample_start = None
+    else:
+        samples = raw_range.samples_i16
+        flags = _quality_flags(
+            metadata=metadata,
+            plan=plan,
+            sensor=sensor,
+            raw_range=raw_range,
+            warnings=warnings,
+            window_index=window.window_index,
+        )
+        returned_sample_start = raw_range.returned_sample_start
+
+    axis_x, axis_y, axis_z = _axis_arrays(samples)
+    if samples.ndim != 2 or samples.shape[1] != _AXIS_COUNT:
+        _append_unique_flag(flags, "invalid_axis_data")
+    location = _sensor_location(metadata, sensor.client_id)
+    if not location:
+        _append_unique_flag(flags, "missing_sensor_location")
+    sensor_window = PostRunRawSensorWindow(
+        run_id=run_id,
+        client_id=sensor.client_id,
+        location=location,
+        window=window,
+        sample_rate_hz=sensor.sample_rate_hz,
+        axis_x_i16=axis_x,
+        axis_y_i16=axis_y,
+        axis_z_i16=axis_z,
+        requested_sample_start=window.sample_start,
+        requested_sample_count=window.sample_count,
+        returned_sample_start=returned_sample_start,
+        returned_sample_count=int(axis_x.shape[0]),
+        data_quality_flags=tuple(flags),
+    )
+    return sensor_window, tuple(warnings)
+
+
+def _quality_flags(
+    *,
+    metadata: RunMetadata | None,
+    plan: PostRunRawWindowPlan,
+    sensor: RawCaptureSensorManifest,
+    raw_range: RawCaptureSensorRange,
+    warnings: list[PostRunRawWindowWarning],
+    window_index: int,
+) -> list[PostRunRawWindowDataQualityFlag]:
+    flags: list[PostRunRawWindowDataQualityFlag] = []
+    if raw_range.coverage_state != "full":
+        _append_unique_flag(flags, "partial_window")
+    if raw_range.coverage_state in {"missing", "empty"} or (
+        raw_range.returned_sample_count < raw_range.requested_sample_count
+    ):
+        _append_unique_flag(flags, "missing_samples")
+    if raw_range.returned_sample_count < plan.min_valid_samples:
+        _append_unique_flag(flags, "low_sample_count")
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="low_sample_count",
+                message=(
+                    f"sensor {sensor.client_id} returned {raw_range.returned_sample_count} "
+                    f"sample(s), below the {plan.min_valid_samples} sample window threshold"
+                ),
+                sensor_id=sensor.client_id,
+                window_index=window_index,
+            )
+        )
+    if sensor.sample_rate_unverified:
+        _append_unique_flag(flags, "sample_rate_unverified")
+    metadata_sample_rate_hz = int(metadata.raw_sample_rate_hz or 0) if metadata else 0
+    if metadata_sample_rate_hz > 0 and sensor.sample_rate_hz != metadata_sample_rate_hz:
+        _append_unique_flag(flags, "sample_rate_mismatch")
+    if _has_timestamp_gap(raw_range.chunks, sample_rate_hz=sensor.sample_rate_hz):
+        _append_unique_flag(flags, "timestamp_gap")
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="timestamp_gap",
+                message=f"sensor {sensor.client_id} has non-monotonic or gapped chunk timestamps",
+                sensor_id=sensor.client_id,
+                window_index=window_index,
+            )
+        )
+    if raw_range.samples_i16.ndim != 2 or raw_range.samples_i16.shape[1] != _AXIS_COUNT:
+        _append_unique_flag(flags, "invalid_axis_data")
+        warnings.append(
+            PostRunRawWindowWarning(
+                code="invalid_axis_data",
+                message=f"sensor {sensor.client_id} returned invalid raw axis data shape",
+                sensor_id=sensor.client_id,
+                window_index=window_index,
+            )
+        )
+    return flags
+
+
+def _append_unique_flag(
+    flags: list[PostRunRawWindowDataQualityFlag],
+    flag: PostRunRawWindowDataQualityFlag,
+) -> None:
+    if flag not in flags:
+        flags.append(flag)
+
+
+def _axis_arrays(
+    samples: npt.NDArray[np.int16],
+) -> tuple[npt.NDArray[np.int16], npt.NDArray[np.int16], npt.NDArray[np.int16]]:
+    if samples.ndim != 2 or samples.shape[1] != _AXIS_COUNT:
+        empty = np.empty((0,), dtype=np.int16)
+        return empty, empty, empty
+    return samples[:, 0], samples[:, 1], samples[:, 2]
+
+
+def _sensor_location(metadata: RunMetadata | None, sensor_id: str) -> str:
+    snapshot: RunSensorMetadata | None = (
+        metadata.sensor_snapshot_for(sensor_id) if metadata is not None else None
+    )
+    return snapshot.location_code.strip() if snapshot is not None else ""
+
+
+def _has_timestamp_gap(
+    chunks: Sequence[RawCaptureChunkIndex],
+    *,
+    sample_rate_hz: int,
+) -> bool:
+    if sample_rate_hz <= 0 or len(chunks) < 2:
+        return False
+    sample_period_us = 1_000_000.0 / float(sample_rate_hz)
+    tolerance_us = max(sample_period_us, 1_000.0)
+    ordered = sorted(chunks, key=lambda chunk: chunk.sample_start)
+    previous = ordered[0]
+    for current in ordered[1:]:
+        if current.t0_us < previous.t0_us:
+            return True
+        expected_delta_us = (current.sample_start - previous.sample_start) * sample_period_us
+        actual_delta_us = current.t0_us - previous.t0_us
+        if abs(actual_delta_us - expected_delta_us) > tolerance_us:
+            return True
+        previous = current
+    return False

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -44,6 +44,17 @@ frequency-bin, and peak-detection steps live in
 coordination stays under `apps/server/vibesensor/infra/processing/`. The same
 persisted peak/floor outputs are then reused by diagnostics/reporting.
 
+Full-run dense analysis stages use
+`use_cases/diagnostics/post_run_raw_windows.py` as the raw waveform access
+boundary. It prepares a manifest-backed, deterministic window graph from run
+metadata and raw-capture manifests, then reads each sensor/window through the
+history raw range-read API. That keeps long runs streaming: downstream dense
+stages consume bounded axis arrays per window instead of materializing the full
+raw artifact bundle. Each emitted sensor window carries run ID, sensor ID,
+location snapshot, start/end timing, sample rate, x/y/z `int16` arrays, and
+data-quality flags such as partial windows, timestamp gaps, missing samples,
+low sample count, invalid axis data, sample-rate mismatch, and missing sidecars.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -121,6 +132,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `_reference_resolution.py` | ~80 | Engine/tire/reference resolution helpers reused by order analysis |
 | `_sensor_locations.py` | ~80 | Stable sensor-location labels and connected-throughout-run detection |
 | `_run_loader.py` | ~20 | JSONL run loader used by analysis/report adapters |
+| `post_run_raw_windows.py` | ~300 | Manifest-aware streaming raw waveform reader and configurable overlapping-window iterator for dense post-run stages |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -55,6 +55,10 @@ does not track implementation status or old branch plans.
   `RunPersistence.aload_raw_capture_sensor_range(...)`, but there is still no
   canonical offline executor that walks the full run as a deterministic window
   graph.
+- POSTRUN-01 adds that diagnostics-layer access boundary in
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py`: it
+  validates raw manifests, derives configurable overlapping windows, filters
+  sensors, and streams each window through range reads with structured warnings.
 
 ### Persisted analysis and reporting
 
@@ -110,7 +114,7 @@ raw capture manifest/files (#3065)
 | Layer | Owner area | Responsibility |
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
-| Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata |
+| Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
 | Whole-run spectra | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -13,6 +13,10 @@ one big state-machine class:
   artifact finalization for the active run.
 - `PostAnalysisWorker` owns the background queue and retry policy after a run
   stops.
+- `post_run_raw_windows.py` owns post-stop raw artifact window access for dense
+  diagnostics. It reads finalized raw sidecars by bounded ranges and emits
+  structured window warnings instead of reusing live buffers or loading full
+  runs into memory.
 - `CaptureReadinessTracker` owns the backend pre-record readiness checklist for
   idle/live states.
 - `RunRecorder` coordinates those helpers without re-owning their internals.


### PR DESCRIPTION
## What changed

Added a diagnostics-layer raw waveform window iterator for post-run analysis.

- Adds `post_run_raw_windows.py` with manifest validation, configurable window size/overlap/min-valid threshold, sensor filtering, and streaming range reads through the existing raw-capture history API.
- Emits per-window DTOs with run ID, sensor ID, location snapshot, timing, sample rate, x/y/z `int16` axis arrays, and data-quality flags.
- Reports structured warnings for missing manifests/sidecars, unsupported manifests, sample-rate problems, missing locations, low sample count, invalid axis data, and timestamp gaps.
- Adds focused history-backed tests for streaming range reads, partial windows, missing artifacts, timestamp gaps, unsupported schema, and config validation.
- Documents the new raw-window access boundary in analysis and run lifecycle docs.

## Why

POSTRUN-01 needs a reusable foundation for dense post-run stages. Existing raw capture storage and indexed range reads were present, but diagnostics had no narrow iterator that walks completed raw artifacts without full-loading long runs.

## Validation/tests

- `python -m ruff check apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py`
- `python -m ruff format --check apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py`
- `cd apps/server && python -m mypy --config-file pyproject.toml vibesensor/use_cases/diagnostics/post_run_raw_windows.py`
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py apps/server/tests/use_cases/diagnostics/test_whole_run_window_planner.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py`
- `python tools/dev/docs_lint.py`
- `python tools/tests/run_changed.py --base-ref origin/main`

## Risks, tradeoffs, edge cases

- This is an internal foundation only. It does not wire dense STFT or reports yet.
- Unsupported raw-capture schema versions produce structured warnings and no windows instead of speculative reads.
- Partial trailing windows are emitted only when they meet `min_valid_samples_pct`.
- Timestamp gap detection is range-local and based on chunk timestamps returned for each requested window.

## Follow-ups / out of scope

- POSTRUN-02 should consume this iterator for dense STFT/spectrogram generation.
- Later issues should persist dense outputs and connect them to findings/reports.

Closes #3713
