### PR TITLE
Handle sensor orientation in post-run diagnostics

### DIFF
--- a/apps/server/tests/shared/test_sensor_orientation.py
+++ b/apps/server/tests/shared/test_sensor_orientation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.shared.sensor_orientation import (
+    estimate_gravity_axis,
+    parse_mount_orientation,
+    transform_axis_matrix_to_vehicle,
+)
+
+
+def test_parse_mount_orientation_accepts_identity_aliases() -> None:
+    orientation = parse_mount_orientation("vehicle-aligned")
+
+    assert orientation is not None
+    assert orientation.vehicle_axes_from_sensor == ("+x", "+y", "+z")
+
+
+def test_parse_mount_orientation_accepts_signed_axis_mapping() -> None:
+    orientation = parse_mount_orientation("+y,-x,+z")
+
+    assert orientation is not None
+    assert orientation.vehicle_axes_from_sensor == ("+y", "-x", "+z")
+
+
+def test_parse_mount_orientation_rejects_unknown_or_duplicate_mapping() -> None:
+    assert parse_mount_orientation(None) is None
+    assert parse_mount_orientation("diagonal") is None
+    assert parse_mount_orientation("+x,+x,+z") is None
+
+
+def test_transform_axis_matrix_to_vehicle_reorders_and_flips_axes() -> None:
+    orientation = parse_mount_orientation("+y,-x,+z")
+    assert orientation is not None
+    samples = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [10.0, 20.0, 30.0],
+            [100.0, 200.0, 300.0],
+        ],
+        dtype=np.float32,
+    )
+
+    transformed = transform_axis_matrix_to_vehicle(samples, orientation)
+
+    assert np.array_equal(transformed[0], samples[1])
+    assert np.array_equal(transformed[1], -samples[0])
+    assert np.array_equal(transformed[2], samples[2])
+
+
+def test_estimate_gravity_axis_uses_window_mean_acceleration() -> None:
+    samples = np.array(
+        [
+            [0.02, -0.01, 0.0],
+            [0.01, 0.02, -0.01],
+            [-1.0, -0.98, -1.02],
+        ],
+        dtype=np.float32,
+    )
+
+    assert estimate_gravity_axis(samples) == "-z"

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_stft.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_stft.py
@@ -54,6 +54,7 @@ def _raw_window(
     window_index: int = 0,
     flags: tuple[PostRunRawWindowDataQualityFlag, ...] = (),
     returned_sample_count: int | None = None,
+    mount_orientation: str | None = "+x,+y,+z",
 ) -> PostRunRawWindow:
     descriptor = _window_descriptor(window_index)
     sensor = PostRunRawSensorWindow(
@@ -72,6 +73,7 @@ def _raw_window(
             int(samples.shape[0]) if returned_sample_count is None else returned_sample_count
         ),
         data_quality_flags=flags,
+        mount_orientation=mount_orientation,
     )
     return PostRunRawWindow(run_id=_RUN_ID, window=descriptor, sensors=(sensor,))
 
@@ -217,3 +219,53 @@ def test_dense_stft_rejects_invalid_config() -> None:
             (),
             config=PostRunStftConfig(spectrum_min_hz=20.0, spectrum_max_hz=10.0),
         )
