### PR TITLE
Require persistence evidence for diagnostic peaks

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_peak_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_peak_scoring.py
@@ -44,6 +44,8 @@ class TestPeakBin:
     def test_presence_ratio(self) -> None:
         peak_bin = _make_peak_bin(amps=[0.05] * 50, n_samples=100)
         assert peak_bin.presence_ratio == pytest.approx(0.50)
+        assert peak_bin.sample_count == 50
+        assert peak_bin.total_sample_count == 100
 
     def test_burstiness_uniform(self) -> None:
         peak_bin = _make_peak_bin(amps=[0.05] * 20)
@@ -122,5 +124,8 @@ class TestAssemblePeakFinding:
         metrics = finding.evidence
         assert metrics is not None
         assert metrics.presence_ratio > 0.0
+        assert metrics.matched_samples == 50
+        assert metrics.possible_samples == 100
+        assert metrics.match_rate == pytest.approx(metrics.presence_ratio)
         assert metrics.burstiness >= 0.0
         assert metrics.spatial_concentration > 0.0

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py
@@ -31,7 +31,13 @@ def _episode(
     quality_penalty: float = 0.0,
     transient: bool = False,
     affected_sensors: tuple[str, ...] = ("sensor-a",),
+    frequencies: tuple[float, ...] | None = None,
 ) -> VibrationEpisode:
