### PR TITLE
Add diagnostic finding data quality summaries

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -119,6 +119,7 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     history_run = schema_dict["components"]["schemas"]["HistoryRunResponse"]
     analysis_summary = schema_dict["components"]["schemas"]["AnalysisSummaryResponse"]
     diagnosis_summary = schema_dict["components"]["schemas"]["WholeRunDiagnosisSummaryResponse"]
+    diagnosis_quality = schema_dict["components"]["schemas"]["DiagnosisDataQualitySummaryResponse"]
     diagnosis_factor = schema_dict["components"]["schemas"]["DiagnosisFactorResponse"]
     finding_payload = schema_dict["components"]["schemas"]["FindingPayload"]
     car_gearbox = schema_dict["components"]["schemas"]["CarLibraryGearboxEntry"]
@@ -194,6 +195,12 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     }
     assert diagnosis_summary["properties"]["counterevidence_factors"]["items"] == {
         "$ref": "#/components/schemas/DiagnosisFactorResponse",
+    }
+    assert diagnosis_summary["properties"]["data_quality_summary"] == {
+        "$ref": "#/components/schemas/DiagnosisDataQualitySummaryResponse",
+    }
+    assert diagnosis_quality["properties"]["limitation_keys"]["items"] == {
+        "$ref": "#/components/schemas/DiagnosisDataQualityLimitation",
     }
     assert diagnosis_factor["properties"]["details"] == {
         "$ref": "#/components/schemas/DiagnosisFactorDetailsResponse",

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -227,6 +227,7 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
             "sensor_clipping_window_count": 0,
             "sensor_mounting_artifact_window_count": 0,
             "sensor_timing_integrity_window_count": 0,
+            "speed_context_limited_window_count": 0,
             "mean_quality_score": 0.92,
             "support_intervals": [
                 {
@@ -378,6 +379,18 @@ async def test_whole_run_diagnosis_summaries_survive_persistence_and_http_layers
             "weak_spatial_separation": False,
             "has_reference_gap": True,
             "uses_summary_fallback": False,
+            "data_quality_summary": {
+                "usable_window_count": 7,
+                "limited_window_count": 1,
+                "excluded_window_count": 0,
+                "mean_quality_score": 0.9,
+                "speed_context_limited_window_count": 0,
+                "sensor_timing_integrity_window_count": 0,
+                "sensor_mounting_artifact_window_count": 0,
+                "sensor_clipping_window_count": 0,
+                "shock_transient_window_count": 0,
+                "limitation_keys": ["reference_gap"],
+            },
             "support_factors": [
                 {
                     "factor_key": "raw_backed",

--- a/apps/server/tests/shared/boundaries/test_report_summary_row_decoding.py
+++ b/apps/server/tests/shared/boundaries/test_report_summary_row_decoding.py
@@ -65,3 +65,46 @@ def test_report_summary_from_mapping_keeps_diagnosis_factor_with_non_mapping_det
     assert factor.factor_key == "summary_only"
     assert factor.details.raw_backed_sample_count is None
     assert factor.details.fallback_reason is None
+
+
+def test_report_summary_from_mapping_decodes_diagnosis_data_quality_summary() -> None:
+    summary = report_summary_from_mapping(
+        {
+            "whole_run_diagnosis_summaries": [
+                {
+                    "diagnosis_key": "wheel_1x",
+                    "suspected_source": "wheel/tire",
+                    "rank": 1,
+                    "data_basis": "raw_backed",
+                    "data_quality_summary": {
+                        "usable_window_count": 7,
+                        "limited_window_count": 2,
+                        "excluded_window_count": 1,
+                        "mean_quality_score": 0.81,
+                        "speed_context_limited_window_count": 1,
+                        "sensor_timing_integrity_window_count": 2,
+                        "sensor_mounting_artifact_window_count": 0,
+                        "sensor_clipping_window_count": 1,
+                        "shock_transient_window_count": 0,
+                        "limitation_keys": [
+                            "speed_context",
+                            "sensor_timing",
+                            "bad-value",
+                            "speed_context",
+                        ],
+                    },
+                }
+            ]
+        }
+    )
+
+    quality = summary.whole_run_diagnosis_summaries[0].data_quality_summary
+
+    assert quality.usable_window_count == 7
+    assert quality.limited_window_count == 2
+    assert quality.excluded_window_count == 1
+    assert quality.mean_quality_score == 0.81
+    assert quality.speed_context_limited_window_count == 1
+    assert quality.sensor_timing_integrity_window_count == 2
+    assert quality.sensor_clipping_window_count == 1
+    assert quality.limitation_keys == ("speed_context", "sensor_timing")

--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -265,6 +265,7 @@ def test_history_order_trace_response_contracts_expose_named_summary_fields() ->
         "sensor_clipping_window_count",
         "sensor_mounting_artifact_window_count",
         "sensor_timing_integrity_window_count",
+        "speed_context_limited_window_count",
         "mean_quality_score",
         "support_intervals",
         "phase_support",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.shared.types.history_analysis_contracts import (
+    DiagnosisDataQualitySummaryResponse,
     DiagnosisExemplarReferenceResponse,
     DiagnosisFactorDetailsResponse,
     DiagnosisFactorResponse,
     WholeRunDiagnosisSummaryResponse,
 )
 from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    DiagnosisDataQualitySummary,
     DiagnosisExemplarReference,
     DiagnosisFactor,
     DiagnosisFactorDetails,
@@ -59,6 +61,14 @@ def test_whole_run_diagnosis_summary_round_trips_nested_compact_contracts() -> N
         weak_spatial_separation=False,
         has_reference_gap=True,
         uses_summary_fallback=False,
+        data_quality_summary=DiagnosisDataQualitySummary(
+            usable_window_count=7,
+            limited_window_count=1,
+            excluded_window_count=2,
+            mean_quality_score=0.82,
+            speed_context_limited_window_count=1,
+            limitation_keys=("reference_gap", "speed_context"),
+        ),
         exemplar_references=(
             DiagnosisExemplarReference(
                 kind="order_support_interval",
@@ -168,6 +178,20 @@ def test_whole_run_diagnosis_summary_skips_non_mapping_nested_rows() -> None:
     ]
 
 
+def test_whole_run_diagnosis_summary_defaults_missing_quality_summary() -> None:
+    payload = WholeRunDiagnosisSummary(
+        diagnosis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        rank=1,
+        data_basis="raw_backed",
+    ).to_json_object()
+    del payload["data_quality_summary"]
+
+    restored = WholeRunDiagnosisSummary.from_mapping(payload)
+
+    assert restored.data_quality_summary == DiagnosisDataQualitySummary()
+
+
 def test_diagnosis_exemplar_reference_rejects_unsupported_kind() -> None:
     with pytest.raises(ValueError, match="supported diagnosis exemplar kind"):
         DiagnosisExemplarReference.from_mapping({"kind": "bad-kind"})
@@ -259,6 +283,18 @@ def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> N
         "weight",
         "details",
     }
+    assert set(DiagnosisDataQualitySummaryResponse.__annotations__) == {
+        "usable_window_count",
+        "limited_window_count",
+        "excluded_window_count",
+        "mean_quality_score",
+        "speed_context_limited_window_count",
+        "sensor_timing_integrity_window_count",
+        "sensor_mounting_artifact_window_count",
+        "sensor_clipping_window_count",
+        "shock_transient_window_count",
+        "limitation_keys",
+    }
     assert set(WholeRunDiagnosisSummaryResponse.__annotations__) == {
         "diagnosis_key",
         "suspected_source",
@@ -290,6 +326,7 @@ def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> N
         "has_reference_gap",
         "uses_summary_fallback",
         "fallback_reason",
+        "data_quality_summary",
         "exemplar_references",
         "support_factors",
         "counterevidence_factors",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
@@ -206,6 +206,8 @@ def test_build_whole_run_diagnosis_summaries_ranks_candidates_and_projects_exemp
     assert "incomplete_reference" in {
         factor.factor_key for factor in top_summary.counterevidence_factors
     }
+    assert top_summary.data_quality_summary.usable_window_count == 0
+    assert top_summary.data_quality_summary.limitation_keys == ("reference_gap",)
 
 
 def test_diagnosis_ranking_marks_context_gaps_and_weak_spatial_as_suspicious() -> None:
@@ -273,6 +275,12 @@ def test_diagnosis_ranking_marks_context_gaps_and_weak_spatial_as_suspicious() -
                 peak_intensity_db=12.0,
                 mean_vibration_strength_db=10.2,
                 ref_sources=("speed+engine",),
+                usable_window_count=1,
+                limited_window_count=2,
+                excluded_window_count=1,
+                mean_quality_score=0.62,
+                speed_context_limited_window_count=1,
+                sensor_timing_integrity_window_count=1,
             ),
         ),
         spatial_summaries=(
@@ -322,3 +330,16 @@ def test_diagnosis_ranking_marks_context_gaps_and_weak_spatial_as_suspicious() -
     assert "speed_context_gaps" in {factor.factor_key for factor in summary.counterevidence_factors}
     assert "rpm_context_gaps" in {factor.factor_key for factor in summary.counterevidence_factors}
     assert "weak_spatial" in {factor.factor_key for factor in summary.counterevidence_factors}
+    quality = summary.data_quality_summary
+    assert quality.usable_window_count == 1
+    assert quality.limited_window_count == 2
+    assert quality.excluded_window_count == 1
+    assert quality.mean_quality_score == 0.62
+    assert quality.limitation_keys == (
+        "reference_gap",
+        "speed_context",
+        "sensor_timing",
+        "weak_spatial",
+        "ambiguous_location",
+        "window_quality",
+    )

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -100,6 +100,18 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
                 "weak_spatial_separation": False,
                 "has_reference_gap": False,
                 "uses_summary_fallback": False,
+                "data_quality_summary": {
+                    "usable_window_count": 10,
+                    "limited_window_count": 2,
+                    "excluded_window_count": 1,
+                    "mean_quality_score": 0.78,
+                    "speed_context_limited_window_count": 2,
+                    "sensor_timing_integrity_window_count": 0,
+                    "sensor_mounting_artifact_window_count": 0,
+                    "sensor_clipping_window_count": 0,
+                    "shock_transient_window_count": 0,
+                    "limitation_keys": ["speed_context"],
+                },
                 "support_factors": [
                     {
                         "factor_key": "raw_backed",
@@ -146,6 +158,18 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
                 "weak_spatial_separation": False,
                 "has_reference_gap": False,
                 "uses_summary_fallback": False,
+                "data_quality_summary": {
+                    "usable_window_count": 9,
+                    "limited_window_count": 0,
+                    "excluded_window_count": 0,
+                    "mean_quality_score": 0.92,
+                    "speed_context_limited_window_count": 0,
+                    "sensor_timing_integrity_window_count": 0,
+                    "sensor_mounting_artifact_window_count": 0,
+                    "sensor_clipping_window_count": 0,
+                    "shock_transient_window_count": 0,
+                    "limitation_keys": [],
+                },
                 "support_factors": [],
                 "counterevidence_factors": [],
                 "exemplar_references": [],
@@ -163,6 +187,9 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
     assert document.appendix_b.runner_up_corner == "Front-Left"
     assert document.appendix_a.ranked_candidates[0].source_name == "Driveline"
     assert document.appendix_a.ranked_candidates[1].source_name == "Wheel / Tire"
+    assert "quality limited" in document.appendix_a.ranked_candidates[0].reason
+    assert "speed context" in document.appendix_a.ranked_candidates[0].reason
+    assert "quality clean" in document.appendix_a.ranked_candidates[1].reason
     assert prepared.report_facts.confidence.signal_keys == ("raw_backed",)
     assert prepared.report_facts.confidence.caveat_keys == ("close_alternative",)
     assert any(

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -2483,6 +2483,54 @@
     "en": "No retained supporting windows",
     "nl": "Geen bewaarde ondersteunende vensters"
   },
+  "REPORT_FINDING_DATA_QUALITY_CLEAN": {
+    "en": "quality clean: {usable} usable, {excluded} excluded",
+    "nl": "kwaliteit schoon: {usable} bruikbaar, {excluded} uitgesloten"
+  },
+  "REPORT_FINDING_DATA_QUALITY_LIMITED": {
+    "en": "quality limited: {usable} usable, {excluded} excluded; {limitations}",
+    "nl": "kwaliteit beperkt: {usable} bruikbaar, {excluded} uitgesloten; {limitations}"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_REFERENCE": {
+    "en": "reference gaps",
+    "nl": "referentiegaten"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_SPEED_CONTEXT": {
+    "en": "speed context",
+    "nl": "snelheidscontext"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_SENSOR_TIMING": {
+    "en": "sensor timing",
+    "nl": "sensortiming"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_SENSOR_MOUNTING": {
+    "en": "sensor mounting",
+    "nl": "sensorbevestiging"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_SENSOR_CLIPPING": {
+    "en": "sensor clipping",
+    "nl": "sensorclipping"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_ROAD_SHOCK": {
+    "en": "road shock",
+    "nl": "wegschok"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_WEAK_SPATIAL": {
+    "en": "weak location split",
+    "nl": "zwakke locatiescheiding"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_AMBIGUOUS_LOCATION": {
+    "en": "ambiguous location",
+    "nl": "dubbelzinnige locatie"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_SUMMARY_FALLBACK": {
+    "en": "summary fallback",
+    "nl": "samenvattingsfallback"
+  },
+  "REPORT_DATA_QUALITY_LIMIT_WINDOW": {
+    "en": "window quality",
+    "nl": "vensterkwaliteit"
+  },
   "REPORT_MEASUREMENT_ID_COLUMN": {
     "en": "Measurement",
     "nl": "Meting"

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -19,6 +19,8 @@ from vibesensor.shared.boundaries.summary_fields.hotspot import (
 )
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
+    DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES,
+    DiagnosisDataQualityLimitation,
     DiagnosisExemplarKind,
     DiagnosisFactorKey,
     DiagnosisFactorPolarity,
@@ -31,6 +33,7 @@ from vibesensor.shared.types.run_schema import RunMetadata
 __all__ = [
     "NormalizedReportSummary",
     "ReportDiagnosisExemplarReference",
+    "ReportDiagnosisDataQualitySummary",
     "ReportDiagnosisFactor",
     "ReportDiagnosisFactorDetails",
     "ReportOrderHarmonicEvidenceSummary",
@@ -221,6 +224,22 @@ class ReportDiagnosisFactor:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportDiagnosisDataQualitySummary:
+    """Typed persisted data-quality summary for report/history reload paths."""
+
+    usable_window_count: int | None
+    limited_window_count: int | None
+    excluded_window_count: int | None
+    mean_quality_score: float | None
+    speed_context_limited_window_count: int
+    sensor_timing_integrity_window_count: int
+    sensor_mounting_artifact_window_count: int
+    sensor_clipping_window_count: int
+    shock_transient_window_count: int
+    limitation_keys: tuple[DiagnosisDataQualityLimitation, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class ReportSpatialLocationSummary:
     """Typed persisted per-location spatial evidence row for report/history reload."""
 
@@ -289,6 +308,7 @@ class ReportWholeRunDiagnosisSummary:
     has_reference_gap: bool
     uses_summary_fallback: bool
     fallback_reason: str | None
+    data_quality_summary: ReportDiagnosisDataQualitySummary
     exemplar_references: tuple[ReportDiagnosisExemplarReference, ...]
     support_factors: tuple[ReportDiagnosisFactor, ...]
     counterevidence_factors: tuple[ReportDiagnosisFactor, ...]
@@ -391,6 +411,19 @@ def _text_tuple_field(name: str) -> _FieldDecoder:
     return _payload_field(name, _text_tuple)
 
 
+def _data_quality_limitations(raw_values: object) -> tuple[DiagnosisDataQualityLimitation, ...]:
+    if not isinstance(raw_values, list):
+        return ()
+    limitations: list[DiagnosisDataQualityLimitation] = []
+    seen: set[str] = set()
+    for raw_value in raw_values:
+        limitation = _literal_text_or_none(raw_value, DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES)
+        if limitation is not None and limitation not in seen:
+            limitations.append(limitation)
+            seen.add(limitation)
+    return tuple(limitations)
+
+
 def _literal_text_or_none[LiteralTextT: str](
     raw_value: object,
     allowed: frozenset[LiteralTextT],
@@ -440,6 +473,17 @@ def _rows_field[RowModelT](
         return _decode_rows(raw, decoder)
 
     return _payload_field(name, read_rows)
+
+
+def _row_field[RowModelT](
+    name: str,
+    decoder: _RowDecoder[RowModelT],
+    default: RowModelT,
+) -> _FieldDecoder:
+    def read_row(raw: object) -> object:
+        return _decode_row(raw, decoder) or default
+
+    return _payload_field(name, read_row)
 
 
 _PROOF_BASIS_VALUES: frozenset[LocationProofBasis] = frozenset(
@@ -657,6 +701,33 @@ _DIAGNOSIS_FACTOR_DECODER = _RowDecoder(
     ),
     required_fields=frozenset({"factor_key", "polarity", "severity"}),
 )
+_DIAGNOSIS_DATA_QUALITY_DECODER = _RowDecoder(
+    factory=ReportDiagnosisDataQualitySummary,
+    fields=(
+        _optional_count_field("usable_window_count"),
+        _optional_count_field("limited_window_count"),
+        _optional_count_field("excluded_window_count"),
+        _float_field("mean_quality_score"),
+        _count_field("speed_context_limited_window_count"),
+        _count_field("sensor_timing_integrity_window_count"),
+        _count_field("sensor_mounting_artifact_window_count"),
+        _count_field("sensor_clipping_window_count"),
+        _count_field("shock_transient_window_count"),
+        _payload_field("limitation_keys", _data_quality_limitations),
+    ),
+)
+_EMPTY_DIAGNOSIS_DATA_QUALITY = ReportDiagnosisDataQualitySummary(
+    usable_window_count=None,
+    limited_window_count=None,
+    excluded_window_count=None,
+    mean_quality_score=None,
+    speed_context_limited_window_count=0,
+    sensor_timing_integrity_window_count=0,
+    sensor_mounting_artifact_window_count=0,
+    sensor_clipping_window_count=0,
+    shock_transient_window_count=0,
+    limitation_keys=(),
+)
 _WHOLE_RUN_ORDER_SUMMARY_DECODER = _RowDecoder(
     factory=ReportWholeRunOrderSummary,
     fields=(
@@ -755,6 +826,11 @@ _WHOLE_RUN_DIAGNOSIS_SUMMARY_DECODER = _RowDecoder(
         _bool_field("has_reference_gap"),
         _bool_field("uses_summary_fallback"),
         _text_field("fallback_reason"),
+        _row_field(
+            "data_quality_summary",
+            _DIAGNOSIS_DATA_QUALITY_DECODER,
+            _EMPTY_DIAGNOSIS_DATA_QUALITY,
+        ),
         _rows_field("exemplar_references", _DIAGNOSIS_EXEMPLAR_REFERENCE_DECODER),
         _rows_field("support_factors", _DIAGNOSIS_FACTOR_DECODER),
         _rows_field("counterevidence_factors", _DIAGNOSIS_FACTOR_DECODER),

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -48,7 +48,10 @@ __all__ = [
     "DataQualityRequiredMissingPctResponse",
     "DataQualityResponse",
     "DataQualitySpeedCoverageResponse",
+    "DiagnosisDataQualityLimitation",
+    "DiagnosisDataQualitySummaryResponse",
     "DIAGNOSIS_EXEMPLAR_KIND_VALUES",
+    "DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES",
     "DIAGNOSIS_FACTOR_KEY_VALUES",
     "DIAGNOSIS_FACTOR_POLARITY_VALUES",
     "DIAGNOSIS_FACTOR_SEVERITY_VALUES",
@@ -122,6 +125,32 @@ type DiagnosisFactorKey = Literal[
     "approximate_vehicle_data",
     "unverified_vehicle_data",
 ]
+type DiagnosisDataQualityLimitation = Literal[
+    "reference_gap",
+    "speed_context",
+    "sensor_timing",
+    "sensor_mounting",
+    "sensor_clipping",
+    "road_shock",
+    "weak_spatial",
+    "ambiguous_location",
+    "summary_fallback",
+    "window_quality",
+]
+DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES: frozenset[DiagnosisDataQualityLimitation] = frozenset(
+    {
+        "reference_gap",
+        "speed_context",
+        "sensor_timing",
+        "sensor_mounting",
+        "sensor_clipping",
+        "road_shock",
+        "weak_spatial",
+        "ambiguous_location",
+        "summary_fallback",
+        "window_quality",
+    }
+)
 type DiagnosisFactorPolarity = Literal["support", "counterevidence"]
 type DiagnosisFactorSeverity = Literal["low", "medium", "high"]
 type WholeRunDiagnosisDataBasis = Literal["raw_backed", "partial_raw_backed", "summary_only"]
@@ -320,6 +349,7 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     sensor_clipping_window_count: Required[int]
     sensor_mounting_artifact_window_count: Required[int]
     sensor_timing_integrity_window_count: Required[int]
+    speed_context_limited_window_count: Required[int]
     mean_quality_score: float | None
     support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
     phase_support: Required[list[OrderTracePhaseSupportResponse]]
@@ -417,6 +447,21 @@ class DiagnosisFactorResponse(TypedDict, total=False):
     details: Required[DiagnosisFactorDetailsResponse]
 
 
+class DiagnosisDataQualitySummaryResponse(TypedDict, total=False):
+    """Compact report-facing data-quality summary for one diagnosis/finding."""
+
+    usable_window_count: int | None
+    limited_window_count: int | None
+    excluded_window_count: int | None
+    mean_quality_score: float | None
+    speed_context_limited_window_count: Required[int]
+    sensor_timing_integrity_window_count: Required[int]
+    sensor_mounting_artifact_window_count: Required[int]
+    sensor_clipping_window_count: Required[int]
+    shock_transient_window_count: Required[int]
+    limitation_keys: Required[list[DiagnosisDataQualityLimitation]]
+
+
 class WholeRunDiagnosisSummaryResponse(TypedDict, total=False):
     """Future persisted/report-facing summary shape for fused whole-run diagnoses."""
 
@@ -450,6 +495,7 @@ class WholeRunDiagnosisSummaryResponse(TypedDict, total=False):
     has_reference_gap: Required[bool]
     uses_summary_fallback: Required[bool]
     fallback_reason: str | None
+    data_quality_summary: Required[DiagnosisDataQualitySummaryResponse]
     exemplar_references: Required[list[DiagnosisExemplarReferenceResponse]]
     support_factors: Required[list[DiagnosisFactorResponse]]
     counterevidence_factors: Required[list[DiagnosisFactorResponse]]

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from vibesensor.shared.types.history_analysis_contracts import (
+    DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES,
     DIAGNOSIS_EXEMPLAR_KIND_VALUES,
     DIAGNOSIS_FACTOR_KEY_VALUES,
     DIAGNOSIS_FACTOR_POLARITY_VALUES,
     DIAGNOSIS_FACTOR_SEVERITY_VALUES,
     LOCATION_PROOF_BASIS_VALUES,
     WHOLE_RUN_DIAGNOSIS_DATA_BASIS_VALUES,
+    DiagnosisDataQualityLimitation,
     DiagnosisExemplarKind,
     DiagnosisFactorKey,
     DiagnosisFactorPolarity,
@@ -52,6 +54,7 @@ from vibesensor.shared.types.whole_run_json_helpers import (
 
 __all__ = [
     "DiagnosisExemplarReference",
+    "DiagnosisDataQualitySummary",
     "DiagnosisFactor",
     "DiagnosisFactorDetails",
     "WholeRunDiagnosisSummary",
@@ -234,6 +237,84 @@ class DiagnosisFactor:
         )
 
 
+def _require_nonnegative(value: int, *, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisDataQualitySummary:
+    """Compact persisted data-quality rollup for one fused diagnosis."""
+
+    usable_window_count: int | None = None
+    limited_window_count: int | None = None
+    excluded_window_count: int | None = None
+    mean_quality_score: float | None = None
+    speed_context_limited_window_count: int = 0
+    sensor_timing_integrity_window_count: int = 0
+    sensor_mounting_artifact_window_count: int = 0
+    sensor_clipping_window_count: int = 0
+    shock_transient_window_count: int = 0
+    limitation_keys: tuple[DiagnosisDataQualityLimitation, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("usable_window_count", self.usable_window_count),
+            ("limited_window_count", self.limited_window_count),
+            ("excluded_window_count", self.excluded_window_count),
+        ):
+            if value is not None:
+                _require_nonnegative(value, field_name=field_name)
+        for field_name, value in (
+            ("speed_context_limited_window_count", self.speed_context_limited_window_count),
+            ("sensor_timing_integrity_window_count", self.sensor_timing_integrity_window_count),
+            ("sensor_mounting_artifact_window_count", self.sensor_mounting_artifact_window_count),
+            ("sensor_clipping_window_count", self.sensor_clipping_window_count),
+            ("shock_transient_window_count", self.shock_transient_window_count),
+        ):
+            _require_nonnegative(value, field_name=field_name)
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "speed_context_limited_window_count": self.speed_context_limited_window_count,
+            "sensor_timing_integrity_window_count": self.sensor_timing_integrity_window_count,
+            "sensor_mounting_artifact_window_count": self.sensor_mounting_artifact_window_count,
+            "sensor_clipping_window_count": self.sensor_clipping_window_count,
+            "shock_transient_window_count": self.shock_transient_window_count,
+            "limitation_keys": list(self.limitation_keys),
+        }
+        _set_optional(payload, "usable_window_count", self.usable_window_count)
+        _set_optional(payload, "limited_window_count", self.limited_window_count)
+        _set_optional(payload, "excluded_window_count", self.excluded_window_count)
+        _set_optional(payload, "mean_quality_score", self.mean_quality_score)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> DiagnosisDataQualitySummary:
+        return cls(
+            usable_window_count=_optional_int(data.get("usable_window_count")),
+            limited_window_count=_optional_int(data.get("limited_window_count")),
+            excluded_window_count=_optional_int(data.get("excluded_window_count")),
+            mean_quality_score=_optional_float(data.get("mean_quality_score")),
+            speed_context_limited_window_count=(
+                _optional_int(data.get("speed_context_limited_window_count")) or 0
+            ),
+            sensor_timing_integrity_window_count=(
+                _optional_int(data.get("sensor_timing_integrity_window_count")) or 0
+            ),
+            sensor_mounting_artifact_window_count=(
+                _optional_int(data.get("sensor_mounting_artifact_window_count")) or 0
+            ),
+            sensor_clipping_window_count=(
+                _optional_int(data.get("sensor_clipping_window_count")) or 0
+            ),
+            shock_transient_window_count=(
+                _optional_int(data.get("shock_transient_window_count")) or 0
+            ),
+            limitation_keys=_data_quality_limitations_from_json(data.get("limitation_keys")),
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class WholeRunDiagnosisSummary:
     """Compact persisted/report-facing summary for one fused whole-run diagnosis."""
@@ -268,6 +349,7 @@ class WholeRunDiagnosisSummary:
     has_reference_gap: bool = False
     uses_summary_fallback: bool = False
     fallback_reason: str | None = None
+    data_quality_summary: DiagnosisDataQualitySummary = DiagnosisDataQualitySummary()
     exemplar_references: tuple[DiagnosisExemplarReference, ...] = ()
     support_factors: tuple[DiagnosisFactor, ...] = ()
     counterevidence_factors: tuple[DiagnosisFactor, ...] = ()
@@ -321,6 +403,7 @@ class WholeRunDiagnosisSummary:
         _set_optional(payload, "alternative_source", self.alternative_source)
         _set_optional(payload, "confidence_gap_to_alternative", self.confidence_gap_to_alternative)
         _set_optional(payload, "fallback_reason", self.fallback_reason)
+        payload["data_quality_summary"] = self.data_quality_summary.to_json_object()
         return payload
 
     @classmethod
@@ -358,6 +441,7 @@ class WholeRunDiagnosisSummary:
             has_reference_gap=_required_bool(data, "has_reference_gap"),
             uses_summary_fallback=_required_bool(data, "uses_summary_fallback"),
             fallback_reason=_optional_text(data.get("fallback_reason")),
+            data_quality_summary=_data_quality_summary_from_json(data.get("data_quality_summary")),
             exemplar_references=_tuple_from_mapping_list_field(
                 data,
                 "exemplar_references",
@@ -380,11 +464,6 @@ def _require_text(value: object, *, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field_name} must be a non-empty string")
     return value
-
-
-def _require_nonnegative(value: int, *, field_name: str) -> None:
-    if value < 0:
-        raise ValueError(f"{field_name} must be >= 0")
 
 
 def _required_text(data: JsonObject, field_name: str) -> str:
@@ -475,3 +554,50 @@ def _optional_int(value: object) -> int | None:
 
 def _optional_text(value: object) -> str | None:
     return _non_empty_text_or_none(value, strict=True)
+
+
+def _data_quality_summary_from_json(value: object) -> DiagnosisDataQualitySummary:
+    if isinstance(value, dict):
+        return DiagnosisDataQualitySummary.from_mapping(value)
+    return DiagnosisDataQualitySummary()
+
+
+def _data_quality_limitations_from_json(
+    value: object,
+) -> tuple[DiagnosisDataQualityLimitation, ...]:
+    if not isinstance(value, list):
+        return ()
+    limitations: list[DiagnosisDataQualityLimitation] = []
+    seen: set[str] = set()
+    for item in value:
+        limitation = _data_quality_limitation_from_json(item)
+        if limitation is not None and limitation not in seen:
+            limitations.append(limitation)
+            seen.add(limitation)
+    return tuple(limitations)
+
+
+def _data_quality_limitation_from_json(value: object) -> DiagnosisDataQualityLimitation | None:
+    if not isinstance(value, str) or value not in DIAGNOSIS_DATA_QUALITY_LIMITATION_VALUES:
+        return None
+    if value == "reference_gap":
+        return "reference_gap"
+    if value == "speed_context":
+        return "speed_context"
+    if value == "sensor_timing":
+        return "sensor_timing"
+    if value == "sensor_mounting":
+        return "sensor_mounting"
+    if value == "sensor_clipping":
+        return "sensor_clipping"
+    if value == "road_shock":
+        return "road_shock"
+    if value == "weak_spatial":
+        return "weak_spatial"
+    if value == "ambiguous_location":
+        return "ambiguous_location"
+    if value == "summary_fallback":
+        return "summary_fallback"
+    if value == "window_quality":
+        return "window_quality"
+    return None

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -13,10 +13,12 @@ from vibesensor.domain import (
     DiagnosisAssessmentInputs,
     score_diagnosis_assessment_inputs,
 )
+from vibesensor.shared.types.history_analysis_contracts import DiagnosisDataQualityLimitation
 from vibesensor.shared.types.whole_run_analysis import WholeRunContextInterval
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
 from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import SpatialEvidenceSummary
 from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    DiagnosisDataQualitySummary,
     DiagnosisExemplarReference,
     DiagnosisFactor,
     DiagnosisFactorDetails,
@@ -150,6 +152,7 @@ def build_whole_run_diagnosis_summaries(
                 has_reference_gap=candidate.assessment.has_reference_gap,
                 uses_summary_fallback=candidate.assessment.uses_summary_fallback,
                 fallback_reason=candidate.assessment.fallback_reason,
+                data_quality_summary=_data_quality_summary(candidate),
                 exemplar_references=_exemplar_references(candidate, context_intervals),
                 support_factors=tuple(
                     _diagnosis_factor_from_assessment_factor(factor)
@@ -321,6 +324,59 @@ def _context_source(analysis_metadata: Mapping[str, object]) -> str:
     if _data_basis(analysis_metadata, None) == "summary_only":
         return "summary_only"
     return "legacy"
+
+
+def _data_quality_summary(candidate: _CandidateEvaluation) -> DiagnosisDataQualitySummary:
+    order_summary = candidate.order_summary
+    limitation_keys = _data_quality_limitation_keys(candidate)
+    return DiagnosisDataQualitySummary(
+        usable_window_count=order_summary.usable_window_count,
+        limited_window_count=order_summary.limited_window_count,
+        excluded_window_count=order_summary.excluded_window_count,
+        mean_quality_score=order_summary.mean_quality_score,
+        speed_context_limited_window_count=order_summary.speed_context_limited_window_count,
+        sensor_timing_integrity_window_count=order_summary.sensor_timing_integrity_window_count,
+        sensor_mounting_artifact_window_count=(order_summary.sensor_mounting_artifact_window_count),
+        sensor_clipping_window_count=order_summary.sensor_clipping_window_count,
+        shock_transient_window_count=order_summary.shock_transient_window_count,
+        limitation_keys=limitation_keys,
+    )
+
+
+def _data_quality_limitation_keys(
+    candidate: _CandidateEvaluation,
+) -> tuple[DiagnosisDataQualityLimitation, ...]:
+    order_summary = candidate.order_summary
+    spatial_summary = candidate.spatial_summary
+    assessment = candidate.assessment
+    limitations: list[DiagnosisDataQualityLimitation] = []
+    if assessment.has_reference_gap:
+        limitations.append("reference_gap")
+    if order_summary.speed_context_limited_window_count > 0:
+        limitations.append("speed_context")
+    if order_summary.sensor_timing_integrity_window_count > 0:
+        limitations.append("sensor_timing")
+    if order_summary.sensor_mounting_artifact_window_count > 0:
+        limitations.append("sensor_mounting")
+    if order_summary.sensor_clipping_window_count > 0:
+        limitations.append("sensor_clipping")
+    if order_summary.shock_transient_window_count > 0:
+        limitations.append("road_shock")
+    if spatial_summary is not None and spatial_summary.weak_spatial_separation:
+        limitations.append("weak_spatial")
+    if spatial_summary is not None and spatial_summary.ambiguous_location:
+        limitations.append("ambiguous_location")
+    if assessment.uses_summary_fallback:
+        limitations.append("summary_fallback")
+    if (
+        order_summary.limited_window_count > 0
+        or order_summary.excluded_window_count > 0
+        or (
+            order_summary.mean_quality_score is not None and order_summary.mean_quality_score < 0.75
+        )
+    ):
+        limitations.append("window_quality")
+    return tuple(dict.fromkeys(limitations))
 
 
 def _supporting_duration_s(order_summary: OrderTraceSummary) -> float | None:

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -361,20 +361,82 @@ def _diagnosis_summary_reason_text(
     matched_finding: Finding | None,
     tr: Callable[..., str],
 ) -> str:
+    quality_text = _diagnosis_quality_text(summary, tr=tr)
     if summary.supporting_duration_s is not None and summary.supporting_window_count is not None:
-        return tr(
+        support_text = tr(
             "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
             count=str(summary.supporting_window_count),
             duration=f"{summary.supporting_duration_s:.1f}",
         )
+        return _append_quality_summary(support_text, quality_text)
     if summary.supporting_window_count is not None and summary.supporting_window_count > 0:
-        return tr(
+        support_text = tr(
             "REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY",
             count=str(summary.supporting_window_count),
         )
+        return _append_quality_summary(support_text, quality_text)
+    if quality_text is not None:
+        return quality_text
     if matched_finding is not None:
         return _candidate_reason_text(matched_finding, tr=tr)
     return tr("REPORT_SIGNAL_FALLBACK")
+
+
+def _append_quality_summary(support_text: str, quality_text: str | None) -> str:
+    if quality_text is None:
+        return support_text
+    return f"{support_text}; {quality_text}"
+
+
+def _diagnosis_quality_text(
+    summary: ReportWholeRunDiagnosisSummary,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    quality = summary.data_quality_summary
+    usable = quality.usable_window_count
+    limited = quality.limited_window_count
+    excluded = quality.excluded_window_count
+    if usable is None and limited is None and excluded is None and not quality.limitation_keys:
+        return None
+    if not quality.limitation_keys:
+        return tr(
+            "REPORT_FINDING_DATA_QUALITY_CLEAN",
+            usable=str(usable or 0),
+            excluded=str(excluded or 0),
+        )
+    return tr(
+        "REPORT_FINDING_DATA_QUALITY_LIMITED",
+        usable=str(usable or 0),
+        excluded=str(excluded or 0),
+        limitations=_data_quality_limitations_text(quality.limitation_keys, tr=tr),
+    )
+
+
+def _data_quality_limitations_text(
+    limitation_keys: Sequence[str],
+    *,
+    tr: Callable[..., str],
+) -> str:
+    labels = [
+        tr(_DATA_QUALITY_LIMITATION_LABEL_KEYS.get(key, "REPORT_DATA_QUALITY_LIMIT_WINDOW"))
+        for key in limitation_keys[:3]
+    ]
+    return ", ".join(labels)
+
+
+_DATA_QUALITY_LIMITATION_LABEL_KEYS: dict[str, str] = {
+    "reference_gap": "REPORT_DATA_QUALITY_LIMIT_REFERENCE",
+    "speed_context": "REPORT_DATA_QUALITY_LIMIT_SPEED_CONTEXT",
+    "sensor_timing": "REPORT_DATA_QUALITY_LIMIT_SENSOR_TIMING",
+    "sensor_mounting": "REPORT_DATA_QUALITY_LIMIT_SENSOR_MOUNTING",
+    "sensor_clipping": "REPORT_DATA_QUALITY_LIMIT_SENSOR_CLIPPING",
+    "road_shock": "REPORT_DATA_QUALITY_LIMIT_ROAD_SHOCK",
+    "weak_spatial": "REPORT_DATA_QUALITY_LIMIT_WEAK_SPATIAL",
+    "ambiguous_location": "REPORT_DATA_QUALITY_LIMIT_AMBIGUOUS_LOCATION",
+    "summary_fallback": "REPORT_DATA_QUALITY_LIMIT_SUMMARY_FALLBACK",
+    "window_quality": "REPORT_DATA_QUALITY_LIMIT_WINDOW",
+}
 
 
 def _path_role_text(index: int, *, tr: Callable[..., str]) -> str:

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -2161,6 +2161,107 @@
         "title": "DeleteHistoryRunResponse",
         "type": "object"
       },
+      "DiagnosisDataQualityLimitation": {
+        "enum": [
+          "reference_gap",
+          "speed_context",
+          "sensor_timing",
+          "sensor_mounting",
+          "sensor_clipping",
+          "road_shock",
+          "weak_spatial",
+          "ambiguous_location",
+          "summary_fallback",
+          "window_quality"
+        ],
+        "type": "string"
+      },
+      "DiagnosisDataQualitySummaryResponse": {
+        "description": "Compact report-facing data-quality summary for one diagnosis/finding.",
+        "properties": {
+          "excluded_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Excluded Window Count"
+          },
+          "limitation_keys": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnosisDataQualityLimitation"
+            },
+            "title": "Limitation Keys",
+            "type": "array"
+          },
+          "limited_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limited Window Count"
+          },
+          "mean_quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Quality Score"
+          },
+          "sensor_clipping_window_count": {
+            "title": "Sensor Clipping Window Count",
+            "type": "integer"
+          },
+          "sensor_mounting_artifact_window_count": {
+            "title": "Sensor Mounting Artifact Window Count",
+            "type": "integer"
+          },
+          "sensor_timing_integrity_window_count": {
+            "title": "Sensor Timing Integrity Window Count",
+            "type": "integer"
+          },
+          "shock_transient_window_count": {
+            "title": "Shock Transient Window Count",
+            "type": "integer"
+          },
+          "speed_context_limited_window_count": {
+            "title": "Speed Context Limited Window Count",
+            "type": "integer"
+          },
+          "usable_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Usable Window Count"
+          }
+        },
+        "required": [
+          "speed_context_limited_window_count",
+          "sensor_timing_integrity_window_count",
+          "sensor_mounting_artifact_window_count",
+          "sensor_clipping_window_count",
+          "shock_transient_window_count",
+          "limitation_keys"
+        ],
+        "title": "DiagnosisDataQualitySummaryResponse",
+        "type": "object"
+      },
       "DiagnosisExemplarKind": {
         "enum": [
           "order_support_interval",
@@ -6330,6 +6431,10 @@
             "title": "Shock Transient Window Count",
             "type": "integer"
           },
+          "speed_context_limited_window_count": {
+            "title": "Speed Context Limited Window Count",
+            "type": "integer"
+          },
           "stable_frequency_max_hz": {
             "anyOf": [
               {
@@ -6406,6 +6511,7 @@
           "sensor_clipping_window_count",
           "sensor_mounting_artifact_window_count",
           "sensor_timing_integrity_window_count",
+          "speed_context_limited_window_count",
           "support_intervals",
           "phase_support",
           "harmonic_summaries",
@@ -9219,6 +9325,9 @@
           "data_basis": {
             "$ref": "#/components/schemas/WholeRunDiagnosisDataBasis"
           },
+          "data_quality_summary": {
+            "$ref": "#/components/schemas/DiagnosisDataQualitySummaryResponse"
+          },
           "diagnosis_key": {
             "title": "Diagnosis Key",
             "type": "string"
@@ -9459,6 +9568,7 @@
           "weak_spatial_separation",
           "has_reference_gap",
           "uses_summary_fallback",
+          "data_quality_summary",
           "exemplar_references",
           "support_factors",
           "counterevidence_factors"


### PR DESCRIPTION
Closes #3750

Size: medium

What changed:
- Added a persisted `data_quality_summary` to whole-run diagnosis summaries.
- Reused existing order/window/spatial quality counters for usable, limited, excluded, and limited-reason fields.
- Added report-boundary decoding and concise Appendix A quality text per ranked finding.
- Updated HTTP schema contracts and focused tests.
- Fixed CI contract fixture drift for required order and diagnosis summary fields.

Why:
- Reports need to show when a diagnosis is backed by clean evidence versus limited evidence.
- Low-quality speed, timing, mounting, clipping, road-shock, spatial, reference, and fallback limits should not look like clean high-confidence findings.

Validation/tests:
- `./.venv/bin/python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py apps/server/tests/shared/boundaries/test_report_summary_row_decoding.py apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py apps/server/tests/adapters/http/test_http_api_schema_export.py apps/server/tests/integration/test_contract_analysis_persistence_http.py`
- `./.venv/bin/python -m ruff check ...` on touched Python files
- `cd apps/server && ../../.venv/bin/python -m mypy --config-file pyproject.toml`
- `./.venv/bin/python tools/dev/verify_backend_static_guards.py`
- `cd apps/ui && PYTHON=/workspace/VibeSensor/.venv/bin/python npm run sync:contracts -- --check`
- UI generated-contract, format, lint, dependency, unused, app typecheck, and test typecheck gate run directly because host `make` is unavailable.
- `./.venv/bin/python tools/dev/check_hygiene.py`
- `./.venv/bin/python tools/dev/loc_check.py`

Risks, tradeoffs, edge cases:
- Existing persisted rows without `data_quality_summary` decode to an empty summary for report reload safety.
- Report text lists only the first few limitation labels to keep finding rows readable.
- No new DSP quality model was added; this uses the existing quality counters.

Follow-ups / out of scope:
- No UI rendering change beyond generated HTTP schema.
