### PR TITLE
Add dense golden replay regression harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev clean format shell-lint lint maintainability-check typecheck-backend typecheck ui-lint ui-typecheck ui-test test test-changed test-golden-replay plan-validation test-ci-fast test-ci-lite test-all test-full-suite benchmark-backend benchmark-golden-replay benchmark-compare-backend sync-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -82,6 +82,10 @@ test-changed: ## Run heuristic checks for files changed vs origin/main
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/run_changed.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
 
+test-golden-replay: ## Run fast generated dense post-run golden replay tests
+	@$(RESOLVE_PYTHON) \
+	"$$PYTHON" -m pytest -q apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
+
 plan-validation: ## Plan changed-file validation from CI path rules
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/plan_validation.py $(if $(BASE_REF),--base-ref $(BASE_REF),)
@@ -105,6 +109,10 @@ test-full-suite: ## Run the full end-to-end suite locally
 benchmark-backend: ## Run explicit backend benchmark suite (set BENCHMARK_OPTS / BACKEND_BENCHMARK_TARGETS as needed)
 	@$(RESOLVE_PYTHON) \
 	cd $(SERVER_DIR) && "$$PYTHON" -m pytest --benchmark-only $(BACKEND_BENCHMARK_TARGETS) $(BENCHMARK_OPTS)