+    frequency_path = (
+        frequencies if frequencies is not None else tuple(frequency_hz for _ in windows)
+    )
+    if len(frequency_path) != len(windows):
+        raise ValueError("frequency path must match windows")
     return VibrationEpisode(
         episode_id=episode_id,
         run_id=_RUN_ID,
@@ -43,9 +49,9 @@ def _episode(
         start_window_index=windows[0],
         end_window_index=windows[-1],
         supporting_window_ids=windows,
-        frequency_path_hz=tuple(frequency_hz for _ in windows),
-        median_frequency_hz=frequency_hz,
-        peak_frequency_hz=frequency_hz,
+        frequency_path_hz=frequency_path,
+        median_frequency_hz=frequency_path[len(frequency_path) // 2],
+        peak_frequency_hz=max(frequency_path),
         frequency_slope_hz_per_s=0.0,
         median_strength_db=strength_db,
         peak_strength_db=strength_db,
@@ -137,6 +143,9 @@ def test_dense_findings_classify_clear_wheel_episode() -> None:
     assert finding.confidence_score >= 0.7
     assert finding.alternatives[0].best_band_label == "wheel_1x"
     assert all(window.matched for window in finding.evidence_windows)
+    assert finding.supporting_window_count == 4
+    assert finding.duration_s == pytest.approx(2.0)
+    assert finding.support_density == pytest.approx(1.0)
 
 
 def test_dense_findings_classify_clear_driveshaft_episode() -> None:
@@ -202,6 +211,60 @@ def test_dense_findings_penalize_conflicting_sensor_evidence() -> None:
     assert finding.confidence_score < 0.9
 
 
+def test_dense_findings_cap_one_window_peak_confidence() -> None:
+    findings = classify_post_run_dense_findings(
+        (
+            _episode(
+                frequency_hz=10.0,
+                windows=(0,),
+                strength_db=35.0,
+                transient=True,
+            ),
+        ),
+        _timeline(windows=(0,)),
+    )
+
+    finding = findings[0]
+    assert finding.confidence_label != "high"
+    assert "low_peak_persistence" in finding.caveats
+    assert "transient_only" in finding.caveats
+    assert finding.supporting_window_count == 1
+
+
+def test_dense_findings_penalize_intermittent_peak_support() -> None:
+    stable = classify_post_run_dense_findings(
+        (_episode(frequency_hz=10.0, windows=(0, 1, 2, 3)),),
+        _timeline(windows=(0, 1, 2, 3)),
+    )[0]
+    intermittent = classify_post_run_dense_findings(
+        (_episode(frequency_hz=10.0, windows=(0, 2, 4, 6)),),
+        _timeline(windows=(0, 2, 4, 6)),
+    )[0]
+
+    assert "intermittent_support" in intermittent.caveats
+    assert intermittent.support_density == pytest.approx(4 / 7)
+    assert intermittent.confidence_score < stable.confidence_score
+
+
+def test_dense_findings_track_drifting_peak_evidence_path() -> None:
+    finding = classify_post_run_dense_findings(
+        (
+            _episode(
+                frequency_hz=10.0,
+                windows=(0, 1, 2, 3),
+                frequencies=(10.0, 10.2, 10.4, 10.6),
+                quality_penalty=0.1,
+            ),
+        ),
+        _timeline(windows=(0, 1, 2, 3), wheel_hz=10.3),
+    )[0]
+
+    assert [window.frequency_hz for window in finding.evidence_windows] == pytest.approx(
+        [10.0, 10.2, 10.4, 10.6],
+    )
+    assert "poor_quality" in finding.caveats
+
+
 def test_dense_finding_maps_to_domain_finding() -> None:
     finding = classify_post_run_dense_findings((_episode(frequency_hz=10.0),), _timeline())[0]
 
@@ -211,6 +274,9 @@ def test_dense_finding_maps_to_domain_finding() -> None:
     assert domain_finding.suspected_source is VibrationSource.WHEEL_TIRE
     assert domain_finding.confidence == pytest.approx(finding.confidence_score)
     assert domain_finding.frequency_hz == pytest.approx(finding.median_frequency_hz)
+    assert domain_finding.evidence is not None
+    assert domain_finding.evidence.matched_samples == 4
+    assert domain_finding.evidence.possible_samples == 4
 
 
 def test_dense_finding_debug_rows_are_stable() -> None:
@@ -220,3 +286,4 @@ def test_dense_finding_debug_rows_are_stable() -> None:
 
     assert rows[0]["likely_origin"] == "wheel/tire"
     assert rows[0]["evidence_window_count"] == 4
+    assert rows[0]["supporting_duration_s"] == pytest.approx(2.0)

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/finding_builder.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/finding_builder.py
@@ -50,10 +50,14 @@ def assemble_peak_finding(peak_bin: PeakBin) -> DomainFinding:
         vibration_strength_db=peak_bin.peak_strength_db,
         cruise_fraction=cruise_fraction,
         evidence=FindingEvidence(
+            match_rate=peak_bin.presence_ratio,
+            possible_samples=peak_bin.total_sample_count,
+            matched_samples=peak_bin.sample_count,
             presence_ratio=peak_bin.presence_ratio,
             burstiness=peak_bin.burstiness,
             spatial_concentration=peak_bin.spatial_concentration,
             spatial_uniformity=peak_bin.spatial_uniformity or 0.0,
             speed_uniformity=peak_bin.speed_uniformity or 0.0,
+            vibration_strength_db=max(0.0, peak_bin.peak_strength_db),
         ),
     )

--- a/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/peaks/scoring.py
@@ -112,10 +112,12 @@ class PeakBin:
         "_presence_ratio",
         "_ranking_score",
         "_raw_snr",
+        "_sample_count",
         "_spatial_concentration",
         "_spatial_uniformity",
         "_speed_amp_pairs",
         "_speed_uniformity",
+        "_total_sample_count",
     )
 
     def __init__(
@@ -183,10 +185,12 @@ class PeakBin:
             p95_amp=stats.p95_amp,
         )
         self._raw_snr = raw_snr
+        self._sample_count = count
         self._spatial_concentration = spatial_concentration
         self._spatial_uniformity = spatial_uniformity
         self._speed_amp_pairs = list(speed_amp_pairs)
         self._speed_uniformity = speed_uniformity
+        self._total_sample_count = n_samples
         self._confidence = _compute_peak_confidence(
             peak_type=peak_type,
             presence_ratio=presence_ratio,
@@ -204,6 +208,14 @@ class PeakBin:
     @property
     def presence_ratio(self) -> float:
         return self._presence_ratio
+
+    @property
+    def sample_count(self) -> int:
+        return self._sample_count
+
+    @property
+    def total_sample_count(self) -> int:
+        return self._total_sample_count
 
     @property
     def burstiness(self) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from math import isfinite
 from typing import Literal
 
-from vibesensor.domain import Finding, FindingKind, VibrationSource
+from vibesensor.domain import Finding, FindingEvidence, FindingKind, VibrationSource
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.whole_run_json_helpers import set_optional_value
 from vibesensor.use_cases.diagnostics.post_run_order_bands import (
@@ -25,6 +25,8 @@ type DenseFindingCaveat = Literal[
     "missing_reference_data",
     "poor_quality",
     "low_usable_duration",
+    "low_peak_persistence",
+    "intermittent_support",
     "transient_only",
     "unmatched_strong_episode",
 ]
@@ -56,6 +58,9 @@ class DenseFindingConfig:
     high_confidence_threshold: float = 0.7
     medium_confidence_threshold: float = 0.4
     strong_unknown_strength_db: float = 18.0
+    min_persistent_windows: int = 3
+    min_persistent_duration_s: float = 0.75
+    min_support_density: float = 0.75
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,6 +129,9 @@ class DenseFinding:
     median_frequency_hz: float
     peak_strength_db: float
     duration_s: float
+    supporting_window_count: int
+    matched_evidence_window_count: int
+    support_density: float
     supporting_window_ids: tuple[int, ...]
 
     def to_json_object(self) -> JsonObject:
@@ -140,6 +148,9 @@ class DenseFinding:
             "median_frequency_hz": self.median_frequency_hz,
             "peak_strength_db": self.peak_strength_db,
             "duration_s": self.duration_s,
+            "supporting_window_count": self.supporting_window_count,
+            "matched_evidence_window_count": self.matched_evidence_window_count,
+            "support_density": self.support_density,
             "supporting_window_ids": list(self.supporting_window_ids),
         }
 
@@ -157,6 +168,17 @@ class DenseFinding:
             kind=FindingKind.DIAGNOSTIC,
             ranking_score=self.confidence_score * max(0.0, self.peak_strength_db),
             vibration_strength_db=self.peak_strength_db,
+            evidence=FindingEvidence(
+                match_rate=(
+                    self.matched_evidence_window_count / self.supporting_window_count
+                    if self.supporting_window_count > 0
+                    else 0.0
+                ),
+                possible_samples=self.supporting_window_count,
+                matched_samples=self.supporting_window_count,
+                presence_ratio=self.support_density,
+                vibration_strength_db=self.peak_strength_db,
+            ),
         )
 
 
@@ -215,6 +237,9 @@ def dense_finding_debug_rows(findings: Iterable[DenseFinding]) -> tuple[JsonObje
             "confidence_label": finding.confidence_label,
             "caveats": list(finding.caveats),
             "evidence_window_count": len(finding.evidence_windows),
+            "supporting_window_count": finding.supporting_window_count,
+            "supporting_duration_s": finding.duration_s,
+            "support_density": finding.support_density,
         }
         for finding in findings
     )
