### PR TITLE
Add post-run vehicle reference timeline

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_vehicle_reference.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_vehicle_reference.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vibesensor.shared.order_bands import build_diagnostic_settings
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.post_run_vehicle_reference import (
+    VehicleReferenceTimelineConfig,
+    build_post_run_vehicle_reference_timeline,
+    vehicle_reference_debug_fixtures,
+)
+
+_RUN_ID = "run-reference"
+_SAMPLE_RATE_HZ = 100
+
+
+def _metadata(*, current_gear_ratio: float | None = None) -> RunMetadata:
+    settings = build_diagnostic_settings()
+    if current_gear_ratio is not None:
+        settings = replace(settings, current_gear_ratio=current_gear_ratio)
+    return RunMetadata.create(
+        run_id=_RUN_ID,
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="adxl345",
+        raw_sample_rate_hz=_SAMPLE_RATE_HZ,
+        feature_interval_s=0.5,
+        fft_window_size_samples=100,
+        accel_scale_g_per_lsb=0.001,
+        analysis_settings=settings,
+    )
+
+
+def _window(index: int, *, center_t_s: float) -> WholeRunWindowDescriptor:
+    policy = WholeRunWindowPolicy(
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        window_size_samples=20,
+        stride_samples=20,
+        overlap_samples=0,
+        feature_interval_s=0.2,
+    )
+    descriptor = WholeRunWindowDescriptor.from_policy(
+        window_index=index,
+        sample_start=max(0, int(round((center_t_s * _SAMPLE_RATE_HZ) - 10))),
+        policy=policy,
+    )
+    return WholeRunWindowDescriptor(
+        window_index=index,
+        sample_start=descriptor.sample_start,
+        sample_end=descriptor.sample_end,
+        center_sample=descriptor.center_sample,
+        start_t_s=center_t_s - 0.1,
+        end_t_s=center_t_s + 0.1,
+        center_t_s=center_t_s,
+    )
+
+
+def _sample(
+    t_s: float,
+    *,
+    speed_kmh: float | None = 72.0,
+    gps_speed_kmh: float | None = None,
+    speed_source: str = "obd",
+    engine_rpm: float | None = 3000.0,
+    engine_rpm_source: str = "obd",
+    gear: float | None = None,
+    final_drive_ratio: float | None = None,
+    sample_rate_hz: int | None = _SAMPLE_RATE_HZ,
+) -> SensorFrame:
+    return SensorFrame(
+        run_id=_RUN_ID,
+        timestamp_utc=f"2026-01-01T00:00:{int(t_s):02d}Z",
+        t_s=t_s,
+        client_id="sensor-a",
+        client_name="Sensor A",
+        location="front_left",
+        sample_rate_hz=sample_rate_hz,
+        speed_kmh=speed_kmh,
+        gps_speed_kmh=gps_speed_kmh,
+        speed_source=speed_source,
+        engine_rpm=engine_rpm,
+        engine_rpm_source=engine_rpm_source,
+        gear=gear,
+        final_drive_ratio=final_drive_ratio,
+        accel_x_g=0.0,
+        accel_y_g=0.0,
+        accel_z_g=0.0,
+        dominant_freq_hz=None,
+        dominant_axis="",
+        top_peaks=(),
+        vibration_strength_db=None,
+        strength_bucket=None,
+        strength_peak_amp_g=None,
+        strength_floor_amp_g=None,
+        frames_dropped_total=0,
+        queue_overflow_drops=0,
+    )
+
+
+def test_vehicle_reference_timeline_fixed_speed_derives_order_frequencies() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=metadata,
+        samples=(_sample(0.0), _sample(1.0)),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert point.speed_kmh == pytest.approx(72.0)
+    assert point.speed_quality == "interpolated"
+    assert point.engine_hz == pytest.approx(50.0)
+    assert point.wheel_hz == pytest.approx(
+        metadata.order_reference_spec.wheel_hz_from_speed_kmh(72.0)
+    )
+    assert point.wheel_hz is not None
+    assert point.final_drive_ratio is not None
+    assert point.driveshaft_hz == pytest.approx(point.wheel_hz * point.final_drive_ratio)
+    assert point.unavailable_reasons == ()
+
+
+def test_vehicle_reference_timeline_interpolates_speed_sweep() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(
+            _sample(0.0, speed_kmh=36.0, engine_rpm=2000.0),
+            _sample(1.0, speed_kmh=72.0, engine_rpm=3000.0),
+        ),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert point.speed_kmh == pytest.approx(54.0)
+    assert point.engine_rpm == pytest.approx(2500.0)
+    assert point.speed_quality == "interpolated"
+    assert point.engine_rpm_quality == "interpolated"
+
+
+def test_vehicle_reference_timeline_marks_long_gps_gap_unavailable() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(
+            _sample(0.0, speed_kmh=None, gps_speed_kmh=60.0, speed_source="gps"),
+            _sample(3.0, speed_kmh=None, gps_speed_kmh=61.0, speed_source="gps"),
+        ),
+        windows=(_window(0, center_t_s=1.5),),
+        config=VehicleReferenceTimelineConfig(
+            max_interpolation_gap_s=1.0,
+            max_stale_sample_age_s=0.4,
+        ),
+    )
+
+    point = timeline.points[0]
+    assert point.speed_kmh is None
+    assert point.speed_quality == "unavailable"
+    assert "stale_speed" in point.unavailable_reasons
+
+
+def test_vehicle_reference_timeline_rejects_ambiguous_speed_source_switch() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(
+            _sample(0.0, speed_kmh=70.0, speed_source="manual"),
+            _sample(1.0, speed_kmh=None, gps_speed_kmh=72.0, speed_source="gps"),
+        ),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert point.speed_kmh is None
+    assert "ambiguous_gap" in point.unavailable_reasons
+
+
+def test_vehicle_reference_timeline_derives_engine_from_settings_when_rpm_missing() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(_sample(0.0, engine_rpm=None), _sample(1.0, engine_rpm=None)),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert "missing_rpm" in point.unavailable_reasons
+    assert point.driveshaft_hz is not None
+    assert point.gear_ratio is not None
+    assert point.engine_hz == pytest.approx(point.driveshaft_hz * point.gear_ratio)
+    assert point.engine_rpm is None
+
+
+def test_vehicle_reference_timeline_marks_missing_gear_without_speculation() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(current_gear_ratio=0.0),
+        samples=(_sample(0.0, engine_rpm=None), _sample(1.0, engine_rpm=None)),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert point.gear_ratio is None
+    assert point.engine_hz is None
+    assert "missing_gear" in point.unavailable_reasons
+
+
+def test_vehicle_reference_timeline_rejects_changing_final_drive_values() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(
+            _sample(0.0, final_drive_ratio=3.0),
+            _sample(1.0, final_drive_ratio=4.0),
+        ),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    point = timeline.points[0]
+    assert point.final_drive_ratio is None
+    assert point.driveshaft_hz is None
+    assert "ambiguous_gap" in point.unavailable_reasons
+    assert "unknown_final_drive" in point.unavailable_reasons
+
+
+def test_vehicle_reference_timeline_marks_inconsistent_sample_rate() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(_sample(0.0, sample_rate_hz=100), _sample(1.0, sample_rate_hz=200)),
+        windows=(_window(0, center_t_s=0.5),),
+    )
+
+    assert "inconsistent_sample_rate" in timeline.points[0].unavailable_reasons
+
+
+def test_vehicle_reference_debug_fixtures_are_stable_rows() -> None:
+    timeline = build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=_metadata(),
+        samples=(_sample(0.0), _sample(1.0)),
+        windows=(_window(0, center_t_s=0.5), _window(1, center_t_s=0.7)),
+    )
+
+    rows = vehicle_reference_debug_fixtures(timeline)
+
+    assert [row.window_index for row in rows] == [0, 1]
+    assert rows[0].speed_kmh == pytest.approx(72.0)
+    assert rows[0].unavailable_reasons == ()

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py
@@ -1,0 +1,484 @@
+"""Vehicle-reference timeline aligned to dense post-run windows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from typing import Literal
+
+from vibesensor.domain import OrderReferenceSpec
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import WholeRunWindowDescriptor
+from vibesensor.use_cases.diagnostics.post_run_stft import (
+    PostRunDenseStftResult,
+    PostRunStftFrame,
+)
+
+type VehicleReferenceValueQuality = Literal["sampled", "interpolated", "unavailable"]
+type VehicleReferenceUnavailableReason = Literal[
+    "missing_speed",
+    "stale_speed",
+    "missing_rpm",
+    "missing_gear",
+    "inconsistent_sample_rate",
+    "unknown_final_drive",
+    "unknown_tire",
+    "ambiguous_gap",
+    "no_samples",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleReferenceTimelineConfig:
+    """Conservative alignment settings for vehicle-reference values."""
+
+    max_interpolation_gap_s: float = 1.0
+    max_stale_sample_age_s: float = 0.75
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleReferencePoint:
+    """Vehicle reference values aligned to one dense analysis window."""
+
+    run_id: str
+    window_index: int
+    window_start_t_s: float
+    window_end_t_s: float
+    window_center_t_s: float
+    speed_kmh: float | None
+    speed_source: str | None
+    speed_quality: VehicleReferenceValueQuality
+    engine_rpm: float | None
+    engine_rpm_source: str | None
+    engine_rpm_quality: VehicleReferenceValueQuality
+    gear_ratio: float | None
+    gear_quality: VehicleReferenceValueQuality
+    final_drive_ratio: float | None
+    final_drive_quality: VehicleReferenceValueQuality
+    wheel_hz: float | None
+    driveshaft_hz: float | None
+    engine_hz: float | None
+    wheel_uncertainty_pct: float | None
+    driveshaft_uncertainty_pct: float | None
+    engine_uncertainty_pct: float | None
+    unavailable_reasons: tuple[VehicleReferenceUnavailableReason, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleReferenceTimeline:
+    """Dense-window vehicle reference timeline."""
+
+    run_id: str
+    config: VehicleReferenceTimelineConfig
+    points: tuple[VehicleReferencePoint, ...]
+
+    def point_for_window(self, window_index: int) -> VehicleReferencePoint | None:
+        for point in self.points:
+            if point.window_index == window_index:
+                return point
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleReferenceDebugFixture:
+    """Compact reusable fixture row for later order-tracking tests."""
+
+    window_index: int
+    t_s: float
+    speed_kmh: float | None
+    wheel_hz: float | None
+    driveshaft_hz: float | None
+    engine_hz: float | None
+    unavailable_reasons: tuple[VehicleReferenceUnavailableReason, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _TimedValue:
+    t_s: float
+    value: float
+    source: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _AlignedValue:
+    value: float | None
+    source: str | None
+    quality: VehicleReferenceValueQuality
+    reason: VehicleReferenceUnavailableReason | None = None
+
+
+def build_post_run_vehicle_reference_timeline(
+    *,
+    run_id: str,
+    metadata: RunMetadata,
+    samples: Sequence[SensorFrame],
+    windows: (
+        PostRunDenseStftResult | Iterable[PostRunStftFrame] | Iterable[WholeRunWindowDescriptor]
+    ),
+    config: VehicleReferenceTimelineConfig | None = None,
+) -> VehicleReferenceTimeline:
+    """Align vehicle speed/RPM/gear references to dense post-run windows."""
+
+    effective_config = config or VehicleReferenceTimelineConfig()
+    _validate_config(effective_config)
+    window_rows = _window_rows(windows)
+    sample_rows = sorted(
+        (sample for sample in samples if sample.t_s is not None and isfinite(sample.t_s)),
+        key=lambda sample: float(sample.t_s or 0.0),
+    )
+    sample_rate_inconsistent = _sample_rate_inconsistent(metadata=metadata, samples=sample_rows)
+    order_spec = metadata.order_reference_spec
+    points = tuple(
+        _build_point(
+            run_id=run_id,
+            window=window,
+            samples=sample_rows,
+            metadata=metadata,
+            order_spec=order_spec,
+            sample_rate_inconsistent=sample_rate_inconsistent,
+            config=effective_config,
+        )
+        for window in window_rows
+    )
+    return VehicleReferenceTimeline(run_id=run_id, config=effective_config, points=points)
+
+
+def vehicle_reference_debug_fixtures(
+    timeline: VehicleReferenceTimeline,
+) -> tuple[VehicleReferenceDebugFixture, ...]:
+    """Return compact reference rows reusable by later order-tracking tests."""
+
+    return tuple(
+        VehicleReferenceDebugFixture(
+            window_index=point.window_index,
+            t_s=point.window_center_t_s,
+            speed_kmh=point.speed_kmh,
+            wheel_hz=point.wheel_hz,
+            driveshaft_hz=point.driveshaft_hz,
+            engine_hz=point.engine_hz,
+            unavailable_reasons=point.unavailable_reasons,
+        )
+        for point in timeline.points
+    )
+
+
+def _validate_config(config: VehicleReferenceTimelineConfig) -> None:
+    if config.max_interpolation_gap_s < 0:
+        raise ValueError("vehicle reference timeline requires max_interpolation_gap_s >= 0")
+    if config.max_stale_sample_age_s < 0:
+        raise ValueError("vehicle reference timeline requires max_stale_sample_age_s >= 0")
+
+
+def _window_rows(
+    windows: (
+        PostRunDenseStftResult | Iterable[PostRunStftFrame] | Iterable[WholeRunWindowDescriptor]
+    ),
+) -> tuple[WholeRunWindowDescriptor, ...]:
+    if isinstance(windows, PostRunDenseStftResult):
+        iterable: Iterable[PostRunStftFrame | WholeRunWindowDescriptor] = windows.frames
+    else:
+        iterable = windows
+    by_index: dict[int, WholeRunWindowDescriptor] = {}
+    for item in iterable:
+        if isinstance(item, PostRunStftFrame):
+            sample_end = item.requested_sample_start + item.requested_sample_count
+            descriptor = WholeRunWindowDescriptor(
+                window_index=item.window_index,
+                sample_start=item.requested_sample_start,
+                sample_end=sample_end,
+                center_sample=item.requested_sample_start + (item.requested_sample_count // 2),
+                start_t_s=item.window_start_t_s,
+                end_t_s=item.window_end_t_s,
+                center_t_s=item.window_center_t_s,
+            )
+        else:
+            descriptor = item
+        by_index.setdefault(descriptor.window_index, descriptor)
+    return tuple(by_index[index] for index in sorted(by_index))
+
+
+def _build_point(
+    *,
+    run_id: str,
+    window: WholeRunWindowDescriptor,
+    samples: Sequence[SensorFrame],
+    metadata: RunMetadata,
+    order_spec: OrderReferenceSpec | None,
+    sample_rate_inconsistent: bool,
+    config: VehicleReferenceTimelineConfig,
+) -> VehicleReferencePoint:
+    center_t = window.center_t_s
+    reasons: list[VehicleReferenceUnavailableReason] = []
+    if not samples:
+        _append_unique_reason(reasons, "no_samples")
+    if sample_rate_inconsistent:
+        _append_unique_reason(reasons, "inconsistent_sample_rate")
+    speed = _aligned_value(
+        _speed_values(samples),
+        center_t,
+        config=config,
+        missing_reason="missing_speed",
+        stale_reason="stale_speed",
+        allow_interpolation=True,
+    )
+    rpm = _aligned_value(
+        _sample_values(samples, attr="engine_rpm", source_attr="engine_rpm_source"),
+        center_t,
+        config=config,
+        missing_reason="missing_rpm",
+        stale_reason="missing_rpm",
+        allow_interpolation=True,
+    )
+    gear = _aligned_value(
+        _sample_values(samples, attr="gear"),
+        center_t,
+        config=config,
+        missing_reason="missing_gear",
+        stale_reason="missing_gear",
+        allow_interpolation=False,
+    )
+    final_drive = _aligned_value(
+        _sample_values(samples, attr="final_drive_ratio"),
+        center_t,
+        config=config,
+        missing_reason="unknown_final_drive",
+        stale_reason="unknown_final_drive",
+        allow_interpolation=False,
+    )
+    if (
+        final_drive.value is None
+        and final_drive.reason != "ambiguous_gap"
+        and order_spec is not None
+        and order_spec.final_drive_ratio > 0
+    ):
+        final_drive = _AlignedValue(
+            value=order_spec.final_drive_ratio,
+            source="settings",
+            quality="sampled",
+        )
+    if (
+        gear.value is None
+        and gear.reason != "ambiguous_gap"
+        and order_spec is not None
+        and order_spec.current_gear_ratio > 0
+    ):
+        gear = _AlignedValue(
+            value=order_spec.current_gear_ratio,
+            source="settings",
+            quality="sampled",
+        )
+    for aligned in (speed, rpm, gear, final_drive):
+        if aligned.reason is not None:
+            _append_unique_reason(reasons, aligned.reason)
+    wheel_hz = _wheel_hz(order_spec=order_spec, speed_kmh=speed.value)
+    if speed.value is not None and wheel_hz is None:
+        _append_unique_reason(reasons, "unknown_tire")
+    driveshaft_hz = _driveshaft_hz(wheel_hz=wheel_hz, final_drive_ratio=final_drive.value)
+    if wheel_hz is not None and driveshaft_hz is None:
+        _append_unique_reason(reasons, "unknown_final_drive")
+    engine_hz = _engine_hz(
+        engine_rpm=rpm.value,
+        driveshaft_hz=driveshaft_hz,
+        gear_ratio=gear.value,
+    )
+    if driveshaft_hz is not None and engine_hz is None:
+        _append_unique_reason(reasons, "missing_gear")
+    return VehicleReferencePoint(
+        run_id=run_id,
+        window_index=window.window_index,
+        window_start_t_s=window.start_t_s,
+        window_end_t_s=window.end_t_s,
+        window_center_t_s=center_t,
+        speed_kmh=speed.value,
+        speed_source=speed.source,
+        speed_quality=speed.quality,
+        engine_rpm=rpm.value,
+        engine_rpm_source=rpm.source,
+        engine_rpm_quality=rpm.quality,
+        gear_ratio=gear.value,
+        gear_quality=gear.quality,
+        final_drive_ratio=final_drive.value,
+        final_drive_quality=final_drive.quality,
+        wheel_hz=wheel_hz,
+        driveshaft_hz=driveshaft_hz,
+        engine_hz=engine_hz,
+        wheel_uncertainty_pct=(
+            order_spec.wheel_uncertainty_pct
+            if order_spec is not None and wheel_hz is not None
+            else None
+        ),
+        driveshaft_uncertainty_pct=(
+            order_spec.drive_uncertainty_pct
+            if order_spec is not None and driveshaft_hz is not None
+            else None
+        ),
+        engine_uncertainty_pct=(
+            order_spec.engine_uncertainty_pct
+            if order_spec is not None and engine_hz is not None
+            else None
+        ),
+        unavailable_reasons=tuple(reasons),
+    )
+
+
+def _aligned_value(
+    values: Sequence[_TimedValue],
+    t_s: float,
+    *,
+    config: VehicleReferenceTimelineConfig,
+    missing_reason: VehicleReferenceUnavailableReason,
+    stale_reason: VehicleReferenceUnavailableReason,
+    allow_interpolation: bool,
+) -> _AlignedValue:
+    if not values:
+        return _AlignedValue(None, None, "unavailable", missing_reason)
+    before = _last_at_or_before(values, t_s)
+    after = _first_at_or_after(values, t_s)
+    exact = before if before is not None and abs(before.t_s - t_s) <= 1e-9 else None
+    if exact is not None:
+        return _AlignedValue(exact.value, exact.source, "sampled")
+    if before is not None and after is not None:
+        gap_s = after.t_s - before.t_s
+        if gap_s <= config.max_interpolation_gap_s:
+            if before.source != after.source:
+                return _nearest_or_unavailable(values, t_s, config=config, reason="ambiguous_gap")
+            if allow_interpolation:
+                fraction = (t_s - before.t_s) / gap_s if gap_s > 0 else 0.0
+                value = before.value + ((after.value - before.value) * fraction)
+                return _AlignedValue(value, before.source, "interpolated")
+            if before.value == after.value:
+                return _AlignedValue(before.value, before.source, "sampled")
+            return _nearest_or_unavailable(values, t_s, config=config, reason="ambiguous_gap")
+    return _nearest_or_unavailable(values, t_s, config=config, reason=stale_reason)
+
+
+def _nearest_or_unavailable(
+    values: Sequence[_TimedValue],
+    t_s: float,
+    *,
+    config: VehicleReferenceTimelineConfig,
+    reason: VehicleReferenceUnavailableReason,
+) -> _AlignedValue:
+    nearest = min(values, key=lambda value: abs(value.t_s - t_s))
+    if abs(nearest.t_s - t_s) <= config.max_stale_sample_age_s and reason != "ambiguous_gap":
+        return _AlignedValue(nearest.value, nearest.source, "sampled")
+    return _AlignedValue(None, None, "unavailable", reason)
+
+
+def _speed_values(samples: Sequence[SensorFrame]) -> tuple[_TimedValue, ...]:
+    values: list[_TimedValue] = []
+    for sample in samples:
+        t_s = float(sample.t_s or 0.0)
+        speed = _finite_positive_or_zero(sample.speed_kmh)
+        source = sample.speed_source or None
+        if speed is None:
+            speed = _finite_positive_or_zero(sample.gps_speed_kmh)
+            source = "gps" if speed is not None else source
+        if speed is not None:
+            values.append(_TimedValue(t_s=t_s, value=speed, source=source))
+    return tuple(values)
+
+
+def _sample_values(
+    samples: Sequence[SensorFrame],
+    *,
+    attr: str,
+    source_attr: str | None = None,
+) -> tuple[_TimedValue, ...]:
+    values: list[_TimedValue] = []
+    for sample in samples:
+        value = _finite_positive_or_zero(getattr(sample, attr))
+        if value is None:
+            continue
+        source = getattr(sample, source_attr) if source_attr is not None else None
+        values.append(
+            _TimedValue(
+                t_s=float(sample.t_s or 0.0),
+                value=value,
+                source=str(source) if source else None,
+            )
+        )
+    return tuple(values)
+
+
+def _sample_rate_inconsistent(
+    *,
+    metadata: RunMetadata,
+    samples: Sequence[SensorFrame],
+) -> bool:
+    sample_rates = {
+        int(sample.sample_rate_hz)
+        for sample in samples
+        if sample.sample_rate_hz is not None and sample.sample_rate_hz > 0
+    }
+    if len(sample_rates) > 1:
+        return True
+    metadata_rate = metadata.raw_sample_rate_hz or metadata.configured_raw_sample_rate_hz
+    if metadata_rate is None or not sample_rates:
+        return False
+    return int(metadata_rate) not in sample_rates
+
+
+def _wheel_hz(*, order_spec: OrderReferenceSpec | None, speed_kmh: float | None) -> float | None:
+    if order_spec is None or speed_kmh is None:
+        return None
+    return order_spec.wheel_hz_from_speed_kmh(speed_kmh)
+
+
+def _driveshaft_hz(
+    *,
+    wheel_hz: float | None,
+    final_drive_ratio: float | None,
+) -> float | None:
+    if wheel_hz is None or final_drive_ratio is None or final_drive_ratio <= 0:
+        return None
+    driveshaft_hz = wheel_hz * final_drive_ratio
+    return driveshaft_hz if isfinite(driveshaft_hz) and driveshaft_hz > 0 else None
+
+
+def _engine_hz(
+    *,
+    engine_rpm: float | None,
+    driveshaft_hz: float | None,
+    gear_ratio: float | None,
+) -> float | None:
+    if engine_rpm is not None and engine_rpm > 0:
+        engine_hz = engine_rpm / 60.0
+        return engine_hz if isfinite(engine_hz) else None
+    if driveshaft_hz is None or gear_ratio is None or gear_ratio <= 0:
+        return None
+    engine_hz = driveshaft_hz * gear_ratio
+    return engine_hz if isfinite(engine_hz) and engine_hz > 0 else None
+
+
+def _last_at_or_before(values: Sequence[_TimedValue], t_s: float) -> _TimedValue | None:
+    for value in reversed(values):
+        if value.t_s <= t_s:
+            return value
+    return None
+
+
+def _first_at_or_after(values: Sequence[_TimedValue], t_s: float) -> _TimedValue | None:
+    for value in values:
+        if value.t_s >= t_s:
+            return value
+    return None
+
+
+def _finite_positive_or_zero(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    value_float = float(value)
+    if not isfinite(value_float) or value_float < 0:
+        return None
+    return value_float
+
+
+def _append_unique_reason(
+    reasons: list[VehicleReferenceUnavailableReason],
+    reason: VehicleReferenceUnavailableReason,
+) -> None:
+    if reason not in reasons:
+        reasons.append(reason)

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -72,6 +72,14 @@ compact debug rows for synthetic runs. Frequency masks live at this layer so
 later episode/order/finding logic can ignore unusable bands without recomputing
 the dense spectra.
 
+`use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
+and final-drive references onto the same window grid. It uses conservative
+interpolation only across short, same-source gaps; rejects ambiguous source,
+gear, or final-drive changes; and records explicit unavailable reasons such as
+missing speed/RPM/gear, stale samples, inconsistent sample rate, and missing
+vehicle configuration. Wheel, driveshaft, and engine frequencies are derived via
+the shared `OrderReferenceSpec` math instead of diagnostics-local formulas.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -152,6 +160,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `post_run_raw_windows.py` | ~300 | Manifest-aware streaming raw waveform reader and configurable overlapping-window iterator for dense post-run stages |
 | `post_run_stft.py` | ~350 | In-memory dense STFT engine over POSTRUN-01 raw-window DTOs |
 | `post_run_window_features.py` | ~300 | Window-level feature extraction over POSTRUN-02 STFT frames |
+| `post_run_vehicle_reference.py` | ~350 | Per-window vehicle speed/RPM/gear/final-drive reference normalization for dense order stages |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -68,6 +68,12 @@ does not track implementation status or old branch plans.
   a deterministic reduction from STFT frames to per-window/per-sensor diagnostic
   features, including canonical dB strength, top peaks, axis dominance, RMS/P2P,
   frequency masking, and propagated quality flags.
+- POSTRUN-04 adds
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py`:
+  a deterministic vehicle-reference timeline aligned to the dense window grid.
+  It normalizes speed, RPM, gear, and final-drive inputs, rejects ambiguous or
+  stale references, and derives wheel/driveshaft/engine Hz through
+  `OrderReferenceSpec`.
 
 ### Persisted analysis and reporting
 
@@ -125,7 +131,7 @@ raw capture manifest/files (#3065)
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
 | Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine and `post_run_window_features.py` owns the compact per-window feature reduction |
-| Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
+| Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments; `post_run_vehicle_reference.py` owns the conservative vehicle-reference timeline for dense stages |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |
 | Fusion/report summary | `use_cases/diagnostics/`, `shared/boundaries/reporting/` | Convert whole-run evidence into ranked diagnoses and compact persisted facts |

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -18,6 +18,7 @@ lives in `apps/server/vibesensor/use_cases/diagnostics/orders/`.
 | `OrderReferenceSpec` | `domain/order_reference.py` | Tire geometry, final-drive ratio, gear ratio, and uncertainty settings for order analysis. |
 | `vehicle_orders_hz()` | `shared/order_bands.py` | Resolve wheel / driveshaft / engine reference frequencies for one speed sample. |
 | `build_order_bands()` | `shared/order_bands.py` | Precompute live order-band payloads so the frontend does not duplicate tolerance math. |
+| `build_post_run_vehicle_reference_timeline()` | `use_cases/diagnostics/post_run_vehicle_reference.py` | Normalize speed/RPM/gear/final-drive references onto whole-run windows for dense post-run order stages. |
 | `OrderHypothesis` | `use_cases/diagnostics/orders/physics.py` | One named order candidate such as `wheel_1x` or `engine_2x`. |
 | `OrderAnalysisSession` | `use_cases/diagnostics/orders/pipeline.py` | Run all eligible hypotheses across stored samples and return ranked findings. |
 
@@ -40,6 +41,28 @@ The spec exposes capability checks before any of that math is used:
 
 If the required tire or driveline data is missing, VibeSensor omits the order
 reference instead of inventing one.
+
+## Per-window post-run references
+
+Dense post-run order work first maps vehicle context onto the deterministic
+window grid with
+`build_post_run_vehicle_reference_timeline()` in
+`use_cases/diagnostics/post_run_vehicle_reference.py`.
+
+The timeline keeps interpolation deliberately narrow:
+
+- speed and RPM interpolate only across short gaps from the same source
+- stale nearest samples remain unavailable instead of being stretched across long
+  gaps
+- gear and final-drive values are never interpolated across changed values
+- source switches, missing speed/RPM/gear, inconsistent sample rates, and missing
+  vehicle configuration are recorded as explicit unavailable reasons
+
+When inputs are valid, wheel/driveshaft/engine Hz are derived through
+`OrderReferenceSpec`; diagnostics does not duplicate the tire or driveline
+formulas. Missing RPM can still produce an engine reference only when speed,
+final drive, and gear ratio are available from aligned samples or settings, and
+the missing-RPM reason remains visible to downstream coverage scoring.
 
 ## Uncertainty and tolerance bands
 
@@ -140,6 +163,7 @@ That shared ownership is why `shared/order_bands.py` exists outside
 |------|----------------|
 | `apps/server/vibesensor/domain/order_reference.py` | Vehicle-physics reference model and frequency derivation helpers. |
 | `apps/server/vibesensor/shared/order_bands.py` | Shared uncertainty, tolerance-band, and live band-payload helpers. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py` | Dense per-window vehicle reference normalization and debug fixtures. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py` | Fixed hypothesis catalog and per-sample predicted-Hz helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py` | Match predicted order bands against stored sample peaks. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |


### PR DESCRIPTION
Closes #3714

## What changed
- Added post-run vehicle reference timeline builder for dense windows.
- Aligns speed, RPM, gear ratio, and final-drive ratio to window centers.
- Derives wheel, driveshaft, and engine Hz through OrderReferenceSpec.
- Adds explicit unavailable reasons for missing, stale, ambiguous, or inconsistent references.
- Adds stable debug fixture rows for later dense order tests.
- Documents POSTRUN-04 in pipeline and order-tracking docs.

## Why
Dense order tracking needs one window-aligned vehicle context source before per-window order bands can be computed. This keeps reference math shared and keeps bad context visible instead of silently guessed.

## Validation
- ruff check and format check on touched Python files
- mypy on new module and tests
- backend static guards
- focused post-run diagnostics tests
- docs_lint
- run_changed use-case suite

## Risks, tradeoffs, edge cases
- Conservative interpolation may mark more windows unavailable across source switches or long gaps. That is intentional for diagnostic truth.
- Gear uses the existing numeric sample gear field as a gear ratio. Settings fallback supplies the configured gear ratio when samples do not carry it.
- Heavy artifact persistence remains out of scope.
