### PR TITLE
Add post-run dense STFT engine

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/benchmark_post_run_stft.py
+++ b/apps/server/tests/use_cases/diagnostics/benchmark_post_run_stft.py
@@ -1,0 +1,104 @@
+"""Opt-in benchmark for dense post-run STFT over POSTRUN-01 window DTOs."""
+
+from __future__ import annotations
+
+from math import pi
+
+import numpy as np
+import pytest
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawSensorWindow,
+    PostRunRawWindow,
+)
+from vibesensor.use_cases.diagnostics.post_run_stft import (
+    PostRunStftConfig,
+    compute_post_run_dense_stft,
+)
+
+_SAMPLE_RATE_HZ = 800
+_FFT_N = 2048
+_DURATION_S = 30 * 60
+_SENSOR_COUNT = 4
+_STRIDE_SAMPLES = 800
+_WINDOW_COUNT = ((_SAMPLE_RATE_HZ * _DURATION_S) - _FFT_N) // _STRIDE_SAMPLES + 1
+
+
+@pytest.fixture(scope="session")
+def dense_stft_windows() -> tuple[PostRunRawWindow, ...]:
+    policy = WholeRunWindowPolicy(
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        window_size_samples=_FFT_N,
+        stride_samples=_STRIDE_SAMPLES,
+        overlap_samples=_FFT_N - _STRIDE_SAMPLES,
+        feature_interval_s=float(_STRIDE_SAMPLES) / float(_SAMPLE_RATE_HZ),
+    )
+    base_t = np.arange(_FFT_N, dtype=np.float64) / float(_SAMPLE_RATE_HZ)
+    windows: list[PostRunRawWindow] = []
+    for window_index in range(_WINDOW_COUNT):
+        descriptor = WholeRunWindowDescriptor.from_policy(
+            window_index=window_index,
+            sample_start=window_index * _STRIDE_SAMPLES,
+            policy=policy,
+        )
+        sensors: list[PostRunRawSensorWindow] = []
+        for sensor_index in range(_SENSOR_COUNT):
+            freq_hz = 18.0 + (sensor_index * 7.0) + (window_index % 11)
+            x = np.round(
+                900.0 * np.sin((2.0 * pi * freq_hz * base_t) + (sensor_index * 0.2))
+            ).astype(np.int16)
+            y = np.round(500.0 * np.sin(2.0 * pi * (freq_hz + 3.0) * base_t)).astype(np.int16)
+            z = np.round(250.0 * np.sin(2.0 * pi * (freq_hz * 0.5) * base_t)).astype(np.int16)
+            sensors.append(
+                PostRunRawSensorWindow(
+                    run_id="run-stft-benchmark",
+                    client_id=f"sensor-{sensor_index:02d}",
+                    location=f"location-{sensor_index}",
+                    window=descriptor,
+                    sample_rate_hz=_SAMPLE_RATE_HZ,
+                    axis_x_i16=x,
+                    axis_y_i16=y,
+                    axis_z_i16=z,
+                    requested_sample_start=descriptor.sample_start,
+                    requested_sample_count=descriptor.sample_count,
+                    returned_sample_start=descriptor.sample_start,
+                    returned_sample_count=descriptor.sample_count,
+                    data_quality_flags=(),
+                )
+            )
+        windows.append(
+            PostRunRawWindow(
+                run_id="run-stft-benchmark",
+                window=descriptor,
+                sensors=tuple(sensors),
+            )
+        )
+    return tuple(windows)
+
+
+@pytest.mark.benchmark(group="post-run-dense-stft")
+def test_post_run_dense_stft_benchmark(benchmark, dense_stft_windows) -> None:
+    config = PostRunStftConfig(
+        fft_size_samples=_FFT_N,
+        spectrum_min_hz=1.0,
+        spectrum_max_hz=250.0,
+        accel_scale_g_per_lsb=0.001,
+    )
+
+    benchmark.extra_info["duration_s"] = _DURATION_S
+    benchmark.extra_info["sensor_count"] = _SENSOR_COUNT
+    benchmark.extra_info["window_count"] = len(dense_stft_windows)
+    result = benchmark.pedantic(
+        compute_post_run_dense_stft,
+        args=(dense_stft_windows,),
+        kwargs={"config": config},
+        iterations=1,
+        rounds=1,
+        warmup_rounds=0,
+    )
+
+    assert len(result.frames) == len(dense_stft_windows) * _SENSOR_COUNT

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_stft.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_stft.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from math import pi
+
+import numpy as np
+import pytest
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawSensorWindow,
+    PostRunRawWindow,
+    PostRunRawWindowDataQualityFlag,
+)
+from vibesensor.use_cases.diagnostics.post_run_stft import (
+    PostRunStftConfig,
+    compute_post_run_dense_stft,
+)
+
+_RUN_ID = "run-stft"
+_SAMPLE_RATE_HZ = 64
+_FFT_N = 64
+
+
+def _policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        window_size_samples=_FFT_N,
+        stride_samples=32,
+        overlap_samples=32,
+        feature_interval_s=0.5,
+    )
+
+
+def _window_descriptor(index: int = 0) -> WholeRunWindowDescriptor:
+    return WholeRunWindowDescriptor.from_policy(
+        window_index=index,
+        sample_start=index * 32,
+        policy=_policy(),
+    )
+
+
+def _tone(freq_hz: float, *, amplitude: float = 1000.0, phase_rad: float = 0.0) -> np.ndarray:
+    t = np.arange(_FFT_N, dtype=np.float64) / float(_SAMPLE_RATE_HZ)
+    x = np.round(amplitude * np.sin((2.0 * pi * freq_hz * t) + phase_rad)).astype(np.int16)
+    return np.stack([x, np.zeros_like(x), np.zeros_like(x)], axis=1)
+
+
+def _raw_window(
+    samples: np.ndarray,
+    *,
+    window_index: int = 0,
+    flags: tuple[PostRunRawWindowDataQualityFlag, ...] = (),
+    returned_sample_count: int | None = None,
+) -> PostRunRawWindow:
+    descriptor = _window_descriptor(window_index)
+    sensor = PostRunRawSensorWindow(
+        run_id=_RUN_ID,
+        client_id="sensor-a",
+        location="front_left",
+        window=descriptor,
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        axis_x_i16=samples[:, 0],
+        axis_y_i16=samples[:, 1],
+        axis_z_i16=samples[:, 2],
+        requested_sample_start=descriptor.sample_start,
+        requested_sample_count=descriptor.sample_count,
+        returned_sample_start=descriptor.sample_start if samples.size else None,
+        returned_sample_count=(
+            int(samples.shape[0]) if returned_sample_count is None else returned_sample_count
+        ),
+        data_quality_flags=flags,
+    )
+    return PostRunRawWindow(run_id=_RUN_ID, window=descriptor, sensors=(sensor,))
+
+
+def _dominant_freq(window: PostRunRawWindow) -> float | None:
+    result = compute_post_run_dense_stft(
+        (window,),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+    assert len(result.frames) == 1
+    return result.frames[0].dominant_freq_hz
+
+
+def test_dense_stft_detects_known_single_tone() -> None:
+    frame_freq = _dominant_freq(_raw_window(_tone(8.0)))
+
+    assert frame_freq == pytest.approx(8.0, abs=0.25)
+
+
+def test_dense_stft_orders_two_tone_peaks_by_strength() -> None:
+    samples = _tone(7.0, amplitude=1200.0)
+    samples[:, 0] += _tone(15.0, amplitude=400.0)[:, 0]
+
+    result = compute_post_run_dense_stft(
+        (_raw_window(samples),),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    peaks = result.frames[0].top_peaks
+    assert peaks[0]["hz"] == pytest.approx(7.0, abs=0.25)
+    assert any(peak["hz"] == pytest.approx(15.0, abs=0.25) for peak in peaks[:4])
+
+
+def test_dense_stft_tracks_sweep_across_windows() -> None:
+    windows = [
+        _raw_window(_tone(freq), window_index=index) for index, freq in enumerate((6.0, 9.0, 12.0))
+    ]
+
+    result = compute_post_run_dense_stft(
+        windows,
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    assert [frame.window_index for frame in result.frames] == [0, 1, 2]
+    assert [frame.dominant_freq_hz for frame in result.frames] == pytest.approx(
+        [6.0, 9.0, 12.0],
+        abs=0.25,
+    )
+
+
+def test_dense_stft_handles_silence_with_empty_peaks() -> None:
+    samples = np.zeros((_FFT_N, 3), dtype=np.int16)
+
+    result = compute_post_run_dense_stft(
+        (_raw_window(samples),),
+        config=PostRunStftConfig(fft_size_samples=_FFT_N, accel_scale_g_per_lsb=0.001),
+    )
+
+    frame = result.frames[0]
+    assert frame.dominant_freq_hz is None
+    assert frame.top_peaks == ()
+    assert np.allclose(frame.combined_amp_g, 0.0)
+
+
+def test_dense_stft_keeps_noisy_tone_dominant() -> None:
+    rng = np.random.default_rng(42)
+    samples = _tone(11.0, amplitude=1000.0)
+    noise = rng.normal(0.0, 80.0, size=samples.shape).astype(np.int16)
+    samples = (samples + noise).astype(np.int16)
+
+    frame_freq = _dominant_freq(_raw_window(samples))
+
+    assert frame_freq == pytest.approx(11.0, abs=0.5)
+
+
+def test_dense_stft_marks_partial_windows_without_padding_by_default() -> None:
+    partial = _tone(10.0)[:24]
+
+    result = compute_post_run_dense_stft(
+        (
+            _raw_window(
+                partial,
+                flags=("partial_window", "missing_samples", "low_sample_count"),
+                returned_sample_count=24,
+            ),
+        ),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            partial_window_policy="mark",
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    assert len(result.frames) == 1
+    assert result.frames[0].coverage_state == "partial"
+    assert result.frames[0].dominant_freq_hz is None
+    assert np.allclose(result.frames[0].combined_amp_g, 0.0)
+
+
+def test_dense_stft_can_zero_pad_partial_windows_explicitly() -> None:
+    partial = _tone(10.0)[:40]
+
+    result = compute_post_run_dense_stft(
+        (
+            _raw_window(
+                partial,
+                flags=("partial_window", "missing_samples"),
+                returned_sample_count=40,
+            ),
+        ),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            partial_window_policy="zero_pad",
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    frame = result.frames[0]
+    assert frame.coverage_state == "partial"
+    assert frame.dominant_freq_hz == pytest.approx(10.0, abs=0.75)
+
+
+def test_dense_stft_rejects_invalid_config() -> None:
+    with pytest.raises(ValueError, match="spectrum_max_hz >= spectrum_min_hz"):
+        compute_post_run_dense_stft(
+            (),
+            config=PostRunStftConfig(spectrum_min_hz=20.0, spectrum_max_hz=10.0),
+        )

--- a/apps/server/vibesensor/shared/fft_analysis.py
+++ b/apps/server/vibesensor/shared/fft_analysis.py
@@ -25,6 +25,7 @@ __all__ = [
     "AXES",
     "Axis",
     "BoolArray",
+    "FftWindowFunction",
     "FftSpectrumResult",
     "FloatArray",
     "IntIndexArray",
@@ -32,6 +33,8 @@ __all__ = [
     "SpectrumAxisData",
     "SpectrumByAxis",
     "compute_fft_spectrum",
+    "fft_frequency_slice",
+    "fft_window_values",
     "float_list",
     "medfilt3",
     "noise_floor",
@@ -40,6 +43,7 @@ __all__ = [
 type FloatArray = npt.NDArray[np.float32]
 type IntIndexArray = npt.NDArray[np.intp]
 type BoolArray = npt.NDArray[np.bool_]
+type FftWindowFunction = Literal["hann", "boxcar"]
 
 Axis = Literal["x", "y", "z"]
 
@@ -113,6 +117,39 @@ def _sanitize_float_array(values: FloatArray) -> FloatArray:
         posinf=0.0,
         neginf=0.0,
     ).astype(np.float32, copy=False)
+
+
+def fft_window_values(
+    *,
+    fft_n: int,
+    window_function: FftWindowFunction = "hann",
+) -> FloatArray:
+    """Return FFT window coefficients for supported shared analysis windows."""
+
+    if window_function == "hann":
+        return np.asarray(signal_windows.hann(fft_n, sym=True), dtype=np.float32)
+    if window_function == "boxcar":
+        return np.ones(fft_n, dtype=np.float32)
+    raise ValueError(f"unsupported FFT window_function={window_function!r}")
+
+
+def fft_frequency_slice(
+    *,
+    fft_n: int,
+    sample_rate_hz: int,
+    spectrum_min_hz: float,
+    spectrum_max_hz: float,
+) -> tuple[FloatArray, IntIndexArray, BoolArray]:
+    """Return shared frequency bins, valid indices, and strength mask."""
+
+    if sample_rate_hz <= 0 or fft_n <= 0:
+        return _EMPTY_F32, np.empty(0, dtype=np.intp), _EMPTY_BOOL
+    freqs = scipy_fft.rfftfreq(fft_n, d=1.0 / float(sample_rate_hz))
+    valid = (freqs >= spectrum_min_hz) & (freqs <= spectrum_max_hz)
+    freq_slice = freqs[valid].astype(np.float32)
+    valid_idx = np.flatnonzero(valid)
+    strength_range_mask = np.ones(freq_slice.shape, dtype=np.bool_)
+    return freq_slice, valid_idx, strength_range_mask
 
 
 def _empty_fft_spectrum_result(freq_slice: FloatArray) -> FftSpectrumResult:
@@ -338,10 +375,7 @@ class SpectralAnalysisComputer:
         self._fft_n = int(fft_n)
         self._spectrum_min_hz = float(spectrum_min_hz)
         self._spectrum_max_hz = float(spectrum_max_hz)
-        self.fft_window: FloatArray = np.asarray(
-            signal_windows.hann(self._fft_n, sym=True),
-            dtype=np.float32,
-        )
+        self.fft_window = fft_window_values(fft_n=self._fft_n)
         self.fft_scale = float(2.0 / max(1.0, float(np.sum(self.fft_window))))
         self.fft_cache: OrderedDict[int, tuple[FloatArray, IntIndexArray, BoolArray]] = (
             OrderedDict()
@@ -354,13 +388,12 @@ class SpectralAnalysisComputer:
             if cached is not None:
                 self.fft_cache.move_to_end(sample_rate_hz)
                 return cached
-            if sample_rate_hz <= 0:
-                return _EMPTY_F32, np.empty(0, dtype=np.intp), _EMPTY_BOOL
-            freqs = scipy_fft.rfftfreq(self._fft_n, d=1.0 / sample_rate_hz)
-            valid = (freqs >= self._spectrum_min_hz) & (freqs <= self._spectrum_max_hz)
-            freq_slice = freqs[valid].astype(np.float32)
-            valid_idx = np.flatnonzero(valid)
-            strength_range_mask = np.ones(freq_slice.shape, dtype=np.bool_)
+            freq_slice, valid_idx, strength_range_mask = fft_frequency_slice(
+                fft_n=self._fft_n,
+                sample_rate_hz=sample_rate_hz,
+                spectrum_min_hz=self._spectrum_min_hz,
+                spectrum_max_hz=self._spectrum_max_hz,
+            )
             self.fft_cache[sample_rate_hz] = (freq_slice, valid_idx, strength_range_mask)
             if len(self.fft_cache) > _FFT_CACHE_MAXSIZE:
                 self.fft_cache.popitem(last=False)

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
@@ -1,0 +1,366 @@
+"""Dense post-run STFT over raw-window DTOs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import numpy.typing as npt
+from scipy import fft as scipy_fft
+from scipy.signal import windows as signal_windows
+
+from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
+from vibesensor.shared.fft_analysis import AXES, Axis, FloatArray, compute_fft_spectrum
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawSensorWindow,
+    PostRunRawWindow,
+    PostRunRawWindowDataQualityFlag,
+)
+from vibesensor.vibration_strength import StrengthPeak
+
+type PostRunStftWindowFunction = Literal["hann", "boxcar"]
+type PostRunStftPartialWindowPolicy = Literal["mark", "skip", "zero_pad"]
+type PostRunStftCoverageState = Literal["full", "partial", "missing", "invalid"]
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunStftConfig:
+    """Configuration for dense post-run spectral analysis.
+
+    Window size and overlap are normally owned by the POSTRUN-01 raw-window
+    iterator. ``fft_size_samples`` lets callers decouple FFT size from the raw
+    window size when a later stage intentionally wants a different transform.
+    """
+
+    fft_size_samples: int | None = None
+    window_function: PostRunStftWindowFunction = "hann"
+    spectrum_min_hz: float = SPECTRUM_MIN_HZ
+    spectrum_max_hz: float = SPECTRUM_MAX_HZ
+    partial_window_policy: PostRunStftPartialWindowPolicy = "mark"
+    accel_scale_g_per_lsb: float | None = None
+    spike_filter_enabled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunStftFrame:
+    """One dense time-frequency frame for one sensor/window."""
+
+    run_id: str
+    client_id: str
+    location: str
+    window_index: int
+    window_start_t_s: float
+    window_end_t_s: float
+    window_center_t_s: float
+    sample_rate_hz: int
+    requested_sample_start: int
+    requested_sample_count: int
+    returned_sample_start: int | None
+    returned_sample_count: int
+    coverage_state: PostRunStftCoverageState
+    data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
+    freq_hz: FloatArray
+    spectrum_by_axis_amp_g: dict[Axis, FloatArray]
+    combined_amp_g: FloatArray
+    dominant_freq_hz: float | None = None
+    vibration_strength_db: float | None = None
+    strength_peak_amp_g: float | None = None
+    strength_floor_amp_g: float | None = None
+    strength_bucket: str | None = None
+    top_peaks: tuple[StrengthPeak, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunDenseStftResult:
+    """In-memory dense STFT output for a batch of post-run windows."""
+
+    config: PostRunStftConfig
+    frames: tuple[PostRunStftFrame, ...]
+
+    def frames_for_sensor(self, client_id: str) -> tuple[PostRunStftFrame, ...]:
+        return tuple(frame for frame in self.frames if frame.client_id == client_id)
+
+
+def compute_post_run_dense_stft(
+    windows: Iterable[PostRunRawWindow],
+    *,
+    config: PostRunStftConfig | None = None,
+) -> PostRunDenseStftResult:
+    """Compute deterministic dense STFT frames from POSTRUN-01 raw-window DTOs."""
+
+    effective_config = config or PostRunStftConfig()
+    _validate_config(effective_config)
+    frames: list[PostRunStftFrame] = []
+    cache: dict[tuple[int, int, str, float, float], _FftContext] = {}
+    for raw_window in windows:
+        for sensor_window in raw_window.sensors:
+            fft_size_samples = effective_config.fft_size_samples or (
+                sensor_window.requested_sample_count
+            )
+            key = (
+                int(sensor_window.sample_rate_hz),
+                int(fft_size_samples),
+                effective_config.window_function,
+                float(effective_config.spectrum_min_hz),
+                float(effective_config.spectrum_max_hz),
+            )
+            context = cache.get(key)
+            if context is None:
+                context = _build_fft_context(
+                    sample_rate_hz=sensor_window.sample_rate_hz,
+                    fft_size_samples=fft_size_samples,
+                    config=effective_config,
+                )
+                cache[key] = context
+            frame = _compute_sensor_frame(
+                sensor_window=sensor_window,
+                context=context,
+                config=effective_config,
+            )
+            if frame is not None:
+                frames.append(frame)
+    return PostRunDenseStftResult(config=effective_config, frames=tuple(frames))
+
+
+@dataclass(frozen=True, slots=True)
+class _FftContext:
+    fft_size_samples: int
+    freq_hz: FloatArray
+    valid_idx: npt.NDArray[np.intp]
+    strength_range_mask: npt.NDArray[np.bool_]
+    fft_window: FloatArray
+    fft_scale: float
+
+
+def _validate_config(config: PostRunStftConfig) -> None:
+    if config.fft_size_samples is not None and config.fft_size_samples <= 0:
+        raise ValueError("post-run dense STFT requires fft_size_samples > 0")
+    if config.spectrum_min_hz < 0:
+        raise ValueError("post-run dense STFT requires spectrum_min_hz >= 0")
+    if config.spectrum_max_hz < config.spectrum_min_hz:
+        raise ValueError("post-run dense STFT requires spectrum_max_hz >= spectrum_min_hz")
+    if config.accel_scale_g_per_lsb is not None and config.accel_scale_g_per_lsb <= 0:
+        raise ValueError("post-run dense STFT requires accel_scale_g_per_lsb > 0")
+
+
+def _build_fft_context(
+    *,
+    sample_rate_hz: int,
+    fft_size_samples: int,
+    config: PostRunStftConfig,
+) -> _FftContext:
+    if sample_rate_hz <= 0:
+        return _FftContext(
+            fft_size_samples=fft_size_samples,
+            freq_hz=np.empty(0, dtype=np.float32),
+            valid_idx=np.empty(0, dtype=np.intp),
+            strength_range_mask=np.empty(0, dtype=np.bool_),
+            fft_window=np.empty(0, dtype=np.float32),
+            fft_scale=1.0,
+        )
+    fft_window = _window_values(
+        window_function=config.window_function,
+        fft_size_samples=fft_size_samples,
+    )
+    freqs = scipy_fft.rfftfreq(fft_size_samples, d=1.0 / float(sample_rate_hz))
+    valid = (freqs >= config.spectrum_min_hz) & (freqs <= config.spectrum_max_hz)
+    freq_hz = freqs[valid].astype(np.float32)
+    valid_idx = np.flatnonzero(valid)
+    return _FftContext(
+        fft_size_samples=fft_size_samples,
+        freq_hz=freq_hz,
+        valid_idx=valid_idx,
+        strength_range_mask=np.ones(freq_hz.shape, dtype=np.bool_),
+        fft_window=fft_window,
+        fft_scale=float(2.0 / max(1.0, float(np.sum(fft_window)))),
+    )
+
+
+def _window_values(
+    *,
+    window_function: PostRunStftWindowFunction,
+    fft_size_samples: int,
+) -> FloatArray:
+    if window_function == "hann":
+        return np.asarray(signal_windows.hann(fft_size_samples, sym=True), dtype=np.float32)
+    if window_function == "boxcar":
+        return np.ones(fft_size_samples, dtype=np.float32)
+    raise ValueError(f"unsupported post-run STFT window_function={window_function!r}")
+
+
+def _compute_sensor_frame(
+    *,
+    sensor_window: PostRunRawSensorWindow,
+    context: _FftContext,
+    config: PostRunStftConfig,
+) -> PostRunStftFrame | None:
+    coverage_state = _coverage_state(sensor_window)
+    if coverage_state == "missing" and config.partial_window_policy == "skip":
+        return None
+    if context.freq_hz.size == 0 or context.fft_window.size == 0:
+        return _empty_frame(
+            sensor_window=sensor_window,
+            context=context,
+            coverage_state="invalid",
+        )
+    axis_samples = _sensor_window_axis_matrix(sensor_window)
+    if axis_samples is None:
+        return _empty_frame(
+            sensor_window=sensor_window,
+            context=context,
+            coverage_state="invalid",
+        )
+    prepared_samples = _prepare_fft_samples(
+        axis_samples=axis_samples,
+        fft_size_samples=context.fft_size_samples,
+        coverage_state=coverage_state,
+        partial_window_policy=config.partial_window_policy,
+    )
+    if prepared_samples is None:
+        if config.partial_window_policy == "mark":
+            return _empty_frame(
+                sensor_window=sensor_window,
+                context=context,
+                coverage_state=coverage_state,
+            )
+        return None
+    if config.accel_scale_g_per_lsb is not None:
+        prepared_samples = prepared_samples * np.float32(config.accel_scale_g_per_lsb)
+    fft_result = compute_fft_spectrum(
+        prepared_samples,
+        sensor_window.sample_rate_hz,
+        fft_window=context.fft_window,
+        fft_scale=context.fft_scale,
+        freq_slice=context.freq_hz,
+        valid_idx=context.valid_idx,
+        strength_range_mask=context.strength_range_mask,
+        spike_filter_enabled=config.spike_filter_enabled,
+    )
+    spectrum_by_axis = {
+        axis: np.asarray(fft_result["spectrum_by_axis"][axis]["amp"], dtype=np.float32, copy=True)
+        for axis in AXES
+    }
+    strength_metrics = fft_result["strength_metrics"]
+    top_peaks = tuple(
+        peak for peak in strength_metrics["top_peaks"] if peak["hz"] > 0 and peak["amp"] > 0
+    )
+    dominant_freq_hz = top_peaks[0]["hz"] if top_peaks else None
+    return PostRunStftFrame(
+        run_id=sensor_window.run_id,
+        client_id=sensor_window.client_id,
+        location=sensor_window.location,
+        window_index=sensor_window.window.window_index,
+        window_start_t_s=sensor_window.window.start_t_s,
+        window_end_t_s=sensor_window.window.end_t_s,
+        window_center_t_s=sensor_window.window.center_t_s,
+        sample_rate_hz=sensor_window.sample_rate_hz,
+        requested_sample_start=sensor_window.requested_sample_start,
+        requested_sample_count=sensor_window.requested_sample_count,
+        returned_sample_start=sensor_window.returned_sample_start,
+        returned_sample_count=sensor_window.returned_sample_count,
+        coverage_state=coverage_state,
+        data_quality_flags=sensor_window.data_quality_flags,
+        freq_hz=np.asarray(fft_result["freq_slice"], dtype=np.float32, copy=True),
+        spectrum_by_axis_amp_g=spectrum_by_axis,
+        combined_amp_g=np.asarray(fft_result["combined_amp"], dtype=np.float32, copy=True),
+        dominant_freq_hz=dominant_freq_hz,
+        vibration_strength_db=_float_or_none(strength_metrics.get("vibration_strength_db")),
+        strength_peak_amp_g=_float_or_none(strength_metrics.get("peak_amp_g")),
+        strength_floor_amp_g=_float_or_none(strength_metrics.get("noise_floor_amp_g")),
+        strength_bucket=strength_metrics.get("strength_bucket"),
+        top_peaks=top_peaks,
+    )
+
+
+def _coverage_state(sensor_window: PostRunRawSensorWindow) -> PostRunStftCoverageState:
+    flags = set(sensor_window.data_quality_flags)
+    if "invalid_axis_data" in flags:
+        return "invalid"
+    if "missing_sidecar" in flags or sensor_window.returned_sample_count <= 0:
+        return "missing"
+    if flags.intersection({"partial_window", "missing_samples", "low_sample_count"}):
+        return "partial"
+    return "full"
+
+
+def _sensor_window_axis_matrix(sensor_window: PostRunRawSensorWindow) -> FloatArray | None:
+    if (
+        sensor_window.axis_x_i16.ndim != 1
+        or sensor_window.axis_y_i16.ndim != 1
+        or sensor_window.axis_z_i16.ndim != 1
+    ):
+        return None
+    if not all(
+        axis.shape == sensor_window.axis_x_i16.shape
+        for axis in (sensor_window.axis_y_i16, sensor_window.axis_z_i16)
+    ):
+        return None
+    return np.stack(
+        [
+            sensor_window.axis_x_i16.astype(np.float32, copy=False),
+            sensor_window.axis_y_i16.astype(np.float32, copy=False),
+            sensor_window.axis_z_i16.astype(np.float32, copy=False),
+        ],
+        axis=0,
+    ).astype(np.float32, copy=False)
+
+
+def _prepare_fft_samples(
+    *,
+    axis_samples: FloatArray,
+    fft_size_samples: int,
+    coverage_state: PostRunStftCoverageState,
+    partial_window_policy: PostRunStftPartialWindowPolicy,
+) -> FloatArray | None:
+    sample_count = int(axis_samples.shape[1])
+    if sample_count == fft_size_samples and coverage_state in {"full", "partial"}:
+        return axis_samples.copy()
+    if coverage_state == "full" and sample_count > fft_size_samples:
+        return axis_samples[:, :fft_size_samples].copy()
+    if partial_window_policy == "skip":
+        return None
+    if partial_window_policy == "mark":
+        return None
+    padded = np.zeros((3, fft_size_samples), dtype=np.float32)
+    copy_count = min(sample_count, fft_size_samples)
+    if copy_count > 0:
+        padded[:, :copy_count] = axis_samples[:, :copy_count]
+    return padded
+
+
+def _empty_frame(
+    *,
+    sensor_window: PostRunRawSensorWindow,
+    context: _FftContext,
+    coverage_state: PostRunStftCoverageState,
+) -> PostRunStftFrame:
+    empty = np.zeros(context.freq_hz.shape, dtype=np.float32)
+    return PostRunStftFrame(
+        run_id=sensor_window.run_id,
+        client_id=sensor_window.client_id,
+        location=sensor_window.location,
+        window_index=sensor_window.window.window_index,
+        window_start_t_s=sensor_window.window.start_t_s,
+        window_end_t_s=sensor_window.window.end_t_s,
+        window_center_t_s=sensor_window.window.center_t_s,
+        sample_rate_hz=sensor_window.sample_rate_hz,
+        requested_sample_start=sensor_window.requested_sample_start,
+        requested_sample_count=sensor_window.requested_sample_count,
+        returned_sample_start=sensor_window.returned_sample_start,
+        returned_sample_count=sensor_window.returned_sample_count,
+        coverage_state=coverage_state,
+        data_quality_flags=sensor_window.data_quality_flags,
+        freq_hz=context.freq_hz.copy(),
+        spectrum_by_axis_amp_g={axis: empty.copy() for axis in AXES},
+        combined_amp_g=empty.copy(),
+    )
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
@@ -7,12 +7,19 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
-import numpy.typing as npt
-from scipy import fft as scipy_fft
-from scipy.signal import windows as signal_windows
 
 from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
-from vibesensor.shared.fft_analysis import AXES, Axis, FloatArray, compute_fft_spectrum
+from vibesensor.shared.fft_analysis import (
+    AXES,
+    Axis,
+    BoolArray,
+    FftWindowFunction,
+    FloatArray,
+    IntIndexArray,
+    compute_fft_spectrum,
+    fft_frequency_slice,
+    fft_window_values,
+)
 from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
     PostRunRawSensorWindow,
     PostRunRawWindow,
@@ -20,7 +27,6 @@ from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
 )
 from vibesensor.vibration_strength import StrengthPeak
 
-type PostRunStftWindowFunction = Literal["hann", "boxcar"]
 type PostRunStftPartialWindowPolicy = Literal["mark", "skip", "zero_pad"]
 type PostRunStftCoverageState = Literal["full", "partial", "missing", "invalid"]
 
@@ -35,7 +41,7 @@ class PostRunStftConfig:
     """
 
     fft_size_samples: int | None = None
-    window_function: PostRunStftWindowFunction = "hann"
+    window_function: FftWindowFunction = "hann"
     spectrum_min_hz: float = SPECTRUM_MIN_HZ
     spectrum_max_hz: float = SPECTRUM_MAX_HZ
     partial_window_policy: PostRunStftPartialWindowPolicy = "mark"
@@ -128,8 +134,8 @@ def compute_post_run_dense_stft(
 class _FftContext:
     fft_size_samples: int
     freq_hz: FloatArray
-    valid_idx: npt.NDArray[np.intp]
-    strength_range_mask: npt.NDArray[np.bool_]
+    valid_idx: IntIndexArray
+    strength_range_mask: BoolArray
     fft_window: FloatArray
     fft_scale: float
 
@@ -160,34 +166,24 @@ def _build_fft_context(
             fft_window=np.empty(0, dtype=np.float32),
             fft_scale=1.0,
         )
-    fft_window = _window_values(
+    fft_window = fft_window_values(
+        fft_n=fft_size_samples,
         window_function=config.window_function,
-        fft_size_samples=fft_size_samples,
     )
-    freqs = scipy_fft.rfftfreq(fft_size_samples, d=1.0 / float(sample_rate_hz))
-    valid = (freqs >= config.spectrum_min_hz) & (freqs <= config.spectrum_max_hz)
-    freq_hz = freqs[valid].astype(np.float32)
-    valid_idx = np.flatnonzero(valid)
+    freq_hz, valid_idx, strength_range_mask = fft_frequency_slice(
+        fft_n=fft_size_samples,
+        sample_rate_hz=sample_rate_hz,
+        spectrum_min_hz=config.spectrum_min_hz,
+        spectrum_max_hz=config.spectrum_max_hz,
+    )
     return _FftContext(
         fft_size_samples=fft_size_samples,
         freq_hz=freq_hz,
         valid_idx=valid_idx,
-        strength_range_mask=np.ones(freq_hz.shape, dtype=np.bool_),
+        strength_range_mask=strength_range_mask,
         fft_window=fft_window,
         fft_scale=float(2.0 / max(1.0, float(np.sum(fft_window)))),
     )
-
-
-def _window_values(
-    *,
-    window_function: PostRunStftWindowFunction,
-    fft_size_samples: int,
-) -> FloatArray:
-    if window_function == "hann":
-        return np.asarray(signal_windows.hann(fft_size_samples, sym=True), dtype=np.float32)
-    if window_function == "boxcar":
-        return np.ones(fft_size_samples, dtype=np.float32)
-    raise ValueError(f"unsupported post-run STFT window_function={window_function!r}")
 
 
 def _compute_sensor_frame(

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -55,6 +55,14 @@ location snapshot, start/end timing, sample rate, x/y/z `int16` arrays, and
 data-quality flags such as partial windows, timestamp gaps, missing samples,
 low sample count, invalid axis data, sample-rate mismatch, and missing sidecars.
 
+The first dense analysis consumer is
+`use_cases/diagnostics/post_run_stft.py`. It consumes those POSTRUN-01 window
+DTOs and produces in-memory STFT frames with per-axis spectra, combined spectra,
+window timing, sensor metadata, dominant frequency, top peaks, and dB strength
+facts. The STFT layer is deliberately post-run only: callers configure FFT size,
+window function, frequency range, and partial-window behavior independently from
+the live UI cadence, while still reusing the shared FFT/strength primitives.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -133,6 +141,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `_sensor_locations.py` | ~80 | Stable sensor-location labels and connected-throughout-run detection |
 | `_run_loader.py` | ~20 | JSONL run loader used by analysis/report adapters |
 | `post_run_raw_windows.py` | ~300 | Manifest-aware streaming raw waveform reader and configurable overlapping-window iterator for dense post-run stages |
+| `post_run_stft.py` | ~350 | In-memory dense STFT engine over POSTRUN-01 raw-window DTOs |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -59,6 +59,10 @@ does not track implementation status or old branch plans.
   `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py`: it
   validates raw manifests, derives configurable overlapping windows, filters
   sensors, and streams each window through range reads with structured warnings.
+- POSTRUN-02 adds the first dense consumer in
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py`: an in-memory
+  STFT engine over those raw-window DTOs. Persistence of dense arrays remains
+  owned by POSTRUN-08.
 
 ### Persisted analysis and reporting
 
@@ -115,7 +119,7 @@ raw capture manifest/files (#3065)
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
-| Whole-run spectra | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling |
+| Whole-run spectra | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |


### PR DESCRIPTION
## What changed
- Added diagnostics-layer dense STFT over POSTRUN-01 raw-window DTOs.
- Added shared FFT frequency/window helpers so FFT setup stays centralized.
- Added configurable FFT size, window function, frequency band, partial-window policy, accel scaling, spike filtering, strength metrics, dominant frequency, and top peaks.
- Added focused unit tests, opt-in benchmark, and docs for the post-run analysis pipeline.

## Why
#3715 needs a deterministic in-memory spectrogram/STFT engine before window feature extraction, timeline normalization, and later dense artifact persistence can build on it.

## Validation
- Ruff check and format on touched STFT/FFT files.
- Backend static guards passed.
- Mypy on shared FFT and new STFT modules.
- Focused STFT tests: 8 passed.
- Related/failed CI tests: 17 passed.
- Docs lint passed.
- Changed-file suite: 2520 passed.

## Risks, tradeoffs, edge cases
- Persistence is intentionally out of scope; POSTRUN-08 owns dense artifact storage.
- Default partial-window handling marks partial frames with zero spectra instead of silently padding or dropping. Callers can opt into skip or zero_pad.
- Acceleration scaling is caller-provided so calibration policy stays outside this engine.

## Follow-ups
- Window feature extraction in #3712.
- Dense artifact persistence in #3719.

Fixes #3715