@@ -227,11 +252,17 @@ def _validate_config(config: DenseFindingConfig) -> None:
         ("high_confidence_threshold", config.high_confidence_threshold),
         ("medium_confidence_threshold", config.medium_confidence_threshold),
         ("strong_unknown_strength_db", config.strong_unknown_strength_db),
+        ("min_persistent_duration_s", config.min_persistent_duration_s),
+        ("min_support_density", config.min_support_density),
     ):
         if not isfinite(value) or value < 0:
             raise ValueError(f"dense finding config requires {field_name} >= 0")
+    if config.min_persistent_windows < 1:
+        raise ValueError("dense finding config requires min_persistent_windows >= 1")
     if config.min_match_ratio > 1 or config.ambiguity_margin > 1:
         raise ValueError("dense finding ratio thresholds must be <= 1")
+    if config.min_support_density > 1:
+        raise ValueError("dense finding support-density threshold must be <= 1")
     if config.high_confidence_threshold < config.medium_confidence_threshold:
         raise ValueError("high_confidence_threshold must be >= medium_confidence_threshold")
 
@@ -278,6 +309,16 @@ def _classify_episode(
     if episode.duration_s < 1.0:
         _append_unique(caveats, "low_usable_duration")
         confidence_score *= 0.9
+    if (
+        episode.peak_count < config.min_persistent_windows
+        or episode.duration_s < config.min_persistent_duration_s
+    ):
+        _append_unique(caveats, "low_peak_persistence")
+        confidence_score *= 0.65
+    support_density = _support_density(episode.supporting_window_ids)
+    if support_density < config.min_support_density:
+        _append_unique(caveats, "intermittent_support")
+        confidence_score *= max(0.5, support_density)
     if episode.transient:
         _append_unique(caveats, "transient_only")
         confidence_score *= 0.75
@@ -298,6 +339,9 @@ def _classify_episode(
         median_frequency_hz=episode.median_frequency_hz,
         peak_strength_db=episode.peak_strength_db,
         duration_s=episode.duration_s,
+        supporting_window_count=len(episode.supporting_window_ids),
+        matched_evidence_window_count=sum(1 for window in evidence_windows if window.matched),
+        support_density=support_density,
         supporting_window_ids=episode.supporting_window_ids,
     )
 
@@ -398,6 +442,16 @@ def _unknown_confidence(episode: VibrationEpisode, top: _SourceScore) -> float:
         + (localization_score * 0.10)
         + (top.score * 0.20)
     )