+
+benchmark-golden-replay: ## Run the opt-in 30-minute dense golden replay benchmark
+	@$(RESOLVE_PYTHON) \
+	cd $(SERVER_DIR) && "$$PYTHON" -m pytest --benchmark-only -o addopts='' tests/use_cases/run/benchmark_post_analysis_golden_replay.py $(BENCHMARK_OPTS)
 
 benchmark-compare-backend: ## Compare saved backend benchmark runs from apps/server/.benchmarks
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/tests/test_support/golden_replay.py
+++ b/apps/server/tests/test_support/golden_replay.py
@@ -1,0 +1,684 @@
+"""Generated golden replay fixtures for dense post-run regression tests."""
+
+from __future__ import annotations
+
+import json
+import tracemalloc
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import pi
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Literal, cast
+
+import numpy as np
+
+from test_support.core import ALL_SENSORS, FINAL_DRIVE, GEAR_RATIO, standard_metadata, wheel_hz
+from test_support.sample_scenarios import make_sample
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorClockSync,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
+from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+
+GoldenUnavailableReason = Literal["missing_speed", "missing_rpm"]
+GoldenScenarioGroup = Literal[
+    "baseline",
+    "wheel",
+    "driveline",
+    "engine",
+    "transient",
+    "data_quality",
+]
+
+_RUN_START_US = 1_000_000
+_SAMPLE_RATE_HZ = 256
+_FFT_WINDOW_SIZE_SAMPLES = 256
+_DEFAULT_DURATION_S = 8.0
+_DEFAULT_SPEED_KMH = 80.0
+_DEFAULT_ENGINE_RPM = 1500.0
+_RAW_ACCEL_SCALE_G_PER_LSB = 0.001
+_NOISE_FREQS_HZ = (37.0, 55.0)
+_DRIVESHAFT_SOURCE = "driveline"
+_ENGINE_SOURCE = "engine"
+_WHEEL_SOURCE = "wheel/tire"
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenReplayExpected:
+    """Stable assertions attached to one generated replay fixture."""
+
+    suspected_source: str | None
+    strongest_location: str | None = None
+    confidence_range: tuple[float, float] = (0.0, 1.0)
+    unavailable_reasons: tuple[GoldenUnavailableReason, ...] = ()
+    tolerance_bands: Mapping[str, tuple[float, float]] | None = None
+    max_false_positive_confidence: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenReplayFixture:
+    """Compact fixture format; all raw waveform and summary rows are generated."""
+
+    case_id: str
+    title: str
+    group: GoldenScenarioGroup
+    seed: int
+    expected: GoldenReplayExpected
+    primary_frequency_hz: float | None = None
+    strongest_sensor: str | None = None
+    signal_amp_g: float = 0.08
+    transfer_amp_g: float = 0.024
+    speed_kmh: float | None = _DEFAULT_SPEED_KMH
+    speed_source: str = "gps"
+    engine_rpm: float | None = _DEFAULT_ENGINE_RPM
+    final_drive_ratio: float | None = FINAL_DRIVE
+    current_gear_ratio: float | None = GEAR_RATIO
+    duration_s: float = _DEFAULT_DURATION_S
+    sample_rate_hz: int = _SAMPLE_RATE_HZ
+    fft_window_size_samples: int = _FFT_WINDOW_SIZE_SAMPLES
+    fast_ci: bool = True
+
+    def build(self, *, duration_s: float | None = None) -> GoldenReplayRun:
+        run_id = f"golden-{self.case_id}"
+        actual_duration_s = self.duration_s if duration_s is None else duration_s
+        metadata = _metadata_for_fixture(self, run_id=run_id)
+        samples = _summary_samples(self, run_id=run_id, duration_s=actual_duration_s)
+        raw_capture = _raw_capture_for_fixture(self, run_id=run_id, duration_s=actual_duration_s)
+        return GoldenReplayRun(
+            fixture=self,
+            run_id=run_id,
+            metadata=metadata,
+            samples=sensor_frames_from_mappings(samples),
+            raw_capture=raw_capture,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenReplayRun:
+    fixture: GoldenReplayFixture
+    run_id: str
+    metadata: RunMetadata
+    samples: list[SensorFrame]
+    raw_capture: RawRunCapture
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenReplayResult:
+    fixture: GoldenReplayFixture
+    analysis: dict[str, object]
+    manifest: WholeRunArtifactManifest
+    artifact_contents: Mapping[str, bytes]
+
+
+@dataclass(frozen=True, slots=True)
+class GoldenReplayBenchmarkResult:
+    elapsed_s: float
+    peak_memory_bytes: int
+    result: GoldenReplayResult
+
+
+class GoldenReplayRecorder:
+    """Minimal async persistence port used by the executor harness."""
+
+    def __init__(self) -> None:
+        self.analysis: dict[str, object] | None = None
+        self.manifest: WholeRunArtifactManifest | None = None
+        self.artifact_contents: dict[str, bytes] = {}
+        self.errors: list[tuple[str, str]] = []
+
+    async def astore_whole_run_artifacts(
+        self,
+        run_id: str,
+        manifest: WholeRunArtifactManifest,
+        *,
+        artifact_contents: Mapping[str, bytes],
+    ) -> WholeRunArtifactManifest:
+        self.manifest = manifest
+        self.artifact_contents = dict(artifact_contents)
+        return manifest
+
+    async def astore_analysis(
+        self,
+        _run_id: str,
+        analysis: PersistedAnalysis | Mapping[str, object],
+    ) -> None:
+        if isinstance(analysis, PersistedAnalysis):
+            self.analysis = cast(dict[str, object], analysis.to_json_object())
+        else:
+            self.analysis = dict(analysis)
+
+    async def astore_analysis_error(self, run_id: str, error: str) -> None:
+        self.errors.append((run_id, error))
+
+
+def golden_replay_fixtures(*, fast_ci_only: bool = False) -> tuple[GoldenReplayFixture, ...]:
+    fixtures = (
+        _balanced_fixture(),
+        _front_wheel_fixture(),
+        _rear_wheel_fixture(),
+        _driveshaft_fixture(),
+        _engine_fixture(),
+        _transient_fixture(),
+        _noisy_sensor_fixture(),
+        _gps_dropout_fixture(),
+        _missing_rpm_fixture(),
+    )
+    if fast_ci_only:
+        return tuple(fixture for fixture in fixtures if fixture.fast_ci)
+    return fixtures
+
+
+def execute_golden_replay_fixture(
+    fixture: GoldenReplayFixture,
+    *,
+    duration_s: float | None = None,
+    analysis_runner: object | None = None,
+) -> GoldenReplayResult:
+    run = fixture.build(duration_s=duration_s)
+    recorder = GoldenReplayRecorder()
+    result = execute_post_analysis(
+        run_id=run.run_id,
+        db=cast(RunPersistence, recorder),
+        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+            run_id=run_id,
+            metadata=run.metadata,
+            language=run.metadata.language or "en",
+            samples=list(run.samples),
+            total_summary_row_count=len(run.samples),
+            stride=1,
+            summary_duration_s=duration_s or fixture.duration_s,
+            context_samples=list(run.samples),
+            raw_capture=run.raw_capture,
+            raw_capture_manifest=run.raw_capture.manifest,
+        ),
+        analysis_runner=(
+            build_post_analysis_summary if analysis_runner is None else cast(Any, analysis_runner)
+        ),
+    )
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    assert recorder.analysis is not None
+    assert recorder.manifest is not None
+    return GoldenReplayResult(
+        fixture=fixture,
+        analysis=recorder.analysis,
+        manifest=recorder.manifest,
+        artifact_contents=recorder.artifact_contents,
+    )
+
+
+def benchmark_golden_replay_fixture(
+    fixture: GoldenReplayFixture,
+    *,
+    duration_s: float,
+) -> GoldenReplayBenchmarkResult:
+    tracemalloc.start()
+    started = perf_counter()
+    try:
+        result = execute_golden_replay_fixture(
+            fixture,
+            duration_s=duration_s,
+            analysis_runner=_minimal_benchmark_summary,
+        )
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return GoldenReplayBenchmarkResult(
+        elapsed_s=perf_counter() - started,
+        peak_memory_bytes=peak,
+        result=result,
+    )
+
+
+def _minimal_benchmark_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
+    return PersistedAnalysis.from_json_object(
+        {
+            "run_id": run.run_id,
+            "findings": [],
+            "top_causes": [],
+            "warnings": [],
+            "run_suitability": [],
+            "analysis_metadata": {
+                "analyzed_sample_count": len(run.samples),
+                "benchmark_fixture": run.run_id,
+            },
+        }
+    )
+
+
+def write_golden_replay_snapshot(
+    *,
+    result: GoldenReplayResult,
+    output_dir: Path,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{result.fixture.case_id}.json"
+    top_causes = result.analysis.get("top_causes")
+    analysis_metadata = result.analysis.get("analysis_metadata")
+    diagnosis_summaries = result.analysis.get("whole_run_diagnosis_summaries")
+    path.write_text(
+        json.dumps(
+            {
+                "case_id": result.fixture.case_id,
+                "title": result.fixture.title,
+                "seed": result.fixture.seed,
+                "expected": _expected_snapshot(result.fixture.expected),
+                "top_causes": top_causes if isinstance(top_causes, list) else [],
+                "whole_run_diagnosis_summaries": (
+                    diagnosis_summaries if isinstance(diagnosis_summaries, list) else []
+                ),
+                "analysis_metadata": (
+                    analysis_metadata if isinstance(analysis_metadata, dict) else {}
+                ),
+                "artifact_keys": [artifact.artifact_key for artifact in result.manifest.artifacts],
+                "artifact_paths": result.manifest.generated_artifact_paths,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _expected_snapshot(expected: GoldenReplayExpected) -> dict[str, object]:
+    return {
+        "suspected_source": expected.suspected_source,
+        "strongest_location": expected.strongest_location,
+        "confidence_range": list(expected.confidence_range),
+        "unavailable_reasons": list(expected.unavailable_reasons),
+        "tolerance_bands": dict(expected.tolerance_bands or {}),
+        "max_false_positive_confidence": expected.max_false_positive_confidence,
+    }
+
+
+def _metadata_for_fixture(fixture: GoldenReplayFixture, *, run_id: str) -> RunMetadata:
+    return run_metadata_from_mapping(
+        standard_metadata(
+            run_id=run_id,
+            raw_sample_rate_hz=fixture.sample_rate_hz,
+            sample_rate_hz=fixture.sample_rate_hz,
+            feature_interval_s=1.0,
+            fft_window_size_samples=fixture.fft_window_size_samples,
+            accel_scale_g_per_lsb=_RAW_ACCEL_SCALE_G_PER_LSB,
+            final_drive_ratio=fixture.final_drive_ratio,
+            current_gear_ratio=fixture.current_gear_ratio,
+        )
+    )
+
+
+def _summary_samples(
+    fixture: GoldenReplayFixture,
+    *,
+    run_id: str,
+    duration_s: float,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    summary_count = max(1, int(duration_s))
+    for index in range(summary_count):
+        for sensor in ALL_SENSORS:
+            rows.append(
+                _summary_sample(
+                    fixture,
+                    run_id=run_id,
+                    t_s=float(index),
+                    sensor=sensor,
+                    transient_active=fixture.case_id == "transient-spike" and index < 2,
+                )
+            )
+    return rows
+
+
+def _summary_sample(
+    fixture: GoldenReplayFixture,
+    *,
+    run_id: str,
+    t_s: float,
+    sensor: str,
+    transient_active: bool,
+) -> dict[str, Any]:
+    frequency = _effective_frequency(fixture, transient_active=transient_active)
+    amp = _sensor_amp(fixture, sensor=sensor, transient_active=transient_active)
+    speed = 0.0 if fixture.speed_kmh is None else fixture.speed_kmh
+    peaks = _peaks_for_frequency(frequency, amp)
+    row = make_sample(
+        t_s=t_s,
+        speed_kmh=speed,
+        client_name=sensor,
+        client_id=sensor,
+        location=sensor,
+        top_peaks=peaks,
+        vibration_strength_db=28.0 if amp >= fixture.signal_amp_g else 12.0,
+        strength_floor_amp_g=0.004,
+        engine_rpm=fixture.engine_rpm,
+        strength_peak_amp_g=max((peak["amp"] for peak in peaks), default=0.004),
+    )
+    row["run_id"] = run_id
+    row["speed_source"] = fixture.speed_source
+    if fixture.speed_kmh is None:
+        row.pop("speed_kmh", None)
+    if fixture.engine_rpm is not None:
+        row["engine_rpm_source"] = "obd2"
+    return row
+
+
+def _raw_capture_for_fixture(
+    fixture: GoldenReplayFixture,
+    *,
+    run_id: str,
+    duration_s: float,
+) -> RawRunCapture:
+    sensors = tuple(
+        _raw_sensor_data(
+            fixture,
+            run_id=run_id,
+            sensor=sensor,
+            duration_s=duration_s,
+        )
+        for sensor in ALL_SENSORS
+    )
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=tuple(sensor.manifest for sensor in sensors),
+        total_samples=sum(sensor.manifest.sample_count for sensor in sensors),
+        total_bytes=sum(sensor.manifest.bytes_written for sensor in sensors),
+        created_at="2026-01-01T00:00:00Z",
+        run_start_monotonic_us=_RUN_START_US,
+    )
+    return RawRunCapture(manifest=manifest, sensors=sensors)
+
+
+def _raw_sensor_data(
+    fixture: GoldenReplayFixture,
+    *,
+    run_id: str,
+    sensor: str,
+    duration_s: float,
+) -> RawCaptureSensorData:
+    total_samples = max(fixture.fft_window_size_samples, int(duration_s * fixture.sample_rate_hz))
+    samples = _sensor_waveform(fixture, sensor=sensor, total_samples=total_samples)
+    chunk = RawCaptureChunkIndex(
+        sample_start=0,
+        sample_count=total_samples,
+        t0_us=_RUN_START_US,
+        byte_offset=0,
+    )
+    manifest = RawCaptureSensorManifest(
+        client_id=sensor,
+        sample_rate_hz=fixture.sample_rate_hz,
+        data_file=f"{sensor}.raw.i16le",
+        index_file=f"{sensor}.index.jsonl",
+        sample_count=total_samples,
+        chunk_count=1,
+        bytes_written=int(samples.shape[0] * samples.shape[1] * 2),
+        first_t0_us=_RUN_START_US,
+        last_t0_us=_RUN_START_US,
+        clock_sync=RawCaptureSensorClockSync(
+            clock_domain="server_monotonic",
+            proof_state="verified",
+            observed_monotonic_us=_RUN_START_US + 10_000,
+            last_sync_monotonic_us=_RUN_START_US,
+            sync_offset_us=0,
+            sync_rtt_us=2_000,
+            max_sync_age_us=15_000_000,
+            max_sync_rtt_us=50_000,
+        ),
+        declared_sample_rate_hz=fixture.sample_rate_hz,
+        sample_rate_proof_state="observed_consistent",
+    )
+    return RawCaptureSensorData(manifest=manifest, samples_i16=samples, chunks=(chunk,))
+
+
+def _sensor_waveform(
+    fixture: GoldenReplayFixture,
+    *,
+    sensor: str,
+    total_samples: int,
+) -> np.ndarray:
+    rng = np.random.default_rng(fixture.seed + sum(ord(char) for char in sensor))
+    t = np.arange(total_samples, dtype=np.float64) / float(fixture.sample_rate_hz)
+    frequency = _effective_frequency(fixture, transient_active=True)
+    amp_g = _sensor_amp(fixture, sensor=sensor, transient_active=True)
+    if frequency is None:
+        base = np.zeros(total_samples, dtype=np.float64)
+    else:
+        envelope = np.ones(total_samples, dtype=np.float64)
+        if fixture.case_id == "transient-spike":
+            envelope[:] = 0.05
+            envelope[: fixture.sample_rate_hz * 2] = 1.0
+        base = amp_g * envelope * np.sin((2.0 * pi * frequency * t) + _phase_for_sensor(sensor))
+        if frequency * 2.0 < fixture.sample_rate_hz / 2.0:
+            base += (amp_g * 0.35) * envelope * np.sin(2.0 * pi * frequency * 2.0 * t)
+    for noise_freq in _NOISE_FREQS_HZ:
+        if noise_freq < fixture.sample_rate_hz / 2.0:
+            base += 0.004 * np.sin((2.0 * pi * noise_freq * t) + _phase_for_sensor(sensor))
+    base += rng.normal(loc=0.0, scale=0.0015, size=total_samples)
+    x = np.round(base / _RAW_ACCEL_SCALE_G_PER_LSB).astype(np.int16)
+    y = np.round(base * 0.35 / _RAW_ACCEL_SCALE_G_PER_LSB).astype(np.int16)
+    z = np.round(base * 0.15 / _RAW_ACCEL_SCALE_G_PER_LSB).astype(np.int16)
+    return np.stack([x, y, z], axis=1)
+
+
+def _phase_for_sensor(sensor: str) -> float:
+    return (sum(ord(char) for char in sensor) % 17) * 0.11
+
+
+def _effective_frequency(
+    fixture: GoldenReplayFixture,
+    *,
+    transient_active: bool,
+) -> float | None:
+    if fixture.case_id == "transient-spike" and transient_active:
+        return 50.0
+    return fixture.primary_frequency_hz
+
+
+def _sensor_amp(
+    fixture: GoldenReplayFixture,
+    *,
+    sensor: str,
+    transient_active: bool,
+) -> float:
+    if fixture.primary_frequency_hz is None and fixture.case_id != "transient-spike":
+        return 0.006 if fixture.case_id == "noisy-sensor" else 0.003
+    if fixture.case_id == "transient-spike" and not transient_active:
+        return 0.004
+    if fixture.strongest_sensor is None:
+        return fixture.transfer_amp_g
+    return fixture.signal_amp_g if sensor == fixture.strongest_sensor else fixture.transfer_amp_g
+
+
+def _peaks_for_frequency(frequency: float | None, amp: float) -> list[dict[str, float]]:
+    if frequency is None:
+        return [
+            {"hz": 37.0, "amp": amp},
+            {"hz": 55.0, "amp": amp * 0.7},
+        ]
+    peaks = [{"hz": frequency, "amp": amp}]
+    if frequency * 2.0 < 120.0:
+        peaks.append({"hz": frequency * 2.0, "amp": amp * 0.35})
+    peaks.append({"hz": 55.0, "amp": max(0.003, amp * 0.12)})
+    return peaks
+
+
+def _balanced_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="balanced-no-issue",
+        title="Balanced/no issue",
+        group="baseline",
+        seed=1001,
+        primary_frequency_hz=None,
+        strongest_sensor=None,
+        engine_rpm=None,
+        expected=GoldenReplayExpected(
+            suspected_source=None,
+            confidence_range=(0.0, 0.35),
+            max_false_positive_confidence=0.35,
+            tolerance_bands={"top_confidence": (0.0, 0.35)},
+        ),
+    )
+
+
+def _front_wheel_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="front-wheel-imbalance",
+        title="Front wheel imbalance",
+        group="wheel",
+        seed=1002,
+        primary_frequency_hz=wheel_hz(_DEFAULT_SPEED_KMH),
+        strongest_sensor="front-left",
+        expected=GoldenReplayExpected(
+            suspected_source=_WHEEL_SOURCE,
+            strongest_location="front-left",
+            confidence_range=(0.45, 0.9),
+            tolerance_bands={"frequency_hz": (9.0, 12.0), "top_confidence": (0.45, 0.9)},
+        ),
+    )
+
+
+def _rear_wheel_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="rear-wheel-imbalance",
+        title="Rear wheel imbalance",
+        group="wheel",
+        seed=1003,
+        primary_frequency_hz=wheel_hz(_DEFAULT_SPEED_KMH),
+        strongest_sensor="rear-right",
+        expected=GoldenReplayExpected(
+            suspected_source=_WHEEL_SOURCE,
+            strongest_location="rear-right",
+            confidence_range=(0.45, 0.9),
+            tolerance_bands={"frequency_hz": (9.0, 12.0), "top_confidence": (0.45, 0.9)},
+        ),
+    )
+
+
+def _driveshaft_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="driveshaft-rumble",
+        title="Driveshaft rumble",
+        group="driveline",
+        seed=1004,
+        primary_frequency_hz=wheel_hz(_DEFAULT_SPEED_KMH) * FINAL_DRIVE,
+        strongest_sensor="rear-left",
+        expected=GoldenReplayExpected(
+            suspected_source=_DRIVESHAFT_SOURCE,
+            strongest_location="rear-left",
+            confidence_range=(0.4, 0.9),
+            tolerance_bands={"frequency_hz": (29.0, 34.0), "top_confidence": (0.4, 0.9)},
+        ),
+    )
+
+
+def _engine_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="engine-harmonic",
+        title="Engine harmonic",
+        group="engine",
+        seed=1005,
+        primary_frequency_hz=_DEFAULT_ENGINE_RPM / 60.0,
+        strongest_sensor="front-left",
+        expected=GoldenReplayExpected(
+            suspected_source=_ENGINE_SOURCE,
+            strongest_location="front-left",
+            confidence_range=(0.4, 0.9),
+            tolerance_bands={"frequency_hz": (23.0, 27.0), "top_confidence": (0.4, 0.9)},
+        ),
+    )
+
+
+def _transient_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="transient-spike",
+        title="Transient spike",
+        group="transient",
+        seed=1006,
+        primary_frequency_hz=None,
+        strongest_sensor="front-left",
+        signal_amp_g=0.12,
+        transfer_amp_g=0.006,
+        engine_rpm=None,
+        final_drive_ratio=None,
+        current_gear_ratio=None,
+        expected=GoldenReplayExpected(
+            suspected_source=None,
+            confidence_range=(0.0, 0.45),
+            max_false_positive_confidence=0.45,
+            tolerance_bands={"top_confidence": (0.0, 0.45)},
+        ),
+    )
+
+
+def _noisy_sensor_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="noisy-sensor",
+        title="Noisy sensor",
+        group="data_quality",
+        seed=1007,
+        primary_frequency_hz=None,
+        strongest_sensor="front-right",
+        signal_amp_g=0.018,
+        transfer_amp_g=0.006,
+        expected=GoldenReplayExpected(
+            suspected_source=None,
+            confidence_range=(0.0, 0.45),
+            max_false_positive_confidence=0.45,
+            tolerance_bands={"top_confidence": (0.0, 0.45)},
+        ),
+    )
+
+
+def _gps_dropout_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="gps-dropout",
+        title="GPS dropout",
+        group="data_quality",
+        seed=1008,
+        primary_frequency_hz=wheel_hz(_DEFAULT_SPEED_KMH),
+        strongest_sensor="front-left",
+        speed_source="gps_unaligned",
+        expected=GoldenReplayExpected(
+            suspected_source=_WHEEL_SOURCE,
+            strongest_location="front-left",
+            confidence_range=(0.35, 0.9),
+            unavailable_reasons=("missing_speed",),
+            tolerance_bands={"missing_speed_windows_min": (1.0, 9999.0)},
+        ),
+    )
+
+
+def _missing_rpm_fixture() -> GoldenReplayFixture:
+    return GoldenReplayFixture(
+        case_id="missing-rpm",
+        title="Missing RPM",
+        group="data_quality",
+        seed=1009,
+        primary_frequency_hz=_DEFAULT_ENGINE_RPM / 60.0,
+        strongest_sensor="front-left",
+        engine_rpm=None,
+        final_drive_ratio=None,
+        current_gear_ratio=None,
+        expected=GoldenReplayExpected(
+            suspected_source=None,
+            confidence_range=(0.0, 0.45),
+            unavailable_reasons=("missing_rpm",),
+            max_false_positive_confidence=0.45,
+            tolerance_bands={"missing_rpm_windows_min": (1.0, 9999.0)},
+        ),
+    )

