### PR TITLE
Add post-run order band timeline

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_order_bands.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_order_bands.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from vibesensor.shared.order_bands import build_diagnostic_settings, tolerance_for_order
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.post_run_order_bands import (
+    OrderBand,
+    OrderBandWindow,
+    PostRunOrderBandsConfig,
+    build_post_run_order_band_timeline,
+    serialize_order_band_rows,
+)
+from vibesensor.use_cases.diagnostics.post_run_vehicle_reference import (
+    VehicleReferenceTimeline,
+    VehicleReferenceTimelineConfig,
+    build_post_run_vehicle_reference_timeline,
+)
+
+_RUN_ID = "run-order-bands"
+_SAMPLE_RATE_HZ = 100
+
+
+def _metadata(**overrides: float) -> RunMetadata:
+    settings = build_diagnostic_settings(overrides)
+    return RunMetadata.create(
+        run_id=_RUN_ID,
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="adxl345",
+        raw_sample_rate_hz=_SAMPLE_RATE_HZ,
+        feature_interval_s=0.5,
+        fft_window_size_samples=100,
+        accel_scale_g_per_lsb=0.001,
+        analysis_settings=settings,
+    )
+
+
+def _window(index: int, *, center_t_s: float) -> WholeRunWindowDescriptor:
+    policy = WholeRunWindowPolicy(
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        window_size_samples=20,
+        stride_samples=20,
+        overlap_samples=0,
+        feature_interval_s=0.2,
+    )
+    descriptor = WholeRunWindowDescriptor.from_policy(
+        window_index=index,
+        sample_start=max(0, int(round((center_t_s * _SAMPLE_RATE_HZ) - 10))),
+        policy=policy,
+    )
+    return WholeRunWindowDescriptor(
+        window_index=index,
+        sample_start=descriptor.sample_start,
+        sample_end=descriptor.sample_end,
+        center_sample=descriptor.center_sample,
+        start_t_s=center_t_s - 0.1,
+        end_t_s=center_t_s + 0.1,
+        center_t_s=center_t_s,
+    )
+
+
+def _sample(
+    t_s: float,
+    *,
+    speed_kmh: float | None = 72.0,
+    gps_speed_kmh: float | None = None,
+    speed_source: str = "obd",
+    engine_rpm: float | None = 3000.0,
+    engine_rpm_source: str = "obd",
+    gear: float | None = None,
+    final_drive_ratio: float | None = None,
+) -> SensorFrame:
+    return SensorFrame(
+        run_id=_RUN_ID,
+        timestamp_utc=f"2026-01-01T00:00:{int(t_s):02d}Z",
+        t_s=t_s,
+        client_id="sensor-a",
+        client_name="Sensor A",
+        location="front_left",
+        sample_rate_hz=_SAMPLE_RATE_HZ,
+        speed_kmh=speed_kmh,
+        gps_speed_kmh=gps_speed_kmh,
+        speed_source=speed_source,
+        engine_rpm=engine_rpm,
+        engine_rpm_source=engine_rpm_source,
+        gear=gear,
+        final_drive_ratio=final_drive_ratio,
+        accel_x_g=0.0,
+        accel_y_g=0.0,
+        accel_z_g=0.0,
+        dominant_freq_hz=None,
+        dominant_axis="",
+        top_peaks=(),
+        vibration_strength_db=None,
+        strength_bucket=None,
+        strength_peak_amp_g=None,
+        strength_floor_amp_g=None,
+        frames_dropped_total=0,
+        queue_overflow_drops=0,
+    )
+
+
+def _vehicle_timeline(
+    *,
+    metadata: RunMetadata,
+    samples: tuple[SensorFrame, ...],
+    windows: tuple[WholeRunWindowDescriptor, ...] = (_window(0, center_t_s=0.5),),
+) -> VehicleReferenceTimeline:
+    return build_post_run_vehicle_reference_timeline(
+        run_id=_RUN_ID,
+        metadata=metadata,
+        samples=samples,
+        windows=windows,
+        config=VehicleReferenceTimelineConfig(max_interpolation_gap_s=1.0),
+    )
+
+
+def _bands_by_label(window: OrderBandWindow) -> dict[str, OrderBand]:
+    return {band.label: band for band in window.bands}
+
+
+def test_post_run_order_bands_fixed_speed_emit_expected_harmonics() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    vehicle_timeline = _vehicle_timeline(
+        metadata=metadata,
+        samples=(_sample(0.0), _sample(1.0)),
+    )
+
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=vehicle_timeline,
+        order_reference_spec=metadata.order_reference_spec,
+    )
+
+    point = vehicle_timeline.points[0]
+    bands = _bands_by_label(timeline.windows[0])
+    assert tuple(bands) == (
+        "wheel_1x",
+        "wheel_2x",
+        "driveshaft_1x",
+        "driveshaft_2x",
+        "engine_1x",
+        "engine_2x",
+    )
+    wheel_1x = bands["wheel_1x"]
+    assert wheel_1x.center_hz == pytest.approx(point.wheel_hz)
+    assert wheel_1x.unavailable_reason is None
+    assert wheel_1x.center_hz is not None
+    assert point.wheel_uncertainty_pct is not None
+    expected_tolerance = tolerance_for_order(
+        metadata.order_reference_spec.wheel_bandwidth_pct,
+        wheel_1x.center_hz,
+        point.wheel_uncertainty_pct,
+        min_abs_band_hz=metadata.order_reference_spec.min_abs_band_hz,
+        max_band_half_width_pct=metadata.order_reference_spec.max_band_half_width_pct,
+    )
+    assert wheel_1x.tolerance == pytest.approx(expected_tolerance)
+    assert wheel_1x.min_hz == pytest.approx(wheel_1x.center_hz * (1.0 - expected_tolerance))
+    assert wheel_1x.max_hz == pytest.approx(wheel_1x.center_hz * (1.0 + expected_tolerance))
+    assert bands["engine_1x"].reference_source == "obd"
+
+
+def test_post_run_order_bands_follow_speed_sweep() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    vehicle_timeline = _vehicle_timeline(
+        metadata=metadata,
+        samples=(
+            _sample(0.0, speed_kmh=36.0, engine_rpm=2000.0),
+            _sample(1.0, speed_kmh=72.0, engine_rpm=3000.0),
+        ),
+        windows=(_window(0, center_t_s=0.25), _window(1, center_t_s=0.75)),
+    )
+
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=vehicle_timeline,
+        order_reference_spec=metadata.order_reference_spec,
+    )
+
+    first = _bands_by_label(timeline.windows[0])["wheel_1x"]
+    second = _bands_by_label(timeline.windows[1])["wheel_1x"]
+    assert first.center_hz is not None
+    assert second.center_hz is not None
+    assert second.center_hz > first.center_hz
+
+
+def test_post_run_order_bands_keep_engine_available_when_speed_missing_but_rpm_valid() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    vehicle_timeline = _vehicle_timeline(
+        metadata=metadata,
+        samples=(
+            _sample(0.0, speed_kmh=None, gps_speed_kmh=None, engine_rpm=2400.0),
+            _sample(1.0, speed_kmh=None, gps_speed_kmh=None, engine_rpm=2400.0),
+        ),
+    )
+
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=vehicle_timeline,
+        order_reference_spec=metadata.order_reference_spec,
+    )
+
+    bands = _bands_by_label(timeline.windows[0])
+    assert bands["wheel_1x"].unavailable_reason == "missing_speed"
+    assert bands["driveshaft_1x"].unavailable_reason == "missing_speed"
+    assert bands["engine_1x"].center_hz == pytest.approx(40.0)
+    assert bands["engine_1x"].unavailable_reason is None
+
+
+def test_post_run_order_bands_mark_engine_unavailable_when_gear_missing() -> None:
+    settings = replace(build_diagnostic_settings(), current_gear_ratio=0.0)
+    metadata = RunMetadata.create(
+        run_id=_RUN_ID,
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="adxl345",
+        raw_sample_rate_hz=_SAMPLE_RATE_HZ,
+        feature_interval_s=0.5,
+        fft_window_size_samples=100,
+        accel_scale_g_per_lsb=0.001,
+        analysis_settings=settings,
+    )
+    assert metadata.order_reference_spec is not None
+    vehicle_timeline = _vehicle_timeline(
+        metadata=metadata,
+        samples=(_sample(0.0, engine_rpm=None), _sample(1.0, engine_rpm=None)),
+    )
+
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=vehicle_timeline,
+        order_reference_spec=metadata.order_reference_spec,
+    )
+
+    bands = _bands_by_label(timeline.windows[0])
+    assert bands["wheel_1x"].unavailable_reason is None
+    assert bands["driveshaft_1x"].unavailable_reason is None
+    assert bands["engine_1x"].unavailable_reason == "missing_gear"
+
+
+def test_post_run_order_bands_expand_with_uncertainty_settings() -> None:
+    default_metadata = _metadata()
+    high_uncertainty_metadata = _metadata(speed_uncertainty_pct=20.0)
+    assert default_metadata.order_reference_spec is not None
+    assert high_uncertainty_metadata.order_reference_spec is not None
+    default_timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=_vehicle_timeline(
+            metadata=default_metadata,
+            samples=(_sample(0.0), _sample(1.0)),
+        ),
+        order_reference_spec=default_metadata.order_reference_spec,
+    )
+    high_timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=_vehicle_timeline(
+            metadata=high_uncertainty_metadata,
+            samples=(_sample(0.0), _sample(1.0)),
+        ),
+        order_reference_spec=high_uncertainty_metadata.order_reference_spec,
+    )
+
+    default_band = _bands_by_label(default_timeline.windows[0])["wheel_1x"]
+    high_band = _bands_by_label(high_timeline.windows[0])["wheel_1x"]
+    assert default_band.tolerance is not None
+    assert high_band.tolerance is not None
+    assert high_band.tolerance > default_band.tolerance
+
+
+def test_post_run_order_bands_clamp_to_spectrum_range() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    vehicle_timeline = _vehicle_timeline(
+        metadata=metadata,
+        samples=(_sample(0.0), _sample(1.0)),
+    )
+    point = vehicle_timeline.points[0]
+    assert point.wheel_hz is not None
+
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=vehicle_timeline,
+        order_reference_spec=metadata.order_reference_spec,
+        config=PostRunOrderBandsConfig(
+            wheel_harmonics=(1,),
+            driveshaft_harmonics=(1,),
+            engine_harmonics=(1,),
+            min_frequency_hz=point.wheel_hz - 0.05,
+            max_frequency_hz=point.wheel_hz + 0.05,
+        ),
+    )
+
+    wheel = _bands_by_label(timeline.windows[0])["wheel_1x"]
+    engine = _bands_by_label(timeline.windows[0])["engine_1x"]
+    assert wheel.min_hz == pytest.approx(point.wheel_hz - 0.05)
+    assert wheel.max_hz == pytest.approx(point.wheel_hz + 0.05)
+    assert engine.unavailable_reason == "outside_spectrum"
+
+
+def test_post_run_order_band_rows_are_serializable_for_reports() -> None:
+    metadata = _metadata()
+    assert metadata.order_reference_spec is not None
+    timeline = build_post_run_order_band_timeline(
+        vehicle_timeline=_vehicle_timeline(
+            metadata=metadata,
+            samples=(_sample(0.0), _sample(1.0)),
+        ),
+        order_reference_spec=metadata.order_reference_spec,
+        config=PostRunOrderBandsConfig(
+            wheel_harmonics=(1,),
+            driveshaft_harmonics=(1,),
+            engine_harmonics=(1,),
+        ),
+    )
+
+    rows = serialize_order_band_rows(timeline)
+
+    assert [row["label"] for row in rows] == ["wheel_1x", "driveshaft_1x", "engine_1x"]
+    assert rows[0]["window_index"] == 0
+    assert "center_hz" in rows[0]

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py
@@ -1,0 +1,442 @@
+"""Per-window order-frequency bands for dense post-run analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from math import isfinite
+from typing import Literal
+
+from vibesensor.domain import OrderReferenceSpec
+from vibesensor.shared.order_bands import tolerance_for_order
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import set_optional_value
+from vibesensor.use_cases.diagnostics.post_run_vehicle_reference import (
+    VehicleReferencePoint,
+    VehicleReferenceTimeline,
+    VehicleReferenceUnavailableReason,
+)
+
+type OrderBandSource = Literal["wheel", "driveshaft", "engine"]
+type OrderBandUnavailableReason = (
+    VehicleReferenceUnavailableReason
+    | Literal[
+        "missing_order_reference",
+        "invalid_center",
+        "outside_spectrum",
+    ]
+)
+
+_DEFAULT_WHEEL_HARMONICS = (1, 2)
+_DEFAULT_DRIVESHAFT_HARMONICS = (1, 2)
+_DEFAULT_ENGINE_HARMONICS = (1, 2)
+
+__all__ = [
+    "OrderBand",
+    "OrderBandSource",
+    "OrderBandUnavailableReason",
+    "OrderBandWindow",
+    "PostRunOrderBandTimeline",
+    "PostRunOrderBandsConfig",
+    "build_post_run_order_band_timeline",
+    "serialize_order_band_rows",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunOrderBandsConfig:
+    """Order-band harmonics and output spectrum clamp."""
+
+    wheel_harmonics: tuple[int, ...] = _DEFAULT_WHEEL_HARMONICS
+    driveshaft_harmonics: tuple[int, ...] = _DEFAULT_DRIVESHAFT_HARMONICS
+    engine_harmonics: tuple[int, ...] = _DEFAULT_ENGINE_HARMONICS
+    min_frequency_hz: float = 0.0
+    max_frequency_hz: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OrderBand:
+    """One expected order-frequency band for one dense analysis window."""
+
+    label: str
+    source: OrderBandSource
+    harmonic: int
+    center_hz: float | None
+    min_hz: float | None
+    max_hz: float | None
+    uncertainty_pct: float | None
+    tolerance: float | None
+    unavailable_reason: OrderBandUnavailableReason | None = None
+    reference_source: str | None = None
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "label": self.label,
+            "source": self.source,
+            "harmonic": self.harmonic,
+        }
+        set_optional_value(payload, "center_hz", self.center_hz)
+        set_optional_value(payload, "min_hz", self.min_hz)
+        set_optional_value(payload, "max_hz", self.max_hz)
+        set_optional_value(payload, "uncertainty_pct", self.uncertainty_pct)
+        set_optional_value(payload, "tolerance", self.tolerance)
+        set_optional_value(payload, "unavailable_reason", self.unavailable_reason)
+        set_optional_value(payload, "reference_source", self.reference_source)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class OrderBandWindow:
+    """Order bands aligned to one vehicle-reference window."""
+
+    run_id: str
+    window_index: int
+    window_start_t_s: float
+    window_end_t_s: float
+    window_center_t_s: float
+    bands: tuple[OrderBand, ...]
+    vehicle_unavailable_reasons: tuple[VehicleReferenceUnavailableReason, ...] = ()
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "run_id": self.run_id,
+            "window_index": self.window_index,
+            "window_start_t_s": self.window_start_t_s,
+            "window_end_t_s": self.window_end_t_s,
+            "window_center_t_s": self.window_center_t_s,
+            "vehicle_unavailable_reasons": list(self.vehicle_unavailable_reasons),
+            "bands": [band.to_json_object() for band in self.bands],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunOrderBandTimeline:
+    """Dense-window order-band timeline."""
+
+    run_id: str
+    config: PostRunOrderBandsConfig
+    windows: tuple[OrderBandWindow, ...]
+
+    def window_for_index(self, window_index: int) -> OrderBandWindow | None:
+        for window in self.windows:
+            if window.window_index == window_index:
+                return window
+        return None
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "run_id": self.run_id,
+            "windows": [window.to_json_object() for window in self.windows],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _FamilyBandInput:
+    source: OrderBandSource
+    harmonics: tuple[int, ...]
+    base_center_hz: float | None
+    base_bandwidth_pct: float
+    uncertainty_pct: float | None
+    unavailable_reason: OrderBandUnavailableReason | None
+    reference_source: str | None
+
+
+def build_post_run_order_band_timeline(
+    *,
+    vehicle_timeline: VehicleReferenceTimeline,
+    order_reference_spec: OrderReferenceSpec | None,
+    config: PostRunOrderBandsConfig | None = None,
+) -> PostRunOrderBandTimeline:
+    """Build order-frequency bands for every POSTRUN-04 vehicle-reference window."""
+
+    effective_config = config or PostRunOrderBandsConfig()
+    _validate_config(effective_config)
+    windows = tuple(
+        _build_window(
+            point=point,
+            order_reference_spec=order_reference_spec,
+            config=effective_config,
+        )
+        for point in vehicle_timeline.points
+    )
+    return PostRunOrderBandTimeline(
+        run_id=vehicle_timeline.run_id,
+        config=effective_config,
+        windows=windows,
+    )
+
+
+def serialize_order_band_rows(timeline: PostRunOrderBandTimeline) -> tuple[JsonObject, ...]:
+    """Flatten a band timeline into stable rows for later report/UI consumers."""
+
+    rows: list[JsonObject] = []
+    for window in timeline.windows:
+        for band in window.bands:
+            row: JsonObject = {
+                "run_id": window.run_id,
+                "window_index": window.window_index,
+                "window_start_t_s": window.window_start_t_s,
+                "window_end_t_s": window.window_end_t_s,
+                "window_center_t_s": window.window_center_t_s,
+            }
+            row.update(band.to_json_object())
+            rows.append(row)
+    return tuple(rows)
+
+
+def _validate_config(config: PostRunOrderBandsConfig) -> None:
+    if not _harmonics_valid(config.wheel_harmonics):
+        raise ValueError("wheel_harmonics must contain positive harmonic integers")
+    if not _harmonics_valid(config.driveshaft_harmonics):
+        raise ValueError("driveshaft_harmonics must contain positive harmonic integers")
+    if not _harmonics_valid(config.engine_harmonics):
+        raise ValueError("engine_harmonics must contain positive harmonic integers")
+    if not isfinite(config.min_frequency_hz) or config.min_frequency_hz < 0:
+        raise ValueError("min_frequency_hz must be finite and >= 0")
+    if config.max_frequency_hz is not None and (
+        not isfinite(config.max_frequency_hz) or config.max_frequency_hz < config.min_frequency_hz
+    ):
+        raise ValueError("max_frequency_hz must be finite and >= min_frequency_hz")
+
+
+def _harmonics_valid(harmonics: Sequence[int]) -> bool:
+    return bool(harmonics) and all(
+        not isinstance(harmonic, bool) and isinstance(harmonic, int) and harmonic > 0
+        for harmonic in harmonics
+    )
+
+
+def _build_window(
+    *,
+    point: VehicleReferencePoint,
+    order_reference_spec: OrderReferenceSpec | None,
+    config: PostRunOrderBandsConfig,
+) -> OrderBandWindow:
+    bands: list[OrderBand] = []
+    for family in _family_inputs(
+        point=point,
+        order_reference_spec=order_reference_spec,
+        config=config,
+    ):
+        bands.extend(
+            _build_band(
+                family=family,
+                harmonic=harmonic,
+                order_reference_spec=order_reference_spec,
+                config=config,
+            )
+            for harmonic in family.harmonics
+        )
+    return OrderBandWindow(
+        run_id=point.run_id,
+        window_index=point.window_index,
+        window_start_t_s=point.window_start_t_s,
+        window_end_t_s=point.window_end_t_s,
+        window_center_t_s=point.window_center_t_s,
+        bands=tuple(bands),
+        vehicle_unavailable_reasons=point.unavailable_reasons,
+    )
+
+
+def _family_inputs(
+    *,
+    point: VehicleReferencePoint,
+    order_reference_spec: OrderReferenceSpec | None,
+    config: PostRunOrderBandsConfig,
+) -> tuple[_FamilyBandInput, ...]:
+    if order_reference_spec is None:
+        return (
+            _missing_family("wheel", config.wheel_harmonics),
+            _missing_family("driveshaft", config.driveshaft_harmonics),
+            _missing_family("engine", config.engine_harmonics),
+        )
+    return (
+        _FamilyBandInput(
+            source="wheel",
+            harmonics=config.wheel_harmonics,
+            base_center_hz=point.wheel_hz,
+            base_bandwidth_pct=order_reference_spec.wheel_bandwidth_pct,
+            uncertainty_pct=point.wheel_uncertainty_pct,
+            unavailable_reason=_reason_for_family(point, "wheel"),
+            reference_source="speed+tire",
+        ),
+        _FamilyBandInput(
+            source="driveshaft",
+            harmonics=config.driveshaft_harmonics,
+            base_center_hz=point.driveshaft_hz,
+            base_bandwidth_pct=order_reference_spec.driveshaft_bandwidth_pct,
+            uncertainty_pct=point.driveshaft_uncertainty_pct,
+            unavailable_reason=_reason_for_family(point, "driveshaft"),
+            reference_source="speed+tire+final_drive",
+        ),
+        _FamilyBandInput(
+            source="engine",
+            harmonics=config.engine_harmonics,
+            base_center_hz=point.engine_hz,
+            base_bandwidth_pct=order_reference_spec.engine_bandwidth_pct,
+            uncertainty_pct=point.engine_uncertainty_pct,
+            unavailable_reason=_reason_for_family(point, "engine"),
+            reference_source=_engine_reference_source(point),
+        ),
+    )
+
+
+def _missing_family(
+    source: OrderBandSource,
+    harmonics: tuple[int, ...],
+) -> _FamilyBandInput:
+    return _FamilyBandInput(
+        source=source,
+        harmonics=harmonics,
+        base_center_hz=None,
+        base_bandwidth_pct=0.0,
+        uncertainty_pct=None,
+        unavailable_reason="missing_order_reference",
+        reference_source=None,
+    )
+
+
+def _build_band(
+    *,
+    family: _FamilyBandInput,
+    harmonic: int,
+    order_reference_spec: OrderReferenceSpec | None,
+    config: PostRunOrderBandsConfig,
+) -> OrderBand:
+    label = f"{family.source}_{harmonic}x"
+    unavailable_reason = family.unavailable_reason
+    center_hz = _harmonic_center(family.base_center_hz, harmonic)
+    if unavailable_reason is None and center_hz is None:
+        unavailable_reason = "invalid_center"
+    if unavailable_reason is not None or center_hz is None or order_reference_spec is None:
+        return OrderBand(
+            label=label,
+            source=family.source,
+            harmonic=harmonic,
+            center_hz=center_hz,
+            min_hz=None,
+            max_hz=None,
+            uncertainty_pct=family.uncertainty_pct,
+            tolerance=None,
+            unavailable_reason=unavailable_reason or "missing_order_reference",
+            reference_source=family.reference_source,
+        )
+    tolerance = tolerance_for_order(
+        family.base_bandwidth_pct,
+        center_hz,
+        family.uncertainty_pct or 0.0,
+        min_abs_band_hz=order_reference_spec.min_abs_band_hz,
+        max_band_half_width_pct=order_reference_spec.max_band_half_width_pct,
+    )
+    raw_min_hz = center_hz * (1.0 - tolerance)
+    raw_max_hz = center_hz * (1.0 + tolerance)
+    min_hz = max(config.min_frequency_hz, raw_min_hz)
+    max_hz = raw_max_hz
+    if config.max_frequency_hz is not None:
+        max_hz = min(config.max_frequency_hz, max_hz)
+    if max_hz < min_hz:
+        return OrderBand(
+            label=label,
+            source=family.source,
+            harmonic=harmonic,
+            center_hz=center_hz,
+            min_hz=None,
+            max_hz=None,
+            uncertainty_pct=family.uncertainty_pct,
+            tolerance=tolerance,
+            unavailable_reason="outside_spectrum",
+            reference_source=family.reference_source,
+        )
+    return OrderBand(
+        label=label,
+        source=family.source,
+        harmonic=harmonic,
+        center_hz=center_hz,
+        min_hz=min_hz,
+        max_hz=max_hz,
+        uncertainty_pct=family.uncertainty_pct,
+        tolerance=tolerance,
+        reference_source=family.reference_source,
+    )
+
+
+def _harmonic_center(base_center_hz: float | None, harmonic: int) -> float | None:
+    if base_center_hz is None or harmonic <= 0:
+        return None
+    center_hz = base_center_hz * harmonic
+    if not isfinite(center_hz) or center_hz <= 0:
+        return None
+    return center_hz
+
+
+def _reason_for_family(
+    point: VehicleReferencePoint,
+    source: OrderBandSource,
+) -> OrderBandUnavailableReason | None:
+    if source == "wheel":
+        if point.wheel_hz is not None:
+            return None
+        return _first_reason(
+            point,
+            (
+                "unknown_tire",
+                "ambiguous_gap",
+                "stale_speed",
+                "missing_speed",
+                "no_samples",
+            ),
+            default="missing_speed",
+        )
+    if source == "driveshaft":
+        if point.driveshaft_hz is not None:
+            return None
+        return _first_reason(
+            point,
+            (
+                "unknown_final_drive",
+                "unknown_tire",
+                "ambiguous_gap",
+                "stale_speed",
+                "missing_speed",
+                "no_samples",
+            ),
+            default="unknown_final_drive",
+        )
+    if point.engine_hz is not None:
+        return None
+    return _first_reason(
+        point,
+        (
+            "missing_gear",
+            "missing_rpm",
+            "unknown_final_drive",
+            "unknown_tire",
+            "ambiguous_gap",
+            "stale_speed",
+            "missing_speed",
+            "no_samples",
+        ),
+        default="missing_rpm",
+    )
+
+
+def _first_reason(
+    point: VehicleReferencePoint,
+    candidates: Sequence[VehicleReferenceUnavailableReason],
+    *,
+    default: VehicleReferenceUnavailableReason,
+) -> VehicleReferenceUnavailableReason:
+    for reason in candidates:
+        if reason in point.unavailable_reasons:
+            return reason
+    return default
+
+
+def _engine_reference_source(point: VehicleReferencePoint) -> str | None:
+    if point.engine_hz is None:
+        return None
+    if point.engine_rpm is not None and point.engine_rpm > 0:
+        return point.engine_rpm_source or "rpm"
+    if point.driveshaft_hz is not None and point.gear_ratio is not None:
+        return "speed+tire+final_drive+gear"
+    return None

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -80,6 +80,13 @@ missing speed/RPM/gear, stale samples, inconsistent sample rate, and missing
 vehicle configuration. Wheel, driveshaft, and engine frequencies are derived via
 the shared `OrderReferenceSpec` math instead of diagnostics-local formulas.
 
+`use_cases/diagnostics/post_run_order_bands.py` consumes that vehicle-reference
+timeline and emits per-window wheel, driveshaft, and engine order bands. It uses
+the existing `tolerance_for_order()` math, the run's configured uncertainty and
+bandwidth settings, optional harmonic lists, and an explicit output spectrum
+clamp. Unavailable reference inputs become unavailable band rows with reasons
+instead of being dropped or guessed.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -161,6 +168,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `post_run_stft.py` | ~350 | In-memory dense STFT engine over POSTRUN-01 raw-window DTOs |
 | `post_run_window_features.py` | ~300 | Window-level feature extraction over POSTRUN-02 STFT frames |
 | `post_run_vehicle_reference.py` | ~350 | Per-window vehicle speed/RPM/gear/final-drive reference normalization for dense order stages |
+| `post_run_order_bands.py` | ~400 | Per-window wheel/driveshaft/engine order-band generation over POSTRUN-04 vehicle references |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -74,6 +74,12 @@ does not track implementation status or old branch plans.
   It normalizes speed, RPM, gear, and final-drive inputs, rejects ambiguous or
   stale references, and derives wheel/driveshaft/engine Hz through
   `OrderReferenceSpec`.
+- POSTRUN-05 adds
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py`:
+  a deterministic per-window order-band timeline for wheel, driveshaft, and
+  engine harmonics. It reuses shared tolerance math, clamps to the configured
+  dense spectrum range, and carries explicit unavailable reasons for missing
+  references.
 
 ### Persisted analysis and reporting
 
@@ -132,7 +138,7 @@ raw capture manifest/files (#3065)
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
 | Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine and `post_run_window_features.py` owns the compact per-window feature reduction |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments; `post_run_vehicle_reference.py` owns the conservative vehicle-reference timeline for dense stages |
-| Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
+| Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability; `post_run_order_bands.py` owns the pre-classification per-window expected band grid |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |
 | Fusion/report summary | `use_cases/diagnostics/`, `shared/boundaries/reporting/` | Convert whole-run evidence into ranked diagnoses and compact persisted facts |
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -19,6 +19,7 @@ lives in `apps/server/vibesensor/use_cases/diagnostics/orders/`.
 | `vehicle_orders_hz()` | `shared/order_bands.py` | Resolve wheel / driveshaft / engine reference frequencies for one speed sample. |
 | `build_order_bands()` | `shared/order_bands.py` | Precompute live order-band payloads so the frontend does not duplicate tolerance math. |
 | `build_post_run_vehicle_reference_timeline()` | `use_cases/diagnostics/post_run_vehicle_reference.py` | Normalize speed/RPM/gear/final-drive references onto whole-run windows for dense post-run order stages. |
+| `build_post_run_order_band_timeline()` | `use_cases/diagnostics/post_run_order_bands.py` | Compute per-window wheel/driveshaft/engine order bands from the vehicle-reference timeline. |
 | `OrderHypothesis` | `use_cases/diagnostics/orders/physics.py` | One named order candidate such as `wheel_1x` or `engine_2x`. |
 | `OrderAnalysisSession` | `use_cases/diagnostics/orders/pipeline.py` | Run all eligible hypotheses across stored samples and return ranked findings. |
 
@@ -63,6 +64,33 @@ When inputs are valid, wheel/driveshaft/engine Hz are derived through
 formulas. Missing RPM can still produce an engine reference only when speed,
 final drive, and gear ratio are available from aligned samples or settings, and
 the missing-RPM reason remains visible to downstream coverage scoring.
+
+## Per-window dense order bands
+
+`build_post_run_order_band_timeline()` consumes the POSTRUN-04
+`VehicleReferenceTimeline` and the run's `OrderReferenceSpec`. For each window it
+emits deterministic `OrderBand` rows for configured harmonics:
+
+- default wheel bands: `wheel_1x`, `wheel_2x`
+- default driveshaft bands: `driveshaft_1x`, `driveshaft_2x`
+- default engine bands: `engine_1x`, `engine_2x`
+
+Each row carries `label`, `source`, `harmonic`, `center_hz`, `min_hz`, `max_hz`,
+`uncertainty_pct`, `tolerance`, optional `reference_source`, and optional
+`unavailable_reason`. The band half-width is computed with the same
+`tolerance_for_order()` helper used by live order-band payloads:
+
+```text
+center_hz = base_reference_hz * harmonic
+min_hz    = max(config.min_frequency_hz, center_hz * (1 - tolerance))
+max_hz    = min(config.max_frequency_hz, center_hz * (1 + tolerance))
+```
+
+If the configured spectrum range does not overlap a band, the row stays present
+with `unavailable_reason = "outside_spectrum"`. Missing speed, tire,
+final-drive, gear, RPM, or whole order-reference settings also stay explicit on
+the affected rows. Engine bands can remain available from RPM even when
+speed-derived wheel/driveshaft bands are unavailable.
 
 ## Uncertainty and tolerance bands
 
@@ -164,6 +192,7 @@ That shared ownership is why `shared/order_bands.py` exists outside
 | `apps/server/vibesensor/domain/order_reference.py` | Vehicle-physics reference model and frequency derivation helpers. |
 | `apps/server/vibesensor/shared/order_bands.py` | Shared uncertainty, tolerance-band, and live band-payload helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py` | Dense per-window vehicle reference normalization and debug fixtures. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py` | Dense per-window order-band DTOs, clamping, unavailable reasons, and serializer rows. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py` | Fixed hypothesis catalog and per-sample predicted-Hz helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py` | Match predicted order bands against stored sample peaks. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |


### PR DESCRIPTION
Closes #3716

## What changed
- Added post-run order-band timeline DTOs for dense windows.
- Computes wheel, driveshaft, and engine harmonics from the POSTRUN-04 vehicle reference timeline.
- Reuses shared tolerance_for_order math and run order-reference settings.
- Clamps bands to a configured spectrum range.
- Keeps unavailable band rows with explicit reasons instead of dropping bad references.
- Adds stable serializer rows for later report/UI consumers.
- Documents POSTRUN-05 semantics.

## Why
Dense order tracking needs expected frequency bands per window before classification can compare spectral peaks against vehicle context.

## Validation
- ruff check and format check on touched Python files
- mypy on new module and tests
- backend static guards
- focused order-band and vehicle-reference tests
- docs_lint
- run_changed use-case suite

## Risks, tradeoffs, edge cases
- This is band generation only. It does not classify peaks or create findings.
- Missing references remain as unavailable rows so later coverage scoring can see gaps.
- Engine bands can still be valid from RPM when speed-derived wheel/driveshaft bands are unavailable.
