### PR TITLE
Add dense post-run finding classification

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import FindingKind, VibrationSource
+from vibesensor.use_cases.diagnostics.post_run_dense_findings import (
+    classify_post_run_dense_findings,
+    dense_finding_debug_rows,
+)
+from vibesensor.use_cases.diagnostics.post_run_order_bands import (
+    OrderBand,
+    OrderBandSource,
+    OrderBandUnavailableReason,
+    OrderBandWindow,
+    PostRunOrderBandsConfig,
+    PostRunOrderBandTimeline,
+)
+from vibesensor.use_cases.diagnostics.post_run_vibration_episodes import (
+    VibrationEpisode,
+)
+
+_RUN_ID = "run-dense-findings"
+
+
+def _episode(
+    *,
+    episode_id: str = "episode-1",
+    frequency_hz: float = 10.0,
+    windows: tuple[int, ...] = (0, 1, 2, 3),
+    strength_db: float = 24.0,
+    quality_penalty: float = 0.0,
+    transient: bool = False,
+    affected_sensors: tuple[str, ...] = ("sensor-a",),
+) -> VibrationEpisode:
+    return VibrationEpisode(
+        episode_id=episode_id,
+        run_id=_RUN_ID,
+        client_id="sensor-a",
+        location="front_left",
+        start_t_s=float(windows[0]) * 0.5,
+        end_t_s=(float(windows[-1]) * 0.5) + 0.5,
+        duration_s=((float(windows[-1]) - float(windows[0])) * 0.5) + 0.5,
+        start_window_index=windows[0],
+        end_window_index=windows[-1],
+        supporting_window_ids=windows,
+        frequency_path_hz=tuple(frequency_hz for _ in windows),
+        median_frequency_hz=frequency_hz,
+        peak_frequency_hz=frequency_hz,
+        frequency_slope_hz_per_s=0.0,
+        median_strength_db=strength_db,
+        peak_strength_db=strength_db,
+        peak_count=len(windows),
+        axis_dominance="x",
+        affected_sensors=affected_sensors,
+        quality_penalties=("quality_flags_present",) if quality_penalty else (),
+        quality_penalty=quality_penalty,
+        transient=transient,
+    )
+
+
+def _band(
+    label: str,
+    source: OrderBandSource,
+    center_hz: float,
+    *,
+    half_width_hz: float = 0.4,
+    unavailable: OrderBandUnavailableReason | None = None,
+) -> OrderBand:
+    return OrderBand(
+        label=label,
+        source=source,
+        harmonic=1,
+        center_hz=center_hz,
+        min_hz=center_hz - half_width_hz if unavailable is None else None,
+        max_hz=center_hz + half_width_hz if unavailable is None else None,
+        uncertainty_pct=0.02 if unavailable is None else None,
+        tolerance=0.04 if unavailable is None else None,
+        unavailable_reason=unavailable,
+        reference_source="test",
+    )
+
+
+def _timeline(
+    *,
+    windows: tuple[int, ...] = (0, 1, 2, 3),
+    wheel_hz: float = 10.0,
+    driveshaft_hz: float = 30.0,
+    engine_hz: float = 50.0,
+    unavailable_source: str | None = None,
+) -> PostRunOrderBandTimeline:
+    band_windows = []
+    for window_index in windows:
+        bands = (
+            _band(
+                "wheel_1x",
+                "wheel",
+                wheel_hz,
+                unavailable="missing_speed" if unavailable_source == "wheel" else None,
+            ),
+            _band(
+                "driveshaft_1x",
+                "driveshaft",
+                driveshaft_hz,
+                unavailable=("unknown_final_drive" if unavailable_source == "driveshaft" else None),
+            ),
+            _band(
+                "engine_1x",
+                "engine",
+                engine_hz,
+                unavailable="missing_rpm" if unavailable_source == "engine" else None,
+            ),
+        )
+        band_windows.append(
+            OrderBandWindow(
+                run_id=_RUN_ID,
+                window_index=window_index,
+                window_start_t_s=float(window_index) * 0.5,
+                window_end_t_s=(float(window_index) * 0.5) + 0.5,
+                window_center_t_s=(float(window_index) * 0.5) + 0.25,
+                bands=bands,
+            )
+        )
+    return PostRunOrderBandTimeline(
+        run_id=_RUN_ID,
+        config=PostRunOrderBandsConfig(),
+        windows=tuple(band_windows),
+    )
+
+
+def test_dense_findings_classify_clear_wheel_episode() -> None:
+    findings = classify_post_run_dense_findings((_episode(frequency_hz=10.0),), _timeline())
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.likely_origin is VibrationSource.WHEEL_TIRE
+    assert finding.confidence_label == "high"
+    assert finding.confidence_score >= 0.7
+    assert finding.alternatives[0].best_band_label == "wheel_1x"
+    assert all(window.matched for window in finding.evidence_windows)
+
+
+def test_dense_findings_classify_clear_driveshaft_episode() -> None:
+    findings = classify_post_run_dense_findings((_episode(frequency_hz=30.0),), _timeline())
+
+    assert findings[0].likely_origin is VibrationSource.DRIVELINE
+    assert findings[0].alternatives[0].best_band_label == "driveshaft_1x"
+
+
+def test_dense_findings_classify_clear_engine_episode() -> None:
+    findings = classify_post_run_dense_findings((_episode(frequency_hz=50.0),), _timeline())
+
+    assert findings[0].likely_origin is VibrationSource.ENGINE
+    assert findings[0].alternatives[0].best_band_label == "engine_1x"
+
+
+def test_dense_findings_preserve_unknown_for_unmatched_strong_episode() -> None:
+    findings = classify_post_run_dense_findings(
+        (_episode(frequency_hz=17.0, strength_db=26.0),),
+        _timeline(),
+    )
+
+    assert findings[0].likely_origin is VibrationSource.UNKNOWN_RESONANCE
+    assert "unmatched_strong_episode" in findings[0].caveats
+    assert not any(window.matched for window in findings[0].evidence_windows)
+
+
+def test_dense_findings_mark_ambiguous_close_source_match() -> None:
+    findings = classify_post_run_dense_findings(
+        (_episode(frequency_hz=10.0),),
+        _timeline(wheel_hz=10.0, driveshaft_hz=10.0, engine_hz=40.0),
+    )
+
+    assert findings[0].likely_origin in (VibrationSource.WHEEL_TIRE, VibrationSource.DRIVELINE)
+    assert "ambiguous_origin" in findings[0].caveats
+    assert len(findings[0].alternatives) == 3
+
+
+def test_dense_findings_penalize_poor_quality_and_missing_references() -> None:
+    episode = _episode(frequency_hz=10.0, quality_penalty=0.3)
+    findings = classify_post_run_dense_findings(
+        (episode,),
+        _timeline(windows=(0, 1), wheel_hz=10.0),
+    )
+
+    finding = findings[0]
+    assert finding.likely_origin is VibrationSource.WHEEL_TIRE
+    assert "missing_reference_data" in finding.caveats
+    assert "poor_quality" in finding.caveats
+    assert finding.confidence_score < 0.7
+
+
+def test_dense_findings_penalize_conflicting_sensor_evidence() -> None:
+    episode = _episode(
+        frequency_hz=10.0,
+        affected_sensors=("sensor-a", "sensor-b", "sensor-c"),
+    )
+
+    finding = classify_post_run_dense_findings((episode,), _timeline())[0]
+
+    assert finding.likely_origin is VibrationSource.WHEEL_TIRE
+    assert "conflicting_sensor_evidence" in finding.caveats
+    assert finding.confidence_score < 0.9
+
+
+def test_dense_finding_maps_to_domain_finding() -> None:
+    finding = classify_post_run_dense_findings((_episode(frequency_hz=10.0),), _timeline())[0]
+
+    domain_finding = finding.to_domain_finding()
+
+    assert domain_finding.kind is FindingKind.DIAGNOSTIC
+    assert domain_finding.suspected_source is VibrationSource.WHEEL_TIRE
+    assert domain_finding.confidence == pytest.approx(finding.confidence_score)
+    assert domain_finding.frequency_hz == pytest.approx(finding.median_frequency_hz)
+
+
+def test_dense_finding_debug_rows_are_stable() -> None:
+    findings = classify_post_run_dense_findings((_episode(frequency_hz=10.0),), _timeline())
+
+    rows = dense_finding_debug_rows(findings)
+
+    assert rows[0]["likely_origin"] == "wheel/tire"
+    assert rows[0]["evidence_window_count"] == 4

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py
@@ -1,0 +1,489 @@
+"""Dense post-run finding classification from episodes and order bands."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from math import isfinite
+from typing import Literal
+
+from vibesensor.domain import Finding, FindingKind, VibrationSource
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.whole_run_json_helpers import set_optional_value
+from vibesensor.use_cases.diagnostics.post_run_order_bands import (
+    OrderBand,
+    OrderBandSource,
+    OrderBandWindow,
+    PostRunOrderBandTimeline,
+)
+from vibesensor.use_cases.diagnostics.post_run_vibration_episodes import VibrationEpisode
+
+type DenseConfidenceLabel = Literal["high", "medium", "low"]
+type DenseFindingCaveat = Literal[
+    "ambiguous_origin",
+    "conflicting_sensor_evidence",
+    "missing_reference_data",
+    "poor_quality",
+    "low_usable_duration",
+    "transient_only",
+    "unmatched_strong_episode",
+]
+
+_SOURCE_TO_ORIGIN: Mapping[OrderBandSource, VibrationSource] = {
+    "wheel": VibrationSource.WHEEL_TIRE,
+    "driveshaft": VibrationSource.DRIVELINE,
+    "engine": VibrationSource.ENGINE,
+}
+
+__all__ = [
+    "DenseConfidenceLabel",
+    "DenseFinding",
+    "DenseFindingAlternative",
+    "DenseFindingCaveat",
+    "DenseFindingConfig",
+    "DenseFindingEvidenceWindow",
+    "classify_post_run_dense_findings",
+    "dense_finding_debug_rows",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class DenseFindingConfig:
+    """Scoring weights and thresholds for dense finding classification."""
+
+    min_match_ratio: float = 0.5
+    ambiguity_margin: float = 0.12
+    high_confidence_threshold: float = 0.7
+    medium_confidence_threshold: float = 0.4
+    strong_unknown_strength_db: float = 18.0
+
+
+@dataclass(frozen=True, slots=True)
+class DenseFindingEvidenceWindow:
+    """Window-level evidence used by a dense finding classification."""
+
+    window_index: int
+    frequency_hz: float
+    matched: bool
+    band_label: str | None = None
+    band_source: OrderBandSource | None = None
+    band_min_hz: float | None = None
+    band_max_hz: float | None = None
+    relative_error: float | None = None
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "window_index": self.window_index,
+            "frequency_hz": self.frequency_hz,
+            "matched": self.matched,
+        }
+        set_optional_value(payload, "band_label", self.band_label)
+        set_optional_value(payload, "band_source", self.band_source)
+        set_optional_value(payload, "band_min_hz", self.band_min_hz)
+        set_optional_value(payload, "band_max_hz", self.band_max_hz)
+        set_optional_value(payload, "relative_error", self.relative_error)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class DenseFindingAlternative:
+    """Alternative source hypothesis considered for a dense episode."""
+
+    source: VibrationSource
+    score: float
+    match_ratio: float
+    matched_windows: int
+    eligible_windows: int
+    best_band_label: str | None = None
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "source": str(self.source),
+            "score": self.score,
+            "match_ratio": self.match_ratio,
+            "matched_windows": self.matched_windows,
+            "eligible_windows": self.eligible_windows,
+        }
+        set_optional_value(payload, "best_band_label", self.best_band_label)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class DenseFinding:
+    """Reportable dense-analysis finding with confidence and caveats."""
+
+    finding_id: str
+    episode_id: str
+    likely_origin: VibrationSource
+    confidence_score: float
+    confidence_label: DenseConfidenceLabel
+    evidence_windows: tuple[DenseFindingEvidenceWindow, ...]
+    alternatives: tuple[DenseFindingAlternative, ...]
+    caveats: tuple[DenseFindingCaveat, ...]
+    strongest_location: str | None
+    median_frequency_hz: float
+    peak_strength_db: float
+    duration_s: float
+    supporting_window_ids: tuple[int, ...]
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "finding_id": self.finding_id,
+            "episode_id": self.episode_id,
+            "likely_origin": str(self.likely_origin),
+            "confidence_score": self.confidence_score,
+            "confidence_label": self.confidence_label,
+            "evidence_windows": [window.to_json_object() for window in self.evidence_windows],
+            "alternatives": [alternative.to_json_object() for alternative in self.alternatives],
+            "caveats": list(self.caveats),
+            "strongest_location": self.strongest_location,
+            "median_frequency_hz": self.median_frequency_hz,
+            "peak_strength_db": self.peak_strength_db,
+            "duration_s": self.duration_s,
+            "supporting_window_ids": list(self.supporting_window_ids),
+        }
+
+    def to_domain_finding(self) -> Finding:
+        order_label = self.alternatives[0].best_band_label if self.alternatives else None
+        return Finding(
+            finding_id=self.finding_id,
+            finding_key=f"dense:{self.episode_id}",
+            suspected_source=self.likely_origin,
+            confidence=self.confidence_score,
+            frequency_hz=self.median_frequency_hz,
+            order=order_label or "",
+            severity="diagnostic",
+            strongest_location=self.strongest_location,
+            kind=FindingKind.DIAGNOSTIC,
+            ranking_score=self.confidence_score * max(0.0, self.peak_strength_db),
+            vibration_strength_db=self.peak_strength_db,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceScore:
+    source: OrderBandSource
+    origin: VibrationSource
+    score: float
+    match_ratio: float
+    completeness: float
+    matched_windows: int
+    eligible_windows: int
+    best_band_label: str | None
+    evidence_windows: tuple[DenseFindingEvidenceWindow, ...]
+    unavailable_count: int
+
+
+def classify_post_run_dense_findings(
+    episodes: Iterable[VibrationEpisode],
+    order_bands: PostRunOrderBandTimeline,
+    *,
+    config: DenseFindingConfig | None = None,
+) -> tuple[DenseFinding, ...]:
+    """Classify dense vibration episodes against per-window order bands."""
+
+    effective_config = config or DenseFindingConfig()
+    _validate_config(effective_config)
+    band_windows = {window.window_index: window for window in order_bands.windows}
+    findings = tuple(
+        _classify_episode(
+            episode,
+            band_windows=band_windows,
+            index=index,
+            config=effective_config,
+        )
+        for index, episode in enumerate(episodes)
+    )
+    return tuple(
+        sorted(
+            findings,
+            key=lambda finding: (finding.confidence_score, finding.peak_strength_db),
+            reverse=True,
+        )
+    )
+
+
+def dense_finding_debug_rows(findings: Iterable[DenseFinding]) -> tuple[JsonObject, ...]:
+    """Return compact rows for dense finding inspection and golden tests."""
+
+    return tuple(
+        {
+            "finding_id": finding.finding_id,
+            "episode_id": finding.episode_id,
+            "likely_origin": str(finding.likely_origin),
+            "confidence_score": finding.confidence_score,
+            "confidence_label": finding.confidence_label,
+            "caveats": list(finding.caveats),
+            "evidence_window_count": len(finding.evidence_windows),
+        }
+        for finding in findings
+    )
+
+
+def _validate_config(config: DenseFindingConfig) -> None:
+    for field_name, value in (
+        ("min_match_ratio", config.min_match_ratio),
+        ("ambiguity_margin", config.ambiguity_margin),
+        ("high_confidence_threshold", config.high_confidence_threshold),
+        ("medium_confidence_threshold", config.medium_confidence_threshold),
+        ("strong_unknown_strength_db", config.strong_unknown_strength_db),
+    ):
+        if not isfinite(value) or value < 0:
+            raise ValueError(f"dense finding config requires {field_name} >= 0")
+    if config.min_match_ratio > 1 or config.ambiguity_margin > 1:
+        raise ValueError("dense finding ratio thresholds must be <= 1")
+    if config.high_confidence_threshold < config.medium_confidence_threshold:
+        raise ValueError("high_confidence_threshold must be >= medium_confidence_threshold")
+
+
+def _classify_episode(
+    episode: VibrationEpisode,
+    *,
+    band_windows: Mapping[int, OrderBandWindow],
+    index: int,
+    config: DenseFindingConfig,
+) -> DenseFinding:
+    sources: tuple[OrderBandSource, ...] = ("wheel", "driveshaft", "engine")
+    source_scores = tuple(
+        _score_source(
+            episode,
+            source=source,
+            band_windows=band_windows,
+        )
+        for source in sources
+    )
+    ranked = tuple(sorted(source_scores, key=lambda score: score.score, reverse=True))
+    top = ranked[0]
+    caveats: list[DenseFindingCaveat] = []
+    alternatives = tuple(_alternative(score) for score in ranked if score.eligible_windows > 0)
+    likely_origin = top.origin
+    confidence_score = top.score
+    evidence_windows = top.evidence_windows
+    if top.match_ratio < config.min_match_ratio:
+        likely_origin = VibrationSource.UNKNOWN_RESONANCE
+        confidence_score = _unknown_confidence(episode, top)
+        evidence_windows = _unmatched_evidence(episode)
+        alternatives = tuple(_alternative(score) for score in ranked)
+        if episode.peak_strength_db >= config.strong_unknown_strength_db:
+            _append_unique(caveats, "unmatched_strong_episode")
+    if len(ranked) > 1 and top.score - ranked[1].score <= config.ambiguity_margin:
+        _append_unique(caveats, "ambiguous_origin")
+        confidence_score *= 0.85
+    if top.completeness < 0.75 or top.unavailable_count > 0:
+        _append_unique(caveats, "missing_reference_data")
+        confidence_score *= 0.9
+    if episode.quality_penalty > 0:
+        _append_unique(caveats, "poor_quality")
+        confidence_score *= max(0.4, 1.0 - episode.quality_penalty)
+    if episode.duration_s < 1.0:
+        _append_unique(caveats, "low_usable_duration")
+        confidence_score *= 0.9
+    if episode.transient:
+        _append_unique(caveats, "transient_only")
+        confidence_score *= 0.75
+    if len(episode.affected_sensors) > 2:
+        _append_unique(caveats, "conflicting_sensor_evidence")
+        confidence_score *= 0.9
+    confidence_score = _clamp(confidence_score)
+    return DenseFinding(
+        finding_id=f"dense-{index + 1:03d}",
+        episode_id=episode.episode_id,
+        likely_origin=likely_origin,
+        confidence_score=confidence_score,
+        confidence_label=_confidence_label(confidence_score, config=config),
+        evidence_windows=evidence_windows,
+        alternatives=alternatives,
+        caveats=tuple(caveats),
+        strongest_location=episode.location,
+        median_frequency_hz=episode.median_frequency_hz,
+        peak_strength_db=episode.peak_strength_db,
+        duration_s=episode.duration_s,
+        supporting_window_ids=episode.supporting_window_ids,
+    )
+
+
+def _score_source(
+    episode: VibrationEpisode,
+    *,
+    source: OrderBandSource,
+    band_windows: Mapping[int, OrderBandWindow],
+) -> _SourceScore:
+    evidence: list[DenseFindingEvidenceWindow] = []
+    matched_windows = 0
+    eligible_windows = 0
+    unavailable_count = 0
+    band_label_counts: dict[str, int] = {}
+    for window_index, frequency_hz in zip(
+        episode.supporting_window_ids,
+        episode.frequency_path_hz,
+        strict=True,
+    ):
+        window = band_windows.get(window_index)
+        if window is None:
+            unavailable_count += 1
+            evidence.append(_unmatched_window(window_index, frequency_hz))
+            continue
+        source_bands = tuple(band for band in window.bands if band.source == source)
+        available_bands = tuple(band for band in source_bands if _band_available(band))
+        if not available_bands:
+            unavailable_count += 1
+            evidence.append(_unmatched_window(window_index, frequency_hz))
+            continue
+        eligible_windows += 1
+        best = min(available_bands, key=lambda band: _relative_error(frequency_hz, band))
+        matched = _band_matches(frequency_hz, best)
+        if matched:
+            matched_windows += 1
+            band_label_counts[best.label] = band_label_counts.get(best.label, 0) + 1
+        evidence.append(
+            DenseFindingEvidenceWindow(
+                window_index=window_index,
+                frequency_hz=frequency_hz,
+                matched=matched,
+                band_label=best.label,
+                band_source=best.source,
+                band_min_hz=best.min_hz,
+                band_max_hz=best.max_hz,
+                relative_error=_relative_error(frequency_hz, best),
+            )
+        )
+    total_windows = max(1, len(episode.supporting_window_ids))
+    match_ratio = matched_windows / max(1, eligible_windows)
+    completeness = eligible_windows / total_windows
+    score = _source_confidence(
+        match_ratio=match_ratio,
+        completeness=completeness,
+        episode=episode,
+    )
+    return _SourceScore(
+        source=source,
+        origin=_SOURCE_TO_ORIGIN[source],
+        score=score,
+        match_ratio=match_ratio,
+        completeness=completeness,
+        matched_windows=matched_windows,
+        eligible_windows=eligible_windows,
+        best_band_label=_most_common_label(band_label_counts),
+        evidence_windows=tuple(evidence),
+        unavailable_count=unavailable_count,
+    )
+
+
+def _source_confidence(
+    *,
+    match_ratio: float,
+    completeness: float,
+    episode: VibrationEpisode,
+) -> float:
+    persistence_score = min(1.0, (len(episode.supporting_window_ids) / 5.0) * 0.6)
+    persistence_score += min(1.0, episode.duration_s / 3.0) * 0.4
+    strength_score = _clamp((episode.peak_strength_db - 6.0) / 24.0)
+    confidence = (
+        (match_ratio * 0.35)
+        + (completeness * 0.20)
+        + (_clamp(persistence_score) * 0.15)
+        + (strength_score * 0.20)
+        + (_localization_score(episode) * 0.10)
+    )
+    return _clamp(confidence)
+
+
+def _unknown_confidence(episode: VibrationEpisode, top: _SourceScore) -> float:
+    strength_score = _clamp((episode.peak_strength_db - 6.0) / 24.0)
+    persistence_score = min(1.0, len(episode.supporting_window_ids) / 5.0)
+    localization_score = _localization_score(episode)
+    return _clamp(
+        (strength_score * 0.40)
+        + (persistence_score * 0.30)
+        + (localization_score * 0.10)
+        + (top.score * 0.20)
+    )
+
+
+def _localization_score(episode: VibrationEpisode) -> float:
+    if not episode.location:
+        return 0.4
+    if len(episode.affected_sensors) <= 1:
+        return 1.0
+    if len(episode.affected_sensors) == 2:
+        return 0.8
+    return 0.6
+
+
+def _alternative(score: _SourceScore) -> DenseFindingAlternative:
+    return DenseFindingAlternative(
+        source=score.origin,
+        score=score.score,
+        match_ratio=score.match_ratio,
+        matched_windows=score.matched_windows,
+        eligible_windows=score.eligible_windows,
+        best_band_label=score.best_band_label,
+    )
+
+
+def _unmatched_evidence(episode: VibrationEpisode) -> tuple[DenseFindingEvidenceWindow, ...]:
+    return tuple(
+        _unmatched_window(window_index, frequency_hz)
+        for window_index, frequency_hz in zip(
+            episode.supporting_window_ids,
+            episode.frequency_path_hz,
+            strict=True,
+        )
+    )
+
+
+def _unmatched_window(window_index: int, frequency_hz: float) -> DenseFindingEvidenceWindow:
+    return DenseFindingEvidenceWindow(
+        window_index=window_index,
+        frequency_hz=frequency_hz,
+        matched=False,
+    )
+
+
+def _band_available(band: OrderBand) -> bool:
+    return (
+        band.unavailable_reason is None
+        and band.center_hz is not None
+        and band.min_hz is not None
+        and band.max_hz is not None
+        and band.min_hz <= band.max_hz
+    )
+
+
+def _band_matches(frequency_hz: float, band: OrderBand) -> bool:
+    return (
+        band.min_hz is not None
+        and band.max_hz is not None
+        and band.min_hz <= frequency_hz <= band.max_hz
+    )
+
+
+def _relative_error(frequency_hz: float, band: OrderBand) -> float:
+    if band.center_hz is None or band.center_hz <= 0:
+        return 1.0
+    return abs(frequency_hz - band.center_hz) / band.center_hz
+
+
+def _most_common_label(counts: Mapping[str, int]) -> str | None:
+    if not counts:
+        return None
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _confidence_label(score: float, *, config: DenseFindingConfig) -> DenseConfidenceLabel:
+    if score >= config.high_confidence_threshold:
+        return "high"
+    if score >= config.medium_confidence_threshold:
+        return "medium"
+    return "low"
+
+
+def _clamp(value: float) -> float:
+    if not isfinite(value):
+        return 0.0
+    return max(0.0, min(1.0, value))
+
+
+def _append_unique(caveats: list[DenseFindingCaveat], caveat: DenseFindingCaveat) -> None:
+    if caveat not in caveats:
+        caveats.append(caveat)

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -98,6 +98,17 @@ supporting window IDs, affected sensors, and explainable quality penalties for
 dropout gaps, broad drift, noisy feature flags, short duration, and transient
 extremes.
 
+`use_cases/diagnostics/post_run_dense_findings.py` fuses POSTRUN-06 episodes with
+POSTRUN-05 order bands. It compares each episode frequency path against the
+available wheel, driveshaft, and engine bands for the same `window_index`, ranks
+source hypotheses by match ratio, reference completeness, persistence, and
+strength, then emits compact dense findings. Each finding carries the likely
+origin, alternative hypotheses, confidence score/label, evidence windows, and
+caveats for ambiguity, missing references, quality penalties, short/transient
+events, conflicting multi-sensor evidence, or strong unmatched resonance. The DTO can project back to the existing
+domain `Finding` shape for report/history compatibility without persisting dense
+spectra.
+
 ## Related deep dives
 
 - `docs/order_tracking.md` explains how `OrderReferenceSpec`, shared order-band
@@ -181,6 +192,7 @@ in order. Each step runs exactly once per analysis invocation.
 | `post_run_vehicle_reference.py` | ~350 | Per-window vehicle speed/RPM/gear/final-drive reference normalization for dense order stages |
 | `post_run_order_bands.py` | ~400 | Per-window wheel/driveshaft/engine order-band generation over POSTRUN-04 vehicle references |
 | `post_run_vibration_episodes.py` | ~450 | Deterministic grouping of dense window peaks into persistent or intentional transient vibration episodes |
+| `post_run_dense_findings.py` | ~500 | Dense episode classification into likely origins, alternatives, confidence, caveats, evidence windows, and domain-finding compatibility |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -85,6 +85,16 @@ does not track implementation status or old branch plans.
   deterministic grouping of POSTRUN-03 feature peaks into sustained vibration
   episodes, with explicit transient-spike handling, dropout/drift/noise quality
   penalties, and debug rows for inspection.
+- POSTRUN-07 adds
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py`:
+  deterministic classification of dense episodes against POSTRUN-05 order bands.
+  It ranks wheel, driveshaft, and engine hypotheses by per-window band matches,
+  reference completeness, persistence, and strength; preserves strong unmatched
+  episodes as unknown resonance; records caveats for ambiguity, missing
+  references, poor quality, short duration, transients, and conflicting
+  multi-sensor evidence; and maps compact
+  dense findings back into the existing domain `Finding` contract for
+  report/history compatibility.
 
 ### Persisted analysis and reporting
 
@@ -145,7 +155,7 @@ raw capture manifest/files (#3065)
 | Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments; `post_run_vehicle_reference.py` owns the conservative vehicle-reference timeline for dense stages |
 | Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability; `post_run_order_bands.py` owns the pre-classification per-window expected band grid |
 | Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |
-| Fusion/report summary | `use_cases/diagnostics/`, `shared/boundaries/reporting/` | Convert whole-run evidence into ranked diagnoses and compact persisted facts |
+| Fusion/report summary | `use_cases/diagnostics/`, `shared/boundaries/reporting/` | Convert whole-run evidence into ranked diagnoses and compact persisted facts; `post_run_dense_findings.py` owns the first compact episode/order fusion DTO and compatibility projection |
 
 ## Early design decisions
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -92,6 +92,32 @@ final-drive, gear, RPM, or whole order-reference settings also stay explicit on
 the affected rows. Engine bands can remain available from RPM even when
 speed-derived wheel/driveshaft bands are unavailable.
 
+## Dense episode classification
+
+`use_cases/diagnostics/post_run_dense_findings.py` consumes POSTRUN-06
+`VibrationEpisode` rows and the POSTRUN-05 `PostRunOrderBandTimeline`. For each
+episode it checks the episode frequency at each supporting `window_index` against
+available order bands for wheel, driveshaft, and engine. A source hypothesis is
+scored from:
+
+- match ratio across eligible windows
+- reference completeness across all episode support windows
+- episode persistence and duration
+- peak vibration strength
+- sensor localization quality
+
+The highest-ranked source becomes the likely origin only when its match ratio
+meets the classifier threshold. Otherwise strong persistent episodes stay
+reportable as `unknown_resonance` instead of being forced into a weak mechanical
+order. Close competing scores add an `ambiguous_origin` caveat and reduce
+confidence. Missing bands/reference data, episode quality penalties, short
+usable duration, transient-only evidence, and conflicting multi-sensor evidence
+are also carried as caveats.
+
+Dense findings keep compact evidence windows plus alternatives and can project
+to the existing domain `Finding` model, preserving report/history compatibility
+while leaving dense spectra and traces outside persisted summary JSON.
+
 ## Uncertainty and tolerance bands
 
 Order matching is not based on a single exact frequency bin. Each reference
@@ -193,6 +219,7 @@ That shared ownership is why `shared/order_bands.py` exists outside
 | `apps/server/vibesensor/shared/order_bands.py` | Shared uncertainty, tolerance-band, and live band-payload helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py` | Dense per-window vehicle reference normalization and debug fixtures. |
 | `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py` | Dense per-window order-band DTOs, clamping, unavailable reasons, and serializer rows. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py` | Classify dense vibration episodes against per-window order bands into compact findings with alternatives, caveats, and domain `Finding` projection. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py` | Fixed hypothesis catalog and per-sample predicted-Hz helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py` | Match predicted order bands against stored sample peaks. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |


### PR DESCRIPTION
Closes #3718

## What changed
- Added `post_run_dense_findings.py`.
- Classifies POSTRUN-06 episodes against POSTRUN-05 wheel, driveshaft, and engine order bands.
- Emits dense findings with likely origin, confidence score/label, alternatives, evidence windows, and caveats.
- Preserves strong unmatched episodes as `unknown_resonance` instead of forcing a weak order match.
- Maps dense findings back to the existing domain `Finding` contract.
- Documented scoring inputs and dense finding ownership.

## Why
Reports need compact diagnostic conclusions from dense analysis, not only dense charts or raw traces.

## Validation
- `python -m ruff check apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py`
- `python -m ruff format --check apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py`
- `cd apps/server && python -m mypy --config-file pyproject.toml vibesensor/use_cases/diagnostics/post_run_dense_findings.py tests/use_cases/diagnostics/test_post_run_dense_findings.py`
- `python -m pytest apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py -q`
- `python tools/dev/docs_lint.py`
- `cd apps/server && python ../../tools/dev/verify_backend_static_guards.py`
- `python tools/tests/run_changed.py --base-ref origin/main` (2219 passed)

## Risks / tradeoffs / edge cases
- Scoring is deterministic and conservative, but still heuristic.
- Ambiguous close matches are penalized and exposed as caveats.
- Missing reference data lowers confidence instead of being guessed.
- Dense artifacts are not persisted here; this stays DTO-only.

## Follow-ups
- POSTRUN-08 persists dense artifacts and summaries.
- POSTRUN-09 adds report evidence charts for dense findings.