--- a/apps/server/tests/use_cases/run/benchmark_post_analysis_golden_replay.py
+++ b/apps/server/tests/use_cases/run/benchmark_post_analysis_golden_replay.py
@@ -1,0 +1,38 @@
+"""Opt-in benchmark for dense golden replay over a realistic 30-minute run."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from test_support.golden_replay import (
+    benchmark_golden_replay_fixture,
+    golden_replay_fixtures,
+)
+
+_REALISTIC_DURATION_S = 30 * 60
+
+
+@pytest.mark.benchmark(group="post-analysis-golden-replay")
+def test_post_analysis_golden_replay_30_minute_benchmark(benchmark: Any) -> None:
+    fixture = next(
+        fixture
+        for fixture in golden_replay_fixtures()
+        if fixture.case_id == "front-wheel-imbalance"
+    )
+
+    result = benchmark.pedantic(
+        benchmark_golden_replay_fixture,
+        args=(fixture,),
+        kwargs={"duration_s": _REALISTIC_DURATION_S},
+        iterations=1,
+        rounds=1,
+        warmup_rounds=0,
+    )
+
+    benchmark.extra_info["duration_s"] = _REALISTIC_DURATION_S
+    benchmark.extra_info["sensor_count"] = 4
+    benchmark.extra_info["peak_memory_bytes"] = result.peak_memory_bytes
+    benchmark.extra_info["elapsed_s"] = result.elapsed_s
+    assert result.result.manifest.total_window_count >= _REALISTIC_DURATION_S - 1
+    assert result.peak_memory_bytes > 0

--- a/apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from test_support.golden_replay import (
+    GoldenReplayFixture,
+    execute_golden_replay_fixture,
+    golden_replay_fixtures,
+    write_golden_replay_snapshot,
+)
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    golden_replay_fixtures(fast_ci_only=True),
+    ids=lambda fixture: fixture.case_id,
+)
+def test_post_analysis_golden_replay_fast_subset(
+    fixture: GoldenReplayFixture,
+    tmp_path: Path,
+) -> None:
+    result = execute_golden_replay_fixture(fixture)
+    snapshot_path = write_golden_replay_snapshot(
+        result=result,
+        output_dir=tmp_path / "golden-replay-artifacts",
+    )
+
+    assert snapshot_path.exists()
+    metadata = result.analysis.get("analysis_metadata")
+    assert isinstance(metadata, dict)
+    assert metadata["whole_run_artifacts_available"] is True
+    assert metadata["whole_run_context_available"] is True
+    assert result.manifest.total_window_count > 0
+    assert result.manifest.source_raw_manifests
+    assert result.manifest.algorithm_versions
+    assert result.manifest.generated_artifact_paths
+    _assert_expected_outcome(fixture, result.analysis)
+
+
+def test_golden_replay_fixture_catalog_covers_required_scenarios() -> None:
+    fixtures = golden_replay_fixtures()
+
+    assert [fixture.case_id for fixture in fixtures] == [
+        "balanced-no-issue",
+        "front-wheel-imbalance",
+        "rear-wheel-imbalance",
+        "driveshaft-rumble",
+        "engine-harmonic",
+        "transient-spike",
+        "noisy-sensor",
+        "gps-dropout",
+        "missing-rpm",
+    ]
+    assert all(fixture.seed > 0 for fixture in fixtures)
+    assert all(fixture.expected.tolerance_bands is not None for fixture in fixtures)
+
+
+def _assert_expected_outcome(
+    fixture: GoldenReplayFixture,
+    analysis: dict[str, object],
+) -> None:
+    top = _top_cause(analysis)
+    expected = fixture.expected
+    if expected.suspected_source is not None:
+        assert top is not None
+        assert top.get("suspected_source") == expected.suspected_source
+        if expected.strongest_location is not None:
+            assert top.get("strongest_location") == expected.strongest_location
+        confidence = float(top.get("confidence", 0.0))
+        assert expected.confidence_range[0] <= confidence <= expected.confidence_range[1]
+    elif top is not None and expected.max_false_positive_confidence is not None:
+        assert float(top.get("confidence", 0.0)) <= expected.max_false_positive_confidence
+
+    metadata = analysis.get("analysis_metadata")
+    assert isinstance(metadata, dict)
+    for reason in expected.unavailable_reasons:
+        if reason == "missing_speed":
+            assert int(metadata.get("whole_run_context_missing_speed_window_count", 0)) > 0
+        if reason == "missing_rpm":
+            assert int(metadata.get("whole_run_context_missing_rpm_window_count", 0)) > 0
+
+
+def _top_cause(analysis: dict[str, object]) -> dict[str, Any] | None:
+    top_causes = analysis.get("top_causes")
+    if not isinstance(top_causes, list) or not top_causes:
+        return None
+    top = top_causes[0]
+    assert isinstance(top, dict)
+    return top

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,7 @@
 - Use `make test-ci-fast` for lint, docs, static guards, and type checks without browser, release, firmware, e2e, or backend test suites.
 - Use `make test-ci-lite` for the larger non-Docker workflow surface except e2e; it still includes backend shards, UI smoke, release smoke, and firmware native tests.
 - Local `shell-lint` parity requires host `shellcheck`; `make doctor` reports it, and ACT/GitHub CI install it inside the workflow job.
-- Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
+- Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file. Use `make benchmark-golden-replay` for the opt-in 30-minute dense post-run golden replay runtime/memory check. For direct `--benchmark-only` pytest runs, add `-o addopts=''` so the default xdist addopts do not disable benchmark mode.
 - Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
 - The full end-to-end verification runner is `make test-full-suite` (`./.venv/bin/python tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
 - `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time. It also accepts `--xdist-workers` / `VIBESENSOR_BACKEND_XDIST_WORKERS` for controlled intra-shard xdist; CI currently pins that to `3` because the current five-shard benchmark beat the nearby `5x2`, `4x3`, `4x2`, and `6x2` alternatives without changing shard count or the failure/JUnit surface. Retune only from fresh measurements, not guesswork.
@@ -128,6 +128,9 @@ make plan-validation
 # Changed-file heuristic (current branch vs origin/main, fallback to main)
 make test-changed
 
+# Generated dense post-run golden replay subset
+make test-golden-replay
+
 # Fast iteration — backend unit tests
 make test
 
@@ -140,6 +143,7 @@ make test-all
 
 # Explicit backend benchmarks
 make benchmark-backend BENCHMARK_OPTS="--benchmark-save=baseline"
+make benchmark-golden-replay BENCHMARK_OPTS="--benchmark-save=golden-replay"
 make benchmark-compare-backend
 
 # GitHub workflow via act (requires Docker); default wrapper is changed-scope
@@ -160,6 +164,14 @@ Explicit backend benchmark files stay out of default CI and normal pytest
 discovery so the blocking lanes do not turn noisy or hardware-sensitive.
 Run them on demand when you need regression evidence and save comparison data
 for later runs with `make benchmark-backend` / `make benchmark-compare-backend`.
+The generated dense post-run golden replay fixtures live in
+`apps/server/tests/test_support/golden_replay.py`; they avoid binary payloads by
+building deterministic raw waveforms and summary context from fixture seeds. Add
+new cases by extending the fixture catalog with expected source, confidence
+range, unavailable context reasons, and tolerance bands, then run
+`make test-golden-replay`. Use `make benchmark-golden-replay` for the opt-in
+30-minute dense replay benchmark. Failed golden runs write compact JSON
+snapshots under the pytest temp directory for debugging.
 
 Focused CI job groups and full-stack validation:
 


### PR DESCRIPTION
Fixes #3723

What changed:
- Added generated dense golden replay fixtures for balanced/no issue, front/rear wheel imbalance, driveshaft rumble, engine harmonic, transient spike, noisy sensor, GPS dropout, and missing RPM.
- Added a replay harness that feeds deterministic generated raw capture and summary rows through execute_post_analysis and dense sidecar stages.
- Added fast default golden replay tests with expected source, confidence, unavailable-reason, tolerance, and artifact/provenance assertions.
- Added an opt-in 30-minute, 4-sensor benchmark target that measures dense replay runtime and peak memory without large binary fixtures.
- Documented how to add golden replay cases and added Make targets.

Why:
- Protect dense post-run analysis from silent regressions using generated captured-like runs instead of large committed fixtures.

Validation:
- PATH="$PWD/.venv/bin:$PATH" make test-golden-replay
- PATH="$PWD/.venv/bin:$PATH" make benchmark-golden-replay BENCHMARK_OPTS="--benchmark-columns=min,mean,rounds"
- PATH="$PWD/.venv/bin:$PATH" make lint
- make typecheck-backend
- make test-changed

Risks / tradeoffs / edge cases:
- Golden fixtures are generated, not captured binaries. This keeps git small and deterministic but does not replace future real-world captured baselines.
- The benchmark isolates dense replay/executor sidecar work with a minimal report summary so the legacy summary analyzer does not dominate or timeout the dense benchmark.
- Fast tests exercise the real executor path; benchmark remains opt-in because 30-minute replay takes about a minute locally.

Follow-ups:
- Add captured-field golden fixtures later if the project accepts small sanitized captures.