### PR TITLE
Add speed context order caveats

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
+++ b/apps/server/tests/adapters/pdf/test_report_dense_evidence.py
@@ -223,6 +223,20 @@ def test_build_report_document_projects_sensor_timing_integrity_caveat() -> None
     )
 
 
+def test_build_report_document_projects_limited_speed_context_caveat() -> None:
+    summary = _dense_summary(
+        order_summary_overrides={
+            "reference_coverage_ratio": 1.0,
+            "speed_context_limited_window_count": 3,
+        }
+    )
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.appendix_c.dense_evidence_rows[0].caveat == (
+        "Speed context limited order diagnosis: 3"
+    )
+
+
 def test_build_report_document_skips_dense_evidence_when_artifacts_are_unavailable() -> None:
     document = build_report_document(prepare_report_input(minimal_summary()))
 

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
@@ -74,6 +74,7 @@ def test_normalize_whole_run_context_labels_aligns_to_centers_and_groups_rows() 
     assert labels[0].engine_rpm_source == "obd2"
     assert labels[0].speed_is_stale is False
     assert labels[0].rpm_is_stale is False
+    assert labels[0].speed_context_reasons == ("speed_low",)
     assert labels[0].phase == DrivingPhase.SPEED_UNKNOWN
 
     assert labels[1].context_coverage == "full"
@@ -82,6 +83,7 @@ def test_normalize_whole_run_context_labels_aligns_to_centers_and_groups_rows() 
     assert labels[1].speed_source == "manual"
     assert labels[1].engine_rpm_source == "estimated_from_speed_and_ratios"
     assert labels[1].speed_band == "40-50 km/h"
+    assert labels[1].speed_context_reasons == ("speed_assumed",)
 
     assert labels[2].context_coverage == "full"
     assert labels[2].speed_validity == "measured"
@@ -117,6 +119,7 @@ def test_normalize_whole_run_context_labels_marks_stale_context_explicitly() -> 
     assert label.rpm_validity == "estimated"
     assert label.speed_is_stale is True
     assert label.rpm_is_stale is True
+    assert label.speed_context_reasons == ("speed_assumed", "speed_stale")
     assert label.phase == DrivingPhase.SPEED_UNKNOWN
     assert label.load_state == "unknown"
 
@@ -149,6 +152,7 @@ def test_normalize_whole_run_context_labels_marks_fallback_manual_as_stale_prove
     assert label.speed_source == "fallback_manual"
     assert label.speed_is_stale is True
     assert label.rpm_is_stale is True
+    assert label.speed_context_reasons == ("speed_assumed", "speed_stale")
     assert label.speed_band is None
     assert label.phase == DrivingPhase.SPEED_UNKNOWN
     assert label.load_state == "unknown"
@@ -171,7 +175,39 @@ def test_normalize_whole_run_context_labels_keeps_missing_windows_explicit() -> 
     assert label.engine_rpm_source is None
     assert label.speed_is_stale is False
     assert label.rpm_is_stale is False
+    assert label.speed_context_reasons == ("speed_unavailable",)
     assert label.phase == DrivingPhase.SPEED_UNKNOWN
+
+
+def test_normalize_whole_run_context_labels_marks_unstable_speed_windows() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 1.20,
+                "client_id": "sensor-a",
+                "speed_kmh": 30.0,
+                "speed_source": "gps",
+            },
+            {
+                "t_s": 1.35,
+                "client_id": "sensor-a",
+                "speed_kmh": 70.0,
+                "speed_source": "gps",
+            },
+        ]
+    )
+
+    label = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )[0]
+
+    assert label.speed_validity == "measured"
+    assert label.speed_is_stale is False
+    assert label.speed_context_reasons == ("speed_unstable",)
 
 
 def test_normalize_whole_run_context_labels_marks_idle_when_fresh_speed_is_zero() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py
