### PR TITLE
DSP: add speed-synchronous order tracking over time

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -95,7 +95,7 @@ def test_build_report_document_projects_dense_evidence_rows() -> None:
     assert row.source_name == "Wheel / Tire"
     assert row.order_label == "1x wheel order"
     assert row.confidence_label == "High (78%)"
-    assert row.support == "6/8 (75%)"
+    assert row.support == "6/8 (75%); lock 81%"
     assert row.support_ratio == 0.75
     assert row.reference_coverage_ratio == 0.875
     assert row.frequency_band == "12.4-12.9 Hz"
@@ -112,7 +112,7 @@ def test_build_report_pdf_renders_dense_evidence_chart_text() -> None:
     assert "Support / reference coverage" in text
     assert "support 75% / reference 88%" in text
     assert "High (78%)" in text
-    assert "6/8 (75%)" in text
+    assert "6/8 (75%); lock 81%" in text
     assert "12.4-12.9 Hz" in text
     assert "Reference coverage 88%" in text
 

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
@@ -168,7 +168,16 @@ def test_summarize_whole_run_order_traces_distinguishes_strong_and_weak_lock() -
     assert strong.reference_coverage_ratio == 1.0
     assert strong.stable_frequency_min_hz == 12.0
     assert strong.stable_frequency_max_hz == 12.0
-    assert strong.exemplar_interval_index is None
+    assert strong.exemplar_interval_index == 0
+    assert [
+        (interval.start_window_index, interval.end_window_index)
+        for interval in strong.support_intervals
+    ] == [(0, 5)]
+    assert strong.support_intervals[0].phase == DrivingPhase.CRUISE.value
+    assert {support.phase: support.support_ratio for support in strong.phase_support} == {
+        DrivingPhase.ACCELERATION.value: 0.5,
+        DrivingPhase.CRUISE.value: 1.0,
+    }
     assert strong.dominant_phase == DrivingPhase.CRUISE.value
     assert strong.dominant_speed_band == "50-60 km/h"
     assert strong.strongest_location == "Front Left"

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -13,6 +13,9 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunWindowPolicy,
 )
 from vibesensor.shared.window_quality import WindowQuality, score_window_quality
+from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    build_whole_run_order_trace_summary_artifact_bundle,
+)
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
     build_whole_run_order_trace_artifact_bundle,
@@ -46,9 +49,11 @@ def _window_policy() -> WholeRunWindowPolicy:
     )
 
 
