### PR TITLE
Persist dense whole-run artifact provenance

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_whole_run_artifacts.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_whole_run_artifacts.py
@@ -14,6 +14,8 @@ from vibesensor.shared.types.whole_run_analysis import (
     WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
+    WholeRunSourceRawManifest,
+    WholeRunSourceRawSensorManifest,
     WholeRunWindowPolicy,
 )
 
@@ -30,6 +32,28 @@ def _manifest(run_id: str) -> WholeRunArtifactManifest:
             feature_interval_s=0.25,
         ),
         total_window_count=4,
+        algorithm_versions={"whole_run_spectra": 1},
+        configuration={"spectrum_storage_format": "npy-f32", "summary_storage_format": "jsonl"},
+        source_raw_manifests=(
+            WholeRunSourceRawManifest(
+                run_id=run_id,
+                relative_dir=f"raw-runs/{run_id}",
+                total_samples=1600,
+                total_bytes=9600,
+                sensor_count=1,
+                created_at="2025-01-01T00:00:00Z",
+                sensors=(
+                    WholeRunSourceRawSensorManifest(
+                        client_id="sensor-a",
+                        sample_rate_hz=800,
+                        sample_count=1600,
+                        chunk_count=2,
+                        bytes_written=9600,
+                        sample_rate_proof_state="observed_consistent",
+                    ),
+                ),
+            ),
+        ),
         artifacts=(
             WholeRunArtifactFile(
                 artifact_key="window-spectra",
@@ -76,10 +100,17 @@ def test_whole_run_artifact_round_trip_persists_manifest_and_bytes(tmp_path: Pat
     stored_run = db.run_repository.get_run("run-artifacts")
     assert stored_run is not None
     assert stored_run.whole_run_artifact_manifest == manifest
+    assert stored_run.artifact_availability is not None
+    assert stored_run.artifact_availability.whole_run_artifacts == "available"
     loaded_manifest = db.run_repository._run_sync(
         db.run_repository.aget_whole_run_artifact_manifest("run-artifacts")
     )
     assert loaded_manifest == manifest
+    assert loaded_manifest is not None
+    assert loaded_manifest.generated_artifact_paths == {
+        "window-spectra": "window-spectra.bin",
+        "order-traces": "orders/order-traces.jsonl",
+    }
     loaded_bytes = db.run_repository._run_sync(
         db.run_repository.aload_whole_run_artifact("run-artifacts", "window-spectra")
     )
@@ -116,6 +147,69 @@ def test_delete_run_removes_whole_run_artifacts(tmp_path: Path) -> None:
     db.run_repository.delete_run("run-delete")
 
     assert not artifact_dir.exists()
+
+
+def test_missing_whole_run_artifact_is_reported_without_breaking_history(
+    tmp_path: Path,
+) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-missing-artifact")
+    manifest = _manifest("run-missing-artifact")
+    stored_manifest = _store_whole_run_artifacts(db, "run-missing-artifact", manifest)
+    assert stored_manifest is not None
+    (tmp_path / manifest.relative_dir / "window-spectra.bin").unlink()
+
+    stored_run = db.run_repository.get_run("run-missing-artifact")
+    loaded_bytes = db.run_repository._run_sync(
+        db.run_repository.aload_whole_run_artifact("run-missing-artifact", "window-spectra")
+    )
+
+    assert stored_run is not None
+    assert stored_run.whole_run_artifact_manifest == manifest
+    assert stored_run.artifact_availability is not None
+    assert stored_run.artifact_availability.whole_run_artifacts == "missing"
+    assert loaded_bytes is None
+
+
+def test_corrupt_whole_run_manifest_is_ignored_for_history_reads(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_completed_run(db, "run-corrupt-manifest")
+    manifest = _manifest("run-corrupt-manifest")
+    stored_manifest = _store_whole_run_artifacts(db, "run-corrupt-manifest", manifest)
+    assert stored_manifest is not None
+    _execute_statements(
+        db.lifecycle,
+        (
+            "UPDATE runs SET whole_run_artifact_manifest_json = ? WHERE run_id = ?",
+            ('{"window_policy": "not-an-object"}', "run-corrupt-manifest"),
+        ),
+    )
+
+    stored_run = db.run_repository.get_run("run-corrupt-manifest")
+    listed_run = db.run_repository.list_runs(limit=1)[0]
+
+    assert stored_run is not None
+    assert stored_run.whole_run_artifact_manifest is None
+    assert listed_run.run_id == "run-corrupt-manifest"
+    assert listed_run.artifact_availability is not None
+    assert listed_run.artifact_availability.whole_run_artifacts == "not_recorded"
+
+
+def test_unreadable_whole_run_artifact_returns_none(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-corrupt-artifact")
+    manifest = _manifest("run-corrupt-artifact")
+    stored_manifest = _store_whole_run_artifacts(db, "run-corrupt-artifact", manifest)
+    assert stored_manifest is not None
+    artifact_path = tmp_path / manifest.relative_dir / "window-spectra.bin"
+    artifact_path.unlink()
+    artifact_path.mkdir()
+
+    loaded_bytes = db.run_repository._run_sync(
+        db.run_repository.aload_whole_run_artifact("run-corrupt-artifact", "window-spectra")
+    )
+
+    assert loaded_bytes is None
 
 
 def test_store_whole_run_artifacts_cleans_up_when_run_is_missing(tmp_path: Path) -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context_artifacts.py
@@ -64,6 +64,12 @@ def test_build_whole_run_context_artifact_bundle_round_trips_labels_and_interval
             }
         ],
         "created_at": "2025-01-01T00:00:01Z",
+        "generated_artifact_paths": {
+            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: "context/window-labels.jsonl",
+        },
+        "algorithm_versions": {},
+        "configuration": {},
+        "source_raw_manifests": [],
     }
     assert len(bundle.labels) == 4
     assert len(bundle.intervals) >= 1

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py
@@ -262,6 +262,12 @@ def test_build_whole_run_order_family_summary_artifact_bundle_preserves_manifest
             }
         ],
         "created_at": "2025-01-01T00:00:00Z",
