### PR TITLE
Suppress road-shock transient windows

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -159,6 +159,21 @@ def test_build_report_document_projects_limited_window_quality_caveat() -> None:
     )
 
 
+def test_build_report_document_projects_shock_window_caveat() -> None:
+    summary = _dense_summary(
+        order_summary_overrides={
+            "reference_coverage_ratio": 1.0,
+            "mean_quality_score": 0.62,
+            "limited_window_count": 3,
+            "excluded_window_count": 2,
+            "shock_transient_window_count": 2,
+        }
+    )
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.appendix_c.dense_evidence_rows[0].caveat == ("Road-shock windows filtered: 2")
+
+
 def test_build_report_document_skips_dense_evidence_when_artifacts_are_unavailable() -> None:
     document = build_report_document(prepare_report_input(minimal_summary()))
 

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -223,6 +223,7 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
             "usable_window_count": 5,
             "limited_window_count": 1,
             "excluded_window_count": 0,
+            "shock_transient_window_count": 0,
             "mean_quality_score": 0.92,
             "support_intervals": [
                 {

--- a/apps/server/tests/shared/test_window_quality.py
+++ b/apps/server/tests/shared/test_window_quality.py
@@ -3,21 +3,26 @@ from __future__ import annotations
 from math import pi
 
 import numpy as np
+import pytest
 
 from vibesensor.shared.window_quality import score_window_quality, window_quality_with_context
 
 
-def test_window_quality_scores_clean_window_as_usable() -> None:
+def _sine_samples(*, sample_count: int = 256, amplitude: float = 0.05) -> np.ndarray:
     sample_rate_hz = 256
-    sample_count = 256
     t = np.arange(sample_count, dtype=np.float32) / float(sample_rate_hz)
-    samples_g = np.column_stack(
+    return np.column_stack(
         [
-            0.05 * np.sin(2.0 * pi * 20.0 * t),
+            amplitude * np.sin(2.0 * pi * 20.0 * t),
             np.zeros(sample_count, dtype=np.float32),
             np.zeros(sample_count, dtype=np.float32),
         ]
     )
+
+
+def test_window_quality_scores_clean_window_as_usable() -> None:
+    sample_count = 256
+    samples_g = _sine_samples(sample_count=sample_count)
 
     quality = score_window_quality(
         expected_sample_count=sample_count,
@@ -30,6 +35,8 @@ def test_window_quality_scores_clean_window_as_usable() -> None:
 
     assert quality.state == "usable"
     assert quality.score > 0.95
+    assert quality.shock_broadband_ratio is not None
+    assert quality.shock_broadband_ratio < 0.15
     assert quality.reasons == ()
 
 
@@ -92,3 +99,66 @@ def test_window_quality_context_downgrades_missing_speed_and_rpm() -> None:
     assert quality.state == "limited"
     assert quality.context_score < 0.5
     assert "context_unavailable" in quality.reasons
+
+
+@pytest.mark.parametrize(
+    ("samples_g", "expected_state"),
+    [
+        pytest.param(_sine_samples(), "usable", id="sustained-sine"),
+        pytest.param(
+            np.pad(
+                np.array([[18.0, 0.0, 0.0]], dtype=np.float32),
+                ((127, 128), (0, 0)),
+            ),
+            "excluded",
+            id="impulse-only",
+        ),
+        pytest.param(
+            _sine_samples(amplitude=0.04)
+            + np.pad(
+                np.array([[8.0, 0.0, 0.0]], dtype=np.float32),
+                ((127, 128), (0, 0)),
+            ),
+            "excluded",
+            id="sine-plus-impulse",
+        ),
+        pytest.param(
+            np.pad(
+                np.array(
+                    [
+                        [5.0, 0.0, 0.0],
+                        [-4.0, 2.0, 0.0],
+                        [3.5, -3.0, 1.0],
+                        [-5.5, 0.0, 2.0],
+                    ],
+                    dtype=np.float32,
+                ),
+                ((40, 212), (0, 0)),
+            ),
+            "excluded",
+            id="repeated-rough-road-bursts",
+        ),
+    ],
+)
+def test_window_quality_distinguishes_shock_transients_from_sustained_vibration(
+    samples_g: np.ndarray,
+    expected_state: str,
+) -> None:
+    quality = score_window_quality(
+        expected_sample_count=samples_g.shape[0],
+        returned_sample_count=samples_g.shape[0],
+        coverage_state="full",
+        samples_g=samples_g,
+        peak_amp_g=0.1,
+        noise_floor_amp_g=0.01,
+    )
+
+    assert quality.state == expected_state
+    assert quality.shock_crest_factor is not None
+    assert quality.shock_broadband_ratio is not None
+    if expected_state == "excluded":
+        assert "shock_transient" in quality.reasons
+        assert quality.transient_score < 0.25
+    else:
+        assert "shock_transient" not in quality.reasons
+        assert quality.transient_score > 0.90

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -261,6 +261,7 @@ def test_history_order_trace_response_contracts_expose_named_summary_fields() ->
         "usable_window_count",
         "limited_window_count",
         "excluded_window_count",
+        "shock_transient_window_count",
         "mean_quality_score",
         "support_intervals",
         "phase_support",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 from test_support.report_helpers import diagnostics_context, wheel_metadata
 from test_support.sample_scenarios import make_analysis_sample
 
@@ -11,6 +12,7 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunContextWindowLabel,
     WholeRunWindowPolicy,
 )
+from vibesensor.shared.window_quality import WindowQuality, score_window_quality
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
     build_whole_run_order_trace_artifact_bundle,
@@ -104,7 +106,24 @@ def _context_sample(window_index: int, *, speed_kmh: float, engine_rpm: float):
     )
 
 
-def _summary_rows(*, sensor_scale: float) -> tuple[WholeRunWindowSpectralSummary, ...]:
+def _shock_window_quality() -> WindowQuality:
+    samples_g = np.zeros((256, 3), dtype=np.float32)
+    samples_g[128, 0] = 18.0
+    return score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=256,
+        coverage_state="full",
+        samples_g=samples_g,
+        peak_amp_g=0.2,
+        noise_floor_amp_g=0.01,
+    )
+
+
+def _summary_rows(
+    *,
+    sensor_scale: float,
+    window_quality_by_index: dict[int, WindowQuality] | None = None,
+) -> tuple[WholeRunWindowSpectralSummary, ...]:
     metadata = _metadata()
     rows: list[WholeRunWindowSpectralSummary] = []
     for label in _context_labels():
@@ -167,6 +186,21 @@ def _summary_rows(*, sensor_scale: float) -> tuple[WholeRunWindowSpectralSummary
                 strength_floor_amp_g=0.01,
                 strength_bucket="l3",
                 top_peaks=tuple(peaks),
+                window_quality=(
+                    window_quality_by_index.get(label.window_index)
+                    if window_quality_by_index is not None
+                    else None
+                )
+                or WindowQuality(
+                    score=1.0,
+                    state="usable",
+                    sample_completeness_score=1.0,
+                    packet_integrity_score=1.0,
+                    clipping_score=1.0,
+                    transient_score=1.0,
+                    context_score=1.0,
+                    frequency_stability_score=1.0,
+                ),
             )
         )
     return tuple(rows)
