### PR TITLE
DSP: add mounting-artifact quality caveats

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -191,6 +191,22 @@ def test_build_report_document_projects_sensor_clipping_caveat() -> None:
     )
 
 
+def test_build_report_document_projects_sensor_mounting_artifact_caveat() -> None:
+    summary = _dense_summary(
+        order_summary_overrides={
+            "reference_coverage_ratio": 1.0,
+            "mean_quality_score": 0.86,
+            "limited_window_count": 2,
+            "sensor_mounting_artifact_window_count": 2,
+        }
+    )
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.appendix_c.dense_evidence_rows[0].caveat == (
+        "Sensor mounting artifact windows limited diagnosis: 2"
+    )
+
+
 def test_build_report_document_skips_dense_evidence_when_artifacts_are_unavailable() -> None:
     document = build_report_document(prepare_report_input(minimal_summary()))
 

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -100,6 +100,8 @@ def test_metrics_computer_exposes_clipping_quality_in_live_payload() -> None:
     assert "sensor_clipping" in quality["reasons"]
     assert quality["clipping_sample_count"] > 0
     assert quality["clipping_axis_counts"]["x"] == quality["clipping_sample_count"]
+    assert quality["mounting_score"] >= 0.0
+    assert "mounting_high_frequency_ratio" in quality
 
 
 def test_buffer_store_reuses_fft_snapshot_for_short_time_window() -> None:

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -225,6 +225,7 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
             "excluded_window_count": 0,
             "shock_transient_window_count": 0,
             "sensor_clipping_window_count": 0,
+            "sensor_mounting_artifact_window_count": 0,
             "mean_quality_score": 0.92,
             "support_intervals": [
                 {

--- a/apps/server/tests/shared/test_window_quality.py
+++ b/apps/server/tests/shared/test_window_quality.py
@@ -24,6 +24,18 @@ def _sine_samples(*, sample_count: int = 256, amplitude: float = 0.05) -> np.nda
     )
 
 
+def _sine_at_hz(*, hz: float, sample_count: int = 256, amplitude: float = 0.05) -> np.ndarray:
+    sample_rate_hz = 256
+    t = np.arange(sample_count, dtype=np.float32) / float(sample_rate_hz)
+    return np.column_stack(
+        [
+            amplitude * np.sin(2.0 * pi * hz * t),
+            np.zeros(sample_count, dtype=np.float32),
+            np.zeros(sample_count, dtype=np.float32),
+        ]
+    )
+
+
 def test_window_quality_scores_clean_window_as_usable() -> None:
     sample_count = 256
     samples_g = _sine_samples(sample_count=sample_count)
@@ -42,6 +54,38 @@ def test_window_quality_scores_clean_window_as_usable() -> None:
     assert quality.shock_broadband_ratio is not None
     assert quality.shock_broadband_ratio < 0.15
     assert quality.reasons == ()
+
+
+def test_window_quality_flags_high_frequency_mounting_artifact_as_limited() -> None:
+    clean = _sine_at_hz(hz=18.0, amplitude=0.08)
+    loose_mount = _sine_at_hz(hz=92.0, amplitude=0.08)
+
+    clean_quality = score_window_quality(
+        expected_sample_count=clean.shape[0],
+        returned_sample_count=clean.shape[0],
+        coverage_state="full",
+        samples_g=clean,
+        sample_rate_hz=256,
+        peak_amp_g=0.08,
+        noise_floor_amp_g=0.01,
+    )
+    loose_mount_quality = score_window_quality(
+        expected_sample_count=loose_mount.shape[0],
+        returned_sample_count=loose_mount.shape[0],
+        coverage_state="full",
+        samples_g=loose_mount,
+        sample_rate_hz=256,
+        peak_amp_g=0.08,
+        noise_floor_amp_g=0.01,
+    )
+
+    assert clean_quality.state == "usable"
+    assert "mounting_artifact" not in clean_quality.reasons
+    assert loose_mount_quality.state == "limited"
+    assert "mounting_artifact" in loose_mount_quality.reasons
+    assert loose_mount_quality.mounting_score < 0.25
+    assert loose_mount_quality.mounting_high_frequency_ratio is not None
+    assert loose_mount_quality.to_payload()["mounting_high_frequency_ratio"] is not None
 
 
 def test_window_quality_marks_dropped_clipped_and_shock_windows_low_quality() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -263,6 +263,7 @@ def test_history_order_trace_response_contracts_expose_named_summary_fields() ->
         "excluded_window_count",
         "shock_transient_window_count",
         "sensor_clipping_window_count",
+        "sensor_mounting_artifact_window_count",
         "mean_quality_score",
         "support_intervals",
         "phase_support",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -216,6 +216,7 @@ def _summary_rows(
                     packet_integrity_score=1.0,
                     clipping_score=1.0,
                     transient_score=1.0,
+                    mounting_score=1.0,
                     context_score=1.0,
                     frequency_stability_score=1.0,
                 ),

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
@@ -97,6 +97,29 @@ def _clipped_point(window_index: int) -> OrderTracePoint:
     )
 
 
