### PR TITLE
DSP: add clipping and accelerometer saturation detection

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -174,6 +174,23 @@ def test_build_report_document_projects_shock_window_caveat() -> None:
     assert document.appendix_c.dense_evidence_rows[0].caveat == ("Road-shock windows filtered: 2")
 
 
+def test_build_report_document_projects_sensor_clipping_caveat() -> None:
+    summary = _dense_summary(
+        order_summary_overrides={
+            "reference_coverage_ratio": 1.0,
+            "mean_quality_score": 0.62,
+            "limited_window_count": 3,
+            "excluded_window_count": 2,
+            "sensor_clipping_window_count": 2,
+        }
+    )
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.appendix_c.dense_evidence_rows[0].caveat == (
+        "Sensor clipping windows filtered: 2"
+    )
+
+
 def test_build_report_document_skips_dense_evidence_when_artifacts_are_unavailable() -> None:
     document = build_report_document(prepare_report_input(minimal_summary()))
 

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -79,6 +79,29 @@ def test_metrics_computer_operates_on_snapshot_without_shared_state() -> None:
     assert any(abs(float(peak["hz"]) - 20.0) < 1.0 for peak in result.metrics["combined"]["peaks"])
 
 
+def test_metrics_computer_exposes_clipping_quality_in_live_payload() -> None:
+    config = _config(sample_rate_hz=400, fft_n=256, spectrum_max_hz=150.0)
+    computer = SignalMetricsComputer(config)
+    t = np.arange(config.fft_n, dtype=np.float32) / np.float32(config.sample_rate_hz)
+    clipped_tone = np.clip(2.0 * np.sin(2.0 * np.pi * 20.0 * t), -1.0, 1.0).astype(np.float32)
+    block = np.stack([clipped_tone, np.zeros_like(t), np.zeros_like(t)], axis=0)
+    snapshot = MetricsSnapshot(
+        client_id="client-clipped",
+        sample_rate_hz=config.sample_rate_hz,
+        ingest_generation=8,
+        time_window=block.copy(),
+        fft_block=block.copy(),
+    )
+
+    result = computer.compute(snapshot)
+    quality = result.metrics["combined"]["window_quality"]
+
+    assert quality["state"] == "excluded"
+    assert "sensor_clipping" in quality["reasons"]
+    assert quality["clipping_sample_count"] > 0
+    assert quality["clipping_axis_counts"]["x"] == quality["clipping_sample_count"]
+
+
 def test_buffer_store_reuses_fft_snapshot_for_short_time_window() -> None:
     store = SignalBufferStore(_config(sample_rate_hz=8, waveform_seconds=1, fft_n=4))
     client_id = "client-short-window"

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -224,6 +224,7 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
             "limited_window_count": 1,
             "excluded_window_count": 0,
             "shock_transient_window_count": 0,