@@ -179,6 +213,18 @@ def _artifact_contents() -> dict[str, bytes]:
         ),
         "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
             _summary_rows(sensor_scale=0.08)
+        ),
+    }
+
+
+def _artifact_contents_with_shock_window(window_index: int) -> dict[str, bytes]:
+    quality = _shock_window_quality()
+    return {
+        "spectral-summary:sensor-front": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(sensor_scale=0.14, window_quality_by_index={window_index: quality})
+        ),
+        "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(sensor_scale=0.08, window_quality_by_index={window_index: quality})
         ),
     }
 
@@ -229,6 +275,31 @@ def test_build_whole_run_order_trace_artifact_bundle_emits_supported_candidate_t
     assert all(point.eligible for point in wheel_1x)
     assert all(point.matched for point in wheel_1x)
     assert all(point.strongest_location == "front-left" for point in wheel_1x)
+
+
+def test_build_whole_run_order_trace_artifact_bundle_suppresses_shock_windows() -> None:
+    bundle = build_whole_run_order_trace_artifact_bundle(
+        run_id="run-order-traces",
+        metadata=_metadata(),
+        spectral_manifest=_spectral_manifest(),
+        spectral_artifact_contents=_artifact_contents_with_shock_window(1),
+        context_labels=_context_labels(),
+        samples=_samples(),
+    )
+
+    wheel_1x_by_window = {
+        point.window_index: point
+        for point in bundle.points
+        if point.hypothesis_key == "wheel_1x" and point.harmonic == 1
+    }
+
+    shock_point = wheel_1x_by_window[1]
+    assert shock_point.eligible
+    assert not shock_point.matched
+    assert shock_point.window_quality_state == "excluded"
+    assert "shock_transient" in shock_point.window_quality_reasons
+    assert wheel_1x_by_window[0].matched
+    assert wheel_1x_by_window[2].matched
 
 
 def test_build_whole_run_order_trace_artifact_bundle_is_deterministic() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