+def _mounting_artifact_point(window_index: int) -> OrderTracePoint:
+    return OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=window_index,
+        eligible=True,
+        matched=True,
+        predicted_hz=8.0 + window_index,
+        matched_hz=8.05 + window_index,
+        relative_error=0.01,
+        peak_intensity_db=24.0,
+        vibration_strength_db=20.0,
+        ref_source="speed+tire",
+        strongest_location="Front Left",
+        window_quality_score=0.86,
+        window_quality_state="limited",
+        window_quality_reasons=("mounting_artifact",),
+    )
+
+
 def test_order_trace_scoring_records_and_downweights_limited_window_quality() -> None:
     context_labels = _context_labels()
     clean_summary = summarize_whole_run_order_traces(
@@ -148,3 +171,22 @@ def test_order_trace_scoring_counts_unmatched_clipped_windows() -> None:
     assert summary.excluded_window_count == 1
     assert summary.sensor_clipping_window_count == 1
     assert summary.mean_quality_score == 0.55
+
+
+def test_order_trace_scoring_caps_suspect_mounting_only_lock() -> None:
+    clean_summary = summarize_whole_run_order_traces(
+        points=(
+            _point(0, quality_score=1.0, quality_state="usable"),
+            _point(1, quality_score=1.0, quality_state="usable"),
+        ),
+        context_labels=_context_labels(),
+    )[0]
+    suspect_summary = summarize_whole_run_order_traces(
+        points=(_mounting_artifact_point(0), _mounting_artifact_point(1)),
+        context_labels=_context_labels(),
+    )[0]
+
+    assert suspect_summary.sensor_mounting_artifact_window_count == 2
+    assert suspect_summary.matched_window_count == 2
+    assert suspect_summary.lock_score == 0.45
+    assert suspect_summary.lock_score < clean_summary.lock_score

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2287,6 +2287,10 @@
     "en": "Sensor clipping windows filtered: {count}",
     "nl": "Sensorclippingvensters gefilterd: {count}"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_MOUNTING_ARTIFACT_WINDOWS": {
+    "en": "Sensor mounting artifact windows limited diagnosis: {count}",
+    "nl": "Sensorbevestigingsartefacten beperken diagnose: {count}"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_WINDOW_QUALITY_LIMITED": {
     "en": "Usable window quality {pct}; limited {limited}, excluded {excluded}",
     "nl": "Bruikbare vensterkwaliteit {pct}; beperkt {limited}, uitgesloten {excluded}"

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -113,6 +113,7 @@ class SignalMetricsComputer(SpectralAnalysisComputer):
                     returned_sample_count=int(fft_input.shape[1]),
                     coverage_state="full",
                     samples_g=fft_input,
+                    sample_rate_hz=snapshot.sample_rate_hz,
                     peak_amp_g=strength_metrics.get("peak_amp_g"),
                     noise_floor_amp_g=strength_metrics.get("noise_floor_amp_g"),
                 ).to_payload()

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -150,6 +150,7 @@ class ReportWholeRunOrderSummary:
     excluded_window_count: int
     shock_transient_window_count: int
     sensor_clipping_window_count: int
+    sensor_mounting_artifact_window_count: int
     mean_quality_score: float | None
     support_intervals: tuple[ReportOrderTraceSupportInterval, ...]
     phase_support: tuple[ReportOrderTracePhaseSupport, ...]
