### PR TITLE
Add post-run window feature extraction

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_window_features.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_window_features.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from math import pi
+
+import numpy as np
+import pytest
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics import post_run_window_features as feature_module
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawSensorWindow,
+    PostRunRawWindow,
+    PostRunRawWindowDataQualityFlag,
+)
+from vibesensor.use_cases.diagnostics.post_run_stft import (
+    PostRunDenseStftResult,
+    PostRunStftConfig,
+    compute_post_run_dense_stft,
+)
+from vibesensor.use_cases.diagnostics.post_run_window_features import (
+    PostRunWindowFeatureConfig,
+    extract_post_run_window_features,
+    post_run_window_feature_debug_rows,
+)
+from vibesensor.vibration_strength import VibrationStrengthMetrics
+
+_RUN_ID = "run-features"
+_SAMPLE_RATE_HZ = 64
+_FFT_N = 64
+
+
+def _policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        window_size_samples=_FFT_N,
+        stride_samples=32,
+        overlap_samples=32,
+        feature_interval_s=0.5,
+    )
+
+
+def _window_descriptor(index: int = 0) -> WholeRunWindowDescriptor:
+    return WholeRunWindowDescriptor.from_policy(
+        window_index=index,
+        sample_start=index * 32,
+        policy=_policy(),
+    )
+
+
+def _tone(
+    freq_hz: float,
+    *,
+    amplitude: float = 1000.0,
+    axis: int = 0,
+) -> np.ndarray:
+    t = np.arange(_FFT_N, dtype=np.float64) / float(_SAMPLE_RATE_HZ)
+    samples = np.zeros((_FFT_N, 3), dtype=np.int16)
+    samples[:, axis] = np.round(amplitude * np.sin(2.0 * pi * freq_hz * t)).astype(np.int16)
+    return samples
+
+
+def _raw_window(
+    samples: np.ndarray,
+    *,
+    window_index: int = 0,
+    flags: tuple[PostRunRawWindowDataQualityFlag, ...] = (),
+) -> PostRunRawWindow:
+    descriptor = _window_descriptor(window_index)
+    sensor = PostRunRawSensorWindow(
+        run_id=_RUN_ID,
+        client_id="sensor-a",
+        location="front_left",
+        window=descriptor,
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        axis_x_i16=samples[:, 0],
+        axis_y_i16=samples[:, 1],
+        axis_z_i16=samples[:, 2],
+        requested_sample_start=descriptor.sample_start,
+        requested_sample_count=descriptor.sample_count,
+        returned_sample_start=descriptor.sample_start if samples.size else None,
+        returned_sample_count=int(samples.shape[0]),
+        data_quality_flags=flags,
+    )
+    return PostRunRawWindow(run_id=_RUN_ID, window=descriptor, sensors=(sensor,))
+
+
+def _stft_result(*windows: PostRunRawWindow) -> PostRunDenseStftResult:
+    return compute_post_run_dense_stft(
+        windows,
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+
+def _feature_for(samples: np.ndarray) -> feature_module.PostRunWindowFeature:
+    result = extract_post_run_window_features(_stft_result(_raw_window(samples)))
+    assert len(result.features) == 1
+    return result.features[0]
+
+
+def test_window_features_detect_single_tone_axis_and_time_metrics() -> None:
+    feature = _feature_for(_tone(8.0, amplitude=1000.0, axis=0))
+
+    assert feature.dominant_freq_hz == pytest.approx(8.0, abs=0.25)
+    assert feature.axis_dominance.axis == "x"
+    assert feature.axis_dominance.ratio is not None
+    assert feature.axis_dominance.ratio > 1.6
+    assert feature.rms_by_axis_g["x"] == pytest.approx(0.707, abs=0.04)
+    assert feature.max_axis_p2p_g == pytest.approx(2.0, abs=0.05)
+    assert feature.vibration_strength_db is not None
+    assert feature.strength_bucket is not None
+
+
+def test_window_features_preserve_multi_tone_peak_order() -> None:
+    samples = _tone(7.0, amplitude=1200.0)
+    samples[:, 0] += _tone(15.0, amplitude=400.0)[:, 0]
+
+    feature = _feature_for(samples)
+
+    assert feature.top_peaks[0]["hz"] == pytest.approx(7.0, abs=0.25)
+    assert any(peak["hz"] == pytest.approx(15.0, abs=0.25) for peak in feature.top_peaks[:4])
+
+
+def test_window_features_mark_silence_without_dominant_peak() -> None:
+    feature = _feature_for(np.zeros((_FFT_N, 3), dtype=np.int16))
+
+    assert feature.dominant_freq_hz is None
+    assert feature.vibration_strength_db is None
+    assert feature.peak_amp_g is None
+    assert feature.top_peaks == ()
+    assert "no_dominant_peak" in feature.feature_quality_flags
+    assert feature.strength_bucket == "l0"
+
+
+def test_window_features_keep_noisy_tone_dominant_and_lower_snr() -> None:
+    rng = np.random.default_rng(42)
+    clean_feature = _feature_for(_tone(11.0, amplitude=1000.0))
+    noisy_samples = _tone(11.0, amplitude=250.0)
+    noisy_samples = (noisy_samples + rng.normal(0.0, 120.0, size=noisy_samples.shape)).astype(
+        np.int16
+    )
+
+    noisy_feature = _feature_for(noisy_samples)
+
+    assert noisy_feature.dominant_freq_hz == pytest.approx(11.0, abs=0.75)
+    assert noisy_feature.vibration_strength_db is not None
+    assert clean_feature.vibration_strength_db is not None
+    assert noisy_feature.vibration_strength_db < clean_feature.vibration_strength_db
+
+
+def test_window_features_frequency_mask_excludes_unusable_ranges() -> None:
+    samples = _tone(8.0, amplitude=1200.0)
+    samples[:, 0] += _tone(15.0, amplitude=600.0)[:, 0]
+    stft = _stft_result(_raw_window(samples))
+
+    result = extract_post_run_window_features(
+        stft,
+        config=PostRunWindowFeatureConfig(excluded_frequency_ranges_hz=((7.0, 9.0),)),
+    )
+
+    assert result.features[0].dominant_freq_hz == pytest.approx(15.0, abs=0.5)
+
+
+def test_window_features_propagate_quality_flags_from_raw_windows() -> None:
+    stft = _stft_result(
+        _raw_window(
+            _tone(10.0),
+            flags=("partial_window", "timestamp_gap", "missing_samples"),
+        )
+    )
+
+    feature = extract_post_run_window_features(stft).features[0]
+
+    assert feature.coverage_state == "partial"
+    assert "partial_window" in feature.feature_quality_flags
+    assert "timestamp_gap" in feature.feature_quality_flags
+    assert "missing_samples" in feature.feature_quality_flags
+
+
+def test_window_features_sanitize_invalid_spectrum_values() -> None:
+    frame = _stft_result(_raw_window(_tone(9.0))).frames[0]
+    invalid_frame = replace(
+        frame,
+        freq_hz=np.array([1.0, 9.0, np.inf], dtype=np.float32),
+        combined_amp_g=np.array([0.0, np.nan, np.inf], dtype=np.float32),
+        spectrum_by_axis_amp_g={
+            "x": np.array([0.0, np.nan, np.inf], dtype=np.float32),
+            "y": np.zeros(3, dtype=np.float32),
+            "z": np.zeros(3, dtype=np.float32),
+        },
+    )
+
+    feature = extract_post_run_window_features((invalid_frame,)).features[0]
+
+    assert "invalid_spectrum_values" in feature.feature_quality_flags
+    assert feature.noise_floor_amp_g is not None
+    assert np.isfinite(feature.noise_floor_amp_g)
+    assert feature.max_axis_rms_g >= 0.0
+
+
+def test_window_features_use_canonical_strength_function(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[np.ndarray, np.ndarray]] = []
+
+    def fake_strength(**kwargs: object) -> VibrationStrengthMetrics:
+        calls.append(
+            (
+                np.asarray(kwargs["freq_hz"], dtype=np.float32),
+                np.asarray(kwargs["combined_spectrum_amp_g_values"], dtype=np.float32),
+            )
+        )
+        return {
+            "vibration_strength_db": 12.0,
+            "peak_amp_g": 0.25,
+            "noise_floor_amp_g": 0.05,
+            "strength_bucket": "l1",
+            "top_peaks": [
+                {
+                    "hz": 8.0,
+                    "amp": 0.25,
+                    "vibration_strength_db": 12.0,
+                    "strength_bucket": "l1",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(feature_module, "compute_vibration_strength_db", fake_strength)
+
+    feature = _feature_for(_tone(8.0))
+
+    assert calls
+    assert feature.vibration_strength_db == 12.0
+    assert feature.peak_amp_g == 0.25
+    assert feature.strength_bucket == "l1"
+
+
+def test_window_features_debug_rows_for_synthetic_run() -> None:
+    stft = _stft_result(
+        _raw_window(_tone(6.0), window_index=0),
+        _raw_window(_tone(12.0, axis=1), window_index=1),
+    )
+    features = extract_post_run_window_features(stft).features
+
+    rows = post_run_window_feature_debug_rows(features)
+
+    assert [row["window_index"] for row in rows] == [0, 1]
+    assert rows[0]["dominant_freq_hz"] == pytest.approx(6.0, abs=0.25)
+    assert rows[1]["axis"] == "y"

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
@@ -70,6 +70,8 @@ class PostRunStftFrame:
     freq_hz: FloatArray
     spectrum_by_axis_amp_g: dict[Axis, FloatArray]
     combined_amp_g: FloatArray
+    rms_by_axis_g: dict[Axis, float]
+    p2p_by_axis_g: dict[Axis, float]
     dominant_freq_hz: float | None = None
     vibration_strength_db: float | None = None
     strength_peak_amp_g: float | None = None
@@ -224,6 +226,7 @@ def _compute_sensor_frame(
         return None
     if config.accel_scale_g_per_lsb is not None:
         prepared_samples = prepared_samples * np.float32(config.accel_scale_g_per_lsb)
+    rms_by_axis_g, p2p_by_axis_g = _time_domain_metrics_by_axis(prepared_samples)
     fft_result = compute_fft_spectrum(
         prepared_samples,
         sensor_window.sample_rate_hz,
@@ -261,6 +264,8 @@ def _compute_sensor_frame(
         freq_hz=np.asarray(fft_result["freq_slice"], dtype=np.float32, copy=True),
         spectrum_by_axis_amp_g=spectrum_by_axis,
         combined_amp_g=np.asarray(fft_result["combined_amp"], dtype=np.float32, copy=True),
+        rms_by_axis_g=rms_by_axis_g,
+        p2p_by_axis_g=p2p_by_axis_g,
         dominant_freq_hz=dominant_freq_hz,
         vibration_strength_db=_float_or_none(strength_metrics.get("vibration_strength_db")),
         strength_peak_amp_g=_float_or_none(strength_metrics.get("peak_amp_g")),
@@ -301,6 +306,27 @@ def _sensor_window_axis_matrix(sensor_window: PostRunRawSensorWindow) -> FloatAr
         ],
         axis=0,
     ).astype(np.float32, copy=False)
+
+
+def _time_domain_metrics_by_axis(
+    axis_samples: FloatArray,
+) -> tuple[dict[Axis, float], dict[Axis, float]]:
+    if axis_samples.ndim != 2 or axis_samples.shape[0] != len(AXES) or axis_samples.shape[1] == 0:
+        zeros = {axis: 0.0 for axis in AXES}
+        return zeros.copy(), zeros.copy()
+    clean = np.nan_to_num(
+        axis_samples,
+        copy=True,
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0,
+    ).astype(np.float32, copy=False)
+    rms_values = np.sqrt(np.mean(np.square(clean, dtype=np.float64), axis=1))
+    p2p_values = np.ptp(clean, axis=1)
+    return (
+        {axis: float(rms_values[index]) for index, axis in enumerate(AXES)},
+        {axis: float(p2p_values[index]) for index, axis in enumerate(AXES)},
+    )
 
 
 def _prepare_fft_samples(
@@ -351,6 +377,8 @@ def _empty_frame(
         freq_hz=context.freq_hz.copy(),
         spectrum_by_axis_amp_g={axis: empty.copy() for axis in AXES},
         combined_amp_g=empty.copy(),
+        rms_by_axis_g={axis: 0.0 for axis in AXES},
+        p2p_by_axis_g={axis: 0.0 for axis in AXES},
     )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py
@@ -1,0 +1,351 @@
+"""Window-level diagnostic features extracted from dense post-run STFT frames."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from vibesensor.shared.fft_analysis import AXES, Axis, BoolArray, FloatArray
+from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
+    PostRunRawWindowDataQualityFlag,
+)
+from vibesensor.use_cases.diagnostics.post_run_stft import (
+    PostRunDenseStftResult,
+    PostRunStftCoverageState,
+    PostRunStftFrame,
+)
+from vibesensor.vibration_strength import (
+    StrengthPeak,
+    VibrationStrengthMetrics,
+    compute_vibration_strength_db,
+    empty_vibration_strength_metrics,
+)
+
+type PostRunWindowFeatureQualityFlag = (
+    PostRunRawWindowDataQualityFlag
+    | Literal[
+        "empty_spectrum",
+        "frequency_mask_empty",
+        "invalid_spectrum_values",
+        "no_dominant_peak",
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunWindowFeatureConfig:
+    """Configuration for reducing STFT frames into per-window features."""
+
+    feature_min_hz: float | None = None
+    feature_max_hz: float | None = None
+    excluded_frequency_ranges_hz: tuple[tuple[float, float], ...] = ()
+    top_peak_count: int = 8
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunWindowAxisDominance:
+    """Dominant-axis evidence at the selected feature peak."""
+
+    axis: Axis | None
+    axis_amp_g: float
+    combined_amp_g: float
+    ratio: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunWindowFeature:
+    """Per-window, per-sensor diagnostic feature output."""
+
+    run_id: str
+    client_id: str
+    location: str
+    window_index: int
+    window_start_t_s: float
+    window_end_t_s: float
+    window_center_t_s: float
+    sample_rate_hz: int
+    coverage_state: PostRunStftCoverageState
+    data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
+    feature_quality_flags: tuple[PostRunWindowFeatureQualityFlag, ...]
+    dominant_freq_hz: float | None
+    vibration_strength_db: float | None
+    peak_amp_g: float | None
+    noise_floor_amp_g: float | None
+    strength_bucket: str | None
+    top_peaks: tuple[StrengthPeak, ...]
+    axis_dominance: PostRunWindowAxisDominance
+    rms_by_axis_g: dict[Axis, float]
+    p2p_by_axis_g: dict[Axis, float]
+    max_axis_rms_g: float
+    max_axis_p2p_g: float
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunWindowFeatureResult:
+    """In-memory feature extraction result for dense post-run frames."""
+
+    config: PostRunWindowFeatureConfig
+    features: tuple[PostRunWindowFeature, ...]
+
+    def features_for_sensor(self, client_id: str) -> tuple[PostRunWindowFeature, ...]:
+        return tuple(feature for feature in self.features if feature.client_id == client_id)
+
+
+def extract_post_run_window_features(
+    stft: PostRunDenseStftResult | Iterable[PostRunStftFrame],
+    *,
+    config: PostRunWindowFeatureConfig | None = None,
+) -> PostRunWindowFeatureResult:
+    """Extract deterministic diagnostic features from dense STFT frames."""
+
+    effective_config = config or PostRunWindowFeatureConfig()
+    _validate_config(effective_config)
+    frames = stft.frames if isinstance(stft, PostRunDenseStftResult) else tuple(stft)
+    return PostRunWindowFeatureResult(
+        config=effective_config,
+        features=tuple(_feature_from_frame(frame, config=effective_config) for frame in frames),
+    )
+
+
+def post_run_window_feature_debug_rows(
+    features: Iterable[PostRunWindowFeature],
+) -> tuple[dict[str, object], ...]:
+    """Return compact debug rows for synthetic runs and later pipeline work."""
+
+    rows: list[dict[str, object]] = []
+    for feature in features:
+        rows.append(
+            {
+                "run_id": feature.run_id,
+                "client_id": feature.client_id,
+                "location": feature.location,
+                "window_index": feature.window_index,
+                "window_center_t_s": feature.window_center_t_s,
+                "dominant_freq_hz": feature.dominant_freq_hz,
+                "vibration_strength_db": feature.vibration_strength_db,
+                "strength_bucket": feature.strength_bucket,
+                "axis": feature.axis_dominance.axis,
+                "coverage_state": feature.coverage_state,
+                "quality_flags": list(feature.feature_quality_flags),
+            }
+        )
+    return tuple(rows)
+
+
+def _validate_config(config: PostRunWindowFeatureConfig) -> None:
+    if config.feature_min_hz is not None and config.feature_min_hz < 0:
+        raise ValueError("post-run window features require feature_min_hz >= 0")
+    if config.feature_max_hz is not None and config.feature_max_hz < 0:
+        raise ValueError("post-run window features require feature_max_hz >= 0")
+    if (
+        config.feature_min_hz is not None
+        and config.feature_max_hz is not None
+        and config.feature_max_hz < config.feature_min_hz
+    ):
+        raise ValueError("post-run window features require feature_max_hz >= feature_min_hz")
+    if config.top_peak_count <= 0:
+        raise ValueError("post-run window features require top_peak_count > 0")
+    for start_hz, end_hz in config.excluded_frequency_ranges_hz:
+        if start_hz < 0 or end_hz < 0 or end_hz < start_hz:
+            raise ValueError("excluded frequency ranges must be non-negative and ordered")
+
+
+def _feature_from_frame(
+    frame: PostRunStftFrame,
+    *,
+    config: PostRunWindowFeatureConfig,
+) -> PostRunWindowFeature:
+    freq_hz, combined_amp, axis_spectra, quality_flags = _sanitized_aligned_spectra(frame)
+    frequency_mask = _feature_frequency_mask(freq_hz, config=config)
+    if freq_hz.size == 0 or combined_amp.size == 0:
+        _append_unique_flag(quality_flags, "empty_spectrum")
+    if not np.any(frequency_mask):
+        _append_unique_flag(quality_flags, "frequency_mask_empty")
+    masked_freq = freq_hz[frequency_mask]
+    masked_combined = combined_amp[frequency_mask]
+    masked_axis_spectra = {axis: values[frequency_mask] for axis, values in axis_spectra.items()}
+    strength_metrics = _strength_metrics(
+        freq_hz=masked_freq,
+        combined_amp_g=masked_combined,
+        top_peak_count=config.top_peak_count,
+    )
+    top_peaks = tuple(
+        peak for peak in strength_metrics["top_peaks"] if peak["hz"] > 0 and peak["amp"] > 0
+    )
+    if not top_peaks:
+        _append_unique_flag(quality_flags, "no_dominant_peak")
+    dominant_freq_hz = top_peaks[0]["hz"] if top_peaks else None
+    axis_dominance = _axis_dominance(
+        freq_hz=masked_freq,
+        axis_spectra=masked_axis_spectra,
+        combined_amp_g=masked_combined,
+        dominant_freq_hz=dominant_freq_hz,
+    )
+    rms_by_axis = _axis_float_map(frame.rms_by_axis_g)
+    p2p_by_axis = _axis_float_map(frame.p2p_by_axis_g)
+    return PostRunWindowFeature(
+        run_id=frame.run_id,
+        client_id=frame.client_id,
+        location=frame.location,
+        window_index=frame.window_index,
+        window_start_t_s=frame.window_start_t_s,
+        window_end_t_s=frame.window_end_t_s,
+        window_center_t_s=frame.window_center_t_s,
+        sample_rate_hz=frame.sample_rate_hz,
+        coverage_state=frame.coverage_state,
+        data_quality_flags=frame.data_quality_flags,
+        feature_quality_flags=tuple(quality_flags),
+        dominant_freq_hz=dominant_freq_hz,
+        vibration_strength_db=_positive_peak_metric(
+            strength_metrics,
+            "vibration_strength_db",
+            has_peak=bool(top_peaks),
+        ),
+        peak_amp_g=_positive_peak_metric(strength_metrics, "peak_amp_g", has_peak=bool(top_peaks)),
+        noise_floor_amp_g=float(strength_metrics["noise_floor_amp_g"]),
+        strength_bucket=strength_metrics["strength_bucket"],
+        top_peaks=top_peaks,
+        axis_dominance=axis_dominance,
+        rms_by_axis_g=rms_by_axis,
+        p2p_by_axis_g=p2p_by_axis,
+        max_axis_rms_g=max(rms_by_axis.values(), default=0.0),
+        max_axis_p2p_g=max(p2p_by_axis.values(), default=0.0),
+    )
+
+
+def _sanitized_aligned_spectra(
+    frame: PostRunStftFrame,
+) -> tuple[
+    FloatArray,
+    FloatArray,
+    dict[Axis, FloatArray],
+    list[PostRunWindowFeatureQualityFlag],
+]:
+    quality_flags: list[PostRunWindowFeatureQualityFlag] = list(frame.data_quality_flags)
+    freq_hz = np.asarray(frame.freq_hz, dtype=np.float32)
+    combined_amp = np.asarray(frame.combined_amp_g, dtype=np.float32)
+    axis_spectra = {
+        axis: np.asarray(frame.spectrum_by_axis_amp_g.get(axis, np.empty(0)), dtype=np.float32)
+        for axis in AXES
+    }
+    target_len = min(
+        [freq_hz.size, combined_amp.size, *(values.size for values in axis_spectra.values())],
+        default=0,
+    )
+    freq_hz = freq_hz[:target_len]
+    combined_amp = combined_amp[:target_len]
+    axis_spectra = {axis: values[:target_len] for axis, values in axis_spectra.items()}
+    invalid = (
+        not np.all(np.isfinite(freq_hz))
+        or not np.all(np.isfinite(combined_amp))
+        or any(not np.all(np.isfinite(values)) for values in axis_spectra.values())
+    )
+    if invalid:
+        _append_unique_flag(quality_flags, "invalid_spectrum_values")
+    return (
+        np.nan_to_num(freq_hz, copy=True, nan=0.0, posinf=0.0, neginf=0.0),
+        _clean_amp_array(combined_amp),
+        {axis: _clean_amp_array(values) for axis, values in axis_spectra.items()},
+        quality_flags,
+    )
+
+
+def _feature_frequency_mask(
+    freq_hz: FloatArray,
+    *,
+    config: PostRunWindowFeatureConfig,
+) -> BoolArray:
+    mask = np.ones(freq_hz.shape, dtype=np.bool_)
+    if config.feature_min_hz is not None:
+        mask &= freq_hz >= np.float32(config.feature_min_hz)
+    if config.feature_max_hz is not None:
+        mask &= freq_hz <= np.float32(config.feature_max_hz)
+    for start_hz, end_hz in config.excluded_frequency_ranges_hz:
+        mask &= ~((freq_hz >= np.float32(start_hz)) & (freq_hz <= np.float32(end_hz)))
+    return mask
+
+
+def _strength_metrics(
+    *,
+    freq_hz: FloatArray,
+    combined_amp_g: FloatArray,
+    top_peak_count: int,
+) -> VibrationStrengthMetrics:
+    if freq_hz.size == 0 or combined_amp_g.size == 0:
+        return empty_vibration_strength_metrics()
+    return compute_vibration_strength_db(
+        freq_hz=freq_hz,
+        combined_spectrum_amp_g_values=combined_amp_g,
+        top_n=top_peak_count,
+    )
+
+
+def _axis_dominance(
+    *,
+    freq_hz: FloatArray,
+    axis_spectra: dict[Axis, FloatArray],
+    combined_amp_g: FloatArray,
+    dominant_freq_hz: float | None,
+) -> PostRunWindowAxisDominance:
+    if dominant_freq_hz is None or freq_hz.size == 0:
+        return PostRunWindowAxisDominance(axis=None, axis_amp_g=0.0, combined_amp_g=0.0, ratio=None)
+    peak_idx = int(np.argmin(np.abs(freq_hz - np.float32(dominant_freq_hz))))
+    axis_amps = {axis: float(axis_spectra[axis][peak_idx]) for axis in AXES}
+    dominant_axis, dominant_amp = max(axis_amps.items(), key=lambda item: item[1])
+    combined_amp = float(combined_amp_g[peak_idx]) if peak_idx < combined_amp_g.size else 0.0
+    ratio = dominant_amp / combined_amp if combined_amp > 0.0 else None
+    return PostRunWindowAxisDominance(
+        axis=dominant_axis if dominant_amp > 0.0 else None,
+        axis_amp_g=dominant_amp,
+        combined_amp_g=combined_amp,
+        ratio=ratio,
+    )
+
+
+def _axis_float_map(values: dict[Axis, float]) -> dict[Axis, float]:
+    return {axis: _finite_non_negative(values.get(axis, 0.0)) for axis in AXES}
+
+
+def _clean_amp_array(values: FloatArray) -> FloatArray:
+    return (
+        np.nan_to_num(
+            values,
+            copy=True,
+            nan=0.0,
+            posinf=0.0,
+            neginf=0.0,
+        )
+        .astype(np.float32, copy=False)
+        .clip(min=0.0)
+    )
+
+
+def _finite_non_negative(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return 0.0
+    value_float = float(value)
+    if not np.isfinite(value_float):
+        return 0.0
+    return max(0.0, value_float)
+
+
+def _positive_peak_metric(
+    metrics: VibrationStrengthMetrics,
+    key: Literal["vibration_strength_db", "peak_amp_g"],
+    *,
+    has_peak: bool,
+) -> float | None:
+    if not has_peak:
+        return None
+    return float(metrics[key])
+
+
+def _append_unique_flag(
+    flags: list[PostRunWindowFeatureQualityFlag],
+    flag: PostRunWindowFeatureQualityFlag,
+) -> None:
+    if flag not in flags:
+        flags.append(flag)

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -58,10 +58,19 @@ low sample count, invalid axis data, sample-rate mismatch, and missing sidecars.
 The first dense analysis consumer is
 `use_cases/diagnostics/post_run_stft.py`. It consumes those POSTRUN-01 window
 DTOs and produces in-memory STFT frames with per-axis spectra, combined spectra,
-window timing, sensor metadata, dominant frequency, top peaks, and dB strength
-facts. The STFT layer is deliberately post-run only: callers configure FFT size,
-window function, frequency range, and partial-window behavior independently from
-the live UI cadence, while still reusing the shared FFT/strength primitives.
+window timing, sensor metadata, per-axis RMS/P2P, dominant frequency, top peaks,
+and dB strength facts. The STFT layer is deliberately post-run only: callers
+configure FFT size, window function, frequency range, and partial-window behavior
+independently from the live UI cadence, while still reusing the shared
+FFT/strength primitives.
+
+`use_cases/diagnostics/post_run_window_features.py` is the next reduction layer.
+It consumes POSTRUN-02 STFT frames and emits per-window/per-sensor feature DTOs:
+dominant and top peaks, canonical `vibration_strength_db`, peak amplitude, noise
+floor, strength bucket, axis dominance, RMS/P2P, structured quality flags, and
+compact debug rows for synthetic runs. Frequency masks live at this layer so
+later episode/order/finding logic can ignore unusable bands without recomputing
+the dense spectra.
 
 ## Related deep dives
 
@@ -142,6 +151,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `_run_loader.py` | ~20 | JSONL run loader used by analysis/report adapters |
 | `post_run_raw_windows.py` | ~300 | Manifest-aware streaming raw waveform reader and configurable overlapping-window iterator for dense post-run stages |
 | `post_run_stft.py` | ~350 | In-memory dense STFT engine over POSTRUN-01 raw-window DTOs |
+| `post_run_window_features.py` | ~300 | Window-level feature extraction over POSTRUN-02 STFT frames |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -63,6 +63,11 @@ does not track implementation status or old branch plans.
   `apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py`: an in-memory
   STFT engine over those raw-window DTOs. Persistence of dense arrays remains
   owned by POSTRUN-08.
+- POSTRUN-03 adds
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py`:
+  a deterministic reduction from STFT frames to per-window/per-sensor diagnostic
+  features, including canonical dB strength, top peaks, axis dominance, RMS/P2P,
+  frequency masking, and propagated quality flags.
 
 ### Persisted analysis and reporting
 
@@ -119,7 +124,7 @@ raw capture manifest/files (#3065)
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
-| Whole-run spectra | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine |
+| Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine and `post_run_window_features.py` owns the compact per-window feature reduction |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |


### PR DESCRIPTION
## What changed
- Added post_run_window_features.py to reduce POSTRUN-02 STFT frames into per-window/per-sensor diagnostic feature DTOs.
- Added canonical strength/top peak extraction, noise floor, strength bucket, axis dominance, frequency masks, structured feature quality flags, and compact debug rows.
- Extended STFT frames with per-axis RMS and P2P metrics so feature extraction can stay STFT-output based.
- Added tests for single-tone, multi-tone, silence, noisy/low-SNR, frequency masking, quality flags, invalid spectra, canonical strength usage, and debug rows.
- Updated dense analysis docs.

## Why
#3712 needs reusable window-level features before persistent episode detection, order traces, and dense finding classification can consume the spectrogram output.

## Validation
- Ruff check and format on touched feature/STFT files.
- Backend static guards passed.
- Mypy on STFT and feature modules.
- Related diagnostics tests: 23 passed.
- Docs lint passed.
- Changed-file use-case suite: 2186 passed.

## Risks, tradeoffs, edge cases
- Persistence remains out of scope; POSTRUN-08 owns dense artifact storage.
- Frequency masks are applied at feature extraction time, not by mutating the underlying STFT frames.
- RMS/P2P are per-axis time-domain metrics carried by STFT frames; dense spectra remain the source for strength and peak features.

## Follow-ups
- Persistent vibration episode detection in #3717.
- Dense artifact persistence in #3719.

Fixes #3712