@@ -61,6 +61,24 @@ def _point(window_index: int, *, quality_score: float, quality_state: str) -> Or
     )
 
 
+def _shock_point(window_index: int) -> OrderTracePoint:
+    return OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=window_index,
+        eligible=True,
+        matched=False,
+        predicted_hz=8.0 + window_index,
+        ref_source="speed+tire",
+        window_quality_score=0.12,
+        window_quality_state="excluded",
+        window_quality_reasons=("shock_transient",),
+    )
+
+
 def test_order_trace_scoring_records_and_downweights_limited_window_quality() -> None:
     context_labels = _context_labels()
     clean_summary = summarize_whole_run_order_traces(
@@ -82,3 +100,18 @@ def test_order_trace_scoring_records_and_downweights_limited_window_quality() ->
     assert limited_summary.limited_window_count == 1
     assert limited_summary.mean_quality_score == 0.75
     assert limited_summary.lock_score < clean_summary.lock_score
+
+
+def test_order_trace_scoring_counts_unmatched_shock_windows() -> None:
+    summary = summarize_whole_run_order_traces(
+        points=(
+            _point(0, quality_score=1.0, quality_state="usable"),
+            _shock_point(1),
+        ),
+        context_labels=_context_labels(),
+    )[0]
+
+    assert summary.matched_window_count == 1
+    assert summary.excluded_window_count == 1
+    assert summary.shock_transient_window_count == 1
+    assert summary.mean_quality_score == 0.56

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2275,6 +2275,10 @@
     "en": "Reference coverage {pct}",
     "nl": "Referentiedekking {pct}"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS": {
+    "en": "Road-shock windows filtered: {count}",
+    "nl": "Wegschokvensters gefilterd: {count}"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_WINDOW_QUALITY_LIMITED": {
     "en": "Usable window quality {pct}; limited {limited}, excluded {excluded}",
     "nl": "Bruikbare vensterkwaliteit {pct}; beperkt {limited}, uitgesloten {excluded}"

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -148,6 +148,7 @@ class ReportWholeRunOrderSummary:
     usable_window_count: int
     limited_window_count: int
     excluded_window_count: int
+    shock_transient_window_count: int
     mean_quality_score: float | None
     support_intervals: tuple[ReportOrderTraceSupportInterval, ...]
     phase_support: tuple[ReportOrderTracePhaseSupport, ...]
@@ -669,6 +670,7 @@ _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
         _count_field("usable_window_count"),
         _count_field("limited_window_count"),
         _count_field("excluded_window_count"),
+        _count_field("shock_transient_window_count"),
         _float_field("mean_quality_score"),
         _rows_field("support_intervals", _ORDER_SUPPORT_INTERVAL_DECODER),
         _rows_field("phase_support", _ORDER_PHASE_SUPPORT_DECODER),

--- a/apps/server/vibesensor/shared/fft_analysis.py
+++ b/apps/server/vibesensor/shared/fft_analysis.py
@@ -32,6 +32,7 @@ __all__ = [
     "SpectralAnalysisComputer",
     "SpectrumAxisData",
     "SpectrumByAxis",
+    "broadband_energy_ratio",
     "compute_fft_spectrum",
     "fft_frequency_slice",
     "fft_window_values",
@@ -279,6 +280,33 @@ def float_list(values: FloatArray | list[float]) -> list[float]:
         )
         return sanitized.ravel().tolist()
     return [float(v) if _isfinite(v) else 0.0 for v in values]
+
+
+def broadband_energy_ratio(
+    fft_block: FloatArray,
+    *,
+    top_bin_count: int = 3,
+) -> float | None:
+    """Return broadband energy share outside the strongest spectral bins."""
+
+    if fft_block.ndim != 2 or fft_block.shape[1] < 8:
+        return None
+    sanitized = _sanitize_float_array(fft_block)
+    centered = sanitized - np.mean(sanitized, axis=1, keepdims=True)
+    spectrum = scipy_fft.rfft(centered, axis=1)
+    magnitude = np.abs(spectrum).astype(np.float64, copy=False)
+    power_by_bin = np.sum(magnitude * magnitude, axis=0)
+    if power_by_bin.size <= 1:
+        return None
+    power = power_by_bin[1:]
+    total_power = float(np.sum(power))
+    if not math.isfinite(total_power) or total_power <= 1e-18:
+        return None
+    top_count = min(max(1, top_bin_count), power.size)
+    top_power = float(np.sum(np.partition(power, -top_count)[-top_count:]))
+    if not math.isfinite(top_power):
+        return None
+    return max(0.0, min(1.0, 1.0 - (top_power / total_power)))
 
 
 def compute_fft_spectrum(

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -316,6 +316,7 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     usable_window_count: Required[int]
     limited_window_count: Required[int]
     excluded_window_count: Required[int]
+    shock_transient_window_count: Required[int]
     mean_quality_score: float | None
     support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
     phase_support: Required[list[OrderTracePhaseSupportResponse]]

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -66,6 +66,8 @@ class WindowQualityPayload(TypedDict):
     packet_integrity_score: float
     clipping_score: float
     transient_score: float
+    shock_crest_factor: float | None
+    shock_broadband_ratio: float | None
     context_score: float
     frequency_stability_score: float
     reasons: list[str]

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -45,6 +45,15 @@ _CLIPPING_FULL_SCALE_I16 = 32760
 _CLIPPING_EXCLUDED_RATIO = 0.01
 _CREST_FACTOR_CLEAN = 6.0
 _CREST_FACTOR_EXCLUDED = 12.0
+_BROADBAND_RATIO_CLEAN = 0.55
+_BROADBAND_RATIO_EXCLUDED = 0.82
+
+
+@dataclass(frozen=True, slots=True)
+class _TransientAnalysis:
+    score: float
+    crest_factor: float | None
+    broadband_ratio: float | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,6 +68,8 @@ class WindowQuality:
     transient_score: float
     context_score: float
     frequency_stability_score: float
+    shock_crest_factor: float | None = None
+    shock_broadband_ratio: float | None = None
     reasons: tuple[WindowQualityReason, ...] = ()
 
     def to_payload(self) -> WindowQualityPayload:
@@ -69,6 +80,8 @@ class WindowQuality:
             "packet_integrity_score": self.packet_integrity_score,
             "clipping_score": self.clipping_score,
             "transient_score": self.transient_score,
+            "shock_crest_factor": self.shock_crest_factor,
+            "shock_broadband_ratio": self.shock_broadband_ratio,
             "context_score": self.context_score,
             "frequency_stability_score": self.frequency_stability_score,
             "reasons": list(self.reasons),
@@ -82,6 +95,8 @@ class WindowQuality:
             "packet_integrity_score": self.packet_integrity_score,
             "clipping_score": self.clipping_score,
             "transient_score": self.transient_score,
+            "shock_crest_factor": self.shock_crest_factor,
+            "shock_broadband_ratio": self.shock_broadband_ratio,
             "context_score": self.context_score,
             "frequency_stability_score": self.frequency_stability_score,
             "reasons": list(self.reasons),
@@ -113,6 +128,8 @@ class WindowQuality:
             ),
             clipping_score=_score_from_json(data.get("clipping_score"), default=1.0),
             transient_score=_score_from_json(data.get("transient_score"), default=1.0),
+            shock_crest_factor=_nonnegative_float_from_json(data.get("shock_crest_factor")),
+            shock_broadband_ratio=_optional_score_from_json(data.get("shock_broadband_ratio")),
             context_score=_score_from_json(data.get("context_score"), default=1.0),
             frequency_stability_score=_score_from_json(
                 data.get("frequency_stability_score"),
@@ -160,7 +177,7 @@ def score_window_quality(
         coverage_reason=coverage_reason,
     )
     clipping_score = _clipping_score(samples_i16)
-    transient_score = _transient_score(samples_g)
+    transient_analysis = _transient_analysis(samples_g)
     context_score = _context_score(
         context_coverage=context_coverage,
         speed_validity=speed_validity,
@@ -174,7 +191,9 @@ def score_window_quality(
         sample_completeness_score=sample_score,
         packet_integrity_score=packet_score,
         clipping_score=clipping_score,
-        transient_score=transient_score,
+        transient_score=transient_analysis.score,
+        shock_crest_factor=transient_analysis.crest_factor,
+        shock_broadband_ratio=transient_analysis.broadband_ratio,
         context_score=context_score,
         frequency_stability_score=frequency_score,
     )
@@ -194,6 +213,8 @@ def window_quality_with_context(
         packet_integrity_score=quality.packet_integrity_score,
         clipping_score=quality.clipping_score,
         transient_score=quality.transient_score,
+        shock_crest_factor=quality.shock_crest_factor,
+        shock_broadband_ratio=quality.shock_broadband_ratio,
         context_score=_context_score(
             context_coverage=context_coverage,
             speed_validity=speed_validity,
@@ -209,6 +230,8 @@ def _quality_from_component_scores(
     packet_integrity_score: float,
     clipping_score: float,
     transient_score: float,
+    shock_crest_factor: float | None = None,
+    shock_broadband_ratio: float | None = None,
     context_score: float,
     frequency_stability_score: float,
 ) -> WindowQuality:
@@ -259,6 +282,8 @@ def _quality_from_component_scores(
         transient_score=transient_score,
         context_score=context_score,
         frequency_stability_score=frequency_stability_score,
+        shock_crest_factor=shock_crest_factor,
+        shock_broadband_ratio=shock_broadband_ratio,
         reasons=tuple(dict.fromkeys(reasons)),
     )
 
@@ -296,25 +321,66 @@ def _clipping_score(samples_i16: np.ndarray | None) -> float:
     return _clamp01(1.0 - (ratio / _CLIPPING_EXCLUDED_RATIO))
 
 
-def _transient_score(samples_g: np.ndarray | None) -> float:
+def _transient_analysis(samples_g: np.ndarray | None) -> _TransientAnalysis:
     if samples_g is None or samples_g.size == 0:
-        return 1.0
+        return _TransientAnalysis(score=1.0, crest_factor=None, broadband_ratio=None)
     samples = _time_axis_samples(samples_g)
     if samples.size == 0:
-        return 1.0
+        return _TransientAnalysis(score=1.0, crest_factor=None, broadband_ratio=None)
     detrended = samples - np.mean(samples, axis=0, keepdims=True)
     magnitude = np.linalg.norm(detrended, axis=1)
     rms = float(np.sqrt(np.mean(np.square(magnitude, dtype=np.float64))))
     if not isfinite(rms) or rms <= 1e-12:
-        return 1.0
+        return _TransientAnalysis(score=1.0, crest_factor=None, broadband_ratio=None)
     peak = float(np.max(np.abs(magnitude)))
     crest = peak / rms
+    crest_score = _crest_factor_score(crest)
+    broadband_ratio = _broadband_energy_ratio(detrended)
+    broadband_score = _broadband_ratio_score(broadband_ratio)
+    return _TransientAnalysis(
+        score=min(crest_score, broadband_score),
+        crest_factor=crest,
+        broadband_ratio=broadband_ratio,
+    )
+
+
+def _crest_factor_score(crest: float) -> float:
     if crest <= _CREST_FACTOR_CLEAN:
         return 1.0
     if crest >= _CREST_FACTOR_EXCLUDED:
         return 0.0
     transient_range = _CREST_FACTOR_EXCLUDED - _CREST_FACTOR_CLEAN
     return _clamp01((_CREST_FACTOR_EXCLUDED - crest) / transient_range)
+
+
+def _broadband_energy_ratio(samples: np.ndarray) -> float | None:
+    if samples.shape[0] < 8:
+        return None
+    spectrum = np.fft.rfft(samples, axis=0)
+    magnitude = np.abs(spectrum).astype(np.float64, copy=False)
+    power_by_bin = np.sum(magnitude * magnitude, axis=1)
+    if power_by_bin.size <= 1:
+        return None
+    power = power_by_bin[1:]
+    total_power = float(np.sum(power))
+    if not isfinite(total_power) or total_power <= 1e-18:
+        return None
+    top_count = min(3, power.size)
+    top_power = float(np.sum(np.partition(power, -top_count)[-top_count:]))
+    if not isfinite(top_power):
+        return None
+    return _clamp01(1.0 - (top_power / total_power))
+
+
+def _broadband_ratio_score(ratio: float | None) -> float:
+    if ratio is None:
+        return 1.0
+    if ratio <= _BROADBAND_RATIO_CLEAN:
+        return 1.0
+    if ratio >= _BROADBAND_RATIO_EXCLUDED:
+        return 0.0
+    transient_range = _BROADBAND_RATIO_EXCLUDED - _BROADBAND_RATIO_CLEAN
+    return _clamp01((_BROADBAND_RATIO_EXCLUDED - ratio) / transient_range)
 
 
 def _time_axis_samples(samples: np.ndarray) -> np.ndarray:
@@ -372,6 +438,18 @@ def _score_from_json(value: object, *, default: float) -> float:
     if isinstance(value, int | float) and not isinstance(value, bool) and isfinite(float(value)):
         return _clamp01(float(value))
     return default
+
+
+def _optional_score_from_json(value: object) -> float | None:
+    if isinstance(value, int | float) and not isinstance(value, bool) and isfinite(float(value)):
+        return _clamp01(float(value))
+    return None
+
+
+def _nonnegative_float_from_json(value: object) -> float | None:
+    if isinstance(value, int | float) and not isinstance(value, bool) and isfinite(float(value)):
+        return max(0.0, float(value))
+    return None
 
 
 def _state_or_default(value: object, *, default: WindowQualityState) -> WindowQualityState:

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import numpy as np
 
+from vibesensor.shared.fft_analysis import broadband_energy_ratio
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.payload_types import WindowQualityPayload
 
@@ -335,7 +336,7 @@ def _transient_analysis(samples_g: np.ndarray | None) -> _TransientAnalysis:
     peak = float(np.max(np.abs(magnitude)))
     crest = peak / rms
     crest_score = _crest_factor_score(crest)
-    broadband_ratio = _broadband_energy_ratio(detrended)
+    broadband_ratio = broadband_energy_ratio(detrended.T.astype(np.float32, copy=False))
     broadband_score = _broadband_ratio_score(broadband_ratio)
     return _TransientAnalysis(
         score=min(crest_score, broadband_score),
@@ -351,25 +352,6 @@ def _crest_factor_score(crest: float) -> float:
         return 0.0
     transient_range = _CREST_FACTOR_EXCLUDED - _CREST_FACTOR_CLEAN
     return _clamp01((_CREST_FACTOR_EXCLUDED - crest) / transient_range)
-
-
-def _broadband_energy_ratio(samples: np.ndarray) -> float | None:
-    if samples.shape[0] < 8:
-        return None
-    spectrum = np.fft.rfft(samples, axis=0)
-    magnitude = np.abs(spectrum).astype(np.float64, copy=False)
-    power_by_bin = np.sum(magnitude * magnitude, axis=1)
-    if power_by_bin.size <= 1:
-        return None
-    power = power_by_bin[1:]
-    total_power = float(np.sum(power))
-    if not isfinite(total_power) or total_power <= 1e-18:
-        return None
-    top_count = min(3, power.size)
-    top_power = float(np.sum(np.partition(power, -top_count)[-top_count:]))
-    if not isfinite(top_power):
-        return None
-    return _clamp01(1.0 - (top_power / total_power))
 
 
 def _broadband_ratio_score(ratio: float | None) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -311,6 +311,7 @@ class OrderTraceSummary:
     usable_window_count: int = 0
     limited_window_count: int = 0
     excluded_window_count: int = 0
+    shock_transient_window_count: int = 0
     mean_quality_score: float | None = None
     support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
     phase_support: tuple[OrderTracePhaseSupport, ...] = ()
@@ -343,6 +344,10 @@ class OrderTraceSummary:
         _require_nonnegative(self.usable_window_count, field_name="usable_window_count")
         _require_nonnegative(self.limited_window_count, field_name="limited_window_count")
         _require_nonnegative(self.excluded_window_count, field_name="excluded_window_count")
+        _require_nonnegative(
+            self.shock_transient_window_count,
+            field_name="shock_transient_window_count",
+        )
         _require_ratio(self.support_ratio, field_name="support_ratio")
         _require_ratio(self.reference_coverage_ratio, field_name="reference_coverage_ratio")
         _require_ratio(self.contiguous_support_ratio, field_name="contiguous_support_ratio")
@@ -367,6 +372,7 @@ class OrderTraceSummary:
             "usable_window_count": self.usable_window_count,
             "limited_window_count": self.limited_window_count,
             "excluded_window_count": self.excluded_window_count,
+            "shock_transient_window_count": self.shock_transient_window_count,
             "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
             "phase_support": [row.to_json_object() for row in self.phase_support],
             "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
@@ -408,6 +414,9 @@ class OrderTraceSummary:
             usable_window_count=_optional_int(data.get("usable_window_count")) or 0,
             limited_window_count=_optional_int(data.get("limited_window_count")) or 0,
             excluded_window_count=_optional_int(data.get("excluded_window_count")) or 0,
+            shock_transient_window_count=(
+                _optional_int(data.get("shock_transient_window_count")) or 0
+            ),
             mean_quality_score=_optional_float(data.get("mean_quality_score")),
             support_intervals=_tuple_from_mapping_list_field(
                 data,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -199,6 +199,13 @@ def _family_summary(
     excluded_window_count = sum(
         summary.excluded_window_count for summary in ordered_candidate_summaries
     )
+    shock_transient_window_count = len(
+        {
+            point.window_index
+            for point in points
+            if "shock_transient" in point.window_quality_reasons
+        }
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=1.0,
@@ -277,6 +284,7 @@ def _family_summary(
         usable_window_count=usable_window_count,
         limited_window_count=limited_window_count,
         excluded_window_count=excluded_window_count,
+        shock_transient_window_count=shock_transient_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -185,14 +185,15 @@ def _summarize_hypothesis_trace(
     mean_relative_error = _mean(relative_errors)
     relative_error_stddev = _stddev(relative_errors)
     quality_scores = [
-        point.window_quality_score
-        for point in matched_points
-        if point.window_quality_score is not None
+        point.window_quality_score for point in points if point.window_quality_score is not None
     ]
     mean_quality_score = _mean(quality_scores)
     usable_window_count = sum(1 for point in points if point.window_quality_state == "usable")
     limited_window_count = sum(1 for point in points if point.window_quality_state == "limited")
     excluded_window_count = sum(1 for point in points if point.window_quality_state == "excluded")
+    shock_transient_window_count = sum(
+        1 for point in points if "shock_transient" in point.window_quality_reasons
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=hypothesis.path_compliance if hypothesis is not None else 1.0,
@@ -273,6 +274,7 @@ def _summarize_hypothesis_trace(
         usable_window_count=usable_window_count,
         limited_window_count=limited_window_count,
         excluded_window_count=excluded_window_count,
+        shock_transient_window_count=shock_transient_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=(),
         phase_support=(),

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -157,6 +157,11 @@ def _hypothesis_trace_points(
     for sample, label in zip(window_inputs, context_labels, strict=True):
         predicted_hz, ref_source = hypothesis.predicted_hz(sample, metadata, tire_circumference_m)
         eligible = predicted_hz is not None and predicted_hz > 0
+        window_quality = _representative_window_quality(
+            summaries_by_sensor=summaries_by_sensor,
+            window_index=label.window_index,
+            context_label=label,
+        )
         sensor_match = (
             _best_sensor_peak_match(
                 summaries_by_sensor=summaries_by_sensor,
@@ -168,6 +173,9 @@ def _hypothesis_trace_points(
             )
             if eligible and predicted_hz is not None
             else None
+        )
+        evidence_quality = (
+            sensor_match.window_quality if sensor_match is not None else window_quality
         )
         points.append(
             OrderTracePoint(
@@ -191,17 +199,44 @@ def _hypothesis_trace_points(
                 ref_source=ref_source or None,
                 strongest_location=(sensor_match.location if sensor_match is not None else None),
                 window_quality_score=(
-                    sensor_match.window_quality.score if sensor_match is not None else None
+                    evidence_quality.score if evidence_quality is not None else None
                 ),
                 window_quality_state=(
-                    sensor_match.window_quality.state if sensor_match is not None else None
+                    evidence_quality.state if evidence_quality is not None else None
                 ),
                 window_quality_reasons=(
-                    sensor_match.window_quality.reasons if sensor_match is not None else ()
+                    evidence_quality.reasons if evidence_quality is not None else ()
                 ),
             )
         )
     return tuple(points)
+
+
+def _representative_window_quality(
+    *,
+    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
+    window_index: int,
+    context_label: WholeRunContextWindowLabel,
+) -> WindowQuality | None:
+    qualities: list[WindowQuality] = []
+    for client_id in sorted(summaries_by_sensor):
+        summaries = summaries_by_sensor[client_id]
+        if window_index < 0 or window_index >= len(summaries):
+            continue
+        summary = summaries[window_index]
+        if summary.coverage_state != "full":
+            continue
+        qualities.append(
+            window_quality_with_context(
+                summary.window_quality,
+                context_coverage=context_label.context_coverage,
+                speed_validity=context_label.speed_validity,
+                rpm_validity=context_label.rpm_validity,
+            )
+        )
+    if not qualities:
+        return None
+    return min(qualities, key=lambda quality: quality.score)
 
 
 def _best_sensor_peak_match(

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -182,6 +182,11 @@ def _dense_caveat_text(
             "REPORT_DENSE_EVIDENCE_CAVEAT_REFERENCE_PARTIAL",
             pct=f"{summary.reference_coverage_ratio * 100:.0f}%",
         )
+    if summary.shock_transient_window_count > 0:
+        return tr(
+            "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS",
+            count=str(summary.shock_transient_window_count),
+        )
     if summary.mean_quality_score is not None and (
         summary.mean_quality_score < 0.75
         or summary.limited_window_count > 0

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -6314,6 +6314,10 @@
             ],
             "title": "Relative Error Stddev"
           },
+          "shock_transient_window_count": {
+            "title": "Shock Transient Window Count",
+            "type": "integer"
+          },
           "stable_frequency_max_hz": {
             "anyOf": [
               {
@@ -6386,6 +6390,7 @@
           "usable_window_count",
           "limited_window_count",
           "excluded_window_count",
+          "shock_transient_window_count",
           "support_intervals",
           "phase_support",
           "harmonic_summaries",
@@ -9479,6 +9484,28 @@
             "title": "Score",
             "type": "number"
           },
+          "shock_broadband_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shock Broadband Ratio"
+          },
+          "shock_crest_factor": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shock Crest Factor"
+          },
           "state": {
             "title": "State",
             "type": "string"
@@ -9495,6 +9522,8 @@
           "packet_integrity_score",
           "clipping_score",
           "transient_score",
+          "shock_crest_factor",
+          "shock_broadband_ratio",
           "context_score",
           "frequency_stability_score",
           "reasons"

--- a/apps/ui/src/contracts/ws_payload_schema.json
+++ b/apps/ui/src/contracts/ws_payload_schema.json
@@ -536,6 +536,28 @@
           "title": "Score",
           "type": "number"
         },
+        "shock_broadband_ratio": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Shock Broadband Ratio"
+        },
+        "shock_crest_factor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Shock Crest Factor"
+        },
         "state": {
           "title": "State",
           "type": "string"
@@ -552,6 +574,8 @@
         "packet_integrity_score",
         "clipping_score",
         "transient_score",
+        "shock_crest_factor",
+        "shock_broadband_ratio",
         "context_score",
         "frequency_stability_score",
         "reasons"


### PR DESCRIPTION
## What changed
- Added explicit shock telemetry to `WindowQuality`: crest factor and broadband energy ratio.
- Scores transient windows using both impulse strength and broad-band-vs-narrow-band energy.
- Keeps excluded shock windows visible in order trace points even when they suppress a peak match.
- Aggregates shock-transient window counts into order summaries and report boundaries.
- Adds report wording for filtered road-shock windows.

## Why
Potholes and rough-road bursts can create plausible FFT peaks. They should not become high-confidence wheel, driveshaft, or engine findings by themselves.

Fixes #3741.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/test_window_quality.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py apps/server/tests/integration/test_contract_analysis_persistence_http.py::test_whole_run_order_summaries_survive_persistence_and_http_layers apps/server/tests/adapters/http/test_http_api_schema_export.py::test_export_schema_matches_committed_schema`
- `./.venv/bin/python -m ruff check ... && ./.venv/bin/python -m ruff format --check ...`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `cd apps/ui && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run sync:contracts -- --check && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run sync:generated-contracts && npm run format:check && npm run lint && npm run lint:deps && npm run lint:unused && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run typecheck && npm run typecheck:tests`
- `./.venv/bin/python tools/tests/plan_validation.py`

## Risks and edges
- Thresholds are heuristic. Tests pin sustained sine, impulse-only, sine-plus-impulse, and repeated rough-road burst behavior.
- This handles shock suppression in the shared window-quality/order path. Deeper timing, clipping, mounting, and calibration issues remain separate tracked work.
