### PR TITLE
Add timing integrity quality penalties

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -207,6 +207,22 @@ def test_build_report_document_projects_sensor_mounting_artifact_caveat() -> Non
     )
 
 
+def test_build_report_document_projects_sensor_timing_integrity_caveat() -> None:
+    summary = _dense_summary(
+        order_summary_overrides={
+            "reference_coverage_ratio": 1.0,
+            "mean_quality_score": 0.86,
+            "limited_window_count": 2,
+            "sensor_timing_integrity_window_count": 2,
+        }
+    )
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.appendix_c.dense_evidence_rows[0].caveat == (
+        "Sensor timing integrity windows limited diagnosis: 2"
+    )
+
+
 def test_build_report_document_skips_dense_evidence_when_artifacts_are_unavailable() -> None:
     document = build_report_document(prepare_report_input(minimal_summary()))
 

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -226,6 +226,7 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
             "shock_transient_window_count": 0,
             "sensor_clipping_window_count": 0,
             "sensor_mounting_artifact_window_count": 0,
+            "sensor_timing_integrity_window_count": 0,
             "mean_quality_score": 0.92,
             "support_intervals": [
                 {

--- a/apps/server/tests/shared/test_window_quality.py
+++ b/apps/server/tests/shared/test_window_quality.py
@@ -51,6 +51,7 @@ def test_window_quality_scores_clean_window_as_usable() -> None:
 
     assert quality.state == "usable"
     assert quality.score > 0.95
+    assert quality.timing_integrity_score == 1.0
     assert quality.shock_broadband_ratio is not None
     assert quality.shock_broadband_ratio < 0.15
     assert quality.reasons == ()
@@ -122,6 +123,7 @@ def test_window_quality_marks_dropped_clipped_and_shock_windows_low_quality() ->
     assert dropped.state == "excluded"
     assert "sample_incomplete" in dropped.reasons
     assert "packet_integrity_gap" in dropped.reasons
+    assert "timing_gap" in dropped.reasons
     assert clipped_quality.state == "excluded"
     assert "sensor_clipping" in clipped_quality.reasons
     assert shock.state == "excluded"
@@ -209,6 +211,36 @@ def test_window_quality_context_downgrades_missing_speed_and_rpm() -> None:
     assert quality.state == "limited"
     assert quality.context_score < 0.5
     assert "context_unavailable" in quality.reasons
+
+
+def test_window_quality_flags_late_packets_queue_drops_and_reset_timing_loss() -> None:
+    late_packet = score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=256,
+        coverage_state="full",
+        late_packet_chunk_count=1,
+    )
+    queue_drop = score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=256,
+        coverage_state="full",
+        server_queue_drop_count=1,
+    )
+    reset_overlap = score_window_quality(
+        expected_sample_count=256,
+        returned_sample_count=128,
+        coverage_state="partial",
+        coverage_reason="window_crosses_overlap",
+    )
+
+    assert late_packet.state == "limited"
+    assert late_packet.timing_integrity_score < 1.0
+    assert "late_packet_loss" in late_packet.reasons
+    assert late_packet.to_payload()["timing_integrity_score"] == late_packet.timing_integrity_score
+    assert queue_drop.state == "limited"
+    assert "server_queue_drop" in queue_drop.reasons
+    assert reset_overlap.state == "excluded"
+    assert "sensor_reset" in reset_overlap.reasons
 
 
 @pytest.mark.parametrize(

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -264,6 +264,7 @@ def test_history_order_trace_response_contracts_expose_named_summary_fields() ->
         "shock_transient_window_count",
         "sensor_clipping_window_count",
         "sensor_mounting_artifact_window_count",
+        "sensor_timing_integrity_window_count",
         "mean_quality_score",
         "support_intervals",
         "phase_support",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -214,6 +214,7 @@ def _summary_rows(
                     state="usable",
                     sample_completeness_score=1.0,
                     packet_integrity_score=1.0,
+                    timing_integrity_score=1.0,
                     clipping_score=1.0,
                     transient_score=1.0,
                     mounting_score=1.0,

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py
@@ -14,6 +14,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureManifest,
     RawCaptureSensorClockSync,
     RawCaptureSensorData,
+    RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
     RawRunCapture,
 )
@@ -118,6 +119,7 @@ def _make_sensor(
 def _raw_capture(
     *sensors: RawCaptureSensorData,
     losses: RawCaptureLossStats | None = None,
+    sensor_losses: dict[str, RawCaptureLossStats] | None = None,
 ) -> RawRunCapture:
     manifest = RawCaptureManifest(
         run_id="run-spectra",
@@ -127,6 +129,10 @@ def _raw_capture(
         total_bytes=sum(sensor.manifest.bytes_written for sensor in sensors),
         created_at="2025-01-01T00:00:00Z",
         run_start_monotonic_us=_RUN_START_US,
+        sensor_losses=tuple(
+            RawCaptureSensorLossStats(client_id=client_id, losses=loss_stats)
+            for client_id, loss_stats in (sensor_losses or {}).items()
+        ),
         losses=losses or RawCaptureLossStats(),
     )
     return RawRunCapture(manifest=manifest, sensors=tuple(sensors))
@@ -268,6 +274,69 @@ def test_whole_run_spectra_mark_gap_windows_partial() -> None:
     assert [warning.code for warning in result.coverage_summary.warnings] == [
         "whole_run_alignment_incomplete"
     ]
+
+
+def test_whole_run_spectra_quality_marks_late_packets_and_queue_drops() -> None:
+    raw_capture = _raw_capture(
+        _make_sensor(
+            client_id="sensor-loss",
+            sample_rate_hz=8,
+            chunks=[(_RUN_START_US, _sine_samples(total_samples=16))],
+            clock_sync=_verified_sync(),
+        ),
+        sensor_losses={
+            "sensor-loss": RawCaptureLossStats(
+                late_packet_chunk_count=1,
+                queue_overflow_chunk_count=1,
+            )
+        },
+    )
+
+    result = build_whole_run_spectral_artifact_bundle(
+        run_id="run-spectra",
+        metadata=_metadata(),
+        raw_capture=raw_capture,
+        max_workers=1,
+        chunk_window_count=2,
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    assert result.bundle is not None
+    summaries = _summaries(result.bundle, "sensor-loss")
+    assert summaries
+    assert all(summary.window_quality.state == "limited" for summary in summaries)
+    assert all("late_packet_loss" in summary.window_quality.reasons for summary in summaries)
+    assert all("server_queue_drop" in summary.window_quality.reasons for summary in summaries)
+    assert result.coverage_summary.late_packet_chunk_count == 1
+    assert result.coverage_summary.queue_overflow_chunk_count == 1
+
+
+def test_whole_run_spectra_quality_marks_overlap_windows_as_reset_timing_loss() -> None:
+    raw_capture = _raw_capture(
+        _make_sensor(
+            client_id="sensor-reset",
+            sample_rate_hz=8,
+            chunks=[
+                (_RUN_START_US, _sine_samples(total_samples=8)),
+                (_RUN_START_US + 500_000, _sine_samples(total_samples=8, phase_rad=0.5)),
+            ],
+            clock_sync=_verified_sync(),
+        ),
+    )
+
+    result = build_whole_run_spectral_artifact_bundle(
+        run_id="run-spectra",
+        metadata=_metadata(),
+        raw_capture=raw_capture,
+        max_workers=1,
+        chunk_window_count=4,
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    assert result.bundle is not None
+    rows = _summary_rows(result.bundle.artifact_contents["spectral-summary:sensor-reset"])
+    assert rows[1]["coverage_reason"] == "window_crosses_overlap"
+    assert "sensor_reset" in rows[1]["window_quality"]["reasons"]
 
 
 def test_whole_run_spectra_keep_contiguous_chunk_boundaries_full() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py
@@ -120,6 +120,29 @@ def _mounting_artifact_point(window_index: int) -> OrderTracePoint:
     )
 
 
+def _timing_loss_point(window_index: int) -> OrderTracePoint:
+    return OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=window_index,
+        eligible=True,
+        matched=True,
+        predicted_hz=8.0 + window_index,
+        matched_hz=8.05 + window_index,
+        relative_error=0.01,
+        peak_intensity_db=24.0,
+        vibration_strength_db=20.0,
+        ref_source="speed+tire",
+        strongest_location="Front Left",
+        window_quality_score=0.92,
+        window_quality_state="limited",
+        window_quality_reasons=("late_packet_loss",),
+    )
+
+
 def test_order_trace_scoring_records_and_downweights_limited_window_quality() -> None:
     context_labels = _context_labels()
     clean_summary = summarize_whole_run_order_traces(
@@ -189,4 +212,23 @@ def test_order_trace_scoring_caps_suspect_mounting_only_lock() -> None:
     assert suspect_summary.sensor_mounting_artifact_window_count == 2
     assert suspect_summary.matched_window_count == 2
     assert suspect_summary.lock_score == 0.45
+    assert suspect_summary.lock_score < clean_summary.lock_score
+
+
+def test_order_trace_scoring_counts_and_caps_timing_loss_only_lock() -> None:
+    clean_summary = summarize_whole_run_order_traces(
+        points=(
+            _point(0, quality_score=1.0, quality_state="usable"),
+            _point(1, quality_score=1.0, quality_state="usable"),
+        ),
+        context_labels=_context_labels(),
+    )[0]
+    suspect_summary = summarize_whole_run_order_traces(
+        points=(_timing_loss_point(0), _timing_loss_point(1)),
+        context_labels=_context_labels(),
+    )[0]
+
+    assert suspect_summary.sensor_timing_integrity_window_count == 2
+    assert suspect_summary.matched_window_count == 2
+    assert suspect_summary.lock_score == 0.50
     assert suspect_summary.lock_score < clean_summary.lock_score

--- a/apps/server/tests/use_cases/history/test_report_document_context.py
+++ b/apps/server/tests/use_cases/history/test_report_document_context.py
@@ -27,7 +27,7 @@ def _prepared_report_input() -> PreparedReportInput:
             "sensor_count_used": 2,
             "lang": "en",
             "metadata": {},
-            "report_date": "",
+            "report_date": "2026-01-01T00:00:00Z",
             "record_length": "",
             "start_time_utc": "",
             "end_time_utc": "",

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2291,6 +2291,10 @@
     "en": "Sensor mounting artifact windows limited diagnosis: {count}",
     "nl": "Sensorbevestigingsartefacten beperken diagnose: {count}"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_TIMING_INTEGRITY_WINDOWS": {
+    "en": "Sensor timing integrity windows limited diagnosis: {count}",
+    "nl": "Sensortimingintegriteit beperkt diagnose: {count}"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_WINDOW_QUALITY_LIMITED": {
     "en": "Usable window quality {pct}; limited {limited}, excluded {excluded}",
     "nl": "Bruikbare vensterkwaliteit {pct}; beperkt {limited}, uitgesloten {excluded}"

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -151,6 +151,7 @@ class ReportWholeRunOrderSummary:
     shock_transient_window_count: int
     sensor_clipping_window_count: int
     sensor_mounting_artifact_window_count: int
+    sensor_timing_integrity_window_count: int
     mean_quality_score: float | None
     support_intervals: tuple[ReportOrderTraceSupportInterval, ...]
     phase_support: tuple[ReportOrderTracePhaseSupport, ...]
@@ -675,6 +676,7 @@ _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
         _count_field("shock_transient_window_count"),
         _count_field("sensor_clipping_window_count"),
         _count_field("sensor_mounting_artifact_window_count"),
+        _count_field("sensor_timing_integrity_window_count"),
         _float_field("mean_quality_score"),
         _rows_field("support_intervals", _ORDER_SUPPORT_INTERVAL_DECODER),
         _rows_field("phase_support", _ORDER_PHASE_SUPPORT_DECODER),

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -319,6 +319,7 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     shock_transient_window_count: Required[int]
     sensor_clipping_window_count: Required[int]
     sensor_mounting_artifact_window_count: Required[int]
+    sensor_timing_integrity_window_count: Required[int]
     mean_quality_score: float | None
     support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
     phase_support: Required[list[OrderTracePhaseSupportResponse]]

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -64,6 +64,7 @@ class WindowQualityPayload(TypedDict):
     state: str
     sample_completeness_score: float
     packet_integrity_score: float
+    timing_integrity_score: float
     clipping_score: float
     clipping_sample_count: int
     clipping_sample_ratio: float

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -16,6 +16,10 @@ type WindowQualityState = Literal["usable", "limited", "excluded"]
 type WindowQualityReason = Literal[
     "sample_incomplete",
     "packet_integrity_gap",
+    "timing_gap",
+    "late_packet_loss",
+    "server_queue_drop",
+    "sensor_reset",
     "sensor_clipping",
     "shock_transient",
     "mounting_artifact",
@@ -30,6 +34,10 @@ WINDOW_QUALITY_REASON_VALUES: frozenset[WindowQualityReason] = frozenset(
     {
         "sample_incomplete",
         "packet_integrity_gap",
+        "timing_gap",
+        "late_packet_loss",
+        "server_queue_drop",
+        "sensor_reset",
         "sensor_clipping",
         "shock_transient",
         "mounting_artifact",
@@ -38,13 +46,14 @@ WINDOW_QUALITY_REASON_VALUES: frozenset[WindowQualityReason] = frozenset(
     }
 )
 
-_WEIGHT_SAMPLE_COMPLETENESS = 0.18
-_WEIGHT_PACKET_INTEGRITY = 0.18
-_WEIGHT_CLIPPING = 0.14
-_WEIGHT_TRANSIENT = 0.14
-_WEIGHT_MOUNTING = 0.14
-_WEIGHT_CONTEXT = 0.11
-_WEIGHT_FREQUENCY = 0.11
+_WEIGHT_SAMPLE_COMPLETENESS = 0.16
+_WEIGHT_PACKET_INTEGRITY = 0.14
+_WEIGHT_TIMING_INTEGRITY = 0.14
+_WEIGHT_CLIPPING = 0.13
+_WEIGHT_TRANSIENT = 0.13
+_WEIGHT_MOUNTING = 0.13
+_WEIGHT_CONTEXT = 0.085
+_WEIGHT_FREQUENCY = 0.085
 _CLIPPING_FULL_SCALE_I16 = 32760
 _CLIPPING_EXCLUDED_RATIO = 0.01
 _CLIPPING_MIN_REPEATED_RAIL_SAMPLES = 3
@@ -97,6 +106,7 @@ class WindowQuality:
     state: WindowQualityState
     sample_completeness_score: float
     packet_integrity_score: float
+    timing_integrity_score: float
     clipping_score: float
     transient_score: float
     mounting_score: float
@@ -116,6 +126,7 @@ class WindowQuality:
             "state": self.state,
             "sample_completeness_score": self.sample_completeness_score,
             "packet_integrity_score": self.packet_integrity_score,
+            "timing_integrity_score": self.timing_integrity_score,
             "clipping_score": self.clipping_score,
             "clipping_sample_count": self.clipping_sample_count,
             "clipping_sample_ratio": self.clipping_sample_ratio,
@@ -136,6 +147,7 @@ class WindowQuality:
             "state": self.state,
             "sample_completeness_score": self.sample_completeness_score,
             "packet_integrity_score": self.packet_integrity_score,
+            "timing_integrity_score": self.timing_integrity_score,
             "clipping_score": self.clipping_score,
             "clipping_sample_count": self.clipping_sample_count,
             "clipping_sample_ratio": self.clipping_sample_ratio,
@@ -172,6 +184,10 @@ class WindowQuality:
             ),
             packet_integrity_score=_score_from_json(
                 data.get("packet_integrity_score"),
+                default=1.0,
+            ),
+            timing_integrity_score=_score_from_json(
+                data.get("timing_integrity_score"),
                 default=1.0,
             ),
             clipping_score=_score_from_json(data.get("clipping_score"), default=1.0),
@@ -212,6 +228,7 @@ def clean_window_quality() -> WindowQuality:
         state="usable",
         sample_completeness_score=1.0,
         packet_integrity_score=1.0,
+        timing_integrity_score=1.0,
         clipping_score=1.0,
         clipping_sample_count=0,
         clipping_sample_ratio=0.0,
@@ -237,6 +254,10 @@ def score_window_quality(
     sample_rate_hz: int | None = None,
     peak_amp_g: float | None = None,
     noise_floor_amp_g: float | None = None,
+    dropped_frame_count: int = 0,
+    late_packet_chunk_count: int = 0,
+    server_queue_drop_count: int = 0,
+    reset_detected: bool = False,
 ) -> WindowQuality:
     """Score one FFT/order-analysis window from available signal and context facts."""
 
@@ -247,6 +268,13 @@ def score_window_quality(
     packet_score = _packet_integrity_score(
         coverage_state=coverage_state,
         coverage_reason=coverage_reason,
+    )
+    timing_score, timing_reasons = _timing_integrity_score(
+        coverage_reason=coverage_reason,
+        dropped_frame_count=dropped_frame_count,
+        late_packet_chunk_count=late_packet_chunk_count,
+        server_queue_drop_count=server_queue_drop_count,
+        reset_detected=reset_detected,
     )
     clipping_analysis = analyze_window_clipping(samples_i16=samples_i16, samples_g=samples_g)
     transient_analysis = _transient_analysis(samples_g)
@@ -263,6 +291,8 @@ def score_window_quality(
     return _quality_from_component_scores(
         sample_completeness_score=sample_score,
         packet_integrity_score=packet_score,
+        timing_integrity_score=timing_score,
+        timing_reasons=timing_reasons,
         clipping_score=clipping_analysis.score,
         clipping_sample_count=clipping_analysis.sample_count,
         clipping_sample_ratio=clipping_analysis.sample_ratio,
@@ -289,6 +319,8 @@ def window_quality_with_context(
     return _quality_from_component_scores(
         sample_completeness_score=quality.sample_completeness_score,
         packet_integrity_score=quality.packet_integrity_score,
+        timing_integrity_score=quality.timing_integrity_score,
+        timing_reasons=_timing_reasons_from(quality.reasons),
         clipping_score=quality.clipping_score,
         clipping_sample_count=quality.clipping_sample_count,
         clipping_sample_ratio=quality.clipping_sample_ratio,
@@ -311,6 +343,7 @@ def _quality_from_component_scores(
     *,
     sample_completeness_score: float,
     packet_integrity_score: float,
+    timing_integrity_score: float,
     clipping_score: float,
     transient_score: float,
     mounting_score: float,
@@ -322,9 +355,11 @@ def _quality_from_component_scores(
     shock_crest_factor: float | None = None,
     shock_broadband_ratio: float | None = None,
     mounting_high_frequency_ratio: float | None = None,
+    timing_reasons: tuple[WindowQualityReason, ...] = (),
 ) -> WindowQuality:
     sample_completeness_score = _clamp01(sample_completeness_score)
     packet_integrity_score = _clamp01(packet_integrity_score)
+    timing_integrity_score = _clamp01(timing_integrity_score)
     clipping_score = _clamp01(clipping_score)
     clipping_sample_count = max(0, int(clipping_sample_count))
     clipping_sample_ratio = _clamp01(clipping_sample_ratio)
@@ -336,6 +371,7 @@ def _quality_from_component_scores(
     score = _clamp01(
         (_WEIGHT_SAMPLE_COMPLETENESS * sample_completeness_score)
         + (_WEIGHT_PACKET_INTEGRITY * packet_integrity_score)
+        + (_WEIGHT_TIMING_INTEGRITY * timing_integrity_score)
         + (_WEIGHT_CLIPPING * clipping_score)
         + (_WEIGHT_TRANSIENT * transient_score)
         + (_WEIGHT_MOUNTING * mounting_score)
@@ -347,6 +383,8 @@ def _quality_from_component_scores(
         reasons.append("sample_incomplete")
     if packet_integrity_score < 0.98:
         reasons.append("packet_integrity_gap")
+    if timing_integrity_score < 0.98:
+        reasons.extend(timing_reasons or ("timing_gap",))
     if clipping_score < 0.98:
         reasons.append("sensor_clipping")
     if transient_score < 0.70:
@@ -361,6 +399,7 @@ def _quality_from_component_scores(
     if (
         sample_completeness_score < 0.75
         or packet_integrity_score <= 0.05
+        or timing_integrity_score < 0.20
         or clipping_score < 0.20
         or transient_score < 0.25
         or context_score < 0.25
@@ -373,6 +412,7 @@ def _quality_from_component_scores(
         state=state,
         sample_completeness_score=sample_completeness_score,
         packet_integrity_score=packet_integrity_score,
+        timing_integrity_score=timing_integrity_score,
         clipping_score=clipping_score,
         clipping_sample_count=clipping_sample_count,
         clipping_sample_ratio=clipping_sample_ratio,
@@ -408,6 +448,55 @@ def _packet_integrity_score(*, coverage_state: str, coverage_reason: str | None)
     if coverage_state == "partial":
         return 0.45
     return 0.0
+
+
+_TIMING_GAP_REASONS = frozenset(
+    {
+        "assembled_window_short",
+        "sample_rate_unverified",
+        "window_crosses_gap",
+    }
+)
+_TIMING_RESET_REASONS = frozenset({"window_crosses_overlap"})
+_TIMING_REASON_VALUES = frozenset(
+    {
+        "timing_gap",
+        "late_packet_loss",
+        "server_queue_drop",
+        "sensor_reset",
+    }
+)
+
+
+def _timing_integrity_score(
+    *,
+    coverage_reason: str | None,
+    dropped_frame_count: int,
+    late_packet_chunk_count: int,
+    server_queue_drop_count: int,
+    reset_detected: bool,
+) -> tuple[float, tuple[WindowQualityReason, ...]]:
+    score = 1.0
+    reasons: list[WindowQualityReason] = []
+    if coverage_reason in _TIMING_GAP_REASONS or dropped_frame_count > 0:
+        score = min(score, 0.35)
+        reasons.append("timing_gap")
+    if coverage_reason in _TIMING_RESET_REASONS or reset_detected:
+        score = min(score, 0.20)
+        reasons.append("sensor_reset")
+    if late_packet_chunk_count > 0:
+        score = min(score, 0.65)
+        reasons.append("late_packet_loss")
+    if server_queue_drop_count > 0:
+        score = min(score, 0.55)
+        reasons.append("server_queue_drop")
+    return score, tuple(dict.fromkeys(reasons))
+
+
+def _timing_reasons_from(
+    reasons: tuple[WindowQualityReason, ...],
+) -> tuple[WindowQualityReason, ...]:
+    return tuple(reason for reason in reasons if reason in _TIMING_REASON_VALUES)
 
 
 def analyze_window_clipping(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -314,6 +314,7 @@ class OrderTraceSummary:
     shock_transient_window_count: int = 0
     sensor_clipping_window_count: int = 0
     sensor_mounting_artifact_window_count: int = 0
+    sensor_timing_integrity_window_count: int = 0
     mean_quality_score: float | None = None
     support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
     phase_support: tuple[OrderTracePhaseSupport, ...] = ()
@@ -358,6 +359,10 @@ class OrderTraceSummary:
             self.sensor_mounting_artifact_window_count,
             field_name="sensor_mounting_artifact_window_count",
         )
+        _require_nonnegative(
+            self.sensor_timing_integrity_window_count,
+            field_name="sensor_timing_integrity_window_count",
+        )
         _require_ratio(self.support_ratio, field_name="support_ratio")
         _require_ratio(self.reference_coverage_ratio, field_name="reference_coverage_ratio")
         _require_ratio(self.contiguous_support_ratio, field_name="contiguous_support_ratio")
@@ -385,6 +390,7 @@ class OrderTraceSummary:
             "shock_transient_window_count": self.shock_transient_window_count,
             "sensor_clipping_window_count": self.sensor_clipping_window_count,
             "sensor_mounting_artifact_window_count": (self.sensor_mounting_artifact_window_count),
+            "sensor_timing_integrity_window_count": (self.sensor_timing_integrity_window_count),
             "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
             "phase_support": [row.to_json_object() for row in self.phase_support],
             "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
@@ -434,6 +440,9 @@ class OrderTraceSummary:
             ),
             sensor_mounting_artifact_window_count=(
                 _optional_int(data.get("sensor_mounting_artifact_window_count")) or 0
+            ),
+            sensor_timing_integrity_window_count=(
+                _optional_int(data.get("sensor_timing_integrity_window_count")) or 0
             ),
             mean_quality_score=_optional_float(data.get("mean_quality_score")),
             support_intervals=_tuple_from_mapping_list_field(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -41,6 +41,7 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     _lock_score,
     _longest_contiguous_match_run,
     _mounting_adjusted_lock_score,
+    _timing_adjusted_lock_score,
     whole_run_order_trace_summaries_to_jsonl_bytes,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
@@ -50,6 +51,9 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
 WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY = "order-family-summaries"
 _WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_PATH = "orders/family-summaries.jsonl"
 _FAMILY_ORDER = ("wheel", "driveshaft", "engine")
+_TIMING_QUALITY_REASONS = frozenset(
+    {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
+)
 
 __all__ = [
     "WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY",
@@ -228,6 +232,12 @@ def _family_summary(
             if "mounting_artifact" in point.window_quality_reasons
         }
     )
+    sensor_timing_integrity_window_count = len(
+        {point.window_index for point in points if _has_timing_quality_reason(point)}
+    )
+    matched_timing_integrity_window_count = len(
+        {point.window_index for point in matched_points if _has_timing_quality_reason(point)}
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=1.0,
@@ -245,6 +255,11 @@ def _family_summary(
         lock_score,
         matched_window_count=matched_window_count,
         matched_mounting_artifact_window_count=matched_mounting_artifact_window_count,
+    )
+    lock_score = _timing_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_timing_integrity_window_count=matched_timing_integrity_window_count,
     )
     support_intervals, exemplar_interval_index = _support_intervals(
         eligible_windows=eligible_windows,
@@ -314,6 +329,7 @@ def _family_summary(
         shock_transient_window_count=shock_transient_window_count,
         sensor_clipping_window_count=sensor_clipping_window_count,
         sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
+        sensor_timing_integrity_window_count=sensor_timing_integrity_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,
@@ -332,6 +348,10 @@ def _family_summary(
         mean_vibration_strength_db=mean_vibration_strength_db,
         ref_sources=ref_sources,
     )
+
+
+def _has_timing_quality_reason(point: OrderTracePoint) -> bool:
+    return any(reason in _TIMING_QUALITY_REASONS for reason in point.window_quality_reasons)
 
 
 def _selected_family_matches_by_window(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -57,6 +57,9 @@ _LOCK_SCORE_ERROR_WEIGHT = 0.15
 _LOCK_SCORE_DRIFT_WEIGHT = 0.10
 _RELATIVE_ERROR_DENOMINATOR = 0.25
 _RELATIVE_ERROR_DRIFT_TOLERANCE = 0.08
+_TIMING_QUALITY_REASONS = frozenset(
+    {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
+)
 
 __all__ = [
     "WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY",
@@ -205,6 +208,12 @@ def _summarize_hypothesis_trace(
     matched_mounting_artifact_window_count = sum(
         1 for point in matched_points if "mounting_artifact" in point.window_quality_reasons
     )
+    sensor_timing_integrity_window_count = sum(
+        1 for point in points if _has_timing_quality_reason(point)
+    )
+    matched_timing_integrity_window_count = sum(
+        1 for point in matched_points if _has_timing_quality_reason(point)
+    )
     support_intervals = _support_intervals(
         matched_points=matched_points,
         context_by_window=context_by_window,
@@ -230,6 +239,11 @@ def _summarize_hypothesis_trace(
         lock_score,
         matched_window_count=matched_window_count,
         matched_mounting_artifact_window_count=matched_mounting_artifact_window_count,
+    )
+    lock_score = _timing_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_timing_integrity_window_count=matched_timing_integrity_window_count,
     )
     peak_intensity_db = _max_or_none(
         point.peak_intensity_db for point in matched_points if point.peak_intensity_db is not None
@@ -301,6 +315,7 @@ def _summarize_hypothesis_trace(
         shock_transient_window_count=shock_transient_window_count,
         sensor_clipping_window_count=sensor_clipping_window_count,
         sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
+        sensor_timing_integrity_window_count=sensor_timing_integrity_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,
@@ -367,6 +382,25 @@ def _mounting_adjusted_lock_score(
     if matched_mounting_artifact_window_count / matched_window_count >= 0.5:
         return min(lock_score, 0.60)
     return lock_score
+
+
+def _timing_adjusted_lock_score(
+    lock_score: float,
+    *,
+    matched_window_count: int,
+    matched_timing_integrity_window_count: int,
+) -> float:
+    if matched_window_count <= 0 or matched_timing_integrity_window_count <= 0:
+        return lock_score
+    if matched_timing_integrity_window_count >= matched_window_count:
+        return min(lock_score, 0.50)
+    if matched_timing_integrity_window_count / matched_window_count >= 0.5:
+        return min(lock_score, 0.65)
+    return lock_score
+
+
+def _has_timing_quality_reason(point: OrderTracePoint) -> bool:
+    return any(reason in _TIMING_QUALITY_REASONS for reason in point.window_quality_reasons)
 
 
 def _relative_error_score(*, mean_relative_error: float | None, path_compliance: float) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -24,6 +24,7 @@ from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
+    RawCaptureLossStats,
     RawCaptureSensorData,
     RawCaptureSensorManifest,
     RawRunCapture,
@@ -88,6 +89,7 @@ class WholeRunSpectralBuildResult:
 class _SpectralChunk:
     sensor_data: RawCaptureSensorData
     timeline: RawSensorTimeline
+    loss_stats: RawCaptureLossStats
     chunk_index: int
     windows: tuple[WholeRunWindowDescriptor, ...]
 
@@ -160,6 +162,7 @@ def build_whole_run_spectral_artifact_bundle(
             window_plan=None,
         )
     chunks = _build_chunks(
+        raw_capture=raw_capture,
         sensors=sensors,
         timelines=timelines,
         plan=plan,
@@ -329,6 +332,7 @@ def _build_time_windows(
 
 def _build_chunks(
     *,
+    raw_capture: RawRunCapture,
     sensors: Sequence[RawCaptureSensorData],
     timelines: Mapping[str, RawSensorTimeline],
     plan: WholeRunWindowPlan,
@@ -339,6 +343,8 @@ def _build_chunks(
     for sensor_data in sensors:
         windows = plan.windows
         timeline = timelines[sensor_data.manifest.client_id]
+        sensor_loss = raw_capture.manifest.sensor_loss(sensor_data.manifest.client_id)
+        loss_stats = sensor_loss.losses if sensor_loss is not None else RawCaptureLossStats()
         for chunk_index, start in enumerate(range(0, len(windows), normalized_chunk_size)):
             chunk_windows = windows[start : start + normalized_chunk_size]
             if not chunk_windows:
@@ -347,6 +353,7 @@ def _build_chunks(
                 _SpectralChunk(
                     sensor_data=sensor_data,
                     timeline=timeline,
+                    loss_stats=loss_stats,
                     chunk_index=chunk_index,
                     windows=chunk_windows,
                 )
@@ -483,6 +490,7 @@ def _process_chunk(
             row_index=row_index,
             metadata=metadata,
             sensor_manifest=sensor_manifest,
+            loss_stats=chunk.loss_stats,
             fft_computer=fft_computer,
         )
         for row_index, window in enumerate(chunk.windows)
@@ -505,6 +513,7 @@ def _build_window_summary(
     row_index: int,
     metadata: RunMetadata,
     sensor_manifest: RawCaptureSensorManifest,
+    loss_stats: RawCaptureLossStats,
     fft_computer: SpectralAnalysisComputer,
 ) -> WholeRunWindowSpectralSummary:
     if int(sensor_manifest.sample_rate_hz or 0) <= 0:
@@ -512,12 +521,14 @@ def _build_window_summary(
             window=window,
             coverage_state="missing",
             coverage_reason="sample_rate_missing",
+            loss_stats=loss_stats,
         )
     if sensor_manifest.sample_rate_proof_state == "timing_inconsistent":
         return _coverage_only_summary(
             window=window,
             coverage_state="missing",
             coverage_reason="sample_rate_unverified",
+            loss_stats=loss_stats,
         )
     requested_end_us = float(timeline.run_start_monotonic_us or 0) + (window.end_t_s * 1_000_000.0)
     resolved = resolve_raw_window_end_time(
@@ -530,6 +541,7 @@ def _build_window_summary(
             window=window,
             coverage_state=_summary_coverage_state(resolved.coverage_state),
             coverage_reason=resolved.reason,
+            loss_stats=loss_stats,
         )
     samples_i16 = np.asarray(
         assemble_raw_window_samples(
@@ -544,6 +556,7 @@ def _build_window_summary(
             window=window,
             coverage_state="partial",
             coverage_reason="assembled_window_short",
+            loss_stats=loss_stats,
             returned_sample_start=(
                 resolved.segments[0].sample_start if resolved.segments else None
             ),
@@ -588,6 +601,8 @@ def _build_window_summary(
             sample_rate_hz=sensor_manifest.sample_rate_hz,
             peak_amp_g=peak_amp_g,
             noise_floor_amp_g=floor_amp_g,
+            late_packet_chunk_count=loss_stats.late_packet_chunk_count,
+            server_queue_drop_count=_server_queue_drop_count(loss_stats),
         ),
     )
 
@@ -597,9 +612,11 @@ def _coverage_only_summary(
     window: WholeRunWindowDescriptor,
     coverage_state: RawCaptureCoverageState,
     coverage_reason: str | None,
+    loss_stats: RawCaptureLossStats | None = None,
     returned_sample_start: int | None = None,
     returned_sample_count: int = 0,
 ) -> WholeRunWindowSpectralSummary:
+    loss_stats = loss_stats or RawCaptureLossStats()
     return WholeRunWindowSpectralSummary(
         window_index=window.window_index,
         coverage_state=coverage_state,
@@ -613,7 +630,18 @@ def _coverage_only_summary(
             returned_sample_count=returned_sample_count,
             coverage_state=coverage_state,
             coverage_reason=coverage_reason,
+            late_packet_chunk_count=loss_stats.late_packet_chunk_count,
+            server_queue_drop_count=_server_queue_drop_count(loss_stats),
         ),
+    )
+
+
+def _server_queue_drop_count(loss_stats: RawCaptureLossStats) -> int:
+    return (
+        max(0, loss_stats.udp_ingest_queue_drop_count)
+        + max(0, loss_stats.queue_overflow_chunk_count)
+        + max(0, loss_stats.invalid_chunk_count)
+        + max(0, loss_stats.write_error_chunk_count)
     )
 
 

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
@@ -235,10 +235,16 @@ def build_coverage_summary(
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
     late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
-    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
-    queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
-    invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
-    write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
+    udp_ingest_queue_drop_count = _manifest_loss_count(
+        raw_capture,
+        "udp_ingest_queue_drop_count",
+    )
+    queue_overflow_chunk_count = _manifest_loss_count(
+        raw_capture,
+        "queue_overflow_chunk_count",
+    )
+    invalid_chunk_count = _manifest_loss_count(raw_capture, "invalid_chunk_count")
+    write_error_chunk_count = _manifest_loss_count(raw_capture, "write_error_chunk_count")
     coverage_confidence = build_coverage_confidence(
         total_sensor_window_count=total_sensor_window_count,
         partial_sensor_window_count=partial_sensor_window_count,
@@ -301,6 +307,16 @@ def build_coverage_summary(
         excluded_window_count=excluded_window_count,
         mean_quality_score=(sum(quality_scores) / len(quality_scores) if quality_scores else None),
         warnings=warnings,
+    )
+
+
+def _manifest_loss_count(raw_capture: RawRunCapture, field_name: str) -> int:
+    manifest_total = max(0, int(getattr(raw_capture.manifest.losses, field_name)))
+    if manifest_total > 0:
+        return manifest_total
+    return sum(
+        max(0, int(getattr(sensor_loss.losses, field_name)))
+        for sensor_loss in raw_capture.manifest.sensor_losses
     )
 
 

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -193,6 +193,11 @@ def _dense_caveat_text(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_MOUNTING_ARTIFACT_WINDOWS",
             count=str(summary.sensor_mounting_artifact_window_count),
         )
+    if summary.sensor_timing_integrity_window_count > 0:
+        return tr(
+            "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_TIMING_INTEGRITY_WINDOWS",
+            count=str(summary.sensor_timing_integrity_window_count),
+        )
     if summary.shock_transient_window_count > 0:
         return tr(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS",

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -6322,6 +6322,10 @@
             "title": "Sensor Mounting Artifact Window Count",
             "type": "integer"
           },
+          "sensor_timing_integrity_window_count": {
+            "title": "Sensor Timing Integrity Window Count",
+            "type": "integer"
+          },
           "shock_transient_window_count": {
             "title": "Shock Transient Window Count",
             "type": "integer"
@@ -6401,6 +6405,7 @@
           "shock_transient_window_count",
           "sensor_clipping_window_count",
           "sensor_mounting_artifact_window_count",
+          "sensor_timing_integrity_window_count",
           "support_intervals",
           "phase_support",
           "harmonic_summaries",
@@ -9550,6 +9555,10 @@
             "title": "State",
             "type": "string"
           },
+          "timing_integrity_score": {
+            "title": "Timing Integrity Score",
+            "type": "number"
+          },
           "transient_score": {
             "title": "Transient Score",
             "type": "number"
@@ -9560,6 +9569,7 @@
           "state",
           "sample_completeness_score",
           "packet_integrity_score",
+          "timing_integrity_score",
           "clipping_score",
           "clipping_sample_count",
           "clipping_sample_ratio",

--- a/apps/ui/src/contracts/ws_payload_schema.json
+++ b/apps/ui/src/contracts/ws_payload_schema.json
@@ -592,6 +592,10 @@
           "title": "State",
           "type": "string"
         },
+        "timing_integrity_score": {
+          "title": "Timing Integrity Score",
+          "type": "number"
+        },
         "transient_score": {
           "title": "Transient Score",
           "type": "number"
@@ -602,6 +606,7 @@
         "state",
         "sample_completeness_score",
         "packet_integrity_score",
+        "timing_integrity_score",
         "clipping_score",
         "clipping_sample_count",
         "clipping_sample_ratio",

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -84,10 +84,13 @@ at this layer so later episode/order/finding logic can ignore unusable bands
 without recomputing the dense spectra.
 
 Shared per-window quality scoring detects repeated accelerometer rail hits,
-flat-topped waveforms, and high-frequency mounting/enclosure artifacts. It
-exposes clipping counts/ratios plus mounting-quality scores in live payloads
-and marks clipped or suspect-mounted windows as limited/excluded evidence rather
-than treating local sensor artifacts as trustworthy vibration strength.
+flat-topped waveforms, high-frequency mounting/enclosure artifacts, and raw
+capture timing integrity loss from timestamp gaps, overlaps/resets, late
+packets, and queue drops. It exposes clipping counts/ratios, mounting-quality
+scores, and timing-quality reasons in live/whole-run payloads and marks clipped,
+suspect-mounted, or timing-compromised windows as limited/excluded evidence
+rather than treating local sensor artifacts or corrupted sample timing as
+trustworthy vibration strength.
 
 `use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
 and final-drive references onto the same window grid. It uses conservative


### PR DESCRIPTION
Closes #3747

## What changed
- Added `timing_integrity_score` and timing reasons to shared window quality: timestamp gaps, overlap/reset windows, late packets, and server/ingest queue drops.
- Fed raw-capture per-sensor loss counters and timeline gap/overlap reasons into whole-run spectral window quality.
- Carried timing-compromised window counts into order summaries, report boundaries, schemas, and dense report caveats.
- Capped order lock score when matched support is mostly or entirely timing-compromised.
- Updated analysis docs and regenerated HTTP/WS schemas.
- Stabilized a report-document context regression test that CI exposed as time-boundary flaky.

## Why
FFT/order evidence needs uniform timing. Bad sample timing can still produce plausible spectra, so those windows must not look like clean diagnostic support.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/shared/test_window_quality.py apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py apps/server/tests/use_cases/diagnostics/test_whole_run_window_quality.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/infra/processing/test_processing_components.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/history/test_report_document_context.py::test_compose_report_document_returns_canonical_document`
- `./.venv/bin/python -m ruff check apps/server/vibesensor apps/server/tests`
- `./.venv/bin/python -m ruff format --check apps/server/vibesensor apps/server/tests`
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m mypy --config-file pyproject.toml`
- `./.venv/bin/python tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python tools/dev/docs_lint.py`
- `cd apps/ui && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run sync:contracts -- --check && npm run format:check && npm run lint && npm run typecheck`

## Risks / edge cases
- Raw-capture loss counters are per-sensor/run-level, not timestamped per dropped packet. Full windows for that sensor are conservatively limited when loss counters exist.
- Timestamp gaps/overlaps stay per-window and can exclude affected windows.
- Raw capture remains stored for forensic replay; only diagnostic evidence quality changes.

## Follow-ups
- None for this issue.

Size: medium