### PR TITLE
Add post-run vibration episode detection

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.use_cases.diagnostics.post_run_stft import PostRunStftCoverageState
+from vibesensor.use_cases.diagnostics.post_run_vibration_episodes import (
+    PostRunVibrationEpisodeConfig,
+    detect_post_run_vibration_episodes,
+    vibration_episode_debug_rows,
+)
+from vibesensor.use_cases.diagnostics.post_run_window_features import (
+    PostRunWindowAxisDominance,
+    PostRunWindowFeature,
+    PostRunWindowFeatureQualityFlag,
+)
+from vibesensor.vibration_strength import StrengthPeak
+
+_RUN_ID = "run-episodes"
+
+
+def _peak(hz: float, strength_db: float, amp: float = 1.0) -> StrengthPeak:
+    return {
+        "hz": hz,
+        "amp": amp,
+        "vibration_strength_db": strength_db,
+        "strength_bucket": "l3",
+    }
+
+
+def _feature(
+    window_index: int,
+    *,
+    freq_hz: float,
+    strength_db: float,
+    client_id: str = "sensor-a",
+    location: str = "front_left",
+    top_peaks: tuple[StrengthPeak, ...] | None = None,
+    quality_flags: tuple[PostRunWindowFeatureQualityFlag, ...] = (),
+    coverage_state: PostRunStftCoverageState = "full",
+) -> PostRunWindowFeature:
+    start_t_s = window_index * 0.5
+    end_t_s = start_t_s + 0.5
+    peaks = top_peaks if top_peaks is not None else (_peak(freq_hz, strength_db),)
+    return PostRunWindowFeature(
+        run_id=_RUN_ID,
+        client_id=client_id,
+        location=location,
+        window_index=window_index,
+        window_start_t_s=start_t_s,
+        window_end_t_s=end_t_s,
+        window_center_t_s=start_t_s + 0.25,
+        sample_rate_hz=100,
+        coverage_state=coverage_state,
+        data_quality_flags=(),
+        feature_quality_flags=quality_flags,
+        dominant_freq_hz=freq_hz,
+        vibration_strength_db=strength_db,
+        peak_amp_g=1.0,
+        noise_floor_amp_g=0.1,
+        strength_bucket="l3",
+        top_peaks=peaks,
+        axis_dominance=PostRunWindowAxisDominance(
+            axis="x",
+            axis_amp_g=1.0,
+            combined_amp_g=1.0,
+            ratio=1.0,
+        ),
+        rms_by_axis_g={"x": 0.5, "y": 0.1, "z": 0.1},
+        p2p_by_axis_g={"x": 1.0, "y": 0.2, "z": 0.2},
+        max_axis_rms_g=0.5,
+        max_axis_p2p_g=1.0,
+    )
+
+
+def test_detects_sustained_single_peak_episode() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [_feature(index, freq_hz=10.0, strength_db=18.0) for index in range(4)]
+    )
+
+    assert len(episodes) == 1
+    episode = episodes[0]
+    assert episode.client_id == "sensor-a"
+    assert episode.location == "front_left"
+    assert episode.supporting_window_ids == (0, 1, 2, 3)
+    assert episode.duration_s == pytest.approx(2.0)
+    assert episode.median_frequency_hz == pytest.approx(10.0)
+    assert episode.peak_strength_db == pytest.approx(18.0)
+    assert episode.axis_dominance == "x"
+    assert not episode.transient
+
+
+def test_suppresses_isolated_spike_unless_extreme_transient() -> None:
+    normal = detect_post_run_vibration_episodes([_feature(0, freq_hz=10.0, strength_db=18.0)])
+    extreme = detect_post_run_vibration_episodes([_feature(0, freq_hz=10.0, strength_db=35.0)])
+
+    assert normal == ()
+    assert len(extreme) == 1
+    assert extreme[0].transient
+    assert "transient_extreme" in extreme[0].quality_penalties
+
+
+def test_groups_frequency_sweep_when_drift_is_allowed() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [
+            _feature(0, freq_hz=10.0, strength_db=18.0),
+            _feature(1, freq_hz=10.6, strength_db=19.0),
+            _feature(2, freq_hz=11.2, strength_db=20.0),
+            _feature(3, freq_hz=11.8, strength_db=21.0),
+        ],
+        config=PostRunVibrationEpisodeConfig(max_frequency_drift_hz=0.75),
+    )
+
+    assert len(episodes) == 1
+    assert episodes[0].frequency_path_hz == pytest.approx((10.0, 10.6, 11.2, 11.8))
+    assert episodes[0].frequency_slope_hz_per_s is not None
+    assert episodes[0].frequency_slope_hz_per_s > 0
+    assert "frequency_drift" in episodes[0].quality_penalties
+
+
+def test_keeps_two_concurrent_peak_episodes_separate() -> None:
+    features = [
+        _feature(
+            index,
+            freq_hz=8.0,
+            strength_db=20.0,
+            top_peaks=(_peak(8.0, 20.0), _peak(16.0, 22.0)),
+        )
+        for index in range(3)
+    ]
+
+    episodes = detect_post_run_vibration_episodes(features)
+
+    assert len(episodes) == 2
+    assert [episode.median_frequency_hz for episode in episodes] == [8.0, 16.0]
+    assert all(episode.supporting_window_ids == (0, 1, 2) for episode in episodes)
+
+
+def test_records_quality_penalty_for_noisy_feature_stream() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [
+            _feature(0, freq_hz=12.0, strength_db=18.0),
+            _feature(
+                1,
+                freq_hz=12.1,
+                strength_db=18.0,
+                quality_flags=("invalid_spectrum_values",),
+            ),
+            _feature(2, freq_hz=12.0, strength_db=18.0),
+        ]
+    )
+
+    assert len(episodes) == 1
+    assert "quality_flags_present" in episodes[0].quality_penalties
+    assert episodes[0].quality_penalty > 0
+
+
+def test_merges_dropout_gap_when_within_configured_gap() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [
+            _feature(0, freq_hz=9.0, strength_db=18.0),
+            _feature(1, freq_hz=9.1, strength_db=18.0),
+            _feature(3, freq_hz=9.2, strength_db=18.0),
+            _feature(4, freq_hz=9.1, strength_db=18.0),
+        ],
+        config=PostRunVibrationEpisodeConfig(merge_gap_s=0.75),
+    )
+
+    assert len(episodes) == 1
+    assert episodes[0].supporting_window_ids == (0, 1, 3, 4)
+    assert "dropout_gap" in episodes[0].quality_penalties
+
+
+def test_frequency_jump_starts_new_episode() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [
+            _feature(0, freq_hz=8.0, strength_db=18.0),
+            _feature(1, freq_hz=8.1, strength_db=18.0),
+            _feature(2, freq_hz=8.0, strength_db=18.0),
+            _feature(3, freq_hz=20.0, strength_db=18.0),
+            _feature(4, freq_hz=20.1, strength_db=18.0),
+            _feature(5, freq_hz=20.0, strength_db=18.0),
+        ],
+        config=PostRunVibrationEpisodeConfig(max_frequency_drift_hz=0.5),
+    )
+
+    assert len(episodes) == 2
+    assert [episode.supporting_window_ids for episode in episodes] == [(0, 1, 2), (3, 4, 5)]
+
+
+def test_vibration_episode_debug_rows_are_stable() -> None:
+    episodes = detect_post_run_vibration_episodes(
+        [_feature(index, freq_hz=10.0, strength_db=18.0) for index in range(3)]
+    )
+
+    rows = vibration_episode_debug_rows(episodes)
+
+    assert len(rows) == 1
+    assert rows[0]["window_count"] == 3
+    assert rows[0]["median_frequency_hz"] == pytest.approx(10.0)

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_vibration_episodes.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_vibration_episodes.py
@@ -1,0 +1,438 @@
+"""Persistent vibration episode detection over dense post-run window features."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from math import isfinite
+from statistics import median
+from typing import Literal
+
+from vibesensor.shared.fft_analysis import Axis
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import set_optional_value
+from vibesensor.use_cases.diagnostics.post_run_window_features import (
+    PostRunWindowFeature,
+    PostRunWindowFeatureQualityFlag,
+)
+
+type VibrationEpisodeQualityPenalty = Literal[
+    "dropout_gap",
+    "frequency_drift",
+    "quality_flags_present",
+    "short_duration",
+    "transient_extreme",
+]
+
+__all__ = [
+    "PostRunVibrationEpisodeConfig",
+    "VibrationEpisode",
+    "VibrationEpisodeQualityPenalty",
+    "detect_post_run_vibration_episodes",
+    "vibration_episode_debug_rows",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunVibrationEpisodeConfig:
+    """Deterministic grouping thresholds for dense vibration episodes."""
+
+    min_strength_db: float = 6.0
+    extreme_transient_strength_db: float = 30.0
+    min_windows: int = 3
+    min_duration_s: float = 0.75
+    merge_gap_s: float = 0.5
+    max_frequency_drift_hz: float = 1.0
+    max_relative_frequency_drift_pct: float = 12.0
+    max_peaks_per_window: int = 4
+
+
+@dataclass(frozen=True, slots=True)
+class VibrationEpisode:
+    """Time-bounded persistent or intentional transient vibration evidence."""
+
+    episode_id: str
+    run_id: str
+    client_id: str
+    location: str
+    start_t_s: float
+    end_t_s: float
+    duration_s: float
+    start_window_index: int
+    end_window_index: int
+    supporting_window_ids: tuple[int, ...]
+    frequency_path_hz: tuple[float, ...]
+    median_frequency_hz: float
+    peak_frequency_hz: float
+    frequency_slope_hz_per_s: float | None
+    median_strength_db: float
+    peak_strength_db: float
+    peak_count: int
+    axis_dominance: Axis | None
+    affected_sensors: tuple[str, ...]
+    quality_penalties: tuple[VibrationEpisodeQualityPenalty, ...]
+    quality_penalty: float
+    transient: bool = False
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "episode_id": self.episode_id,
+            "run_id": self.run_id,
+            "client_id": self.client_id,
+            "location": self.location,
+            "start_t_s": self.start_t_s,
+            "end_t_s": self.end_t_s,
+            "duration_s": self.duration_s,
+            "start_window_index": self.start_window_index,
+            "end_window_index": self.end_window_index,
+            "supporting_window_ids": list(self.supporting_window_ids),
+            "frequency_path_hz": list(self.frequency_path_hz),
+            "median_frequency_hz": self.median_frequency_hz,
+            "peak_frequency_hz": self.peak_frequency_hz,
+            "median_strength_db": self.median_strength_db,
+            "peak_strength_db": self.peak_strength_db,
+            "peak_count": self.peak_count,
+            "affected_sensors": list(self.affected_sensors),
+            "quality_penalties": list(self.quality_penalties),
+            "quality_penalty": self.quality_penalty,
+            "transient": self.transient,
+        }
+        set_optional_value(payload, "frequency_slope_hz_per_s", self.frequency_slope_hz_per_s)
+        set_optional_value(payload, "axis_dominance", self.axis_dominance)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class _PeakCandidate:
+    run_id: str
+    client_id: str
+    location: str
+    window_index: int
+    window_start_t_s: float
+    window_end_t_s: float
+    window_center_t_s: float
+    frequency_hz: float
+    strength_db: float
+    axis: Axis | None
+    feature_quality_flags: tuple[PostRunWindowFeatureQualityFlag, ...]
+
+
+@dataclass(slots=True)
+class _EpisodeBuilder:
+    run_id: str
+    client_id: str
+    location: str
+    candidates: list[_PeakCandidate]
+
+    @property
+    def last(self) -> _PeakCandidate:
+        return self.candidates[-1]
+
+    def append(self, candidate: _PeakCandidate) -> None:
+        self.candidates.append(candidate)
+
+
+def detect_post_run_vibration_episodes(
+    features: Iterable[PostRunWindowFeature],
+    *,
+    config: PostRunVibrationEpisodeConfig | None = None,
+) -> tuple[VibrationEpisode, ...]:
+    """Group window-level peaks into deterministic vibration episodes."""
+
+    effective_config = config or PostRunVibrationEpisodeConfig()
+    _validate_config(effective_config)
+    candidates = _peak_candidates(features, config=effective_config)
+    builders: list[_EpisodeBuilder] = []
+    for candidate in candidates:
+        builder = _best_builder(candidate, builders, config=effective_config)
+        if builder is None:
+            builders.append(
+                _EpisodeBuilder(
+                    run_id=candidate.run_id,
+                    client_id=candidate.client_id,
+                    location=candidate.location,
+                    candidates=[candidate],
+                )
+            )
+        else:
+            builder.append(candidate)
+    episodes = [
+        episode
+        for index, builder in enumerate(builders)
+        if (
+            episode := _episode_from_builder(
+                builder,
+                episode_index=index,
+                config=effective_config,
+            )
+        )
+        is not None
+    ]
+    return tuple(
+        sorted(
+            episodes,
+            key=lambda episode: (
+                episode.start_t_s,
+                episode.median_frequency_hz,
+                episode.episode_id,
+            ),
+        )
+    )
+
+
+def vibration_episode_debug_rows(
+    episodes: Iterable[VibrationEpisode],
+) -> tuple[JsonObject, ...]:
+    """Return compact debug rows for synthetic episode inspection."""
+
+    return tuple(
+        {
+            "episode_id": episode.episode_id,
+            "client_id": episode.client_id,
+            "location": episode.location,
+            "start_t_s": episode.start_t_s,
+            "end_t_s": episode.end_t_s,
+            "duration_s": episode.duration_s,
+            "median_frequency_hz": episode.median_frequency_hz,
+            "peak_strength_db": episode.peak_strength_db,
+            "window_count": len(episode.supporting_window_ids),
+            "transient": episode.transient,
+            "quality_penalties": list(episode.quality_penalties),
+        }
+        for episode in episodes
+    )
+
+
+def _validate_config(config: PostRunVibrationEpisodeConfig) -> None:
+    if config.min_windows <= 0:
+        raise ValueError("episode detection requires min_windows > 0")
+    if config.max_peaks_per_window <= 0:
+        raise ValueError("episode detection requires max_peaks_per_window > 0")
+    for field_name, value in (
+        ("min_strength_db", config.min_strength_db),
+        ("extreme_transient_strength_db", config.extreme_transient_strength_db),
+        ("min_duration_s", config.min_duration_s),
+        ("merge_gap_s", config.merge_gap_s),
+        ("max_frequency_drift_hz", config.max_frequency_drift_hz),
+        ("max_relative_frequency_drift_pct", config.max_relative_frequency_drift_pct),
+    ):
+        if not isfinite(value) or value < 0:
+            raise ValueError(f"episode detection requires {field_name} >= 0")
+
+
+def _peak_candidates(
+    features: Iterable[PostRunWindowFeature],
+    *,
+    config: PostRunVibrationEpisodeConfig,
+) -> tuple[_PeakCandidate, ...]:
+    candidates: list[_PeakCandidate] = []
+    for feature in features:
+        if feature.coverage_state != "full":
+            continue
+        for peak in feature.top_peaks[: config.max_peaks_per_window]:
+            frequency_hz = _positive_float(peak.get("hz"))
+            strength_db = _finite_float(peak.get("vibration_strength_db"))
+            if frequency_hz is None or strength_db is None or strength_db < config.min_strength_db:
+                continue
+            candidates.append(
+                _PeakCandidate(
+                    run_id=feature.run_id,
+                    client_id=feature.client_id,
+                    location=feature.location,
+                    window_index=feature.window_index,
+                    window_start_t_s=feature.window_start_t_s,
+                    window_end_t_s=feature.window_end_t_s,
+                    window_center_t_s=feature.window_center_t_s,
+                    frequency_hz=frequency_hz,
+                    strength_db=strength_db,
+                    axis=feature.axis_dominance.axis,
+                    feature_quality_flags=feature.feature_quality_flags,
+                )
+            )
+    return tuple(
+        sorted(
+            candidates,
+            key=lambda candidate: (
+                candidate.client_id,
+                candidate.location,
+                candidate.window_index,
+                candidate.frequency_hz,
+                -candidate.strength_db,
+            ),
+        )
+    )
+
+
+def _best_builder(
+    candidate: _PeakCandidate,
+    builders: Sequence[_EpisodeBuilder],
+    *,
+    config: PostRunVibrationEpisodeConfig,
+) -> _EpisodeBuilder | None:
+    best: _EpisodeBuilder | None = None
+    best_delta = float("inf")
+    for builder in builders:
+        if not _same_sensor(candidate, builder):
+            continue
+        last = builder.last
+        if candidate.window_index <= last.window_index:
+            continue
+        if candidate.window_start_t_s - last.window_end_t_s > config.merge_gap_s:
+            continue
+        delta_hz = abs(candidate.frequency_hz - last.frequency_hz)
+        if not _frequency_drift_allowed(last.frequency_hz, candidate.frequency_hz, config=config):
+            continue
+        if delta_hz < best_delta:
+            best = builder
+            best_delta = delta_hz
+    return best
+
+
+def _same_sensor(candidate: _PeakCandidate, builder: _EpisodeBuilder) -> bool:
+    return candidate.client_id == builder.client_id and candidate.location == builder.location
+
+
+def _frequency_drift_allowed(
+    previous_hz: float,
+    current_hz: float,
+    *,
+    config: PostRunVibrationEpisodeConfig,
+) -> bool:
+    delta_hz = abs(current_hz - previous_hz)
+    if delta_hz <= config.max_frequency_drift_hz:
+        return True
+    relative_pct = (delta_hz / max(previous_hz, current_hz, 1.0)) * 100.0
+    return relative_pct <= config.max_relative_frequency_drift_pct
+
+
+def _episode_from_builder(
+    builder: _EpisodeBuilder,
+    *,
+    episode_index: int,
+    config: PostRunVibrationEpisodeConfig,
+) -> VibrationEpisode | None:
+    candidates = builder.candidates
+    strengths = [candidate.strength_db for candidate in candidates]
+    frequencies = [candidate.frequency_hz for candidate in candidates]
+    start_t_s = candidates[0].window_start_t_s
+    end_t_s = candidates[-1].window_end_t_s
+    duration_s = max(0.0, end_t_s - start_t_s)
+    transient = False
+    penalties: list[VibrationEpisodeQualityPenalty] = []
+    if _has_dropout_gap(candidates):
+        _append_unique(penalties, "dropout_gap")
+    if _has_large_episode_drift(frequencies, config=config):
+        _append_unique(penalties, "frequency_drift")
+    if any(candidate.feature_quality_flags for candidate in candidates):
+        _append_unique(penalties, "quality_flags_present")
+    persistent = len(candidates) >= config.min_windows and duration_s >= config.min_duration_s
+    if not persistent:
+        if len(candidates) == 1 and max(strengths) >= config.extreme_transient_strength_db:
+            transient = True
+            _append_unique(penalties, "transient_extreme")
+        else:
+            return None
+    if duration_s < config.min_duration_s:
+        _append_unique(penalties, "short_duration")
+    episode_id = (
+        f"{builder.client_id}:{builder.location}:"
+        f"{candidates[0].window_index}-{candidates[-1].window_index}:"
+        f"{round(float(median(frequencies)), 3)}"
+    )
+    return VibrationEpisode(
+        episode_id=episode_id,
+        run_id=builder.run_id,
+        client_id=builder.client_id,
+        location=builder.location,
+        start_t_s=start_t_s,
+        end_t_s=end_t_s,
+        duration_s=duration_s,
+        start_window_index=candidates[0].window_index,
+        end_window_index=candidates[-1].window_index,
+        supporting_window_ids=tuple(candidate.window_index for candidate in candidates),
+        frequency_path_hz=tuple(frequencies),
+        median_frequency_hz=float(median(frequencies)),
+        peak_frequency_hz=max(frequencies),
+        frequency_slope_hz_per_s=_frequency_slope(candidates),
+        median_strength_db=float(median(strengths)),
+        peak_strength_db=max(strengths),
+        peak_count=len(candidates),
+        axis_dominance=_dominant_axis(candidates),
+        affected_sensors=(builder.client_id,),
+        quality_penalties=tuple(penalties),
+        quality_penalty=_quality_penalty(penalties),
+        transient=transient,
+    )
+
+
+def _has_dropout_gap(candidates: Sequence[_PeakCandidate]) -> bool:
+    previous: _PeakCandidate | None = None
+    for candidate in candidates:
+        if previous is not None and candidate.window_index > previous.window_index + 1:
+            return True
+        previous = candidate
+    return False
+
+
+def _has_large_episode_drift(
+    frequencies: Sequence[float],
+    *,
+    config: PostRunVibrationEpisodeConfig,
+) -> bool:
+    if len(frequencies) < 2:
+        return False
+    return (max(frequencies) - min(frequencies)) > (config.max_frequency_drift_hz * 2.0)
+
+
+def _frequency_slope(candidates: Sequence[_PeakCandidate]) -> float | None:
+    if len(candidates) < 2:
+        return None
+    start = candidates[0]
+    end = candidates[-1]
+    elapsed_s = end.window_center_t_s - start.window_center_t_s
+    if elapsed_s <= 0:
+        return None
+    return (end.frequency_hz - start.frequency_hz) / elapsed_s
+
+
+def _dominant_axis(candidates: Sequence[_PeakCandidate]) -> Axis | None:
+    counts: dict[Axis, int] = {}
+    for candidate in candidates:
+        if candidate.axis is not None:
+            counts[candidate.axis] = counts.get(candidate.axis, 0) + 1
+    if not counts:
+        return None
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _quality_penalty(penalties: Sequence[VibrationEpisodeQualityPenalty]) -> float:
+    weights: dict[VibrationEpisodeQualityPenalty, float] = {
+        "dropout_gap": 0.15,
+        "frequency_drift": 0.10,
+        "quality_flags_present": 0.15,
+        "short_duration": 0.20,
+        "transient_extreme": 0.25,
+    }
+    return min(1.0, sum(weights[penalty] for penalty in penalties))
+
+
+def _positive_float(value: object) -> float | None:
+    parsed = _finite_float(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+def _finite_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    parsed = float(value)
+    return parsed if isfinite(parsed) else None
+
+
+def _append_unique(
+    penalties: list[VibrationEpisodeQualityPenalty],
+    penalty: VibrationEpisodeQualityPenalty,
+) -> None:
+    if penalty not in penalties:
+        penalties.append(penalty)

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -87,6 +87,17 @@ bandwidth settings, optional harmonic lists, and an explicit output spectrum
 clamp. Unavailable reference inputs become unavailable band rows with reasons
 instead of being dropped or guessed.
 
+`use_cases/diagnostics/post_run_vibration_episodes.py` groups POSTRUN-03
+window-feature peaks into deterministic, time-bounded episodes. Grouping is by
+sensor/location, adjacent time windows, allowed per-step frequency drift, and a
+minimum strength threshold. Defaults require at least three supporting windows
+and 0.75 seconds of duration; isolated spikes are suppressed unless they exceed
+the extreme-transient threshold and are marked as transient. Episode rows carry
+frequency path, median/peak strength, median frequency, slope, dominant axis,
+supporting window IDs, affected sensors, and explainable quality penalties for
+dropout gaps, broad drift, noisy feature flags, short duration, and transient
+extremes.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -169,6 +180,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `post_run_window_features.py` | ~300 | Window-level feature extraction over POSTRUN-02 STFT frames |
 | `post_run_vehicle_reference.py` | ~350 | Per-window vehicle speed/RPM/gear/final-drive reference normalization for dense order stages |
 | `post_run_order_bands.py` | ~400 | Per-window wheel/driveshaft/engine order-band generation over POSTRUN-04 vehicle references |
+| `post_run_vibration_episodes.py` | ~450 | Deterministic grouping of dense window peaks into persistent or intentional transient vibration episodes |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -80,6 +80,11 @@ does not track implementation status or old branch plans.
   engine harmonics. It reuses shared tolerance math, clamps to the configured
   dense spectrum range, and carries explicit unavailable reasons for missing
   references.
+- POSTRUN-06 adds
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_vibration_episodes.py`:
+  deterministic grouping of POSTRUN-03 feature peaks into sustained vibration
+  episodes, with explicit transient-spike handling, dropout/drift/noise quality
+  penalties, and debug rows for inspection.
 
 ### Persisted analysis and reporting
 
@@ -136,7 +141,7 @@ raw capture manifest/files (#3065)
 |---|---|---|
 | Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
 | Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata; `post_run_raw_windows.py` owns raw-window iteration for dense stages |
-| Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine and `post_run_window_features.py` owns the compact per-window feature reduction |
+| Whole-run spectra/features | `apps/server/vibesensor/use_cases/diagnostics/`, `apps/server/vibesensor/shared/fft_analysis.py`, `apps/server/vibesensor/vibration_strength.py` | Reuse canonical shared FFT/strength primitives to compute per-window spectral outputs without `use_cases -> infra` coupling; `post_run_stft.py` owns the in-memory DTO-first STFT engine, `post_run_window_features.py` owns the compact per-window feature reduction, and `post_run_vibration_episodes.py` owns deterministic episode grouping |
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments; `post_run_vehicle_reference.py` owns the conservative vehicle-reference timeline for dense stages |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability; `post_run_order_bands.py` owns the pre-classification per-window expected band grid |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |


### PR DESCRIPTION
Closes #3717

## What changed
- Added deterministic post-run vibration episode detection over window features.
- Groups peaks by sensor/location, time adjacency, frequency continuity, and strength threshold.
- Emits episode DTOs with timing, supporting windows, frequency path, strength stats, slope, axis, affected sensors, and quality penalties.
- Suppresses isolated spikes unless they exceed the extreme transient threshold and marks those as transient.
- Supports simultaneous episodes from multiple top peaks per window.
- Adds debug rows and documents POSTRUN-06 grouping semantics.

## Why
Single-window peaks are noisy. Dense diagnostics need persistent, explainable episode intervals before findings can classify and rank causes.

## Validation
- ruff check and format check on touched Python files
- mypy on new module and tests
- backend static guards
- focused episode and window-feature tests
- docs_lint
- run_changed use-case suite

## Risks, tradeoffs, edge cases
- This is deterministic grouping only. It does not classify causes or create report findings.
- Per-sensor episodes are not fused across sensors here; affected_sensors is kept explicit for later fusion work.
- Extreme isolated spikes are retained as transient evidence; normal isolated spikes are suppressed.