+
+
+def test_dense_stft_rotates_known_mount_orientation_to_vehicle_axes() -> None:
+    samples = _tone(8.0, amplitude=1000.0)
+
+    result = compute_post_run_dense_stft(
+        (_raw_window(samples, mount_orientation="+y,-x,+z"),),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    frame = result.frames[0]
+    assert frame.axis_frame == "vehicle"
+    assert frame.rms_by_axis_g["y"] == pytest.approx(0.707, abs=0.04)
+    assert frame.rms_by_axis_g["x"] == pytest.approx(0.0, abs=0.01)
+
+
+def test_dense_stft_keeps_unknown_mount_orientation_in_sensor_local_frame() -> None:
+    result = compute_post_run_dense_stft(
+        (_raw_window(_tone(8.0), mount_orientation=None),),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    assert result.frames[0].axis_frame == "sensor_local"
+
+
+def test_dense_stft_estimates_static_gravity_axis_before_spectral_analysis() -> None:
+    samples = _tone(8.0, amplitude=200.0)
+    samples[:, 2] += 1000
+
+    result = compute_post_run_dense_stft(
+        (_raw_window(samples, mount_orientation="+x,+y,+z"),),
+        config=PostRunStftConfig(
+            fft_size_samples=_FFT_N,
+            spectrum_min_hz=1.0,
+            spectrum_max_hz=30.0,
+            accel_scale_g_per_lsb=0.001,
+        ),
+    )
+
+    assert result.frames[0].gravity_axis == "+z"

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py
@@ -53,6 +53,9 @@ def _feature(
         coverage_state=coverage_state,
         data_quality_flags=(),
         feature_quality_flags=quality_flags,
+        mount_orientation="+x,+y,+z",
+        axis_frame="vehicle",
+        gravity_axis=None,
         dominant_freq_hz=freq_hz,
         vibration_strength_db=strength_db,
         peak_amp_g=1.0,
@@ -61,6 +64,7 @@ def _feature(
         top_peaks=peaks,
         axis_dominance=PostRunWindowAxisDominance(
             axis="x",
+            axis_frame="vehicle",
             axis_amp_g=1.0,
             combined_amp_g=1.0,
             ratio=1.0,

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_window_features.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_window_features.py
@@ -68,6 +68,7 @@ def _raw_window(
     *,
     window_index: int = 0,
     flags: tuple[PostRunRawWindowDataQualityFlag, ...] = (),
+    mount_orientation: str | None = "+x,+y,+z",
 ) -> PostRunRawWindow:
     descriptor = _window_descriptor(window_index)
     sensor = PostRunRawSensorWindow(
@@ -84,6 +85,7 @@ def _raw_window(
         returned_sample_start=descriptor.sample_start if samples.size else None,
         returned_sample_count=int(samples.shape[0]),
         data_quality_flags=flags,
+        mount_orientation=mount_orientation,
     )
     return PostRunRawWindow(run_id=_RUN_ID, window=descriptor, sensors=(sensor,))
 
@@ -111,6 +113,7 @@ def test_window_features_detect_single_tone_axis_and_time_metrics() -> None:
 
     assert feature.dominant_freq_hz == pytest.approx(8.0, abs=0.25)
     assert feature.axis_dominance.axis == "x"
+    assert feature.axis_dominance.axis_frame == "vehicle"
     assert feature.axis_dominance.ratio is not None
     assert feature.axis_dominance.ratio > 1.6
     assert feature.rms_by_axis_g["x"] == pytest.approx(0.707, abs=0.04)
@@ -253,3 +256,15 @@ def test_window_features_debug_rows_for_synthetic_run() -> None:
     assert [row["window_index"] for row in rows] == [0, 1]
     assert rows[0]["dominant_freq_hz"] == pytest.approx(6.0, abs=0.25)
     assert rows[1]["axis"] == "y"
+    assert rows[1]["axis_frame"] == "vehicle"
+
+
+def test_window_features_suppress_axis_dominance_when_orientation_unknown() -> None:
+    stft = _stft_result(_raw_window(_tone(8.0, axis=0), mount_orientation=None))
+
+    feature = extract_post_run_window_features(stft).features[0]
+
+    assert feature.axis_frame == "sensor_local"
+    assert feature.axis_dominance.axis is None
+    assert "sensor_orientation_unknown" in feature.feature_quality_flags
+    assert feature.dominant_freq_hz == pytest.approx(8.0, abs=0.25)

--- a/apps/server/vibesensor/shared/sensor_orientation.py
+++ b/apps/server/vibesensor/shared/sensor_orientation.py
@@ -1,0 +1,151 @@
+"""Sensor mount-orientation helpers for vehicle-axis analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite, sqrt
+from typing import Literal
+
+import numpy as np
+import numpy.typing as npt
+
+from vibesensor.shared.fft_analysis import AXES, Axis
+
+type AxisFrame = Literal["sensor_local", "vehicle"]
+type SignedAxis = Literal["+x", "-x", "+y", "-y", "+z", "-z"]
+
+_AXIS_INDEX: dict[Axis, int] = {"x": 0, "y": 1, "z": 2}
+_SIGNED_AXIS_ALIASES: dict[str, SignedAxis] = {
+    "x": "+x",
+    "+x": "+x",
+    "forward": "+x",
+    "+forward": "+x",
+    "front": "+x",
+    "+front": "+x",
+    "-x": "-x",
+    "backward": "-x",
+    "-forward": "-x",
+    "rear": "-x",
+    "+rear": "-x",
+    "left": "+y",
+    "+left": "+y",
+    "y": "+y",
+    "+y": "+y",
+    "right": "-y",
+    "+right": "-y",
+    "-left": "-y",
+    "-y": "-y",
+    "up": "+z",
+    "+up": "+z",
+    "z": "+z",
+    "+z": "+z",
+    "down": "-z",
+    "+down": "-z",
+    "-up": "-z",
+    "-z": "-z",
+}
+_IDENTITY_LABELS = frozenset(
+    {
+        "aligned",
+        "identity",
+        "vehicle",
+        "vehicle_aligned",
+        "vehicle-aligned",
+        "vehicle axes",
+        "vehicle_axes",
+    }
+)
+_UNKNOWN_LABELS = frozenset({"", "unknown", "unset", "unspecified", "n/a", "na", "none"})
+
+
+@dataclass(frozen=True, slots=True)
+class AxisOrientation:
+    """Mapping from sensor-local axes into vehicle x/y/z axes."""
+
+    vehicle_axes_from_sensor: tuple[SignedAxis, SignedAxis, SignedAxis]
+
+
+def parse_mount_orientation(value: str | None) -> AxisOrientation | None:
+    """Parse a mount-orientation string into a vehicle-axis mapping.
+
+    Supported explicit mappings use three signed axes, where each token names the sensor-local axis
+    that supplies vehicle x, vehicle y, then vehicle z. For example, ``+y,-x,+z`` means vehicle x
+    comes from sensor +y, vehicle y from sensor -x, and vehicle z from sensor +z.
+    """
+
+    normalized = _normalize_orientation(value)
+    if normalized in _UNKNOWN_LABELS:
+        return None
+    if normalized in _IDENTITY_LABELS:
+        return AxisOrientation(("+x", "+y", "+z"))
+
+    tokens = _mapping_tokens(normalized)
+    if tokens is None:
+        return None
+    signed_axes: list[SignedAxis] = []
+    for token in tokens:
+        signed_axis = _SIGNED_AXIS_ALIASES.get(token)
+        if signed_axis is None:
+            return None
+        signed_axes.append(signed_axis)
+    if {axis[-1] for axis in signed_axes} != {"x", "y", "z"}:
+        return None
+    return AxisOrientation((signed_axes[0], signed_axes[1], signed_axes[2]))
+
+
+def transform_axis_matrix_to_vehicle(
+    axis_samples: npt.NDArray[np.float32],
+    orientation: AxisOrientation,
+) -> npt.NDArray[np.float32]:
+    """Return samples reordered/sign-flipped into vehicle x/y/z axes."""
+
+    transformed = np.empty_like(axis_samples, dtype=np.float32)
+    for vehicle_index, signed_axis in enumerate(orientation.vehicle_axes_from_sensor):
+        sign = -1.0 if signed_axis.startswith("-") else 1.0
+        source_axis = _axis_from_signed_axis(signed_axis)
+        transformed[vehicle_index] = axis_samples[_AXIS_INDEX[source_axis]] * np.float32(sign)
+    return transformed
+
+
+def estimate_gravity_axis(axis_samples_g: npt.NDArray[np.float32]) -> SignedAxis | None:
+    """Estimate the dominant static-gravity axis from window mean acceleration."""
+
+    if axis_samples_g.ndim != 2 or axis_samples_g.shape[0] != len(AXES):
+        return None
+    means = np.mean(axis_samples_g.astype(np.float32, copy=False), axis=1)
+    if not np.all(np.isfinite(means)):
+        return None
+    norm = sqrt(float(np.sum(means * means)))
+    if not isfinite(norm) or norm < 0.25:
+        return None
+    axis_index = int(np.argmax(np.abs(means)))
+    axis = AXES[axis_index]
+    if axis == "x":
+        return "+x" if float(means[axis_index]) >= 0.0 else "-x"
+    if axis == "y":
+        return "+y" if float(means[axis_index]) >= 0.0 else "-y"
+    return "+z" if float(means[axis_index]) >= 0.0 else "-z"
+
+
+def _axis_from_signed_axis(value: SignedAxis) -> Axis:
+    if value.endswith("x"):
+        return "x"
+    if value.endswith("y"):
+        return "y"
+    return "z"
+
+
+def _normalize_orientation(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.strip().lower().replace(";", ",").split())
+
+
+def _mapping_tokens(value: str) -> tuple[str, str, str] | None:
+    if ":" in value:
+        _, value = value.rsplit(":", maxsplit=1)
+    compact = value.replace(" ", "")
+    tokens = tuple(token for token in compact.split(",") if token)
+    if len(tokens) != 3:
+        return None
+    return tokens

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
@@ -141,6 +141,7 @@ class PostRunRawSensorWindow:
     returned_sample_start: int | None
     returned_sample_count: int
     data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
+    mount_orientation: str | None = None
 
     @property
     def start_t_s(self) -> float:
@@ -614,6 +615,7 @@ def _build_sensor_window(
         returned_sample_start=returned_sample_start,
         returned_sample_count=int(axis_x.shape[0]),
         data_quality_flags=tuple(flags),
+        mount_orientation=_sensor_mount_orientation(metadata, sensor.client_id),
     )
     return sensor_window, tuple(warnings)
 
@@ -697,6 +699,16 @@ def _sensor_location(metadata: RunMetadata | None, sensor_id: str) -> str:
         metadata.sensor_snapshot_for(sensor_id) if metadata is not None else None
     )
     return snapshot.location_code.strip() if snapshot is not None else ""
+
+
+def _sensor_mount_orientation(metadata: RunMetadata | None, sensor_id: str) -> str | None:
+    snapshot: RunSensorMetadata | None = (
+        metadata.sensor_snapshot_for(sensor_id) if metadata is not None else None
+    )
+    if snapshot is None:
+        return None
+    orientation = (snapshot.mount_orientation or "").strip()
+    return orientation if orientation else None
 
 
 def _has_timestamp_gap(

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py
@@ -20,6 +20,13 @@ from vibesensor.shared.fft_analysis import (
     fft_frequency_slice,
     fft_window_values,
 )
+from vibesensor.shared.sensor_orientation import (
+    AxisFrame,
+    SignedAxis,
+    estimate_gravity_axis,
+    parse_mount_orientation,
+    transform_axis_matrix_to_vehicle,
+)
 from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
     PostRunRawSensorWindow,
     PostRunRawWindow,
@@ -67,6 +74,9 @@ class PostRunStftFrame:
     returned_sample_count: int
     coverage_state: PostRunStftCoverageState
     data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
+    mount_orientation: str | None
+    axis_frame: AxisFrame
+    gravity_axis: SignedAxis | None
     freq_hz: FloatArray
     spectrum_by_axis_amp_g: dict[Axis, FloatArray]
     combined_amp_g: FloatArray
@@ -226,6 +236,12 @@ def _compute_sensor_frame(
         return None
     if config.accel_scale_g_per_lsb is not None:
         prepared_samples = prepared_samples * np.float32(config.accel_scale_g_per_lsb)
+    gravity_axis = estimate_gravity_axis(prepared_samples)
+    orientation = parse_mount_orientation(sensor_window.mount_orientation)
+    axis_frame: AxisFrame = "sensor_local"
+    if orientation is not None:
+        prepared_samples = transform_axis_matrix_to_vehicle(prepared_samples, orientation)
+        axis_frame = "vehicle"
     rms_by_axis_g, p2p_by_axis_g = _time_domain_metrics_by_axis(prepared_samples)
     fft_result = compute_fft_spectrum(
         prepared_samples,
@@ -261,6 +277,9 @@ def _compute_sensor_frame(
         returned_sample_count=sensor_window.returned_sample_count,
         coverage_state=coverage_state,
         data_quality_flags=sensor_window.data_quality_flags,
+        mount_orientation=sensor_window.mount_orientation,
+        axis_frame=axis_frame,
+        gravity_axis=gravity_axis,
         freq_hz=np.asarray(fft_result["freq_slice"], dtype=np.float32, copy=True),
         spectrum_by_axis_amp_g=spectrum_by_axis,
         combined_amp_g=np.asarray(fft_result["combined_amp"], dtype=np.float32, copy=True),
@@ -359,6 +378,9 @@ def _empty_frame(
     coverage_state: PostRunStftCoverageState,
 ) -> PostRunStftFrame:
     empty = np.zeros(context.freq_hz.shape, dtype=np.float32)
+    axis_frame: AxisFrame = (
+        "vehicle" if parse_mount_orientation(sensor_window.mount_orientation) else "sensor_local"
+    )
     return PostRunStftFrame(
         run_id=sensor_window.run_id,
         client_id=sensor_window.client_id,
@@ -374,6 +396,9 @@ def _empty_frame(
         returned_sample_count=sensor_window.returned_sample_count,
         coverage_state=coverage_state,
         data_quality_flags=sensor_window.data_quality_flags,
+        mount_orientation=sensor_window.mount_orientation,
+        axis_frame=axis_frame,
+        gravity_axis=None,
         freq_hz=context.freq_hz.copy(),
         spectrum_by_axis_amp_g={axis: empty.copy() for axis in AXES},
         combined_amp_g=empty.copy(),

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py
@@ -9,6 +9,7 @@ from typing import Literal
 import numpy as np
 
 from vibesensor.shared.fft_analysis import AXES, Axis, BoolArray, FloatArray
+from vibesensor.shared.sensor_orientation import AxisFrame, SignedAxis
 from vibesensor.use_cases.diagnostics.post_run_raw_windows import (
     PostRunRawWindowDataQualityFlag,
 )
@@ -31,6 +32,7 @@ type PostRunWindowFeatureQualityFlag = (
         "frequency_mask_empty",
         "invalid_spectrum_values",
         "no_dominant_peak",
+        "sensor_orientation_unknown",
     ]
 )
 
@@ -50,6 +52,7 @@ class PostRunWindowAxisDominance:
     """Dominant-axis evidence at the selected feature peak."""
 
     axis: Axis | None
+    axis_frame: AxisFrame
     axis_amp_g: float
     combined_amp_g: float
     ratio: float | None
@@ -70,6 +73,9 @@ class PostRunWindowFeature:
     coverage_state: PostRunStftCoverageState
     data_quality_flags: tuple[PostRunRawWindowDataQualityFlag, ...]
     feature_quality_flags: tuple[PostRunWindowFeatureQualityFlag, ...]
+    mount_orientation: str | None
+    axis_frame: AxisFrame
+    gravity_axis: SignedAxis | None
     dominant_freq_hz: float | None
     vibration_strength_db: float | None
     peak_amp_g: float | None
@@ -128,6 +134,8 @@ def post_run_window_feature_debug_rows(
                 "vibration_strength_db": feature.vibration_strength_db,
                 "strength_bucket": feature.strength_bucket,
                 "axis": feature.axis_dominance.axis,
+                "axis_frame": feature.axis_frame,
+                "gravity_axis": feature.gravity_axis,
                 "coverage_state": feature.coverage_state,
                 "quality_flags": list(feature.feature_quality_flags),
             }
@@ -178,11 +186,14 @@ def _feature_from_frame(
     if not top_peaks:
         _append_unique_flag(quality_flags, "no_dominant_peak")
     dominant_freq_hz = top_peaks[0]["hz"] if top_peaks else None
+    if frame.axis_frame != "vehicle":
+        _append_unique_flag(quality_flags, "sensor_orientation_unknown")
     axis_dominance = _axis_dominance(
         freq_hz=masked_freq,
         axis_spectra=masked_axis_spectra,
         combined_amp_g=masked_combined,
         dominant_freq_hz=dominant_freq_hz,
+        axis_frame=frame.axis_frame,
     )
     rms_by_axis = _axis_float_map(frame.rms_by_axis_g)
     p2p_by_axis = _axis_float_map(frame.p2p_by_axis_g)
@@ -198,6 +209,9 @@ def _feature_from_frame(
         coverage_state=frame.coverage_state,
         data_quality_flags=frame.data_quality_flags,
         feature_quality_flags=tuple(quality_flags),
+        mount_orientation=frame.mount_orientation,
+        axis_frame=frame.axis_frame,
+        gravity_axis=frame.gravity_axis,
         dominant_freq_hz=dominant_freq_hz,
         vibration_strength_db=_positive_peak_metric(
             strength_metrics,
@@ -289,9 +303,16 @@ def _axis_dominance(
     axis_spectra: dict[Axis, FloatArray],
     combined_amp_g: FloatArray,
     dominant_freq_hz: float | None,
+    axis_frame: AxisFrame,
 ) -> PostRunWindowAxisDominance:
-    if dominant_freq_hz is None or freq_hz.size == 0:
-        return PostRunWindowAxisDominance(axis=None, axis_amp_g=0.0, combined_amp_g=0.0, ratio=None)
+    if axis_frame != "vehicle" or dominant_freq_hz is None or freq_hz.size == 0:
+        return PostRunWindowAxisDominance(
+            axis=None,
+            axis_frame=axis_frame,
+            axis_amp_g=0.0,
+            combined_amp_g=0.0,
+            ratio=None,
+        )
     peak_idx = int(np.argmin(np.abs(freq_hz - np.float32(dominant_freq_hz))))
     axis_amps = {axis: float(axis_spectra[axis][peak_idx]) for axis in AXES}
     dominant_axis, dominant_amp = max(axis_amps.items(), key=lambda item: item[1])
@@ -299,6 +320,7 @@ def _axis_dominance(
     ratio = dominant_amp / combined_amp if combined_amp > 0.0 else None
     return PostRunWindowAxisDominance(
         axis=dominant_axis if dominant_amp > 0.0 else None,
+        axis_frame=axis_frame,
         axis_amp_g=dominant_amp,
         combined_amp_g=combined_amp,
         ratio=ratio,

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -56,26 +56,32 @@ metadata and raw-capture manifests, then reads each sensor/window through the
 history raw range-read API. That keeps long runs streaming: downstream dense
 stages consume bounded axis arrays per window instead of materializing the full
 raw artifact bundle. Each emitted sensor window carries run ID, sensor ID,
-location snapshot, start/end timing, sample rate, x/y/z `int16` arrays, and
-data-quality flags such as partial windows, timestamp gaps, missing samples,
-low sample count, invalid axis data, sample-rate mismatch, and missing sidecars.
+location snapshot, mount orientation, start/end timing, sample rate, x/y/z
+`int16` arrays, and data-quality flags such as partial windows, timestamp gaps,
+missing samples, low sample count, invalid axis data, sample-rate mismatch, and
+missing sidecars.
 
 The first dense analysis consumer is
 `use_cases/diagnostics/post_run_stft.py`. It consumes those POSTRUN-01 window
 DTOs and produces in-memory STFT frames with per-axis spectra, combined spectra,
 window timing, sensor metadata, per-axis RMS/P2P, dominant frequency, top peaks,
-and dB strength facts. The STFT layer is deliberately post-run only: callers
-configure FFT size, window function, frequency range, and partial-window behavior
-independently from the live UI cadence, while still reusing the shared
-FFT/strength primitives.
+static-gravity-axis estimate, axis frame, and dB strength facts. Known mount
+orientations are transformed into vehicle-relative axes at this boundary;
+unknown orientations remain `sensor_local` so later stages can caveat or suppress
+axis-specific conclusions while preserving combined-magnitude location evidence.
+The STFT layer is deliberately post-run only: callers configure FFT size, window
+function, frequency range, and partial-window behavior independently from the
+live UI cadence, while still reusing the shared FFT/strength primitives.
 
 `use_cases/diagnostics/post_run_window_features.py` is the next reduction layer.
 It consumes POSTRUN-02 STFT frames and emits per-window/per-sensor feature DTOs:
 dominant and top peaks, canonical `vibration_strength_db`, peak amplitude, noise
-floor, strength bucket, axis dominance, RMS/P2P, structured quality flags, and
-compact debug rows for synthetic runs. Frequency masks live at this layer so
-later episode/order/finding logic can ignore unusable bands without recomputing
-the dense spectra.
+floor, strength bucket, axis dominance, RMS/P2P, axis frame, static gravity
+axis, structured quality flags, and compact debug rows for synthetic runs.
+Axis dominance is only emitted for vehicle-relative frames; sensor-local frames
+carry a `sensor_orientation_unknown` quality flag instead. Frequency masks live
+at this layer so later episode/order/finding logic can ignore unusable bands
+without recomputing the dense spectra.
 
 `use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
 and final-drive references onto the same window grid. It uses conservative


### PR DESCRIPTION
## What changed
- Added a shared mount-orientation parser for vehicle-aligned and signed-axis mappings like `+y,-x,+z`.
- Carried `mount_orientation` from run sensor metadata into post-run raw windows.
- Transformed known sensor axes into vehicle-relative axes at dense STFT time.
- Added static gravity-axis estimation to STFT/window feature outputs.
- Marked unknown orientations as `sensor_local`, added `sensor_orientation_unknown`, and suppressed dominant-axis conclusions for those windows.
- Updated the analysis pipeline docs and tests for aligned, rotated, and unknown orientations.

## Why
Axis x/y/z is not comparable across sensors unless mount orientation is known. Combined magnitude can still support location comparison, but axis-specific evidence must be vehicle-relative or clearly caveated.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/test_sensor_orientation.py apps/server/tests/use_cases/diagnostics/test_post_run_stft.py apps/server/tests/use_cases/diagnostics/test_post_run_window_features.py apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py`
- `./.venv/bin/python -m ruff check ... && ./.venv/bin/python -m ruff format --check ...`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `./.venv/bin/python tools/dev/docs_lint.py`
- `cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/shared apps/server/tests/use_cases`

`./.venv/bin/python tools/tests/run_changed.py` could not execute because this host has no `make`; equivalent planned commands were run directly.

## Risks / edge cases
- Existing free-form values like `radial` or `axial` remain unparsed and therefore sensor-local. That is intentional: unknown physical mappings should not produce vehicle-axis conclusions.
- The signed-axis format requires all three axes exactly once. Invalid mappings are treated as unknown orientation.

Fixes #3742