+            "sensor_clipping_window_count": 0,
             "mean_quality_score": 0.92,
             "support_intervals": [
                 {

--- a/apps/server/tests/shared/test_window_quality.py
+++ b/apps/server/tests/shared/test_window_quality.py
@@ -5,7 +5,11 @@ from math import pi
 import numpy as np
 import pytest
 
-from vibesensor.shared.window_quality import score_window_quality, window_quality_with_context
+from vibesensor.shared.window_quality import (
+    analyze_window_clipping,
+    score_window_quality,
+    window_quality_with_context,
+)
 
 
 def _sine_samples(*, sample_count: int = 256, amplitude: float = 0.05) -> np.ndarray:
@@ -78,6 +82,68 @@ def test_window_quality_marks_dropped_clipped_and_shock_windows_low_quality() ->
     assert "sensor_clipping" in clipped_quality.reasons
     assert shock.state == "excluded"
     assert "shock_transient" in shock.reasons
+
+
+def test_window_clipping_analysis_distinguishes_clipped_and_clean_sine() -> None:
+    clean = _sine_samples(sample_count=256, amplitude=0.4)
+    clipped = np.clip(_sine_samples(sample_count=256, amplitude=2.0), -1.0, 1.0)
+
+    clean_quality = score_window_quality(
+        expected_sample_count=clean.shape[0],
+        returned_sample_count=clean.shape[0],
+        coverage_state="full",
+        samples_g=clean,
+        peak_amp_g=0.4,
+        noise_floor_amp_g=0.01,
+    )
+    clipped_quality = score_window_quality(
+        expected_sample_count=clipped.shape[0],
+        returned_sample_count=clipped.shape[0],
+        coverage_state="full",
+        samples_g=clipped,
+        peak_amp_g=1.0,
+        noise_floor_amp_g=0.01,
+    )
+
+    assert clean_quality.state == "usable"
+    assert "sensor_clipping" not in clean_quality.reasons
+    assert clipped_quality.state == "excluded"
+    assert "sensor_clipping" in clipped_quality.reasons
+    assert clipped_quality.clipping_sample_count > 0
+    assert clipped_quality.clipping_axis_counts[0] == clipped_quality.clipping_sample_count
+    assert clipped_quality.to_payload()["clipping_axis_counts"]["x"] > 0
+
+
+def test_window_clipping_analysis_flags_shock_clipping_not_single_sample_outlier() -> None:
+    single_outlier = np.zeros((256, 3), dtype=np.int16)
+    single_outlier[128, 0] = 32767
+    shock_clip = np.zeros((256, 3), dtype=np.int16)
+    shock_clip[126:130, 0] = 32767
+
+    outlier_quality = score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=256,
+        coverage_state="full",
+        samples_i16=single_outlier,
+        samples_g=single_outlier.astype(np.float32) * 0.001,
+        peak_amp_g=0.1,
+        noise_floor_amp_g=0.01,
+    )
+    shock_quality = score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=256,
+        coverage_state="full",
+        samples_i16=shock_clip,
+        samples_g=shock_clip.astype(np.float32) * 0.001,
+        peak_amp_g=0.1,
+        noise_floor_amp_g=0.01,
+    )
+
+    assert analyze_window_clipping(samples_i16=single_outlier).sample_count == 0
+    assert "sensor_clipping" not in outlier_quality.reasons
+    assert shock_quality.clipping_sample_count == 4
+    assert "sensor_clipping" in shock_quality.reasons
+    assert shock_quality.state == "excluded"
 
 
 def test_window_quality_context_downgrades_missing_speed_and_rpm() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -262,6 +262,7 @@ def test_history_order_trace_response_contracts_expose_named_summary_fields() ->
         "limited_window_count",
         "excluded_window_count",
         "shock_transient_window_count",
+        "sensor_clipping_window_count",
         "mean_quality_score",
         "support_intervals",
         "phase_support",