@@ -95,6 +95,7 @@ def _point(
     vibration_strength_db: float | None = None,
     strongest_location: str | None = None,
     ref_source: str | None = "speed+tire",
+    window_quality_reasons: tuple[str, ...] = (),
 ) -> OrderTracePoint:
     return OrderTracePoint(
         hypothesis_key=hypothesis_key,
@@ -112,6 +113,8 @@ def _point(
         vibration_strength_db=vibration_strength_db,
         ref_source=ref_source if eligible else None,
         strongest_location=strongest_location,
+        window_quality_state="limited" if window_quality_reasons else "usable",
+        window_quality_reasons=window_quality_reasons,
     )
 
 
@@ -299,6 +302,28 @@ def test_summarize_whole_run_order_traces_degrades_partial_reference_explicitly(
     assert full_reference.reference_coverage_ratio == 0.5
     assert partial_reference.reference_coverage_ratio == 0.25
     assert full_reference.lock_score > partial_reference.lock_score
+
+
+def test_summarize_whole_run_order_traces_caps_lock_when_speed_context_is_weak() -> None:
+    labels = tuple(_label(index) for index in range(6))
+    points = tuple(
+        _point(
+            index,
+            matched=True,
+            relative_error=0.01,
+            peak_intensity_db=18.0,
+            vibration_strength_db=12.0,
+            strongest_location="Front Left",
+            window_quality_reasons=("speed_unstable",),
+        )
+        for index in range(6)
+    )
+
+    summary = summarize_whole_run_order_traces(points=points, context_labels=labels)[0]
+
+    assert summary.lock_score == 0.45
+    assert summary.speed_context_limited_window_count == 6
+    assert summary.limited_window_count == 6
 
 
 def test_summarize_whole_run_order_traces_is_deterministic() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import numpy as np
 from test_support.report_helpers import diagnostics_context, wheel_metadata
 from test_support.sample_scenarios import make_analysis_sample
@@ -384,6 +386,31 @@ def test_build_whole_run_order_trace_artifact_bundle_suppresses_shock_windows() 
     assert "shock_transient" in shock_point.window_quality_reasons
     assert wheel_1x_by_window[0].matched
     assert wheel_1x_by_window[2].matched
+
+
+def test_build_whole_run_order_trace_artifact_bundle_propagates_speed_context_quality() -> None:
+    labels = tuple(
+        replace(
+            label,
+            speed_validity="assumed",
+            speed_source="manual",
+            speed_context_reasons=("speed_assumed",),
+        )
+        for label in _context_labels(speeds=(60.0, 60.0, 60.0))
+    )
+
+    trace_bundle = _trace_bundle_for(context_labels=labels)
+    wheel_1x = [
+        point
+        for point in trace_bundle.points
+        if point.hypothesis_key == "wheel_1x" and point.harmonic == 1
+    ]
+    summary = _wheel_1x_summary(_summary_bundle_for(context_labels=labels))
+
+    assert all(point.matched for point in wheel_1x)
+    assert all("speed_assumed" in point.window_quality_reasons for point in wheel_1x)
+    assert summary.speed_context_limited_window_count == 3
+    assert summary.lock_score == 0.45
 
 
 def test_build_whole_run_order_trace_artifact_bundle_is_deterministic() -> None:

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2279,6 +2279,10 @@
     "en": "Reference coverage {pct}",
     "nl": "Referentiedekking {pct}"
   },
+  "REPORT_DENSE_EVIDENCE_CAVEAT_SPEED_CONTEXT_LIMITED": {
+    "en": "Speed context limited order diagnosis: {count}",
+    "nl": "Snelheidscontext beperkt orderdiagnose: {count}"
+  },
   "REPORT_DENSE_EVIDENCE_CAVEAT_SHOCK_TRANSIENT_WINDOWS": {
     "en": "Road-shock windows filtered: {count}",
     "nl": "Wegschokvensters gefilterd: {count}"

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -124,6 +124,9 @@ class ReportContextFacts:
     missing_rpm_window_count: int
     stale_speed_window_count: int
     stale_rpm_window_count: int
+    low_speed_window_count: int
+    unstable_speed_window_count: int
+    assumed_speed_window_count: int
     warnings: tuple[RunContextWarning, ...]
 
     @property
@@ -136,7 +139,13 @@ class ReportContextFacts:
 
     @property
     def speed_gap_window_count(self) -> int:
-        return self.missing_speed_window_count + self.stale_speed_window_count
+        return (
+            self.missing_speed_window_count
+            + self.stale_speed_window_count
+            + self.low_speed_window_count
+            + self.unstable_speed_window_count
+            + self.assumed_speed_window_count
+        )
 
     @property
     def rpm_gap_window_count(self) -> int:
@@ -320,6 +329,9 @@ def _build_report_context_facts(
             missing_rpm_window_count=0,
             stale_speed_window_count=0,
             stale_rpm_window_count=0,
+            low_speed_window_count=0,
+            unstable_speed_window_count=0,
+            assumed_speed_window_count=0,
             warnings=(),
         )
     whole_run_available = bool(analysis_metadata.get("whole_run_context_available")) or bool(
@@ -359,6 +371,18 @@ def _build_report_context_facts(
         analysis_metadata,
         "whole_run_context_stale_speed_window_count",
     )
+    low_speed_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_low_speed_window_count",
+    )
+    unstable_speed_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_unstable_speed_window_count",
+    )
+    assumed_speed_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_assumed_speed_window_count",
+    )
     stale_rpm_window_count = _analysis_metadata_count(
         analysis_metadata,
         "whole_run_context_stale_rpm_window_count",
@@ -389,11 +413,20 @@ def _build_report_context_facts(
         missing_rpm_window_count=missing_rpm_window_count,
         stale_speed_window_count=stale_speed_window_count,
         stale_rpm_window_count=stale_rpm_window_count,
+        low_speed_window_count=low_speed_window_count,
+        unstable_speed_window_count=unstable_speed_window_count,
+        assumed_speed_window_count=assumed_speed_window_count,
         warnings=_report_context_warnings(
             source=source,
             partial_window_count=partial_window_count,
             missing_window_count=missing_window_count,
-            speed_gap_window_count=missing_speed_window_count + stale_speed_window_count,
+            speed_gap_window_count=(
+                missing_speed_window_count
+                + stale_speed_window_count
+                + low_speed_window_count
+                + unstable_speed_window_count
+                + assumed_speed_window_count
+            ),
             rpm_gap_window_count=missing_rpm_window_count + stale_rpm_window_count,
         ),
     )

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -152,6 +152,7 @@ class ReportWholeRunOrderSummary:
     sensor_clipping_window_count: int
     sensor_mounting_artifact_window_count: int
     sensor_timing_integrity_window_count: int
+    speed_context_limited_window_count: int
     mean_quality_score: float | None
     support_intervals: tuple[ReportOrderTraceSupportInterval, ...]
     phase_support: tuple[ReportOrderTracePhaseSupport, ...]
@@ -677,6 +678,7 @@ _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
         _count_field("sensor_clipping_window_count"),
         _count_field("sensor_mounting_artifact_window_count"),
         _count_field("sensor_timing_integrity_window_count"),
+        _count_field("speed_context_limited_window_count"),
         _float_field("mean_quality_score"),
         _rows_field("support_intervals", _ORDER_SUPPORT_INTERVAL_DECODER),
         _rows_field("phase_support", _ORDER_PHASE_SUPPORT_DECODER),

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from math import isclose
-from typing import Literal, cast
+from typing import Literal
 
 from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
@@ -676,8 +676,25 @@ def _speed_context_reasons_from_json(
     reasons: list[WholeRunSpeedContextReason] = []
     seen: set[str] = set()
     for item in value:
-        raw = _str_or_none(item)
-        if raw in WHOLE_RUN_SPEED_CONTEXT_REASON_VALUES and raw not in seen:
-            reasons.append(cast(WholeRunSpeedContextReason, raw))
-            seen.add(raw)
+        reason = _speed_context_reason_from_json(item)
+        if reason is not None and reason not in seen:
+            reasons.append(reason)
+            seen.add(reason)
     return tuple(reasons)
+
+
+def _speed_context_reason_from_json(
+    value: JsonValue | object,
+) -> WholeRunSpeedContextReason | None:
+    raw = _str_or_none(value)
+    if raw == "speed_unavailable":
+        return "speed_unavailable"
+    if raw == "speed_low":
+        return "speed_low"
+    if raw == "speed_stale":
+        return "speed_stale"
+    if raw == "speed_unstable":
+        return "speed_unstable"
+    if raw == "speed_assumed":
+        return "speed_assumed"
+    return None

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from math import isclose
-from typing import Literal
+from typing import Literal, cast
 
 from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
@@ -36,6 +36,7 @@ __all__ = [
     "WHOLE_RUN_CONTEXT_COVERAGE_VALUES",
     "WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES",
     "WHOLE_RUN_RPM_VALIDITY_VALUES",
+    "WHOLE_RUN_SPEED_CONTEXT_REASON_VALUES",
     "WHOLE_RUN_SPEED_VALIDITY_VALUES",
     "WholeRunArtifactFile",
     "WholeRunArtifactManifest",
@@ -44,6 +45,7 @@ __all__ = [
     "WholeRunContextLoadState",
     "WholeRunContextWindowLabel",
     "WholeRunRpmValidity",
+    "WholeRunSpeedContextReason",
     "WholeRunSpeedValidity",
     "WholeRunSourceRawManifest",
     "WholeRunSourceRawSensorManifest",
@@ -69,6 +71,13 @@ type WholeRunContextCoverage = Literal["full", "partial", "missing"]
 type WholeRunSpeedValidity = Literal["measured", "assumed", "missing"]
 type WholeRunRpmValidity = Literal["measured", "estimated", "missing"]
 type WholeRunContextLoadState = Literal["idle", "steady", "transient", "unknown"]
+type WholeRunSpeedContextReason = Literal[
+    "speed_unavailable",
+    "speed_low",
+    "speed_stale",
+    "speed_unstable",
+    "speed_assumed",
+]
 
 WHOLE_RUN_CONTEXT_COVERAGE_VALUES: frozenset[WholeRunContextCoverage] = frozenset(
     {"full", "partial", "missing"}
@@ -78,6 +87,9 @@ WHOLE_RUN_SPEED_VALIDITY_VALUES: frozenset[WholeRunSpeedValidity] = frozenset(
 )
 WHOLE_RUN_RPM_VALIDITY_VALUES: frozenset[WholeRunRpmValidity] = frozenset(
     {"measured", "estimated", "missing"}
+)
+WHOLE_RUN_SPEED_CONTEXT_REASON_VALUES: frozenset[WholeRunSpeedContextReason] = frozenset(
+    {"speed_unavailable", "speed_low", "speed_stale", "speed_unstable", "speed_assumed"}
 )
 WHOLE_RUN_CONTEXT_LOAD_STATE_VALUES: frozenset[WholeRunContextLoadState] = frozenset(
     {"idle", "steady", "transient", "unknown"}
@@ -459,6 +471,7 @@ class WholeRunContextWindowLabel:
     engine_rpm: float | None = None
     engine_rpm_source: str | None = None
     rpm_is_stale: bool = False
+    speed_context_reasons: tuple[WholeRunSpeedContextReason, ...] = ()
 
     def __post_init__(self) -> None:
         if self.window_index < 0:
@@ -477,6 +490,8 @@ class WholeRunContextWindowLabel:
             "speed_is_stale": self.speed_is_stale,
             "rpm_is_stale": self.rpm_is_stale,
         }
+        if self.speed_context_reasons:
+            payload["speed_context_reasons"] = list(self.speed_context_reasons)
         if self.segment_index is not None:
             payload["segment_index"] = self.segment_index
         if self.speed_kmh is not None:
@@ -508,6 +523,9 @@ class WholeRunContextWindowLabel:
             engine_rpm=_float_or_none(data.get("engine_rpm")),
             engine_rpm_source=_str_or_none(data.get("engine_rpm_source")),
             rpm_is_stale=_bool_from_json(data.get("rpm_is_stale")),
+            speed_context_reasons=_speed_context_reasons_from_json(
+                data.get("speed_context_reasons")
+            ),
         )
 
 
@@ -648,3 +666,18 @@ def _load_state_from_json(value: JsonValue | object) -> WholeRunContextLoadState
     if raw == "transient":
         return "transient"
     return "unknown"
+
+
+def _speed_context_reasons_from_json(
+    value: JsonValue | object,
+) -> tuple[WholeRunSpeedContextReason, ...]:
+    if not isinstance(value, list):
+        return ()
+    reasons: list[WholeRunSpeedContextReason] = []
+    seen: set[str] = set()
+    for item in value:
+        raw = _str_or_none(item)
+        if raw in WHOLE_RUN_SPEED_CONTEXT_REASON_VALUES and raw not in seen:
+            reasons.append(cast(WholeRunSpeedContextReason, raw))
+            seen.add(raw)
+    return tuple(reasons)

--- a/apps/server/vibesensor/shared/window_quality.py
+++ b/apps/server/vibesensor/shared/window_quality.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isfinite
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 
@@ -24,6 +24,11 @@ type WindowQualityReason = Literal[
     "shock_transient",
     "mounting_artifact",
     "context_unavailable",
+    "speed_unavailable",
+    "speed_low",
+    "speed_stale",
+    "speed_unstable",
+    "speed_assumed",
     "frequency_unstable",
 ]
 
@@ -42,6 +47,11 @@ WINDOW_QUALITY_REASON_VALUES: frozenset[WindowQualityReason] = frozenset(
         "shock_transient",
         "mounting_artifact",
         "context_unavailable",
+        "speed_unavailable",
+        "speed_low",
+        "speed_stale",
+        "speed_unstable",
+        "speed_assumed",
         "frequency_unstable",
     }
 )
@@ -313,6 +323,7 @@ def window_quality_with_context(
     context_coverage: str | None,
     speed_validity: str | None,
     rpm_validity: str | None,
+    speed_context_reasons: tuple[str, ...] = (),
 ) -> WindowQuality:
     """Return ``quality`` with the context component updated for a window label."""
 
@@ -334,7 +345,9 @@ def window_quality_with_context(
             context_coverage=context_coverage,
             speed_validity=speed_validity,
             rpm_validity=rpm_validity,
+            speed_context_reasons=speed_context_reasons,
         ),
+        context_reasons=_window_quality_reasons_from(speed_context_reasons),
         frequency_stability_score=quality.frequency_stability_score,
     )
 
@@ -356,6 +369,7 @@ def _quality_from_component_scores(
     shock_broadband_ratio: float | None = None,
     mounting_high_frequency_ratio: float | None = None,
     timing_reasons: tuple[WindowQualityReason, ...] = (),
+    context_reasons: tuple[WindowQualityReason, ...] = (),
 ) -> WindowQuality:
     sample_completeness_score = _clamp01(sample_completeness_score)
     packet_integrity_score = _clamp01(packet_integrity_score)
@@ -391,6 +405,7 @@ def _quality_from_component_scores(
         reasons.append("shock_transient")
     if mounting_score < 0.98:
         reasons.append("mounting_artifact")
+    reasons.extend(context_reasons)
     if context_score < 0.70:
         reasons.append("context_unavailable")
     if frequency_stability_score < 0.70:
@@ -707,6 +722,7 @@ def _context_score(
     context_coverage: str | None,
     speed_validity: str | None,
     rpm_validity: str | None,
+    speed_context_reasons: tuple[str, ...] = (),
 ) -> float:
     if context_coverage is None and speed_validity is None and rpm_validity is None:
         return 1.0
@@ -722,7 +738,27 @@ def _context_score(
         str(rpm_validity or "missing"),
         0.50,
     )
-    return (coverage_score + speed_score + rpm_score) / 3.0
+    context_score = (coverage_score + speed_score + rpm_score) / 3.0
+    for reason in speed_context_reasons:
+        context_score = min(context_score, _SPEED_CONTEXT_REASON_SCORE_CAPS.get(reason, 1.0))
+    return context_score
+
+
+_SPEED_CONTEXT_REASON_SCORE_CAPS: dict[str, float] = {
+    "speed_unavailable": 0.35,
+    "speed_low": 0.55,
+    "speed_stale": 0.45,
+    "speed_unstable": 0.55,
+    "speed_assumed": 0.75,
+}
+
+
+def _window_quality_reasons_from(reasons: tuple[str, ...]) -> tuple[WindowQualityReason, ...]:
+    return tuple(
+        cast(WindowQualityReason, reason)
+        for reason in reasons
+        if reason in _SPEED_CONTEXT_REASON_SCORE_CAPS
+    )
 
 
 def _frequency_stability_score(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -315,6 +315,7 @@ class OrderTraceSummary:
     sensor_clipping_window_count: int = 0
     sensor_mounting_artifact_window_count: int = 0
     sensor_timing_integrity_window_count: int = 0
+    speed_context_limited_window_count: int = 0
     mean_quality_score: float | None = None
     support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
     phase_support: tuple[OrderTracePhaseSupport, ...] = ()
@@ -363,6 +364,10 @@ class OrderTraceSummary:
             self.sensor_timing_integrity_window_count,
             field_name="sensor_timing_integrity_window_count",
         )
+        _require_nonnegative(
+            self.speed_context_limited_window_count,
+            field_name="speed_context_limited_window_count",
+        )
         _require_ratio(self.support_ratio, field_name="support_ratio")
         _require_ratio(self.reference_coverage_ratio, field_name="reference_coverage_ratio")
         _require_ratio(self.contiguous_support_ratio, field_name="contiguous_support_ratio")
@@ -391,6 +396,7 @@ class OrderTraceSummary:
             "sensor_clipping_window_count": self.sensor_clipping_window_count,
             "sensor_mounting_artifact_window_count": (self.sensor_mounting_artifact_window_count),
             "sensor_timing_integrity_window_count": (self.sensor_timing_integrity_window_count),
+            "speed_context_limited_window_count": self.speed_context_limited_window_count,
             "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
             "phase_support": [row.to_json_object() for row in self.phase_support],
             "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
@@ -443,6 +449,9 @@ class OrderTraceSummary:
             ),
             sensor_timing_integrity_window_count=(
                 _optional_int(data.get("sensor_timing_integrity_window_count")) or 0
+            ),
+            speed_context_limited_window_count=(
+                _optional_int(data.get("speed_context_limited_window_count")) or 0
             ),
             mean_quality_score=_optional_float(data.get("mean_quality_score")),
             support_intervals=_tuple_from_mapping_list_field(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -74,6 +74,21 @@ class WholeRunOrderFamilySummaryArtifactBundle:
     summaries: tuple[OrderTraceSummary, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class _FamilyQualityCounts:
+    usable_window_count: int
+    limited_window_count: int
+    excluded_window_count: int
+    shock_transient_window_count: int
+    sensor_clipping_window_count: int
+    sensor_mounting_artifact_window_count: int
+    matched_mounting_artifact_window_count: int
+    sensor_timing_integrity_window_count: int
+    matched_timing_integrity_window_count: int
+    speed_context_limited_window_count: int
+    matched_speed_context_limited_window_count: int
+
+
 def build_whole_run_order_family_summary_artifact_bundle(
     *,
     order_trace_bundle: WholeRunOrderTraceArtifactBundle,
@@ -197,54 +212,10 @@ def _family_summary(
         if point.window_quality_score is not None
     ]
     mean_quality_score = _mean(quality_scores)
-    usable_window_count = sum(
-        1 for point in matched_points if point.window_quality_state == "usable"
-    )
-    limited_window_count = sum(
-        1 for point in matched_points if point.window_quality_state == "limited"
-    )
-    excluded_window_count = sum(
-        summary.excluded_window_count for summary in ordered_candidate_summaries
-    )
-    shock_transient_window_count = len(
-        {
-            point.window_index
-            for point in points
-            if "shock_transient" in point.window_quality_reasons
-        }
-    )
-    sensor_clipping_window_count = len(
-        {
-            point.window_index
-            for point in points
-            if "sensor_clipping" in point.window_quality_reasons
-        }
-    )
-    sensor_mounting_artifact_window_count = len(
-        {
-            point.window_index
-            for point in points
-            if "mounting_artifact" in point.window_quality_reasons
-        }
-    )
-    matched_mounting_artifact_window_count = len(
-        {
-            point.window_index
-            for point in matched_points
-            if "mounting_artifact" in point.window_quality_reasons
-        }
-    )
-    sensor_timing_integrity_window_count = len(
-        {point.window_index for point in points if _has_timing_quality_reason(point)}
-    )
-    matched_timing_integrity_window_count = len(
-        {point.window_index for point in matched_points if _has_timing_quality_reason(point)}
-    )
-    speed_context_limited_window_count = len(
-        {point.window_index for point in points if _has_speed_context_quality_reason(point)}
-    )
-    matched_speed_context_limited_window_count = len(
-        {point.window_index for point in matched_points if _has_speed_context_quality_reason(point)}
+    quality_counts = _family_quality_counts(
+        points=points,
+        matched_points=matched_points,
+        candidate_summaries=ordered_candidate_summaries,
     )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
@@ -262,17 +233,21 @@ def _family_summary(
     lock_score = _mounting_adjusted_lock_score(
         lock_score,
         matched_window_count=matched_window_count,
-        matched_mounting_artifact_window_count=matched_mounting_artifact_window_count,
+        matched_mounting_artifact_window_count=(
+            quality_counts.matched_mounting_artifact_window_count
+        ),
     )
     lock_score = _timing_adjusted_lock_score(
         lock_score,
         matched_window_count=matched_window_count,
-        matched_timing_integrity_window_count=matched_timing_integrity_window_count,
+        matched_timing_integrity_window_count=quality_counts.matched_timing_integrity_window_count,
     )
     lock_score = _speed_context_adjusted_lock_score(
         lock_score,
         matched_window_count=matched_window_count,
-        matched_speed_context_limited_window_count=matched_speed_context_limited_window_count,
+        matched_speed_context_limited_window_count=(
+            quality_counts.matched_speed_context_limited_window_count
+        ),
     )
     support_intervals, exemplar_interval_index = _support_intervals(
         eligible_windows=eligible_windows,
@@ -336,14 +311,16 @@ def _family_summary(
         reference_coverage_ratio=reference_coverage_ratio,
         longest_contiguous_support_window_count=longest_contiguous_support_window_count,
         contiguous_support_ratio=contiguous_support_ratio,
-        usable_window_count=usable_window_count,
-        limited_window_count=limited_window_count,
-        excluded_window_count=excluded_window_count,
-        shock_transient_window_count=shock_transient_window_count,
-        sensor_clipping_window_count=sensor_clipping_window_count,
-        sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
-        sensor_timing_integrity_window_count=sensor_timing_integrity_window_count,
-        speed_context_limited_window_count=speed_context_limited_window_count,
+        usable_window_count=quality_counts.usable_window_count,
+        limited_window_count=quality_counts.limited_window_count,
+        excluded_window_count=quality_counts.excluded_window_count,
+        shock_transient_window_count=quality_counts.shock_transient_window_count,
+        sensor_clipping_window_count=quality_counts.sensor_clipping_window_count,
+        sensor_mounting_artifact_window_count=(
+            quality_counts.sensor_mounting_artifact_window_count
+        ),
+        sensor_timing_integrity_window_count=(quality_counts.sensor_timing_integrity_window_count),
+        speed_context_limited_window_count=quality_counts.speed_context_limited_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,
@@ -362,6 +339,53 @@ def _family_summary(
         mean_vibration_strength_db=mean_vibration_strength_db,
         ref_sources=ref_sources,
     )
+
+
+def _family_quality_counts(
+    *,
+    points: Sequence[OrderTracePoint],
+    matched_points: Sequence[OrderTracePoint],
+    candidate_summaries: Sequence[OrderTraceSummary],
+) -> _FamilyQualityCounts:
+    return _FamilyQualityCounts(
+        usable_window_count=sum(
+            1 for point in matched_points if point.window_quality_state == "usable"
+        ),
+        limited_window_count=sum(
+            1 for point in matched_points if point.window_quality_state == "limited"
+        ),
+        excluded_window_count=sum(summary.excluded_window_count for summary in candidate_summaries),
+        shock_transient_window_count=_unique_reason_window_count(points, "shock_transient"),
+        sensor_clipping_window_count=_unique_reason_window_count(points, "sensor_clipping"),
+        sensor_mounting_artifact_window_count=_unique_reason_window_count(
+            points,
+            "mounting_artifact",
+        ),
+        matched_mounting_artifact_window_count=_unique_reason_window_count(
+            matched_points,
+            "mounting_artifact",
+        ),
+        sensor_timing_integrity_window_count=len(
+            {point.window_index for point in points if _has_timing_quality_reason(point)}
+        ),
+        matched_timing_integrity_window_count=len(
+            {point.window_index for point in matched_points if _has_timing_quality_reason(point)}
+        ),
+        speed_context_limited_window_count=len(
+            {point.window_index for point in points if _has_speed_context_quality_reason(point)}
+        ),
+        matched_speed_context_limited_window_count=len(
+            {
+                point.window_index
+                for point in matched_points
+                if _has_speed_context_quality_reason(point)
+            }
+        ),
+    )
+
+
+def _unique_reason_window_count(points: Sequence[OrderTracePoint], reason: str) -> int:
+    return len({point.window_index for point in points if reason in point.window_quality_reasons})
 
 
 def _has_timing_quality_reason(point: OrderTracePoint) -> bool:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py
@@ -38,9 +38,11 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
     WholeRunOrderTraceSummaryArtifactBundle,
     _dominant_context_value,
     _drift_score,
+    _has_speed_context_quality_reason,
     _lock_score,
     _longest_contiguous_match_run,
     _mounting_adjusted_lock_score,
+    _speed_context_adjusted_lock_score,
     _timing_adjusted_lock_score,
     whole_run_order_trace_summaries_to_jsonl_bytes,
 )
@@ -238,6 +240,12 @@ def _family_summary(
     matched_timing_integrity_window_count = len(
         {point.window_index for point in matched_points if _has_timing_quality_reason(point)}
     )
+    speed_context_limited_window_count = len(
+        {point.window_index for point in points if _has_speed_context_quality_reason(point)}
+    )
+    matched_speed_context_limited_window_count = len(
+        {point.window_index for point in matched_points if _has_speed_context_quality_reason(point)}
+    )
     drift_score = _drift_score(
         relative_error_stddev=relative_error_stddev,
         path_compliance=1.0,
@@ -260,6 +268,11 @@ def _family_summary(
         lock_score,
         matched_window_count=matched_window_count,
         matched_timing_integrity_window_count=matched_timing_integrity_window_count,
+    )
+    lock_score = _speed_context_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_speed_context_limited_window_count=matched_speed_context_limited_window_count,
     )
     support_intervals, exemplar_interval_index = _support_intervals(
         eligible_windows=eligible_windows,
@@ -330,6 +343,7 @@ def _family_summary(
         sensor_clipping_window_count=sensor_clipping_window_count,
         sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
         sensor_timing_integrity_window_count=sensor_timing_integrity_window_count,
+        speed_context_limited_window_count=speed_context_limited_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py
@@ -60,6 +60,15 @@ _RELATIVE_ERROR_DRIFT_TOLERANCE = 0.08
 _TIMING_QUALITY_REASONS = frozenset(
     {"timing_gap", "late_packet_loss", "server_queue_drop", "sensor_reset"}
 )
+_SPEED_CONTEXT_QUALITY_REASONS = frozenset(
+    {
+        "speed_unavailable",
+        "speed_low",
+        "speed_stale",
+        "speed_unstable",
+        "speed_assumed",
+    }
+)
 
 __all__ = [
     "WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY",
@@ -214,6 +223,12 @@ def _summarize_hypothesis_trace(
     matched_timing_integrity_window_count = sum(
         1 for point in matched_points if _has_timing_quality_reason(point)
     )
+    speed_context_limited_window_count = sum(
+        1 for point in points if _has_speed_context_quality_reason(point)
+    )
+    matched_speed_context_limited_window_count = sum(
+        1 for point in matched_points if _has_speed_context_quality_reason(point)
+    )
     support_intervals = _support_intervals(
         matched_points=matched_points,
         context_by_window=context_by_window,
@@ -244,6 +259,11 @@ def _summarize_hypothesis_trace(
         lock_score,
         matched_window_count=matched_window_count,
         matched_timing_integrity_window_count=matched_timing_integrity_window_count,
+    )
+    lock_score = _speed_context_adjusted_lock_score(
+        lock_score,
+        matched_window_count=matched_window_count,
+        matched_speed_context_limited_window_count=matched_speed_context_limited_window_count,
     )
     peak_intensity_db = _max_or_none(
         point.peak_intensity_db for point in matched_points if point.peak_intensity_db is not None
@@ -316,6 +336,7 @@ def _summarize_hypothesis_trace(
         sensor_clipping_window_count=sensor_clipping_window_count,
         sensor_mounting_artifact_window_count=sensor_mounting_artifact_window_count,
         sensor_timing_integrity_window_count=sensor_timing_integrity_window_count,
+        speed_context_limited_window_count=speed_context_limited_window_count,
         mean_quality_score=mean_quality_score,
         support_intervals=support_intervals,
         phase_support=phase_support,
@@ -399,8 +420,27 @@ def _timing_adjusted_lock_score(
     return lock_score
 
 
+def _speed_context_adjusted_lock_score(
+    lock_score: float,
+    *,
+    matched_window_count: int,
+    matched_speed_context_limited_window_count: int,
+) -> float:
+    if matched_window_count <= 0 or matched_speed_context_limited_window_count <= 0:
+        return lock_score
+    if matched_speed_context_limited_window_count >= matched_window_count:
+        return min(lock_score, 0.45)
+    if matched_speed_context_limited_window_count / matched_window_count >= 0.5:
+        return min(lock_score, 0.60)
+    return min(lock_score, 0.75)
+
+
 def _has_timing_quality_reason(point: OrderTracePoint) -> bool:
     return any(reason in _TIMING_QUALITY_REASONS for reason in point.window_quality_reasons)
+
+
+def _has_speed_context_quality_reason(point: OrderTracePoint) -> bool:
+    return any(reason in _SPEED_CONTEXT_QUALITY_REASONS for reason in point.window_quality_reasons)
 
 
 def _relative_error_score(*, mean_relative_error: float | None, path_compliance: float) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -232,6 +232,7 @@ def _representative_window_quality(
                 context_coverage=context_label.context_coverage,
                 speed_validity=context_label.speed_validity,
                 rpm_validity=context_label.rpm_validity,
+                speed_context_reasons=context_label.speed_context_reasons,
             )
         )
     if not qualities:
@@ -261,6 +262,7 @@ def _best_sensor_peak_match(
             context_coverage=context_label.context_coverage,
             speed_validity=context_label.speed_validity,
             rpm_validity=context_label.rpm_validity,
+            speed_context_reasons=context_label.speed_context_reasons,
         )
         if window_quality.state == "excluded":
             continue

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
@@ -19,7 +19,9 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunContextLoadState,
     WholeRunContextWindowLabel,
     WholeRunRpmValidity,
+    WholeRunSpeedContextReason,
     WholeRunSpeedValidity,
+    WholeRunWindowDescriptor,
 )
 from vibesensor.use_cases.diagnostics._artifact_bundles import (
     build_single_artifact_bundle_parts,
@@ -56,6 +58,9 @@ _RPM_VALIDITY_RANK: dict[WholeRunRpmValidity, int] = {
     "estimated": 1,
     "measured": 2,
 }
+_LOW_ORDER_SPEED_KMH = 15.0
+_UNSTABLE_SPEED_ABS_DELTA_KMH = 12.0
+_UNSTABLE_SPEED_REL_DELTA = 0.20
 
 
 @dataclass(frozen=True, slots=True)
@@ -195,6 +200,17 @@ def normalize_whole_run_context_labels(
             speed_observation.speed_validity if speed_observation is not None else "missing"
         )
         rpm_validity = rpm_observation.rpm_validity if rpm_observation is not None else "missing"
+        speed_is_unstable = _speed_is_unstable_within_window(
+            window=window,
+            speed_observations=speed_observations,
+            context_span_s=freshness_limit_s,
+        )
+        speed_context_reasons = _speed_context_reasons(
+            speed_kmh=speed_kmh,
+            speed_validity=speed_validity,
+            speed_is_stale=speed_is_stale,
+            speed_is_unstable=speed_is_unstable,
+        )
         phase, load_state = _baseline_phase_state(
             speed_kmh=speed_kmh,
             speed_validity=speed_validity,
@@ -225,6 +241,7 @@ def normalize_whole_run_context_labels(
                 engine_rpm=(rpm_observation.engine_rpm if rpm_observation is not None else None),
                 engine_rpm_source=engine_rpm_source,
                 rpm_is_stale=rpm_is_stale,
+                speed_context_reasons=speed_context_reasons,
             )
         )
     return tuple(labels)
@@ -380,6 +397,48 @@ def _context_coverage(
     if speed_validity != "missing" or rpm_validity != "missing":
         return "partial"
     return "missing"
+
+
+def _speed_context_reasons(
+    *,
+    speed_kmh: float | None,
+    speed_validity: WholeRunSpeedValidity,
+    speed_is_stale: bool,
+    speed_is_unstable: bool,
+) -> tuple[WholeRunSpeedContextReason, ...]:
+    reasons: list[WholeRunSpeedContextReason] = []
+    if speed_validity == "missing":
+        reasons.append("speed_unavailable")
+    elif speed_validity == "assumed":
+        reasons.append("speed_assumed")
+    if speed_kmh is not None and speed_validity != "missing" and speed_kmh < _LOW_ORDER_SPEED_KMH:
+        reasons.append("speed_low")
+    if speed_is_stale:
+        reasons.append("speed_stale")
+    if speed_is_unstable and speed_validity != "missing" and not speed_is_stale:
+        reasons.append("speed_unstable")
+    return tuple(dict.fromkeys(reasons))
+
+
+def _speed_is_unstable_within_window(
+    *,
+    window: WholeRunWindowDescriptor,
+    speed_observations: Sequence[_SpeedObservation],
+    context_span_s: float,
+) -> bool:
+    half_span_s = max(1e-9, context_span_s) / 2.0
+    start_t_s = window.center_t_s - half_span_s
+    end_t_s = window.center_t_s + half_span_s
+    speeds = tuple(
+        observation.speed_kmh
+        for observation in speed_observations
+        if start_t_s <= observation.t_s <= end_t_s
+    )
+    if len(speeds) < 2:
+        return False
+    speed_delta = max(speeds) - min(speeds)
+    relative_threshold = _UNSTABLE_SPEED_REL_DELTA * max(1.0, max(speeds))
+    return speed_delta >= max(_UNSTABLE_SPEED_ABS_DELTA_KMH, relative_threshold)
 
 
 def _baseline_phase_state(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -247,7 +247,10 @@ def _evaluate_candidate(
             speed_gap_window_count=_count(
                 analysis_metadata.get("whole_run_context_missing_speed_window_count")
             )
-            + _count(analysis_metadata.get("whole_run_context_stale_speed_window_count")),
+            + _count(analysis_metadata.get("whole_run_context_stale_speed_window_count"))
+            + _count(analysis_metadata.get("whole_run_context_low_speed_window_count"))
+            + _count(analysis_metadata.get("whole_run_context_unstable_speed_window_count"))
+            + _count(analysis_metadata.get("whole_run_context_assumed_speed_window_count")),
             rpm_gap_window_count=_count(
                 analysis_metadata.get("whole_run_context_missing_rpm_window_count")
             )

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -183,6 +183,11 @@ def _dense_caveat_text(
             "REPORT_DENSE_EVIDENCE_CAVEAT_REFERENCE_PARTIAL",
             pct=f"{summary.reference_coverage_ratio * 100:.0f}%",
         )
+    if summary.speed_context_limited_window_count > 0:
+        return tr(
+            "REPORT_DENSE_EVIDENCE_CAVEAT_SPEED_CONTEXT_LIMITED",
+            count=str(summary.speed_context_limited_window_count),
+        )
     if summary.sensor_clipping_window_count > 0:
         return tr(
             "REPORT_DENSE_EVIDENCE_CAVEAT_SENSOR_CLIPPING_WINDOWS",

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -250,6 +250,15 @@ def append_whole_run_context(
     analysis_metadata["whole_run_context_stale_speed_window_count"] = sum(
         1 for label in bundle.labels if label.speed_is_stale
     )
+    analysis_metadata["whole_run_context_low_speed_window_count"] = sum(
+        1 for label in bundle.labels if "speed_low" in label.speed_context_reasons
+    )
+    analysis_metadata["whole_run_context_unstable_speed_window_count"] = sum(
+        1 for label in bundle.labels if "speed_unstable" in label.speed_context_reasons
+    )
+    analysis_metadata["whole_run_context_assumed_speed_window_count"] = sum(
+        1 for label in bundle.labels if "speed_assumed" in label.speed_context_reasons
+    )
     analysis_metadata["whole_run_context_stale_rpm_window_count"] = sum(
         1 for label in bundle.labels if label.rpm_is_stale
     )


### PR DESCRIPTION
Closes #3749

Size: medium

What changed:
- Added whole-run speed context reasons for unavailable, low, stale, unstable, and assumed speed.
- Fed those reasons into window quality and dense order traces.
- Counted speed-context-limited windows in candidate and family summaries.
- Capped order lock when matched support depends on weak speed context.
- Propagated weak speed context into diagnosis ranking and report dense-evidence caveats.
- Split order-family quality counting after CI hygiene caught the expanded function size.

Why:
- Wheel, driveshaft, and engine attribution needs trustworthy speed context.
- Non-order vibration evidence should remain available, but order-specific confidence must not stay high on missing, stale, unstable, low, or manual/fallback speed.

Validation/tests:
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_context.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_scoring.py apps/server/tests/adapters/pdf/test_report_dense_evidence.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_order_family_summaries.py apps/server/tests/use_cases/run/test_post_analysis_summary_vehicle_context.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py`
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_scenario_regressions.py apps/server/tests/use_cases/run/test_post_analysis_golden_replay.py`
- touched-file `ruff format --check` and `ruff check`
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `./.venv/bin/python tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python tools/dev/check_hygiene.py`
- `cd apps/ui && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run sync:contracts -- --check`

Risks, tradeoffs, edge cases:
- Manual speed is treated as assumed speed context and can limit order confidence. That is intentional for order-specific attribution.
- Missing speed normally prevents order eligibility; stale, low, unstable, or assumed speed can still leave order evidence visible but caveated and capped.
- General vibration metrics are not removed by this change.

Follow-ups/out of scope:
- #3750 owns the broader per-finding report-facing data-quality summary.