-def _context_labels() -> tuple[WholeRunContextWindowLabel, ...]:
-    speeds = (40.0, 60.0, 80.0)
-    rpm_values = (1000.0, 1500.0, 2000.0)
+def _context_labels(
+    *,
+    speeds: tuple[float, float, float] = (40.0, 60.0, 80.0),
+    rpm_values: tuple[float, float, float] = (1000.0, 1500.0, 2000.0),
+) -> tuple[WholeRunContextWindowLabel, ...]:
     return tuple(
         WholeRunContextWindowLabel(
             window_index=index,
@@ -122,11 +127,14 @@ def _shock_window_quality() -> WindowQuality:
 def _summary_rows(
     *,
     sensor_scale: float,
+    context_labels: tuple[WholeRunContextWindowLabel, ...] | None = None,
+    include_predicted_peaks: bool = True,
+    fixed_peak_hz: float | None = None,
     window_quality_by_index: dict[int, WindowQuality] | None = None,
 ) -> tuple[WholeRunWindowSpectralSummary, ...]:
     metadata = _metadata()
     rows: list[WholeRunWindowSpectralSummary] = []
-    for label in _context_labels():
+    for label in context_labels or _context_labels():
         context_sample = _context_sample(
             label.window_index,
             speed_kmh=float(label.speed_kmh or 0.0),
@@ -162,15 +170,25 @@ def _summary_rows(
             engine_hz,
             engine_hz * 2.0 if engine_hz is not None else None,
         )
-        for index, predicted_hz in enumerate(predicted_frequencies, start=1):
-            if predicted_hz is None or predicted_hz <= 0:
-                continue
-            amplitude = sensor_scale / float(index)
+        if include_predicted_peaks:
+            for index, predicted_hz in enumerate(predicted_frequencies, start=1):
+                if predicted_hz is None or predicted_hz <= 0:
+                    continue
+                amplitude = sensor_scale / float(index)
+                peaks.append(
+                    {
+                        "hz": float(predicted_hz),
+                        "amp": amplitude,
+                        "vibration_strength_db": 30.0 + amplitude * 50.0,
+                        "strength_bucket": "l3",
+                    }
+                )
+        if fixed_peak_hz is not None:
             peaks.append(
                 {
-                    "hz": float(predicted_hz),
-                    "amp": amplitude,
-                    "vibration_strength_db": 30.0 + amplitude * 50.0,
+                    "hz": fixed_peak_hz,
+                    "amp": sensor_scale * 1.5,
+                    "vibration_strength_db": 30.0 + sensor_scale * 75.0,
                     "strength_bucket": "l3",
                 }
             )
@@ -206,15 +224,79 @@ def _summary_rows(
     return tuple(rows)
 
 
-def _artifact_contents() -> dict[str, bytes]:
+def _artifact_contents_for(
+    *,
+    context_labels: tuple[WholeRunContextWindowLabel, ...] | None = None,
+    include_predicted_peaks: bool = True,
+    fixed_peak_hz: float | None = None,
+) -> dict[str, bytes]:
     return {
         "spectral-summary:sensor-front": whole_run_window_spectral_summaries_to_jsonl_bytes(
-            _summary_rows(sensor_scale=0.14)
+            _summary_rows(
+                sensor_scale=0.14,
+                context_labels=context_labels,
+                include_predicted_peaks=include_predicted_peaks,
+                fixed_peak_hz=fixed_peak_hz,
+            )
         ),
         "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
-            _summary_rows(sensor_scale=0.08)
+            _summary_rows(
+                sensor_scale=0.08,
+                context_labels=context_labels,
+                include_predicted_peaks=include_predicted_peaks,
+                fixed_peak_hz=fixed_peak_hz,
+            )
         ),
     }
+
+
+def _artifact_contents() -> dict[str, bytes]:
+    return _artifact_contents_for()
+
+
+def _trace_bundle_for(
+    *,
+    context_labels: tuple[WholeRunContextWindowLabel, ...] | None = None,
+    include_predicted_peaks: bool = True,
+    fixed_peak_hz: float | None = None,
+):
+    labels = context_labels or _context_labels()
+    return build_whole_run_order_trace_artifact_bundle(
+        run_id="run-order-traces",
+        metadata=_metadata(),
+        spectral_manifest=_spectral_manifest(),
+        spectral_artifact_contents=_artifact_contents_for(
+            context_labels=labels,
+            include_predicted_peaks=include_predicted_peaks,
+            fixed_peak_hz=fixed_peak_hz,
+        ),
+        context_labels=labels,
+        samples=_samples(),
+    )
+
+
+def _summary_bundle_for(
+    *,
+    context_labels: tuple[WholeRunContextWindowLabel, ...] | None = None,
+    include_predicted_peaks: bool = True,
+    fixed_peak_hz: float | None = None,
+):
+    labels = context_labels or _context_labels()
+    trace_bundle = _trace_bundle_for(
+        context_labels=labels,
+        include_predicted_peaks=include_predicted_peaks,
+        fixed_peak_hz=fixed_peak_hz,
+    )
+    return build_whole_run_order_trace_summary_artifact_bundle(
+        order_trace_bundle=trace_bundle,
+        context_labels=labels,
+    )
+
+
+def _wheel_1x_summary(summary_bundle):
+    return next(
+        summary for summary in summary_bundle.summaries if summary.hypothesis_key == "wheel_1x"
+    )
 
 
 def _artifact_contents_with_shock_window(window_index: int) -> dict[str, bytes]:
@@ -318,3 +400,62 @@ def test_build_whole_run_order_trace_artifact_bundle_is_deterministic() -> None:
     assert first.manifest == second.manifest
     assert first.artifact_contents == second.artifact_contents
     assert first.points == second.points
+
+
+def test_whole_run_order_summary_tracks_constant_speed_order_lock() -> None:
+    labels = _context_labels(speeds=(60.0, 60.0, 60.0), rpm_values=(1500.0, 1500.0, 1500.0))
+    summary = _wheel_1x_summary(_summary_bundle_for(context_labels=labels))
+
+    assert summary.support_ratio == 1.0
+    assert summary.lock_score > 0.95
+    assert summary.stable_frequency_min_hz == summary.stable_frequency_max_hz
+    assert summary.exemplar_interval_index == 0
+    assert [
+        (interval.start_window_index, interval.end_window_index)
+        for interval in summary.support_intervals
+    ] == [(0, 2)]
+    assert summary.phase_support[0].phase == DrivingPhase.CRUISE.value
+    assert summary.phase_support[0].support_ratio == 1.0
+
+
+def test_whole_run_order_summary_tracks_acceleration_sweep_order_lock() -> None:
+    summary = _wheel_1x_summary(_summary_bundle_for())
+
+    assert summary.support_ratio == 1.0
+    assert summary.lock_score > 0.95
+    assert summary.stable_frequency_min_hz is not None
+    assert summary.stable_frequency_max_hz is not None
+    assert summary.stable_frequency_min_hz < summary.stable_frequency_max_hz
+    assert summary.support_intervals[0].matched_window_count == 3
+
+
+def test_whole_run_order_summary_does_not_lock_fixed_resonance_to_speed_sweep() -> None:
+    fixed_resonance_hz = 8.185985592665357
+    summary = _wheel_1x_summary(
+        _summary_bundle_for(include_predicted_peaks=False, fixed_peak_hz=fixed_resonance_hz)
+    )
+
+    assert summary.matched_window_count == 1
+    assert summary.support_ratio < 0.5
+    assert summary.lock_score < 0.5
+    assert [
+        (interval.start_window_index, interval.end_window_index)
+        for interval in summary.support_intervals
+    ] == [(1, 1)]
+
+
+def test_whole_run_order_trace_prefers_synchronous_peak_over_fixed_resonance() -> None:
+    fixed_resonance_hz = 8.185985592665357
+    trace_bundle = _trace_bundle_for(fixed_peak_hz=fixed_resonance_hz)
+    summary = _wheel_1x_summary(_summary_bundle_for(fixed_peak_hz=fixed_resonance_hz))
+    wheel_1x = [
+        point
+        for point in trace_bundle.points
+        if point.hypothesis_key == "wheel_1x" and point.harmonic == 1
+    ]
+
+    assert all(point.matched for point in wheel_1x)
+    assert wheel_1x[0].matched_hz != fixed_resonance_hz
+    assert wheel_1x[2].matched_hz != fixed_resonance_hz
+    assert summary.support_ratio == 1.0
+    assert summary.lock_score > 0.95

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2267,6 +2267,10 @@
     "en": "Limited supporting windows",
     "nl": "Beperkt aantal ondersteunende vensters"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_LOW_LOCK": {
+    "en": "Weak speed-synchronous order lock",
+    "nl": "Zwakke snelheids-synchrone ordervergrendeling"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_REFERENCE_MISSING": {
     "en": "Reference data unavailable",
     "nl": "Referentiegegevens niet beschikbaar"
@@ -2296,16 +2300,16 @@
     "nl": "{low}-{high} Hz"
   },
   "REPORT_DENSE_EVIDENCE_GUIDE": {
-    "en": "Dense rows summarize whole-run order-track evidence: support windows, stable frequency band, strongest location, and caveats when reference or support is limited.",
-    "nl": "Dichte regels vatten orderbewijs over de hele meting samen: ondersteunende vensters, stabiele frequentieband, sterkste locatie en kanttekeningen bij beperkte referentie of ondersteuning."
+    "en": "Dense rows summarize whole-run order-track evidence: support windows, speed-synchronous order lock, stable frequency band, strongest location, and caveats when reference, support, or lock quality is limited.",
+    "nl": "Dichte regels vatten orderbewijs over de hele meting samen: ondersteunende vensters, snelheids-synchrone ordervergrendeling, stabiele frequentieband, sterkste locatie en kanttekeningen bij beperkte referentie, ondersteuning of vergrendelingskwaliteit."
   },
   "REPORT_DENSE_EVIDENCE_SUPPORT_COLUMN": {
     "en": "Support",
     "nl": "Ondersteuning"
   },
   "REPORT_DENSE_EVIDENCE_SUPPORT_VALUE": {
-    "en": "{matched}/{eligible} ({pct})",
-    "nl": "{matched}/{eligible} ({pct})"
+    "en": "{matched}/{eligible} ({pct}); lock {lock}",
+    "nl": "{matched}/{eligible} ({pct}); vergrendeling {lock}"
   },
   "REPORT_DENSE_EVIDENCE_TITLE": {
     "en": "Dense evidence charts",

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -39,8 +39,10 @@ from vibesensor.use_cases.diagnostics.orders._hypothesis_catalog import (
 from vibesensor.use_cases.diagnostics.orders.physics import OrderHypothesis
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
     OrderHarmonicEvidenceSummary,
+    OrderTracePhaseSupport,
     OrderTracePoint,
     OrderTraceSummary,
+    OrderTraceSupportInterval,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WholeRunOrderTraceArtifactBundle,
@@ -194,6 +196,14 @@ def _summarize_hypothesis_trace(
     shock_transient_window_count = sum(
         1 for point in points if "shock_transient" in point.window_quality_reasons
     )
+    support_intervals = _support_intervals(
+        matched_points=matched_points,
+        context_by_window=context_by_window,
+    )
+    phase_support = _phase_support(
+        eligible_points=eligible_points,
+        context_by_window=context_by_window,
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=hypothesis.path_compliance if hypothesis is not None else 1.0,
@@ -276,12 +286,12 @@ def _summarize_hypothesis_trace(
         excluded_window_count=excluded_window_count,
         shock_transient_window_count=shock_transient_window_count,
         mean_quality_score=mean_quality_score,
-        support_intervals=(),
-        phase_support=(),
+        support_intervals=support_intervals,
+        phase_support=phase_support,
         harmonic_summaries=(harmonic_summary,),
         stable_frequency_min_hz=stable_frequency_min_hz,
         stable_frequency_max_hz=stable_frequency_max_hz,
-        exemplar_interval_index=None,
+        exemplar_interval_index=_exemplar_interval_index(support_intervals),
         dominant_phase=dominant_phase,
         dominant_speed_band=dominant_speed_band,
         strongest_location=strongest_location,
@@ -320,6 +330,8 @@ def _lock_score(
             + (_LOCK_SCORE_DRIFT_WEIGHT * drift_score),
         ),
     )
+    if support_ratio < 0.5:
+        base_score = min(base_score, support_ratio)
     if mean_quality_score is None:
         return base_score
     quality_factor = 0.85 + (0.15 * max(0.0, min(1.0, mean_quality_score)))
@@ -352,6 +364,123 @@ def _longest_contiguous_match_run(points: Sequence[OrderTracePoint]) -> int:
         previous_window_index = point.window_index
         longest = max(longest, current)
     return longest
+
+
+def _support_intervals(
+    *,
+    matched_points: Sequence[OrderTracePoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+) -> tuple[OrderTraceSupportInterval, ...]:
+    if not matched_points:
+        return ()
+    sorted_points = sorted(matched_points, key=lambda point: point.window_index)
+    grouped_points: list[list[OrderTracePoint]] = []
+    current_group: list[OrderTracePoint] = []
+    previous_window_index: int | None = None
+    for point in sorted_points:
+        if previous_window_index is None or point.window_index == previous_window_index + 1:
+            current_group.append(point)
+        else:
+            grouped_points.append(current_group)
+            current_group = [point]
+        previous_window_index = point.window_index
+    if current_group:
+        grouped_points.append(current_group)
+
+    return tuple(
+        OrderTraceSupportInterval(
+            interval_index=index,
+            start_window_index=group[0].window_index,
+            end_window_index=group[-1].window_index,
+            matched_window_count=len(group),
+            support_ratio=_ratio(
+                len(group),
+                group[-1].window_index - group[0].window_index + 1,
+            ),
+            phase=_dominant_context_for_points(
+                points=group,
+                context_by_window=context_by_window,
+                attribute_name="phase",
+            ),
+            load_state=_dominant_context_for_points(
+                points=group,
+                context_by_window=context_by_window,
+                attribute_name="load_state",
+            ),
+            speed_band=_dominant_context_for_points(
+                points=group,
+                context_by_window=context_by_window,
+                attribute_name="speed_band",
+            ),
+            mean_relative_error=_mean(
+                point.relative_error for point in group if point.relative_error is not None
+            ),
+        )
+        for index, group in enumerate(grouped_points)
+    )
+
+
+def _phase_support(
+    *,
+    eligible_points: Sequence[OrderTracePoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+) -> tuple[OrderTracePhaseSupport, ...]:
+    points_by_phase: dict[str, list[OrderTracePoint]] = {}
+    for point in eligible_points:
+        label = context_by_window.get(point.window_index)
+        if label is None:
+            continue
+        points_by_phase.setdefault(label.phase.value, []).append(point)
+    return tuple(
+        OrderTracePhaseSupport(
+            phase=phase,
+            eligible_window_count=len(points),
+            matched_window_count=sum(1 for point in points if point.matched),
+            support_ratio=_ratio(
+                sum(1 for point in points if point.matched),
+                len(points),
+            ),
+        )
+        for phase, points in sorted(points_by_phase.items())
+    )
+
+
+def _dominant_context_for_points(
+    *,
+    points: Sequence[OrderTracePoint],
+    context_by_window: Mapping[int, WholeRunContextWindowLabel],
+    attribute_name: str,
+) -> str | None:
+    counts: dict[str, int] = {}
+    for point in points:
+        label = context_by_window.get(point.window_index)
+        if label is None:
+            continue
+        raw_value = getattr(label, attribute_name)
+        value = raw_value.value if hasattr(raw_value, "value") else raw_value
+        if not isinstance(value, str) or not value:
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    if not counts:
+        return None
+    return max(counts.items(), key=lambda item: (item[1], item[0]))[0]
+
+
+def _exemplar_interval_index(
+    intervals: Sequence[OrderTraceSupportInterval],
+) -> int | None:
+    if not intervals:
+        return None
+    exemplar = max(
+        intervals,
+        key=lambda interval: (
+            interval.matched_window_count,
+            interval.support_ratio,
+            -(interval.mean_relative_error or 0.0),
+            -interval.interval_index,
+        ),
+    )
+    return exemplar.interval_index
 
 
 def _dominant_context_value(

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -151,6 +151,7 @@ def _dense_support_text(summary: ReportWholeRunOrderSummary, *, tr: Callable[...
         matched=summary.matched_window_count,
         eligible=summary.eligible_window_count,
         pct=f"{summary.support_ratio * 100:.0f}%",
+        lock=f"{summary.lock_score * 100:.0f}%",
     )
 
 
@@ -200,6 +201,8 @@ def _dense_caveat_text(
         )
     if summary.support_ratio < 0.5:
         return tr("REPORT_DENSE_EVIDENCE_CAVEAT_LIMITED_SUPPORT")
+    if summary.lock_score < 0.5:
+        return tr("REPORT_DENSE_EVIDENCE_CAVEAT_LOW_LOCK")
     if summary.drift_score > 0.25:
         return tr("REPORT_DENSE_EVIDENCE_CAVEAT_DRIFT")
     return None

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -98,6 +98,12 @@ bandwidth settings, optional harmonic lists, and an explicit output spectrum
 clamp. Unavailable reference inputs become unavailable band rows with reasons
 instead of being dropped or guessed.
 
+Whole-run order traces score the same speed/RPM-synchronous hypotheses across
+consecutive analysis windows. Summaries persist matched support intervals,
+phase-level support, contiguous support, drift/error, and an order-lock score, so
+fixed-frequency resonances during speed changes stay weak unless they follow the
+expected wheel, driveshaft, or engine trajectory.
+
 `use_cases/diagnostics/post_run_vibration_episodes.py` groups POSTRUN-03
 window-feature peaks into deterministic, time-bounded episodes. Grouping is by
 sensor/location, adjacent time windows, allowed per-step frequency drift, and a


### PR DESCRIPTION
Fixes #3744

## What changed
- Persist whole-run order support intervals, phase support, and exemplar interval indexes from dense order traces.
- Cap order-lock score when support is too sparse, so one coincidental fixed-frequency match does not look like a real speed-synchronous lock.
- Show order-lock percentage in dense report evidence and add a weak-lock caveat.
- Add synthetic coverage for constant speed, acceleration sweep, fixed-frequency resonance, and mixed fixed resonance plus true order signal.
- Document whole-run speed-synchronous trace behavior in the analysis pipeline.

## Why
Fixed-frequency structural or mounting resonances can overlap an expected order at one speed. They should not be treated as wheel/driveshaft/engine order evidence unless they track the expected speed/RPM trajectory over time.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py`
- `./.venv/bin/python -m ruff check apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py apps/server/vibesensor/use_cases/history/report_document/appendix_c.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py`
- `./.venv/bin/python -m ruff format --check apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py apps/server/vibesensor/use_cases/history/report_document/appendix_c.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python tools/dev/docs_lint.py`

## Risks / tradeoffs / edge cases
- Low-support order summaries now get a lower lock score. That is intentional; sparse support is not enough for a strong speed-synchronous order claim.
- Constant-speed order evidence still locks when support is continuous, but acceleration sweeps now better separate true tracking from fixed resonances.

## Follow-ups
- None in scope.