@@ -673,6 +674,7 @@ _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
         _count_field("excluded_window_count"),
         _count_field("shock_transient_window_count"),
         _count_field("sensor_clipping_window_count"),
+        _count_field("sensor_mounting_artifact_window_count"),
         _float_field("mean_quality_score"),
         _rows_field("support_intervals", _ORDER_SUPPORT_INTERVAL_DECODER),
         _rows_field("phase_support", _ORDER_PHASE_SUPPORT_DECODER),

--- a/apps/server/vibesensor/shared/fft_analysis.py
+++ b/apps/server/vibesensor/shared/fft_analysis.py
@@ -37,6 +37,7 @@ __all__ = [
     "fft_frequency_slice",
     "fft_window_values",
     "float_list",
+    "high_frequency_energy_ratio",
     "medfilt3",
     "noise_floor",
 ]
@@ -307,6 +308,38 @@ def broadband_energy_ratio(
     if not math.isfinite(top_power):
         return None
     return max(0.0, min(1.0, 1.0 - (top_power / total_power)))
+
+
+def high_frequency_energy_ratio(
+    fft_block: FloatArray,
+    *,
+    sample_rate_hz: int,
+    high_frequency_start_hz: float,
+) -> float | None:
+    """Return energy share at or above a high-frequency threshold."""
+
+    if (
+        fft_block.ndim != 2
+        or fft_block.shape[1] < 8
+        or sample_rate_hz <= 0
+        or high_frequency_start_hz <= 0.0
+    ):
+        return None
+    sanitized = _sanitize_float_array(fft_block)
+    spectrum = scipy_fft.rfft(sanitized, axis=1)
+    magnitude = np.abs(spectrum).astype(np.float64, copy=False)
+    power_by_bin = np.sum(magnitude * magnitude, axis=0)
+    if power_by_bin.size <= 1:
+        return None
+    freqs = scipy_fft.rfftfreq(fft_block.shape[1], d=1.0 / float(sample_rate_hz))
+    analysis_mask = freqs > 0.0
+    total_power = float(np.sum(power_by_bin[analysis_mask]))
+    if not math.isfinite(total_power) or total_power <= 1e-18:
+        return None
+    high_frequency_power = float(np.sum(power_by_bin[freqs >= high_frequency_start_hz]))
+    if not math.isfinite(high_frequency_power):
+        return None
+    return max(0.0, min(1.0, high_frequency_power / total_power))
 
 
 def compute_fft_spectrum(

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -318,6 +318,7 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     excluded_window_count: Required[int]
     shock_transient_window_count: Required[int]
     sensor_clipping_window_count: Required[int]
+    sensor_mounting_artifact_window_count: Required[int]
     mean_quality_score: float | None
     support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
     phase_support: Required[list[OrderTracePhaseSupportResponse]]

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -71,6 +71,8 @@ class WindowQualityPayload(TypedDict):
     transient_score: float
     shock_crest_factor: float | None
     shock_broadband_ratio: float | None
+    mounting_score: float
+    mounting_high_frequency_ratio: float | None
     context_score: float
     frequency_stability_score: float
     reasons: list[str]

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 import numpy as np
 
-from vibesensor.shared.fft_analysis import broadband_energy_ratio
+from vibesensor.shared.fft_analysis import broadband_energy_ratio, high_frequency_energy_ratio
 from vibesensor.shared.types.json_types import JsonObject, JsonValue
 from vibesensor.shared.types.payload_types import WindowQualityPayload
 
@@ -18,6 +18,7 @@ type WindowQualityReason = Literal[
     "packet_integrity_gap",
     "sensor_clipping",
     "shock_transient",
+    "mounting_artifact",
     "context_unavailable",
     "frequency_unstable",
 ]
@@ -31,17 +32,19 @@ WINDOW_QUALITY_REASON_VALUES: frozenset[WindowQualityReason] = frozenset(
         "packet_integrity_gap",
         "sensor_clipping",
         "shock_transient",
+        "mounting_artifact",
         "context_unavailable",
         "frequency_unstable",
     }
 )
 
-_WEIGHT_SAMPLE_COMPLETENESS = 0.20
-_WEIGHT_PACKET_INTEGRITY = 0.20
-_WEIGHT_CLIPPING = 0.15
-_WEIGHT_TRANSIENT = 0.15
-_WEIGHT_CONTEXT = 0.15
-_WEIGHT_FREQUENCY = 0.15
+_WEIGHT_SAMPLE_COMPLETENESS = 0.18
+_WEIGHT_PACKET_INTEGRITY = 0.18
+_WEIGHT_CLIPPING = 0.14
+_WEIGHT_TRANSIENT = 0.14
+_WEIGHT_MOUNTING = 0.14
+_WEIGHT_CONTEXT = 0.11
+_WEIGHT_FREQUENCY = 0.11
 _CLIPPING_FULL_SCALE_I16 = 32760
 _CLIPPING_EXCLUDED_RATIO = 0.01
 _CLIPPING_MIN_REPEATED_RAIL_SAMPLES = 3
@@ -54,6 +57,9 @@ _CREST_FACTOR_CLEAN = 6.0
 _CREST_FACTOR_EXCLUDED = 12.0
 _BROADBAND_RATIO_CLEAN = 0.55
 _BROADBAND_RATIO_EXCLUDED = 0.82
+_MOUNTING_HIGH_FREQUENCY_RATIO_CLEAN = 0.35
+_MOUNTING_HIGH_FREQUENCY_RATIO_SUSPECT = 0.70
+_MOUNTING_MIN_HIGH_FREQUENCY_HZ = 45.0
 _AXIS_NAMES = ("x", "y", "z")
 
 
@@ -78,6 +84,12 @@ class WindowClippingAnalysis:
 
 
 @dataclass(frozen=True, slots=True)
+class _MountingArtifactAnalysis:
+    score: float
+    high_frequency_ratio: float | None
+
+
+@dataclass(frozen=True, slots=True)
 class WindowQuality:
     """Typed quality score for one analysis window."""
 
@@ -87,10 +99,12 @@ class WindowQuality:
     packet_integrity_score: float
     clipping_score: float
     transient_score: float
+    mounting_score: float
     context_score: float
     frequency_stability_score: float
     shock_crest_factor: float | None = None
     shock_broadband_ratio: float | None = None
+    mounting_high_frequency_ratio: float | None = None
     clipping_sample_count: int = 0
     clipping_sample_ratio: float = 0.0
     clipping_axis_counts: tuple[int, int, int] = (0, 0, 0)
@@ -109,6 +123,8 @@ class WindowQuality:
             "transient_score": self.transient_score,
             "shock_crest_factor": self.shock_crest_factor,
             "shock_broadband_ratio": self.shock_broadband_ratio,
+            "mounting_score": self.mounting_score,
+            "mounting_high_frequency_ratio": self.mounting_high_frequency_ratio,
             "context_score": self.context_score,
             "frequency_stability_score": self.frequency_stability_score,
             "reasons": list(self.reasons),
@@ -127,6 +143,8 @@ class WindowQuality:
             "transient_score": self.transient_score,
             "shock_crest_factor": self.shock_crest_factor,
             "shock_broadband_ratio": self.shock_broadband_ratio,
+            "mounting_score": self.mounting_score,
+            "mounting_high_frequency_ratio": self.mounting_high_frequency_ratio,
             "context_score": self.context_score,
             "frequency_stability_score": self.frequency_stability_score,
             "reasons": list(self.reasons),
@@ -166,6 +184,10 @@ class WindowQuality:
             transient_score=_score_from_json(data.get("transient_score"), default=1.0),
             shock_crest_factor=_nonnegative_float_from_json(data.get("shock_crest_factor")),
             shock_broadband_ratio=_optional_score_from_json(data.get("shock_broadband_ratio")),
+            mounting_score=_score_from_json(data.get("mounting_score"), default=1.0),
+            mounting_high_frequency_ratio=_optional_score_from_json(
+                data.get("mounting_high_frequency_ratio")
+            ),
             context_score=_score_from_json(data.get("context_score"), default=1.0),
             frequency_stability_score=_score_from_json(
                 data.get("frequency_stability_score"),
@@ -195,6 +217,7 @@ def clean_window_quality() -> WindowQuality:
         clipping_sample_ratio=0.0,
         clipping_axis_counts=(0, 0, 0),
         transient_score=1.0,
+        mounting_score=1.0,
         context_score=1.0,
         frequency_stability_score=1.0,
     )
@@ -211,6 +234,7 @@ def score_window_quality(
     context_coverage: str | None = None,
     speed_validity: str | None = None,
     rpm_validity: str | None = None,
+    sample_rate_hz: int | None = None,
     peak_amp_g: float | None = None,
     noise_floor_amp_g: float | None = None,
 ) -> WindowQuality:
@@ -226,6 +250,7 @@ def score_window_quality(
     )
     clipping_analysis = analyze_window_clipping(samples_i16=samples_i16, samples_g=samples_g)
     transient_analysis = _transient_analysis(samples_g)
+    mounting_analysis = _mounting_artifact_analysis(samples_g, sample_rate_hz=sample_rate_hz)
     context_score = _context_score(
         context_coverage=context_coverage,
         speed_validity=speed_validity,
@@ -245,6 +270,8 @@ def score_window_quality(
         transient_score=transient_analysis.score,
         shock_crest_factor=transient_analysis.crest_factor,
         shock_broadband_ratio=transient_analysis.broadband_ratio,
+        mounting_score=mounting_analysis.score,
+        mounting_high_frequency_ratio=mounting_analysis.high_frequency_ratio,
         context_score=context_score,
         frequency_stability_score=frequency_score,
     )
@@ -269,6 +296,8 @@ def window_quality_with_context(
         transient_score=quality.transient_score,
         shock_crest_factor=quality.shock_crest_factor,
         shock_broadband_ratio=quality.shock_broadband_ratio,
+        mounting_score=quality.mounting_score,
+        mounting_high_frequency_ratio=quality.mounting_high_frequency_ratio,
         context_score=_context_score(
             context_coverage=context_coverage,
             speed_validity=speed_validity,
@@ -284,6 +313,7 @@ def _quality_from_component_scores(
     packet_integrity_score: float,
     clipping_score: float,
     transient_score: float,
+    mounting_score: float,
     context_score: float,
     frequency_stability_score: float,
     clipping_sample_count: int = 0,
@@ -291,6 +321,7 @@ def _quality_from_component_scores(
     clipping_axis_counts: tuple[int, int, int] = (0, 0, 0),
     shock_crest_factor: float | None = None,
     shock_broadband_ratio: float | None = None,
+    mounting_high_frequency_ratio: float | None = None,
 ) -> WindowQuality:
     sample_completeness_score = _clamp01(sample_completeness_score)
     packet_integrity_score = _clamp01(packet_integrity_score)
@@ -299,6 +330,7 @@ def _quality_from_component_scores(
     clipping_sample_ratio = _clamp01(clipping_sample_ratio)
     clipping_axis_counts = _normalized_axis_counts(clipping_axis_counts)
     transient_score = _clamp01(transient_score)
+    mounting_score = _clamp01(mounting_score)
     context_score = _clamp01(context_score)
     frequency_stability_score = _clamp01(frequency_stability_score)
     score = _clamp01(
@@ -306,6 +338,7 @@ def _quality_from_component_scores(
         + (_WEIGHT_PACKET_INTEGRITY * packet_integrity_score)
         + (_WEIGHT_CLIPPING * clipping_score)
         + (_WEIGHT_TRANSIENT * transient_score)
+        + (_WEIGHT_MOUNTING * mounting_score)
         + (_WEIGHT_CONTEXT * context_score)
         + (_WEIGHT_FREQUENCY * frequency_stability_score)
     )
@@ -318,6 +351,8 @@ def _quality_from_component_scores(
         reasons.append("sensor_clipping")
     if transient_score < 0.70:
         reasons.append("shock_transient")
+    if mounting_score < 0.98:
+        reasons.append("mounting_artifact")
     if context_score < 0.70:
         reasons.append("context_unavailable")
     if frequency_stability_score < 0.70:
@@ -343,10 +378,12 @@ def _quality_from_component_scores(
         clipping_sample_ratio=clipping_sample_ratio,
         clipping_axis_counts=clipping_axis_counts,
         transient_score=transient_score,
+        mounting_score=mounting_score,
         context_score=context_score,
         frequency_stability_score=frequency_stability_score,
         shock_crest_factor=shock_crest_factor,
         shock_broadband_ratio=shock_broadband_ratio,
+        mounting_high_frequency_ratio=mounting_high_frequency_ratio,
         reasons=tuple(dict.fromkeys(reasons)),
     )
 
@@ -493,6 +530,43 @@ def _transient_analysis(samples_g: np.ndarray | None) -> _TransientAnalysis:
         crest_factor=crest,
         broadband_ratio=broadband_ratio,
     )
+
+
+def _mounting_artifact_analysis(
+    samples_g: np.ndarray | None,
+    *,
+    sample_rate_hz: int | None,
+) -> _MountingArtifactAnalysis:
+    if samples_g is None or sample_rate_hz is None or sample_rate_hz <= 0:
+        return _MountingArtifactAnalysis(score=1.0, high_frequency_ratio=None)
+    samples = _time_axis_samples(samples_g)
+    if samples.size == 0:
+        return _MountingArtifactAnalysis(score=1.0, high_frequency_ratio=None)
+    detrended = samples - np.mean(samples, axis=0, keepdims=True)
+    high_frequency_start_hz = min(
+        float(sample_rate_hz) * 0.45,
+        max(_MOUNTING_MIN_HIGH_FREQUENCY_HZ, float(sample_rate_hz) * 0.20),
+    )
+    ratio = high_frequency_energy_ratio(
+        detrended.T.astype(np.float32, copy=False),
+        sample_rate_hz=sample_rate_hz,
+        high_frequency_start_hz=high_frequency_start_hz,
+    )
+    if ratio is None:
+        return _MountingArtifactAnalysis(score=1.0, high_frequency_ratio=None)
+    return _MountingArtifactAnalysis(
+        score=_mounting_high_frequency_score(ratio),
+        high_frequency_ratio=ratio,
+    )
+
+
+def _mounting_high_frequency_score(ratio: float) -> float:
+    if ratio <= _MOUNTING_HIGH_FREQUENCY_RATIO_CLEAN:
+        return 1.0
+    if ratio >= _MOUNTING_HIGH_FREQUENCY_RATIO_SUSPECT:
+        return 0.0
+    suspect_range = _MOUNTING_HIGH_FREQUENCY_RATIO_SUSPECT - _MOUNTING_HIGH_FREQUENCY_RATIO_CLEAN
+    return _clamp01((_MOUNTING_HIGH_FREQUENCY_RATIO_SUSPECT - ratio) / suspect_range)
 
 
 def _crest_factor_score(crest: float) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -313,6 +313,7 @@ class OrderTraceSummary:
     excluded_window_count: int = 0
     shock_transient_window_count: int = 0
     sensor_clipping_window_count: int = 0
+    sensor_mounting_artifact_window_count: int = 0
     mean_quality_score: float | None = None
     support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
     phase_support: tuple[OrderTracePhaseSupport, ...] = ()
@@ -353,6 +354,10 @@ class OrderTraceSummary:
             self.sensor_clipping_window_count,
             field_name="sensor_clipping_window_count",
         )
+        _require_nonnegative(
+            self.sensor_mounting_artifact_window_count,
+            field_name="sensor_mounting_artifact_window_count",
+        )
         _require_ratio(self.support_ratio, field_name="support_ratio")
         _require_ratio(self.reference_coverage_ratio, field_name="reference_coverage_ratio")
         _require_ratio(self.contiguous_support_ratio, field_name="contiguous_support_ratio")
@@ -379,6 +384,7 @@ class OrderTraceSummary:
             "excluded_window_count": self.excluded_window_count,
             "shock_transient_window_count": self.shock_transient_window_count,
             "sensor_clipping_window_count": self.sensor_clipping_window_count,
+            "sensor_mounting_artifact_window_count": (self.sensor_mounting_artifact_window_count),
             "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
             "phase_support": [row.to_json_object() for row in self.phase_support],
             "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
@@ -425,6 +431,9 @@ class OrderTraceSummary:
             ),
             sensor_clipping_window_count=(
                 _optional_int(data.get("sensor_clipping_window_count")) or 0
+            ),
+            sensor_mounting_artifact_window_count=(
+                _optional_int(data.get("sensor_mounting_artifact_window_count")) or 0
             ),
             mean_quality_score=_optional_float(data.get("mean_quality_score")),
             support_intervals=_tuple_from_mapping_list_field(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -40,6 +40,7 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     _drift_score,
     _lock_score,
     _longest_contiguous_match_run,
+    _mounting_adjusted_lock_score,
     whole_run_order_trace_summaries_to_jsonl_bytes,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
@@ -213,6 +214,20 @@ def _family_summary(
             if "sensor_clipping" in point.window_quality_reasons
         }
     )
+    sensor_mounting_artifact_window_count = len(
+        {
+            point.window_index
+            for point in points
+            if "mounting_artifact" in point.window_quality_reasons
+        }
+    )
+    matched_mounting_artifact_window_count = len(
+        {
+            point.window_index
+            for point in matched_points
+            if "mounting_artifact" in point.window_quality_reasons
+        }
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=1.0,
@@ -225,6 +240,11 @@ def _family_summary(
         drift_score=drift_score,
         path_compliance=1.0,
         mean_quality_score=mean_quality_score,
+    )
+    lock_score = _mounting_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_mounting_artifact_window_count=matched_mounting_artifact_window_count,
     )
     support_intervals, exemplar_interval_index = _support_intervals(
         eligible_windows=eligible_windows,
@@ -293,6 +313,7 @@ def _family_summary(
         excluded_window_count=excluded_window_count,
         shock_transient_window_count=shock_transient_window_count,
         sensor_clipping_window_count=sensor_clipping_window_count,
+        sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -199,6 +199,12 @@ def _summarize_hypothesis_trace(
     sensor_clipping_window_count = sum(
         1 for point in points if "sensor_clipping" in point.window_quality_reasons
     )
+    sensor_mounting_artifact_window_count = sum(
+        1 for point in points if "mounting_artifact" in point.window_quality_reasons
+    )
+    matched_mounting_artifact_window_count = sum(
+        1 for point in matched_points if "mounting_artifact" in point.window_quality_reasons
+    )
     support_intervals = _support_intervals(
         matched_points=matched_points,
         context_by_window=context_by_window,
@@ -219,6 +225,11 @@ def _summarize_hypothesis_trace(
         drift_score=drift_score,
         path_compliance=hypothesis.path_compliance if hypothesis is not None else 1.0,
         mean_quality_score=mean_quality_score,
+    )
+    lock_score = _mounting_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_mounting_artifact_window_count=matched_mounting_artifact_window_count,
     )
     peak_intensity_db = _max_or_none(
         point.peak_intensity_db for point in matched_points if point.peak_intensity_db is not None
@@ -289,6 +300,7 @@ def _summarize_hypothesis_trace(
         excluded_window_count=excluded_window_count,
         shock_transient_window_count=shock_transient_window_count,
         sensor_clipping_window_count=sensor_clipping_window_count,
+        sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,
@@ -340,6 +352,21 @@ def _lock_score(
         return base_score
     quality_factor = 0.85 + (0.15 * max(0.0, min(1.0, mean_quality_score)))
     return max(0.0, min(1.0, base_score * quality_factor))
+
+
+def _mounting_adjusted_lock_score(
+    lock_score: float,
+    *,
+    matched_window_count: int,
+    matched_mounting_artifact_window_count: int,
+) -> float:
+    if matched_window_count <= 0 or matched_mounting_artifact_window_count <= 0:
+        return lock_score
+    if matched_mounting_artifact_window_count >= matched_window_count:
+        return min(lock_score, 0.45)
+    if matched_mounting_artifact_window_count / matched_window_count >= 0.5:
+        return min(lock_score, 0.60)
+    return lock_score
 
 
 def _relative_error_score(*, mean_relative_error: float | None, path_compliance: float) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -585,6 +585,7 @@ def _build_window_summary(
                 samples_i16=samples_i16,
                 accel_scale_g_per_lsb=metadata.accel_scale_g_per_lsb,
             ),
+            sample_rate_hz=sensor_manifest.sample_rate_hz,
             peak_amp_g=peak_amp_g,
             noise_floor_amp_g=floor_amp_g,
         ),

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -188,6 +188,11 @@ def _dense_caveat_text(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_CLIPPING_WINDOWS",
             count=str(summary.sensor_clipping_window_count),
         )
+    if summary.sensor_mounting_artifact_window_count > 0:
+        return tr(
+            "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_MOUNTING_ARTIFACT_WINDOWS",
+            count=str(summary.sensor_mounting_artifact_window_count),
+        )
     if summary.shock_transient_window_count > 0:
         return tr(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS",

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -6318,6 +6318,10 @@
             "title": "Sensor Clipping Window Count",
             "type": "integer"
           },
+          "sensor_mounting_artifact_window_count": {
+            "title": "Sensor Mounting Artifact Window Count",
+            "type": "integer"
+          },
           "shock_transient_window_count": {
             "title": "Shock Transient Window Count",
             "type": "integer"
@@ -6396,6 +6400,7 @@
           "excluded_window_count",
           "shock_transient_window_count",
           "sensor_clipping_window_count",
+          "sensor_mounting_artifact_window_count",
           "support_intervals",
           "phase_support",
           "harmonic_summaries",
@@ -9485,6 +9490,21 @@
             "title": "Frequency Stability Score",
             "type": "number"
           },
+          "mounting_high_frequency_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mounting High Frequency Ratio"
+          },
+          "mounting_score": {
+            "title": "Mounting Score",
+            "type": "number"
+          },
           "packet_integrity_score": {
             "title": "Packet Integrity Score",
             "type": "number"
@@ -9547,6 +9567,8 @@
           "transient_score",
           "shock_crest_factor",
           "shock_broadband_ratio",
+          "mounting_score",
+          "mounting_high_frequency_ratio",
           "context_score",
           "frequency_stability_score",
           "reasons"

--- a/apps/ui/src/contracts/ws_payload_schema.json
+++ b/apps/ui/src/contracts/ws_payload_schema.json
@@ -532,6 +532,21 @@
           "title": "Frequency Stability Score",
           "type": "number"
         },
+        "mounting_high_frequency_ratio": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Mounting High Frequency Ratio"
+        },
+        "mounting_score": {
+          "title": "Mounting Score",
+          "type": "number"
+        },
         "packet_integrity_score": {
           "title": "Packet Integrity Score",
           "type": "number"
@@ -594,6 +609,8 @@
         "transient_score",
         "shock_crest_factor",
         "shock_broadband_ratio",
+        "mounting_score",
+        "mounting_high_frequency_ratio",
         "context_score",
         "frequency_stability_score",
         "reasons"

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -83,10 +83,11 @@ carry a `sensor_orientation_unknown` quality flag instead. Frequency masks live
 at this layer so later episode/order/finding logic can ignore unusable bands
 without recomputing the dense spectra.
 
-Shared per-window quality scoring detects repeated accelerometer rail hits and
-flat-topped waveforms, exposes clipping counts/ratios by axis in live payloads,
-and marks clipped windows as limited or excluded evidence rather than treating
-high clipped amplitudes as trustworthy vibration strength.
+Shared per-window quality scoring detects repeated accelerometer rail hits,
+flat-topped waveforms, and high-frequency mounting/enclosure artifacts. It
+exposes clipping counts/ratios plus mounting-quality scores in live payloads
+and marks clipped or suspect-mounted windows as limited/excluded evidence rather
+than treating local sensor artifacts as trustworthy vibration strength.
 
 `use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
 and final-drive references onto the same window grid. It uses conservative


### PR DESCRIPTION
Closes #3746

Size: medium

What changed:
- Added high-frequency mounting/enclosure artifact detection to shared window quality.
- Exposed mounting quality in live payload contracts.
- Counted mounting-artifact windows in whole-run order summaries and capped lock score when matched support is suspect-only.
- Added report dense-evidence caveat text for mounting-quality-limited diagnoses.
- Synced HTTP/WS schema artifacts and updated analysis pipeline docs.

Why:
- A loose sensor or enclosure can create local peaks that look like vehicle faults.
- Suspect sensor-local support should not remain high-confidence without a caveat.

Validation:
- Focused pytest set: 51 passed.
- Ruff check and format check on touched Python.
- Configured backend mypy.
- Backend static guards.
- Docs lint.
- UI contract sync check.
- UI format, lint, typecheck.

Risks / tradeoffs / edge cases:
- High-frequency local vibration can be real; this does not delete evidence. It marks it limited, adds a caveat, and caps suspect-only lock score.
- Existing clipping and road-shock caveats stay higher priority than mounting artifacts.

Follow-ups:
- None for this issue.