+        "generated_artifact_paths": {
+            WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY: "orders/family-summaries.jsonl",
+        },
+        "algorithm_versions": {},
+        "configuration": {},
+        "source_raw_manifests": [],
     }
     assert (
         whole_run_order_trace_summaries_from_jsonl_bytes(

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
@@ -231,6 +231,12 @@ def test_build_whole_run_order_trace_summary_artifact_bundle_preserves_manifest_
             }
         ],
         "created_at": "2025-01-01T00:00:00Z",
+        "generated_artifact_paths": {
+            WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY: "orders/trace-summaries.jsonl",
+        },
+        "algorithm_versions": {},
+        "configuration": {},
+        "source_raw_manifests": [],
     }
     assert (
         whole_run_order_trace_summaries_from_jsonl_bytes(

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -379,6 +379,8 @@ def test_execute_post_analysis_stores_whole_run_artifacts_and_appends_metadata()
             feature_interval_s=0.25,
         ),
         total_window_count=3,
+        algorithm_versions={"whole_run_spectra": 1},
+        configuration={"spectrum_storage_format": "npy-f32"},
         artifacts=(
             WholeRunArtifactFile(
                 artifact_key="spectral-grid:sensor-a",
@@ -456,6 +458,26 @@ def test_execute_post_analysis_stores_whole_run_artifacts_and_appends_metadata()
     assert stored["analysis"]["analysis_metadata"]["whole_run_window_count"] == 3
     assert stored["analysis"]["analysis_metadata"]["whole_run_sensor_count"] == 1
     assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 2
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_artifact_manifest_path"]
+        == "whole-run-artifacts/run-whole-run/manifest.json"
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_artifact_generated_at"]
+        == "2025-01-01T00:00:00Z"
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifacts_status"] == "available"
+    assert stored["analysis"]["analysis_metadata"]["whole_run_algorithm_versions"] == {
+        "whole_run_spectra": 1,
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_configuration"] == {
+        "spectrum_storage_format": "npy-f32",
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_paths"] == {
+        "spectral-grid:sensor-a": "spectra/sensor-a/freq.f32.npy",
+        "spectral-summary:sensor-a": "spectra/sensor-a/windows.jsonl",
+    }
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_warnings"] == []
 
 
 def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
@@ -61,9 +61,33 @@ def test_append_whole_run_analysis_metadata_records_sensor_and_artifact_counts()
 
     assert result["analysis_metadata"] == {
         "whole_run_artifacts_available": True,
+        "whole_run_artifacts_status": "available",
+        "whole_run_artifact_manifest_path": "whole-run-artifacts/run-1/manifest.json",
+        "whole_run_artifact_generated_at": "2025-01-01T00:00:00Z",
+        "whole_run_artifact_schema_version": manifest.schema_version,
+        "whole_run_artifact_storage_type": manifest.storage_type,
         "whole_run_window_count": 4,
         "whole_run_sensor_count": 2,
         "whole_run_artifact_count": 3,
+        "whole_run_artifact_keys": [
+            "spectral-summary:sensor-a",
+            "spectral-summary:sensor-b",
+            "context-labels",
+        ],
+        "whole_run_artifact_formats": {
+            "spectral-summary:sensor-a": "jsonl",
+            "spectral-summary:sensor-b": "jsonl",
+            "context-labels": "jsonl",
+        },
+        "whole_run_artifact_paths": {
+            "spectral-summary:sensor-a": "spectra/sensor-a/windows.jsonl",
+            "spectral-summary:sensor-b": "spectra/sensor-b/windows.jsonl",
+            "context-labels": "context/window-labels.jsonl",
+        },
+        "whole_run_algorithm_versions": {},
+        "whole_run_artifact_configuration": {},
+        "whole_run_source_raw_manifest_count": 0,
+        "whole_run_artifact_warnings": [],
     }
 
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -164,7 +164,16 @@ class _HistoryDBQueryMixin(Protocol):
                     type(parsed).__name__,
                 )
             return None
-        return WholeRunArtifactManifest.from_mapping(parsed)
+        try:
+            return WholeRunArtifactManifest.from_mapping(parsed)
+        except (TypeError, ValueError):
+            LOGGER.warning(
+                "%s: run %s whole_run_artifact_manifest_json is corrupt or unsupported",
+                source,
+                run_id,
+                exc_info=True,
+            )
+            return None
 
     def _coerce_raw_capture_finalize(
         self,
@@ -218,7 +227,7 @@ class _HistoryDBQueryMixin(Protocol):
         run_id: str,
         status: RunStatus,
         has_raw_capture_manifest: bool,
-        has_whole_run_artifact_manifest: bool,
+        whole_run_artifact_manifest: WholeRunArtifactManifest | None,
         raw_capture_finalize: RunRawCaptureFinalize | None,
         has_analysis: bool,
         analysis_corrupt: bool,
@@ -229,10 +238,12 @@ class _HistoryDBQueryMixin(Protocol):
             raw_capture_artifacts_present=(
                 has_raw_capture_manifest and self._raw_capture_store.has_run_artifacts(run_id)
             ),
-            has_whole_run_artifact_manifest=has_whole_run_artifact_manifest,
+            has_whole_run_artifact_manifest=whole_run_artifact_manifest is not None,
             whole_run_artifacts_present=(
-                has_whole_run_artifact_manifest
-                and self._whole_run_artifact_store.has_run_artifacts(run_id)
+                whole_run_artifact_manifest is not None
+                and self._whole_run_artifact_store.has_manifest_artifacts(
+                    whole_run_artifact_manifest
+                )
             ),
             raw_capture_finalize=raw_capture_finalize,
             has_analysis=has_analysis,
@@ -293,11 +304,18 @@ class _HistoryDBQueryMixin(Protocol):
                 analysis_json=str(analysis_json) if analysis_json is not None else None,
                 source="list_runs",
             )
+            whole_run_artifact_manifest = self._coerce_whole_run_artifact_manifest(
+                run_id=normalized_run_id,
+                manifest_json=str(whole_run_artifact_manifest_json)
+                if whole_run_artifact_manifest_json is not None
+                else None,
+                source="list_runs",
+            )
             lifecycle = self._run_lifecycle(
                 run_id=normalized_run_id,
                 status=status,
                 has_raw_capture_manifest=raw_capture_manifest_json is not None,
-                has_whole_run_artifact_manifest=whole_run_artifact_manifest_json is not None,
+                whole_run_artifact_manifest=whole_run_artifact_manifest,
                 raw_capture_finalize=raw_capture_finalize,
                 has_analysis=analysis is not None,
                 analysis_corrupt=analysis_corrupt,
@@ -371,7 +389,6 @@ class _HistoryDBQueryMixin(Protocol):
             else None,
             source="get_run",
         )
-        has_whole_run_artifact_manifest = whole_run_artifact_manifest_json is not None
         whole_run_artifact_manifest = self._coerce_whole_run_artifact_manifest(
             run_id=normalized_run_id,
             manifest_json=str(whole_run_artifact_manifest_json)
@@ -388,7 +405,7 @@ class _HistoryDBQueryMixin(Protocol):
             run_id=normalized_run_id,
             status=status,
             has_raw_capture_manifest=has_raw_capture_manifest,
-            has_whole_run_artifact_manifest=has_whole_run_artifact_manifest,
+            whole_run_artifact_manifest=whole_run_artifact_manifest,
             raw_capture_finalize=metadata.raw_capture_finalize,
             has_analysis=analysis is not None,
             analysis_corrupt=analysis_corrupt,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py
@@ -69,7 +69,10 @@ class HistoryWholeRunArtifactStore:
         artifact_path = self._data_dir / manifest.relative_dir / artifact.relative_path
         if not artifact_path.exists():
             return None
-        return artifact_path.read_bytes()
+        try:
+            return artifact_path.read_bytes()
+        except OSError:
+            return None
 
     def delete_run_artifacts(self, run_id: str) -> None:
         with self._lock:
@@ -77,6 +80,12 @@ class HistoryWholeRunArtifactStore:
 
     def has_run_artifacts(self, run_id: str) -> bool:
         return self.run_dir(run_id).exists()
+
+    def has_manifest_artifacts(self, manifest: WholeRunArtifactManifest) -> bool:
+        run_dir = self._data_dir / manifest.relative_dir
+        if not (run_dir / _MANIFEST_FILE_NAME).is_file():
+            return False
+        return all((run_dir / artifact.relative_path).is_file() for artifact in manifest.artifacts)
 
     def run_dir(self, run_id: str) -> Path:
         return self._base_dir / run_id

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import isclose
 from typing import Literal, cast
 
 from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_json_helpers import (
     coerce_float_or_default as _float_from_json,
@@ -31,6 +32,7 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 __all__ = [
     "WHOLE_RUN_ARTIFACT_SCHEMA_VERSION",
     "WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME",
+    "WHOLE_RUN_ALGORITHM_VERSIONS",
     "WHOLE_RUN_CONTEXT_COVERAGE_VALUES",
     "WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES",
     "WHOLE_RUN_RPM_VALIDITY_VALUES",
@@ -43,6 +45,8 @@ __all__ = [
     "WholeRunContextWindowLabel",
     "WholeRunRpmValidity",
     "WholeRunSpeedValidity",
+    "WholeRunSourceRawManifest",
+    "WholeRunSourceRawSensorManifest",
     "WholeRunWindowDescriptor",
     "WholeRunWindowPolicy",
 ]
@@ -50,6 +54,16 @@ __all__ = [
 WHOLE_RUN_ARTIFACT_SCHEMA_VERSION = 1
 WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME = "whole-run-artifacts"
 _WHOLE_RUN_ARTIFACT_STORAGE_TYPE = "run-directory-v1"
+WHOLE_RUN_ALGORITHM_VERSIONS: JsonObject = {
+    "whole_run_artifact_manifest": 1,
+    "whole_run_spectra": 1,
+    "whole_run_context": 1,
+    "whole_run_order_traces": 1,
+    "whole_run_order_trace_summaries": 1,
+    "whole_run_order_family_summaries": 1,
+    "whole_run_spatial_coherence": 1,
+    "whole_run_diagnosis_summaries": 1,
+}
 
 type WholeRunContextCoverage = Literal["full", "partial", "missing"]
 type WholeRunSpeedValidity = Literal["measured", "assumed", "missing"]
@@ -242,6 +256,107 @@ class WholeRunArtifactFile:
 
 
 @dataclass(frozen=True, slots=True)
+class WholeRunSourceRawSensorManifest:
+    """Compact source raw-capture sensor manifest recorded for artifact provenance."""
+
+    client_id: str
+    sample_rate_hz: int
+    sample_count: int
+    chunk_count: int
+    bytes_written: int
+    sample_rate_proof_state: str
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "client_id": self.client_id,
+            "sample_rate_hz": self.sample_rate_hz,
+            "sample_count": self.sample_count,
+            "chunk_count": self.chunk_count,
+            "bytes_written": self.bytes_written,
+            "sample_rate_proof_state": self.sample_rate_proof_state,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunSourceRawSensorManifest:
+        return cls(
+            client_id=_str_from_json(data.get("client_id")),
+            sample_rate_hz=_int_from_json(data.get("sample_rate_hz")),
+            sample_count=_int_from_json(data.get("sample_count")),
+            chunk_count=_int_from_json(data.get("chunk_count")),
+            bytes_written=_int_from_json(data.get("bytes_written")),
+            sample_rate_proof_state=_str_from_json(data.get("sample_rate_proof_state")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunSourceRawManifest:
+    """Compact source raw-capture manifest recorded by whole-run artifacts."""
+
+    run_id: str
+    relative_dir: str
+    total_samples: int
+    total_bytes: int
+    sensor_count: int
+    created_at: str
+    sensors: tuple[WholeRunSourceRawSensorManifest, ...] = ()
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "run_id": self.run_id,
+            "relative_dir": self.relative_dir,
+            "total_samples": self.total_samples,
+            "total_bytes": self.total_bytes,
+            "sensor_count": self.sensor_count,
+            "created_at": self.created_at,
+            "sensors": [sensor.to_json_object() for sensor in self.sensors],
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunSourceRawManifest:
+        sensors_raw = data.get("sensors")
+        sensors: list[WholeRunSourceRawSensorManifest] = []
+        if isinstance(sensors_raw, list):
+            for item in sensors_raw:
+                if is_json_object(item):
+                    sensors.append(WholeRunSourceRawSensorManifest.from_mapping(item))
+        return cls(
+            run_id=_str_from_json(data.get("run_id")),
+            relative_dir=_str_from_json(data.get("relative_dir")),
+            total_samples=_int_from_json(data.get("total_samples")),
+            total_bytes=_int_from_json(data.get("total_bytes")),
+            sensor_count=_int_from_json(data.get("sensor_count")),
+            created_at=_str_from_json(data.get("created_at")),
+            sensors=tuple(sensors),
+        )
+
+    @classmethod
+    def from_raw_capture_manifest(
+        cls,
+        manifest: RawCaptureManifest,
+    ) -> WholeRunSourceRawManifest:
+        sensors = tuple(
+            WholeRunSourceRawSensorManifest(
+                client_id=sensor.client_id,
+                sample_rate_hz=int(sensor.sample_rate_hz),
+                sample_count=int(sensor.sample_count),
+                chunk_count=int(sensor.chunk_count),
+                bytes_written=int(sensor.bytes_written),
+                sample_rate_proof_state=str(sensor.sample_rate_proof_state),
+            )
+            for sensor in sorted(manifest.sensors, key=lambda item: item.client_id)
+        )
+        return cls(
+            run_id=manifest.run_id,
+            relative_dir=manifest.relative_dir,
+            total_samples=int(manifest.total_samples),
+            total_bytes=int(manifest.total_bytes),
+            sensor_count=len(sensors),
+            created_at=manifest.created_at,
+            sensors=sensors,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class WholeRunArtifactManifest:
     """Run-level manifest for dense whole-run artifacts stored outside analysis_json."""
 
@@ -253,6 +368,9 @@ class WholeRunArtifactManifest:
     created_at: str
     schema_version: int = WHOLE_RUN_ARTIFACT_SCHEMA_VERSION
     storage_type: str = _WHOLE_RUN_ARTIFACT_STORAGE_TYPE
+    algorithm_versions: JsonObject = field(default_factory=dict)
+    configuration: JsonObject = field(default_factory=dict)
+    source_raw_manifests: tuple[WholeRunSourceRawManifest, ...] = ()
 
     def to_json_object(self) -> JsonObject:
         return {
@@ -263,7 +381,15 @@ class WholeRunArtifactManifest:
             "window_policy": self.window_policy.to_json_object(),
             "total_window_count": self.total_window_count,
             "artifacts": [artifact.to_json_object() for artifact in self.artifacts],
+            "generated_artifact_paths": {
+                artifact.artifact_key: artifact.relative_path for artifact in self.artifacts
+            },
             "created_at": self.created_at,
+            "algorithm_versions": dict(self.algorithm_versions),
+            "configuration": dict(self.configuration),
+            "source_raw_manifests": [
+                manifest.to_json_object() for manifest in self.source_raw_manifests
+            ],
         }
 
     @classmethod
@@ -277,6 +403,14 @@ class WholeRunArtifactManifest:
             for item in artifacts_raw:
                 if is_json_object(item):
                     artifacts.append(WholeRunArtifactFile.from_mapping(item))
+        source_manifests_raw = data.get("source_raw_manifests")
+        source_manifests: list[WholeRunSourceRawManifest] = []
+        if isinstance(source_manifests_raw, list):
+            for item in source_manifests_raw:
+                if is_json_object(item):
+                    source_manifests.append(WholeRunSourceRawManifest.from_mapping(item))
+        algorithm_versions_raw = data.get("algorithm_versions")
+        configuration_raw = data.get("configuration")
         return cls(
             schema_version=_int_from_json(
                 data.get("schema_version"),
@@ -289,6 +423,11 @@ class WholeRunArtifactManifest:
             total_window_count=_int_from_json(data.get("total_window_count")),
             artifacts=tuple(artifacts),
             created_at=_str_from_json(data.get("created_at")),
+            algorithm_versions=(
+                dict(algorithm_versions_raw) if is_json_object(algorithm_versions_raw) else {}
+            ),
+            configuration=dict(configuration_raw) if is_json_object(configuration_raw) else {},
+            source_raw_manifests=tuple(source_manifests),
         )
 
     def artifact(self, artifact_key: str) -> WholeRunArtifactFile | None:
@@ -296,6 +435,10 @@ class WholeRunArtifactManifest:
             if artifact.artifact_key == artifact_key:
                 return artifact
         return None
+
+    @property
+    def generated_artifact_paths(self) -> dict[str, str]:
+        return {artifact.artifact_key: artifact.relative_path for artifact in self.artifacts}
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/use_cases/diagnostics/_artifact_bundles.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_artifact_bundles.py
@@ -71,6 +71,9 @@ def build_single_artifact_bundle_parts(
             created_at=created_at,
             schema_version=source_manifest.schema_version,
             storage_type=source_manifest.storage_type,
+            algorithm_versions=dict(source_manifest.algorithm_versions),
+            configuration=dict(source_manifest.configuration),
+            source_raw_manifests=source_manifest.source_raw_manifests,
         )
     else:
         manifest = WholeRunArtifactManifest(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -30,9 +30,11 @@ from vibesensor.shared.types.raw_capture import (
 )
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import (
+    WHOLE_RUN_ALGORITHM_VERSIONS,
     WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
+    WholeRunSourceRawManifest,
     WholeRunWindowDescriptor,
     WholeRunWindowPolicy,
 )
@@ -182,6 +184,7 @@ def build_whole_run_spectral_artifact_bundle(
         bundle=_build_artifact_bundle(
             run_id=run_id,
             plan=plan,
+            raw_capture=raw_capture,
             sensors=tuple(sensor.manifest for sensor in sensors),
             chunk_results=chunk_results,
             created_at=created_at or utc_now_iso(),
@@ -656,6 +659,7 @@ def _build_artifact_bundle(
     *,
     run_id: str,
     plan: WholeRunWindowPlan,
+    raw_capture: RawRunCapture,
     sensors: Sequence[RawCaptureSensorManifest],
     chunk_results: Sequence[_SpectralChunkResult],
     created_at: str,
@@ -713,6 +717,22 @@ def _build_artifact_bundle(
         total_window_count=plan.total_window_count,
         artifacts=tuple(artifact_files),
         created_at=created_at,
+        algorithm_versions=dict(WHOLE_RUN_ALGORITHM_VERSIONS),
+        configuration={
+            "sample_rate_hz": plan.policy.sample_rate_hz,
+            "window_size_samples": plan.policy.window_size_samples,
+            "stride_samples": plan.policy.stride_samples,
+            "overlap_samples": plan.policy.overlap_samples,
+            "feature_interval_s": plan.policy.feature_interval_s,
+            "spectrum_min_hz": SPECTRUM_MIN_HZ,
+            "spectrum_max_hz": SPECTRUM_MAX_HZ,
+            "sensor_count": len(sensors),
+            "spectrum_storage_format": "npy-f32",
+            "summary_storage_format": "jsonl",
+        },
+        source_raw_manifests=(
+            WholeRunSourceRawManifest.from_raw_capture_manifest(raw_capture.manifest),
+        ),
     )
     return WholeRunSpectralArtifactBundle(
         manifest=manifest,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -967,7 +967,15 @@ def run_build_report_facts_stage(
                 diagnosis_summaries,
             )
     if stored_artifact_manifest is not None:
-        summary = append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
+        summary = append_whole_run_analysis_metadata(
+            summary,
+            stored_artifact_manifest,
+            warnings=tuple(
+                warning
+                for stage_result in whole_run_output.stage_results
+                for warning in stage_result.warnings
+            ),
+        )
 
     return refresh_report_fallback_metadata(summary), _make_stage_result(
         stage_name=stage_name,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -967,15 +967,7 @@ def run_build_report_facts_stage(
                 diagnosis_summaries,
             )
     if stored_artifact_manifest is not None:
-        summary = append_whole_run_analysis_metadata(
-            summary,
-            stored_artifact_manifest,
-            warnings=tuple(
-                warning
-                for stage_result in whole_run_output.stage_results
-                for warning in stage_result.warnings
-            ),
-        )
+        summary = append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
 
     return refresh_report_fallback_metadata(summary), _make_stage_result(
         stage_name=stage_name,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
@@ -188,6 +188,9 @@ def merge_whole_run_artifact_bundles(
             created_at=base_manifest.created_at,
             schema_version=base_manifest.schema_version,
             storage_type=base_manifest.storage_type,
+            algorithm_versions=dict(base_manifest.algorithm_versions),
+            configuration=dict(base_manifest.configuration),
+            source_raw_manifests=base_manifest.source_raw_manifests,
         ),
         artifact_contents=merged_contents,
     )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -54,8 +54,6 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
 def append_whole_run_analysis_metadata(
     summary: PersistedAnalysis,
     manifest: WholeRunArtifactManifest,
-    *,
-    warnings: tuple[str, ...] = (),
 ) -> PersistedAnalysis:
     payload = summary.to_json_object()
     analysis_metadata = payload.get("analysis_metadata")
@@ -86,8 +84,23 @@ def append_whole_run_analysis_metadata(
     analysis_metadata["whole_run_algorithm_versions"] = dict(manifest.algorithm_versions)
     analysis_metadata["whole_run_artifact_configuration"] = dict(manifest.configuration)
     analysis_metadata["whole_run_source_raw_manifest_count"] = len(manifest.source_raw_manifests)
-    analysis_metadata["whole_run_artifact_warnings"] = list(warnings)
+    analysis_metadata["whole_run_artifact_warnings"] = _warning_codes_from_payload(
+        payload.get("warnings")
+    )
     return PersistedAnalysis.from_json_object(payload)
+
+
+def _warning_codes_from_payload(warnings: JsonValue | object) -> list[JsonValue]:
+    if not isinstance(warnings, list):
+        return []
+    codes: list[JsonValue] = []
+    for warning in warnings:
+        if not is_json_object(warning):
+            continue
+        code = warning.get("code")
+        if isinstance(code, str) and code:
+            codes.append(code)
+    return codes
 
 
 def append_whole_run_spectral_metadata(

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -54,6 +54,8 @@ from vibesensor.use_cases.diagnostics.whole_run_spectra import (
 def append_whole_run_analysis_metadata(
     summary: PersistedAnalysis,
     manifest: WholeRunArtifactManifest,
+    *,
+    warnings: tuple[str, ...] = (),
 ) -> PersistedAnalysis:
     payload = summary.to_json_object()
     analysis_metadata = payload.get("analysis_metadata")
@@ -64,9 +66,27 @@ def append_whole_run_analysis_metadata(
         {artifact.sensor_id for artifact in manifest.artifacts if artifact.sensor_id is not None}
     )
     analysis_metadata["whole_run_artifacts_available"] = True
+    analysis_metadata["whole_run_artifacts_status"] = "available"
+    analysis_metadata["whole_run_artifact_manifest_path"] = f"{manifest.relative_dir}/manifest.json"
+    analysis_metadata["whole_run_artifact_generated_at"] = manifest.created_at
+    analysis_metadata["whole_run_artifact_schema_version"] = manifest.schema_version
+    analysis_metadata["whole_run_artifact_storage_type"] = manifest.storage_type
     analysis_metadata["whole_run_window_count"] = int(manifest.total_window_count)
     analysis_metadata["whole_run_sensor_count"] = len(sensor_ids)
     analysis_metadata["whole_run_artifact_count"] = len(manifest.artifacts)
+    analysis_metadata["whole_run_artifact_keys"] = [
+        artifact.artifact_key for artifact in manifest.artifacts
+    ]
+    analysis_metadata["whole_run_artifact_formats"] = {
+        artifact.artifact_key: artifact.file_format for artifact in manifest.artifacts
+    }
+    analysis_metadata["whole_run_artifact_paths"] = {
+        artifact.artifact_key: artifact.relative_path for artifact in manifest.artifacts
+    }
+    analysis_metadata["whole_run_algorithm_versions"] = dict(manifest.algorithm_versions)
+    analysis_metadata["whole_run_artifact_configuration"] = dict(manifest.configuration)
+    analysis_metadata["whole_run_source_raw_manifest_count"] = len(manifest.source_raw_manifests)
+    analysis_metadata["whole_run_artifact_warnings"] = list(warnings)
     return PersistedAnalysis.from_json_object(payload)
 
 

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -188,3 +188,20 @@ Both cutoffs use the run's terminal timestamp (`analysis_completed_at`, then
 never deleted by the automatic policy. Full run deletion still removes sample
 rows through the existing `ON DELETE CASCADE` foreign key on `samples_v2`, plus
 raw/whole-run sidecar directories.
+
+## Dense whole-run sidecars
+
+Dense post-run arrays stay outside SQLite under
+`whole-run-artifacts/<run_id>/`. The `runs.whole_run_artifact_manifest_json`
+column stores only a compact manifest: schema/storage versions, input `run_id`,
+window policy, algorithm versions, source raw-capture manifest summaries,
+configuration, generated artifact paths, and per-artifact record counts/formats.
+The same manifest is also written to `whole-run-artifacts/<run_id>/manifest.json`.
+
+`analysis_json.analysis_metadata` keeps the query-friendly run summary:
+availability/status, manifest path, generated timestamp, algorithm versions,
+configuration, artifact count/keys/paths/formats, window/sensor counts, warning
+codes, and compact top findings/summaries. Dense spectra use `.npy` float32
+sidecars; window labels, order traces, summary rows, and spatial coherence rows
+use JSONL sidecars. History reads treat missing artifact files as `missing` and
+ignore corrupt manifest JSON instead of failing the whole run detail/list path.


### PR DESCRIPTION
Fixes #3719

What changed
- Extended dense whole-run artifact manifests with algorithm versions, compact source raw-capture provenance, configuration, and generated artifact paths.
- Projected compact artifact status into `analysis_json.analysis_metadata`: availability, status, manifest path, generated timestamp, schema/storage version, artifact keys/formats/paths, algorithm versions, config, source manifest count, warnings.
- Tightened history artifact availability so missing manifest files or sidecars report `missing` instead of `available`.
- Made corrupt manifest JSON and unreadable sidecar files degrade safely in history reads.
- Documented dense sidecar layout and DB-vs-sidecar ownership.
- Fixed the first CI repo-hygiene failure by keeping `post_analysis_executor.py` within its maintainability size gate.

Why
- Dense spectra/order/context artifacts should live as versioned sidecars, not in SQLite sample rows.
- SQLite keeps compact, queryable summaries and references.
- History/report paths need safe behavior when files are pruned, missing, or corrupt.

Validation
- Focused pytest: 19 passed.
- Ruff check and format check.
- Backend mypy with server config.
- Hygiene check and LOC maintainability gate.
- Docs lint.
- Backend static guards.
- `make sync-contracts CHECK=1`.
- `tools/tests/run_changed.py --base-ref origin/main`: 4033 passed after CI hygiene fix.

Risks / edge cases
- Existing manifests stay readable; new fields default to empty values.
- Corrupt manifest JSON is logged and ignored for list/detail reads.
- Missing individual sidecar files mark whole-run artifact availability as `missing`.
- Artifact bytes are still loaded by key when present; unreadable paths return `None`.

Follow-ups
- #3722 can use these sidecar summaries for report evidence charts.
- #3723 can build golden replay coverage on the persisted dense artifact contract.