+
+
+def _support_density(window_ids: tuple[int, ...]) -> float:
+    if not window_ids:
+        return 0.0
+    unique_ids = set(window_ids)
+    span = max(unique_ids) - min(unique_ids) + 1
+    if span <= 0:
+        return 0.0
+    return _clamp(len(unique_ids) / span)
 
 
 def _localization_score(episode: VibrationEpisode) -> float:

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -112,13 +112,16 @@ extremes.
 `use_cases/diagnostics/post_run_dense_findings.py` fuses POSTRUN-06 episodes with
 POSTRUN-05 order bands. It compares each episode frequency path against the
 available wheel, driveshaft, and engine bands for the same `window_index`, ranks
-source hypotheses by match ratio, reference completeness, persistence, and
-strength, then emits compact dense findings. Each finding carries the likely
-origin, alternative hypotheses, confidence score/label, evidence windows, and
-caveats for ambiguity, missing references, quality penalties, short/transient
-events, conflicting multi-sensor evidence, or strong unmatched resonance. The DTO
-can project back to the existing domain `Finding` shape for report/history
-compatibility without persisting dense spectra.
+source hypotheses by match ratio, reference completeness, persistence, support
+density, and strength, then emits compact dense findings. Each finding carries
+the likely origin, alternative hypotheses, confidence score/label, evidence
+windows, supporting window count/duration, support density, and caveats for
+ambiguity, missing references, quality penalties, weak persistence, intermittent
+support, short/transient events, conflicting multi-sensor evidence, or strong
+unmatched resonance. The DTO can project back to the existing domain `Finding`
+shape for report/history compatibility without persisting dense spectra; that
+projection carries evidence counts so report facts can show support duration from
+the run feature interval.
 
 ## Related deep dives
 


### PR DESCRIPTION
## What changed
- Added explicit dense-finding persistence metrics: supporting window count, matched evidence count, duration, and support density.
- Added dense caveats for low peak persistence and intermittent support.
- Penalized one-window/transient and intermittent evidence so it cannot surface as high-confidence support.
- Projected dense finding support counts into domain `FindingEvidence` so report evidence facts can derive support duration.
- Projected persistent peak matched/possible sample counts and non-negative report strength into `FindingEvidence`.
- Updated docs and tests for stable, drifting, one-off, and intermittent peak scenarios.

## Why
Single-window peaks can be road noise, mounting artifacts, or sensor glitches. Findings need repeated support, and reports need to show how much evidence backs the conclusion.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_post_run_dense_findings.py apps/server/tests/use_cases/diagnostics/test_post_run_vibration_episodes.py apps/server/tests/use_cases/diagnostics/test_peak_scoring.py apps/server/tests/adapters/pdf/test_report_document_projection.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_peak_scoring.py apps/server/tests/use_cases/diagnostics/test_localization_and_suppression.py::TestUnitConsistency::test_evidence_metrics_include_strength_db`
- `./.venv/bin/python -m ruff check ... && ./.venv/bin/python -m ruff format --check ...`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `./.venv/bin/python tools/dev/docs_lint.py`
- `cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases`

`./.venv/bin/python tools/tests/run_changed.py` could not execute because this host has no `make`; equivalent planned commands were run directly.

## Risks / edge cases
- Dense findings still keep strong unmatched or transient evidence, but caveat and down-rank it.
- Peak-bin evidence clamps report-facing strength to non-negative dB; the underlying finding strength remains unchanged.

Fixes #3743