--- a/apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py
+++ b/apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py
@@ -110,6 +110,30 @@ def test_post_run_raw_window_iterator_streams_configured_sensor_ranges(tmp_path:
     assert "low_sample_count" in windows[2].sensors[1].data_quality_flags
 
 
+def test_post_run_raw_window_iterator_flags_sensor_clipping(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    _create_run_with_sensor_metadata(db, "run-clipping")
+    samples = _samples(4)
+    samples[:3, 0] = 32767
+    _append_chunk(db, run_id="run-clipping", client_id="sensor-a", t0_us=0, samples=samples)
+    assert _finalize_raw_capture(db, "run-clipping") is not None
+
+    iterator = db.run_repository._run_sync(
+        prepare_post_run_raw_window_iterator(
+            db.run_repository,
+            "run-clipping",
+            config=PostRunRawWindowIteratorConfig(
+                window_size_s=1.0,
+                overlap_pct=0.0,
+                min_valid_samples_pct=0.5,
+            ),
+        )
+    )
+    windows = db.run_repository._run_sync(_collect_windows(iterator))
+
+    assert "sensor_clipping" in windows[0].sensors[0].data_quality_flags
+
+
 def test_post_run_raw_window_iterator_uses_manifest_range_reads_not_full_capture(
     tmp_path: Path,
 ) -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
@@ -79,6 +79,24 @@ def _shock_point(window_index: int) -> OrderTracePoint:
     )
 
 
+def _clipped_point(window_index: int) -> OrderTracePoint:
+    return OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=window_index,
+        eligible=True,
+        matched=False,
+        predicted_hz=8.0 + window_index,
+        ref_source="speed+tire",
+        window_quality_score=0.10,
+        window_quality_state="excluded",
+        window_quality_reasons=("sensor_clipping",),
+    )
+
+
 def test_order_trace_scoring_records_and_downweights_limited_window_quality() -> None:
     context_labels = _context_labels()
     clean_summary = summarize_whole_run_order_traces(
@@ -115,3 +133,18 @@ def test_order_trace_scoring_counts_unmatched_shock_windows() -> None:
     assert summary.excluded_window_count == 1
     assert summary.shock_transient_window_count == 1
     assert summary.mean_quality_score == 0.56
+
+
+def test_order_trace_scoring_counts_unmatched_clipped_windows() -> None:
+    summary = summarize_whole_run_order_traces(
+        points=(
+            _point(0, quality_score=1.0, quality_state="usable"),
+            _clipped_point(1),
+        ),
+        context_labels=_context_labels(),
+    )[0]
+
+    assert summary.matched_window_count == 1
+    assert summary.excluded_window_count == 1
+    assert summary.sensor_clipping_window_count == 1
+    assert summary.mean_quality_score == 0.55

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2283,6 +2283,10 @@
     "en": "Road-shock windows filtered: {count}",
     "nl": "Wegschokvensters gefilterd: {count}"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_CLIPPING_WINDOWS": {
+    "en": "Sensor clipping windows filtered: {count}",
+    "nl": "Sensorclippingvensters gefilterd: {count}"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_WINDOW_QUALITY_LIMITED": {
     "en": "Usable window quality {pct}; limited {limited}, excluded {excluded}",
     "nl": "Bruikbare vensterkwaliteit {pct}; beperkt {limited}, uitgesloten {excluded}"

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -149,6 +149,7 @@ class ReportWholeRunOrderSummary:
     limited_window_count: int
     excluded_window_count: int
     shock_transient_window_count: int
+    sensor_clipping_window_count: int
     mean_quality_score: float | None
     support_intervals: tuple[ReportOrderTraceSupportInterval, ...]
     phase_support: tuple[ReportOrderTracePhaseSupport, ...]
@@ -671,6 +672,7 @@ _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
         _count_field("limited_window_count"),
         _count_field("excluded_window_count"),
         _count_field("shock_transient_window_count"),
+        _count_field("sensor_clipping_window_count"),
         _float_field("mean_quality_score"),
         _rows_field("support_intervals", _ORDER_SUPPORT_INTERVAL_DECODER),
         _rows_field("phase_support", _ORDER_PHASE_SUPPORT_DECODER),

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -317,6 +317,7 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     limited_window_count: Required[int]
     excluded_window_count: Required[int]
     shock_transient_window_count: Required[int]
+    sensor_clipping_window_count: Required[int]
     mean_quality_score: float | None
     support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
     phase_support: Required[list[OrderTracePhaseSupportResponse]]

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -65,6 +65,9 @@ class WindowQualityPayload(TypedDict):
     sample_completeness_score: float
     packet_integrity_score: float
     clipping_score: float
+    clipping_sample_count: int
+    clipping_sample_ratio: float
+    clipping_axis_counts: dict[str, int]
     transient_score: float
     shock_crest_factor: float | None
     shock_broadband_ratio: float | None

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -9,7 +9,7 @@ from typing import Literal
 import numpy as np
 
 from vibesensor.shared.fft_analysis import broadband_energy_ratio
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.shared.types.payload_types import WindowQualityPayload
 
 type WindowQualityState = Literal["usable", "limited", "excluded"]
@@ -44,10 +44,17 @@ _WEIGHT_CONTEXT = 0.15
 _WEIGHT_FREQUENCY = 0.15
 _CLIPPING_FULL_SCALE_I16 = 32760
 _CLIPPING_EXCLUDED_RATIO = 0.01
+_CLIPPING_MIN_REPEATED_RAIL_SAMPLES = 3
+_CLIPPING_MIN_FLAT_TOP_RUN = 2
+_FLAT_TOP_MIN_PEAK_G = 0.5
+_FLAT_TOP_MIN_P2P_G = 0.25
+_FLAT_TOP_REL_TOLERANCE = 0.002
+_FLAT_TOP_ABS_TOLERANCE_G = 0.02
 _CREST_FACTOR_CLEAN = 6.0
 _CREST_FACTOR_EXCLUDED = 12.0
 _BROADBAND_RATIO_CLEAN = 0.55
 _BROADBAND_RATIO_EXCLUDED = 0.82
+_AXIS_NAMES = ("x", "y", "z")
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +62,19 @@ class _TransientAnalysis:
     score: float
     crest_factor: float | None
     broadband_ratio: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class WindowClippingAnalysis:
+    """Clipping/saturation evidence for one raw or scaled sample window."""
+
+    score: float
+    sample_count: int
+    sample_ratio: float
+    axis_counts: tuple[int, int, int] = (0, 0, 0)
+
+    def axis_counts_payload(self) -> dict[str, int]:
+        return dict(zip(_AXIS_NAMES, self.axis_counts, strict=True))
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,6 +91,9 @@ class WindowQuality:
     frequency_stability_score: float
     shock_crest_factor: float | None = None
     shock_broadband_ratio: float | None = None
+    clipping_sample_count: int = 0
+    clipping_sample_ratio: float = 0.0
+    clipping_axis_counts: tuple[int, int, int] = (0, 0, 0)
     reasons: tuple[WindowQualityReason, ...] = ()
 
     def to_payload(self) -> WindowQualityPayload:
@@ -80,6 +103,9 @@ class WindowQuality:
             "sample_completeness_score": self.sample_completeness_score,
             "packet_integrity_score": self.packet_integrity_score,
             "clipping_score": self.clipping_score,
+            "clipping_sample_count": self.clipping_sample_count,
+            "clipping_sample_ratio": self.clipping_sample_ratio,
+            "clipping_axis_counts": self._clipping_axis_counts_payload(),
             "transient_score": self.transient_score,
             "shock_crest_factor": self.shock_crest_factor,
             "shock_broadband_ratio": self.shock_broadband_ratio,
@@ -95,6 +121,9 @@ class WindowQuality:
             "sample_completeness_score": self.sample_completeness_score,
             "packet_integrity_score": self.packet_integrity_score,
             "clipping_score": self.clipping_score,
+            "clipping_sample_count": self.clipping_sample_count,
+            "clipping_sample_ratio": self.clipping_sample_ratio,
+            "clipping_axis_counts": self._clipping_axis_counts_json(),
             "transient_score": self.transient_score,
             "shock_crest_factor": self.shock_crest_factor,
             "shock_broadband_ratio": self.shock_broadband_ratio,
@@ -128,6 +157,12 @@ class WindowQuality:
                 default=1.0,
             ),
             clipping_score=_score_from_json(data.get("clipping_score"), default=1.0),
+            clipping_sample_count=max(0, _int_from_json(data.get("clipping_sample_count")) or 0),
+            clipping_sample_ratio=_score_from_json(
+                data.get("clipping_sample_ratio"),
+                default=0.0,
+            ),
+            clipping_axis_counts=_axis_counts_from_json(data.get("clipping_axis_counts")),
             transient_score=_score_from_json(data.get("transient_score"), default=1.0),
             shock_crest_factor=_nonnegative_float_from_json(data.get("shock_crest_factor")),
             shock_broadband_ratio=_optional_score_from_json(data.get("shock_broadband_ratio")),
@@ -139,6 +174,15 @@ class WindowQuality:
             reasons=reasons,
         )
 
+    def _clipping_axis_counts_payload(self) -> dict[str, int]:
+        return dict(zip(_AXIS_NAMES, self.clipping_axis_counts, strict=True))
+
+    def _clipping_axis_counts_json(self) -> dict[str, JsonValue]:
+        return {
+            axis_name: count
+            for axis_name, count in zip(_AXIS_NAMES, self.clipping_axis_counts, strict=True)
+        }
+
 
 def clean_window_quality() -> WindowQuality:
     return WindowQuality(
@@ -147,6 +191,9 @@ def clean_window_quality() -> WindowQuality:
         sample_completeness_score=1.0,
         packet_integrity_score=1.0,
         clipping_score=1.0,
+        clipping_sample_count=0,
+        clipping_sample_ratio=0.0,
+        clipping_axis_counts=(0, 0, 0),
         transient_score=1.0,
         context_score=1.0,
         frequency_stability_score=1.0,
@@ -177,7 +224,7 @@ def score_window_quality(
         coverage_state=coverage_state,
         coverage_reason=coverage_reason,
     )
-    clipping_score = _clipping_score(samples_i16)
+    clipping_analysis = analyze_window_clipping(samples_i16=samples_i16, samples_g=samples_g)
     transient_analysis = _transient_analysis(samples_g)
     context_score = _context_score(
         context_coverage=context_coverage,
@@ -191,7 +238,10 @@ def score_window_quality(
     return _quality_from_component_scores(
         sample_completeness_score=sample_score,
         packet_integrity_score=packet_score,
-        clipping_score=clipping_score,
+        clipping_score=clipping_analysis.score,
+        clipping_sample_count=clipping_analysis.sample_count,
+        clipping_sample_ratio=clipping_analysis.sample_ratio,
+        clipping_axis_counts=clipping_analysis.axis_counts,
         transient_score=transient_analysis.score,
         shock_crest_factor=transient_analysis.crest_factor,
         shock_broadband_ratio=transient_analysis.broadband_ratio,
@@ -213,6 +263,9 @@ def window_quality_with_context(
         sample_completeness_score=quality.sample_completeness_score,
         packet_integrity_score=quality.packet_integrity_score,
         clipping_score=quality.clipping_score,
+        clipping_sample_count=quality.clipping_sample_count,
+        clipping_sample_ratio=quality.clipping_sample_ratio,
+        clipping_axis_counts=quality.clipping_axis_counts,
         transient_score=quality.transient_score,
         shock_crest_factor=quality.shock_crest_factor,
         shock_broadband_ratio=quality.shock_broadband_ratio,
@@ -231,14 +284,20 @@ def _quality_from_component_scores(
     packet_integrity_score: float,
     clipping_score: float,
     transient_score: float,
-    shock_crest_factor: float | None = None,
-    shock_broadband_ratio: float | None = None,
     context_score: float,
     frequency_stability_score: float,
+    clipping_sample_count: int = 0,
+    clipping_sample_ratio: float = 0.0,
+    clipping_axis_counts: tuple[int, int, int] = (0, 0, 0),
+    shock_crest_factor: float | None = None,
+    shock_broadband_ratio: float | None = None,
 ) -> WindowQuality:
     sample_completeness_score = _clamp01(sample_completeness_score)
     packet_integrity_score = _clamp01(packet_integrity_score)
     clipping_score = _clamp01(clipping_score)
+    clipping_sample_count = max(0, int(clipping_sample_count))
+    clipping_sample_ratio = _clamp01(clipping_sample_ratio)
+    clipping_axis_counts = _normalized_axis_counts(clipping_axis_counts)
     transient_score = _clamp01(transient_score)
     context_score = _clamp01(context_score)
     frequency_stability_score = _clamp01(frequency_stability_score)
@@ -280,6 +339,9 @@ def _quality_from_component_scores(
         sample_completeness_score=sample_completeness_score,
         packet_integrity_score=packet_integrity_score,
         clipping_score=clipping_score,
+        clipping_sample_count=clipping_sample_count,
+        clipping_sample_ratio=clipping_sample_ratio,
+        clipping_axis_counts=clipping_axis_counts,
         transient_score=transient_score,
         context_score=context_score,
         frequency_stability_score=frequency_stability_score,
@@ -311,15 +373,103 @@ def _packet_integrity_score(*, coverage_state: str, coverage_reason: str | None)
     return 0.0
 
 
-def _clipping_score(samples_i16: np.ndarray | None) -> float:
-    if samples_i16 is None or samples_i16.size == 0:
-        return 1.0
-    clipped_mask = np.abs(samples_i16.astype(np.int32)) >= _CLIPPING_FULL_SCALE_I16
-    clipped_count = int(np.count_nonzero(clipped_mask))
-    if clipped_count <= 0:
-        return 1.0
-    ratio = float(clipped_count) / float(samples_i16.size)
-    return _clamp01(1.0 - (ratio / _CLIPPING_EXCLUDED_RATIO))
+def analyze_window_clipping(
+    *,
+    samples_i16: np.ndarray | None = None,
+    samples_g: np.ndarray | None = None,
+) -> WindowClippingAnalysis:
+    """Detect repeated rail hits and flat-topped waveforms in one sample window."""
+
+    raw_samples = _time_axis_samples_any(samples_i16)
+    scaled_samples = _time_axis_samples_any(samples_g)
+    raw_axis_counts = _raw_rail_axis_counts(raw_samples)
+    flat_top_axis_counts = _flat_top_axis_counts(scaled_samples)
+    axis_counts = (
+        max(raw_axis_counts[0], flat_top_axis_counts[0]),
+        max(raw_axis_counts[1], flat_top_axis_counts[1]),
+        max(raw_axis_counts[2], flat_top_axis_counts[2]),
+    )
+    total_slots = max(
+        int(raw_samples.size) if raw_samples is not None else 0,
+        int(scaled_samples.size) if scaled_samples is not None else 0,
+    )
+    sample_count = sum(axis_counts)
+    if sample_count <= 0 or total_slots <= 0:
+        return WindowClippingAnalysis(score=1.0, sample_count=0, sample_ratio=0.0)
+    sample_ratio = _clamp01(float(sample_count) / float(total_slots))
+    score = _clamp01(1.0 - (sample_ratio / _CLIPPING_EXCLUDED_RATIO))
+    return WindowClippingAnalysis(
+        score=score,
+        sample_count=sample_count,
+        sample_ratio=sample_ratio,
+        axis_counts=axis_counts,
+    )
+
+
+def _raw_rail_axis_counts(samples: np.ndarray | None) -> tuple[int, int, int]:
+    if samples is None or samples.size == 0:
+        return (0, 0, 0)
+    raw = samples.astype(np.int32, copy=False)
+    counts: list[int] = []
+    for axis_index in range(3):
+        axis = raw[:, axis_index]
+        rail_mask = np.abs(axis) >= _CLIPPING_FULL_SCALE_I16
+        count = int(np.count_nonzero(rail_mask))
+        counts.append(count if count >= _CLIPPING_MIN_REPEATED_RAIL_SAMPLES else 0)
+    return _normalized_axis_counts(tuple(counts))
+
+
+def _flat_top_axis_counts(samples: np.ndarray | None) -> tuple[int, int, int]:
+    if samples is None or samples.size == 0:
+        return (0, 0, 0)
+    arr = samples.astype(np.float64, copy=False)
+    counts: list[int] = []
+    for axis_index in range(3):
+        axis_values = arr[:, axis_index]
+        finite_axis = axis_values[np.isfinite(axis_values)]
+        if finite_axis.size == 0:
+            counts.append(0)
+            continue
+        upper = float(np.max(finite_axis))
+        lower = float(np.min(finite_axis))
+        peak = max(abs(upper), abs(lower))
+        p2p = upper - lower
+        if peak < _FLAT_TOP_MIN_PEAK_G or p2p < _FLAT_TOP_MIN_P2P_G:
+            counts.append(0)
+            continue
+        tolerance = max(_FLAT_TOP_ABS_TOLERANCE_G, peak * _FLAT_TOP_REL_TOLERANCE)
+        upper_mask = (
+            finite_axis >= upper - tolerance
+            if upper > 0.0
+            else np.zeros_like(
+                finite_axis,
+                dtype=np.bool_,
+            )
+        )
+        lower_mask = (
+            finite_axis <= lower + tolerance
+            if lower < 0.0
+            else np.zeros_like(
+                finite_axis,
+                dtype=np.bool_,
+            )
+        )
+        flat_mask = np.logical_or(upper_mask, lower_mask)
+        count = int(np.count_nonzero(flat_mask))
+        counts.append(count if _longest_true_run(flat_mask) >= _CLIPPING_MIN_FLAT_TOP_RUN else 0)
+    return _normalized_axis_counts(tuple(counts))
+
+
+def _longest_true_run(mask: np.ndarray) -> int:
+    longest = 0
+    current = 0
+    for value in mask:
+        if bool(value):
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
 
 
 def _transient_analysis(samples_g: np.ndarray | None) -> _TransientAnalysis:
@@ -376,6 +526,19 @@ def _time_axis_samples(samples: np.ndarray) -> np.ndarray:
     return np.empty((0, 3), dtype=np.float32)
 
 
+def _time_axis_samples_any(samples: np.ndarray | None) -> np.ndarray | None:
+    if samples is None:
+        return None
+    arr = np.asarray(samples)
+    if arr.ndim != 2:
+        return None
+    if arr.shape[1] == 3:
+        return arr
+    if arr.shape[0] == 3:
+        return arr.T
+    return None
+
+
 def _context_score(
     *,
     context_coverage: str | None,
@@ -420,6 +583,33 @@ def _score_from_json(value: object, *, default: float) -> float:
     if isinstance(value, int | float) and not isinstance(value, bool) and isfinite(float(value)):
         return _clamp01(float(value))
     return default
+
+
+def _int_from_json(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _axis_counts_from_json(value: object) -> tuple[int, int, int]:
+    if isinstance(value, dict):
+        return _normalized_axis_counts(
+            tuple(_int_from_json(value.get(axis_name)) or 0 for axis_name in _AXIS_NAMES)
+        )
+    if isinstance(value, list | tuple):
+        return _normalized_axis_counts(tuple(_int_from_json(raw) or 0 for raw in value[:3]))
+    return (0, 0, 0)
+
+
+def _normalized_axis_counts(values: tuple[int, ...]) -> tuple[int, int, int]:
+    padded = (*values, 0, 0, 0)
+    return (
+        max(0, int(padded[0])),
+        max(0, int(padded[1])),
+        max(0, int(padded[2])),
+    )
 
 
 def _optional_score_from_json(value: object) -> float | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -312,6 +312,7 @@ class OrderTraceSummary:
     limited_window_count: int = 0
     excluded_window_count: int = 0
     shock_transient_window_count: int = 0
+    sensor_clipping_window_count: int = 0
     mean_quality_score: float | None = None
     support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
     phase_support: tuple[OrderTracePhaseSupport, ...] = ()
@@ -348,6 +349,10 @@ class OrderTraceSummary:
             self.shock_transient_window_count,
             field_name="shock_transient_window_count",
         )
+        _require_nonnegative(
+            self.sensor_clipping_window_count,
+            field_name="sensor_clipping_window_count",
+        )
         _require_ratio(self.support_ratio, field_name="support_ratio")
         _require_ratio(self.reference_coverage_ratio, field_name="reference_coverage_ratio")
         _require_ratio(self.contiguous_support_ratio, field_name="contiguous_support_ratio")
@@ -373,6 +378,7 @@ class OrderTraceSummary:
             "limited_window_count": self.limited_window_count,
             "excluded_window_count": self.excluded_window_count,
             "shock_transient_window_count": self.shock_transient_window_count,
+            "sensor_clipping_window_count": self.sensor_clipping_window_count,
             "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
             "phase_support": [row.to_json_object() for row in self.phase_support],
             "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
@@ -416,6 +422,9 @@ class OrderTraceSummary:
             excluded_window_count=_optional_int(data.get("excluded_window_count")) or 0,
             shock_transient_window_count=(
                 _optional_int(data.get("shock_transient_window_count")) or 0
+            ),
+            sensor_clipping_window_count=(
+                _optional_int(data.get("sensor_clipping_window_count")) or 0
             ),
             mean_quality_score=_optional_float(data.get("mean_quality_score")),
             support_intervals=_tuple_from_mapping_list_field(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -206,6 +206,13 @@ def _family_summary(
             if "shock_transient" in point.window_quality_reasons
         }
     )
+    sensor_clipping_window_count = len(
+        {
+            point.window_index
+            for point in points
+            if "sensor_clipping" in point.window_quality_reasons
+        }
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=1.0,
@@ -285,6 +292,7 @@ def _family_summary(
         limited_window_count=limited_window_count,
         excluded_window_count=excluded_window_count,
         shock_transient_window_count=shock_transient_window_count,
+        sensor_clipping_window_count=sensor_clipping_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -196,6 +196,9 @@ def _summarize_hypothesis_trace(
     shock_transient_window_count = sum(
         1 for point in points if "shock_transient" in point.window_quality_reasons
     )
+    sensor_clipping_window_count = sum(
+        1 for point in points if "sensor_clipping" in point.window_quality_reasons
+    )
     support_intervals = _support_intervals(
         matched_points=matched_points,
         context_by_window=context_by_window,
@@ -285,6 +288,7 @@ def _summarize_hypothesis_trace(
         limited_window_count=limited_window_count,
         excluded_window_count=excluded_window_count,
         shock_transient_window_count=shock_transient_window_count,
+        sensor_clipping_window_count=sensor_clipping_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,

--- a/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py
@@ -21,6 +21,7 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunWindowDescriptor,
     WholeRunWindowPolicy,
 )
+from vibesensor.shared.window_quality import analyze_window_clipping
 
 _SUPPORTED_RAW_CAPTURE_SCHEMA_VERSION = 7
 _SUPPORTED_RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
@@ -56,6 +57,7 @@ type PostRunRawWindowDataQualityFlag = Literal[
     "sample_rate_unverified",
     "missing_sensor_location",
     "missing_sidecar",
+    "sensor_clipping",
 ]
 
 
@@ -674,6 +676,8 @@ def _quality_flags(
                 window_index=window_index,
             )
         )
+    elif analyze_window_clipping(samples_i16=raw_range.samples_i16).sample_count > 0:
+        _append_unique_flag(flags, "sensor_clipping")
     return flags
 
 

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -183,6 +183,11 @@ def _dense_caveat_text(
             "REPORT_DENSE_EVIDENCE_CAVEAT_REFERENCE_PARTIAL",
             pct=f"{summary.reference_coverage_ratio * 100:.0f}%",
         )
+    if summary.sensor_clipping_window_count > 0:
+        return tr(
+            "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_CLIPPING_WINDOWS",
+            count=str(summary.sensor_clipping_window_count),
+        )
     if summary.shock_transient_window_count > 0:
         return tr(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS",

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -6314,6 +6314,10 @@
             ],
             "title": "Relative Error Stddev"
           },
+          "sensor_clipping_window_count": {
+            "title": "Sensor Clipping Window Count",
+            "type": "integer"
+          },
           "shock_transient_window_count": {
             "title": "Shock Transient Window Count",
             "type": "integer"
@@ -6391,6 +6395,7 @@
           "limited_window_count",
           "excluded_window_count",
           "shock_transient_window_count",
+          "sensor_clipping_window_count",
           "support_intervals",
           "phase_support",
           "harmonic_summaries",
@@ -9453,6 +9458,21 @@
       },
       "WindowQualityPayload": {
         "properties": {
+          "clipping_axis_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Clipping Axis Counts",
+            "type": "object"
+          },
+          "clipping_sample_count": {
+            "title": "Clipping Sample Count",
+            "type": "integer"
+          },
+          "clipping_sample_ratio": {
+            "title": "Clipping Sample Ratio",
+            "type": "number"
+          },
           "clipping_score": {
             "title": "Clipping Score",
             "type": "number"
@@ -9521,6 +9541,9 @@
           "sample_completeness_score",
           "packet_integrity_score",
           "clipping_score",
+          "clipping_sample_count",
+          "clipping_sample_ratio",
+          "clipping_axis_counts",
           "transient_score",
           "shock_crest_factor",
           "shock_broadband_ratio",

--- a/apps/ui/src/contracts/ws_payload_schema.json
+++ b/apps/ui/src/contracts/ws_payload_schema.json
@@ -505,6 +505,21 @@
     },
     "WindowQualityPayload": {
       "properties": {
+        "clipping_axis_counts": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Clipping Axis Counts",
+          "type": "object"
+        },
+        "clipping_sample_count": {
+          "title": "Clipping Sample Count",
+          "type": "integer"
+        },
+        "clipping_sample_ratio": {
+          "title": "Clipping Sample Ratio",
+          "type": "number"
+        },
         "clipping_score": {
           "title": "Clipping Score",
           "type": "number"
@@ -573,6 +588,9 @@
         "sample_completeness_score",
         "packet_integrity_score",
         "clipping_score",
+        "clipping_sample_count",
+        "clipping_sample_ratio",
+        "clipping_axis_counts",
         "transient_score",
         "shock_crest_factor",
         "shock_broadband_ratio",

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -58,8 +58,8 @@ stages consume bounded axis arrays per window instead of materializing the full
 raw artifact bundle. Each emitted sensor window carries run ID, sensor ID,
 location snapshot, mount orientation, start/end timing, sample rate, x/y/z
 `int16` arrays, and data-quality flags such as partial windows, timestamp gaps,
-missing samples, low sample count, invalid axis data, sample-rate mismatch, and
-missing sidecars.
+missing samples, low sample count, invalid axis data, sample-rate mismatch,
+sensor clipping, and missing sidecars.
 
 The first dense analysis consumer is
 `use_cases/diagnostics/post_run_stft.py`. It consumes those POSTRUN-01 window
@@ -82,6 +82,11 @@ Axis dominance is only emitted for vehicle-relative frames; sensor-local frames
 carry a `sensor_orientation_unknown` quality flag instead. Frequency masks live
 at this layer so later episode/order/finding logic can ignore unusable bands
 without recomputing the dense spectra.
+
+Shared per-window quality scoring detects repeated accelerometer rail hits and
+flat-topped waveforms, exposes clipping counts/ratios by axis in live payloads,
+and marks clipped windows as limited or excluded evidence rather than treating
+high clipped amplitudes as trustworthy vibration strength.
 
 `use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
 and final-drive references onto the same window grid. It uses conservative


### PR DESCRIPTION
Fixes #3745

## What changed
- Added shared window clipping analysis for repeated raw rail hits and flat-topped scaled waveforms.
- Added clipping sample count, ratio, and per-axis counts to live/window-quality payloads and persisted JSON.
- Ignored single-sample rail outliers as clipping evidence.
- Propagated `sensor_clipping` through post-run raw-window quality flags and whole-run order summary counts.
- Added report dense-evidence caveat text for filtered clipping windows.
- Updated analysis docs and focused tests.

## Why
Clipped accelerometer windows can produce misleading FFT/RMS/amplitude values. They must be visible as data-quality evidence and down-ranked or excluded instead of looking like trustworthy high vibration.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/test_window_quality.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/use_cases/diagnostics/test_post_run_raw_windows.py apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py apps/server/tests/integration/test_contract_analysis_persistence_http.py`
- `./.venv/bin/python -m ruff check ...touched backend files...`
- `./.venv/bin/python -m ruff format --check ...touched backend files...`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `cd apps/server && ../../.venv/bin/python ../../tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python tools/dev/docs_lint.py`
- `cd apps/ui && npm run check:contracts`

## Risks / tradeoffs / edge cases
- Repeated rail hits or flat-topped plateaus mark the window as clipped; a single rail sample does not.
- Strong shock windows can carry both transient and clipping quality reasons.
- Additional payload fields are additive and contract drift check is clean.

## Follow-ups
- None in scope.
