### PR TITLE
docs: update stale post-analysis architecture references

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -399,13 +399,23 @@ The public PDF entrypoint is `apps/server/vibesensor/adapters/pdf/pdf_engine.py`
 
 ## Updates
 
-Production devices use the wheel-based updater in `apps/server/vibesensor/use_cases/updates/`, with `manager.py` as the public facade over the focused updater modules.
+Production devices use the wheel-based updater in
+`apps/server/vibesensor/use_cases/updates/`, with `manager.py` as the public
+facade over the focused updater modules.
 
-`firmware_cache.py` is now the thin public cache/CLI surface, while `firmware_release_fetcher.py` owns GitHub firmware HTTP access, `firmware_bundle.py` owns bundle extraction/validation/metadata helpers, and `firmware_types.py` owns the updater-local cache/release contracts.
+Firmware update code lives under
+`apps/server/vibesensor/use_cases/updates/firmware/`:
+`firmware_cache.py` is the thin public cache/CLI surface,
+`firmware_release_fetcher.py` owns GitHub firmware HTTP access,
+`firmware_bundle.py` owns bundle extraction/validation/metadata helpers,
+`firmware_types.py` owns updater-local cache/release contracts, and
+`esp_flash_manager.py` owns ESP flashing orchestration. Wi-Fi/uplink recovery
+code lives under `apps/server/vibesensor/use_cases/updates/wifi/` and
+`apps/server/vibesensor/use_cases/updates/transport/`.
 
 - The updater now centralizes its real retry and polling loops on `tenacity`:
-  `wifi_uplink_setup.py` handles retryable SSID scan lag,
-  `wifi_hotspot_recovery.py` handles hotspot restore retries,
+  `wifi/wifi_uplink_setup.py` handles retryable SSID scan lag,
+  `wifi/wifi_hotspot_recovery.py` handles hotspot restore retries,
   `transport/uplink_readiness.py` handles DNS readiness polling, and
   `releases/release_validation.py` handles packaged smoke-server startup
   polling. `restart_scheduler.py` stays custom because it is a two-command

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ links onward to the scoped instruction files and repo map below.
 | `docs/runtime_support_matrix.md` | Canonical Python and Node support policy by environment plus update ownership. |
 | `docs/history_db_schema.md` | SQLite history database schema. |
 | `docs/run_lifecycle.md` | Recording lifecycle, persistence retries, and post-analysis queue semantics. |
-| `docs/run_schema_v2.md` | Run data persistence schema v2. |
+| `docs/run_schema_v2.md` | Legacy/CLI JSONL run schema v2 boundary. |
 | `docs/intake_buffering.md` | Sample intake, buffering, and live signal-processing flow. |
 | `docs/time_alignment.md` | Multi-sensor time alignment approach. |
 | `docs/multithreading_performance.md` | Threading model and performance considerations. |

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -49,94 +49,50 @@ fallbacks are marked `diagnostic_filtered`. Persisted analysis metadata records
 the active profile, filter chains, and whether raw diagnostic evidence was
 preserved.
 
-Full-run dense analysis stages use
-`use_cases/diagnostics/post_run_raw_windows.py` as the raw waveform access
-boundary. It prepares a manifest-backed, deterministic window graph from run
-metadata and raw-capture manifests, then reads each sensor/window through the
-history raw range-read API. That keeps long runs streaming: downstream dense
-stages consume bounded axis arrays per window instead of materializing the full
-raw artifact bundle. Each emitted sensor window carries run ID, sensor ID,
-location snapshot, mount orientation, start/end timing, sample rate, x/y/z
-`int16` arrays, and data-quality flags such as partial windows, timestamp gaps,
-missing samples, low sample count, invalid axis data, sample-rate mismatch,
-sensor clipping, and missing sidecars.
+The connected full-run dense path is the `whole_run_*` sidecar pipeline wired by
+`use_cases/run/post_analysis_executor.py` through
+`use_cases/run/post_analysis_whole_run_builders.py`. It currently receives the
+full `RawRunCapture` loaded by `post_analysis_loader.py`, then builds and stores
+dense sidecar artifacts before compact report-facing summaries are persisted.
+The future streaming/range-read refactor should reuse the bounded range-read
+boundary in `post_run_raw_windows.py`, but that boundary is not the active
+executor input today.
 
-The first dense analysis consumer is
-`use_cases/diagnostics/post_run_stft.py`. It consumes those POSTRUN-01 window
-DTOs and produces in-memory STFT frames with per-axis spectra, combined spectra,
-window timing, sensor metadata, per-axis RMS/P2P, dominant frequency, top peaks,
-static-gravity-axis estimate, axis frame, and dB strength facts. Known mount
-orientations are transformed into vehicle-relative axes at this boundary;
-unknown orientations remain `sensor_local` so later stages can caveat or suppress
-axis-specific conclusions while preserving combined-magnitude location evidence.
-The STFT layer is deliberately post-run only: callers configure FFT size, window
-function, frequency range, and partial-window behavior independently from the
-live UI cadence, while still reusing the shared FFT/strength primitives.
+Current whole-run sidecar stages:
 
-`use_cases/diagnostics/post_run_window_features.py` is the next reduction layer.
-It consumes POSTRUN-02 STFT frames and emits per-window/per-sensor feature DTOs:
-dominant and top peaks, canonical `vibration_strength_db`, peak amplitude, noise
-floor, strength bucket, axis dominance, RMS/P2P, axis frame, static gravity
-axis, structured quality flags, and compact debug rows for synthetic runs.
-Axis dominance is only emitted for vehicle-relative frames; sensor-local frames
-carry a `sensor_orientation_unknown` quality flag instead. Frequency masks live
-at this layer so later episode/order/finding logic can ignore unusable bands
-without recomputing the dense spectra.
+1. `use_cases/diagnostics/whole_run_spectra.py` computes deterministic
+   raw-window spectra from raw capture and emits `spectral-grid:*`,
+   `spectral-matrix:*`, and `spectral-summary:*` sidecars. The summaries carry
+   window timing, coverage/quality, top peaks, and dB strength facts without
+   forcing reports to read the dense matrices.
+2. `use_cases/diagnostics/whole_run_context.py` projects speed/RPM/reference
+   context onto the same window grid and emits dense `context-window-labels`
+   plus compact `whole_run_context_intervals` for `analysis_json`.
+3. `use_cases/diagnostics/orders/whole_run_traces.py` joins spectral summaries
+   with context labels and scores wheel/driveshaft/engine hypotheses per window,
+   writing dense `order-trace-points` sidecars.
+4. `use_cases/diagnostics/orders/whole_run_scoring.py` collapses trace points
+   into compact lock/stability summaries with reference coverage, contiguous
+   support, drift/error, and lock score.
+5. `use_cases/diagnostics/orders/whole_run_family_summaries.py` rolls harmonic
+   summaries up to family-level support intervals and phase summaries.
+6. `use_cases/diagnostics/whole_run_spatial_coherence.py` builds candidate-level
+   multi-sensor spatial evidence windows and compact spatial summaries.
+7. `post_analysis_executor.py` persists dense artifacts through
+   `RunPersistence.astore_whole_run_artifacts(...)`, appends compact whole-run
+   metadata/summaries into `PersistedAnalysis`, and then stores the report-facing
+   summary through `RunPersistence.astore_analysis(...)`.
 
-Shared per-window quality scoring detects repeated accelerometer rail hits,
-flat-topped waveforms, high-frequency mounting/enclosure artifacts, and raw
-capture timing integrity loss from timestamp gaps, overlaps/resets, late
-packets, and queue drops. It exposes clipping counts/ratios, mounting-quality
-scores, and timing-quality reasons in live/whole-run payloads and marks clipped,
+The older `post_run_*` modules are compatibility/support/prototype components.
+`post_run_raw_windows.py` is the manifest-aware range-read access boundary for
+future streaming work; `post_run_stft.py`, `post_run_window_features.py`,
+`post_run_vehicle_reference.py`, `post_run_order_bands.py`,
+`post_run_vibration_episodes.py`, and `post_run_dense_findings.py` preserve
+useful dense DTO and math seams, but the active sidecar pipeline is the
+`whole_run_*` implementation above. Shared quality scoring still marks clipped,
 suspect-mounted, or timing-compromised windows as limited/excluded evidence
 rather than treating local sensor artifacts or corrupted sample timing as
 trustworthy vibration strength.
-
-`use_cases/diagnostics/post_run_vehicle_reference.py` normalizes speed, RPM, gear,
-and final-drive references onto the same window grid. It uses conservative
-interpolation only across short, same-source gaps; rejects ambiguous source,
-gear, or final-drive changes; and records explicit unavailable reasons such as
-missing speed/RPM/gear, stale samples, inconsistent sample rate, and missing
-vehicle configuration. Wheel, driveshaft, and engine frequencies are derived via
-the shared `OrderReferenceSpec` math instead of diagnostics-local formulas.
-
-`use_cases/diagnostics/post_run_order_bands.py` consumes that vehicle-reference
-timeline and emits per-window wheel, driveshaft, and engine order bands. It uses
-the existing `tolerance_for_order()` math, the run's configured uncertainty and
-bandwidth settings, optional harmonic lists, and an explicit output spectrum
-clamp. Unavailable reference inputs become unavailable band rows with reasons
-instead of being dropped or guessed.
-
-Whole-run order traces score the same speed/RPM-synchronous hypotheses across
-consecutive analysis windows. Summaries persist matched support intervals,
-phase-level support, contiguous support, drift/error, and an order-lock score, so
-fixed-frequency resonances during speed changes stay weak unless they follow the
-expected wheel, driveshaft, or engine trajectory.
-
-`use_cases/diagnostics/post_run_vibration_episodes.py` groups POSTRUN-03
-window-feature peaks into deterministic, time-bounded episodes. Grouping is by
-sensor/location, adjacent time windows, allowed per-step frequency drift, and a
-minimum strength threshold. Defaults require at least three supporting windows
-and 0.75 seconds of duration; isolated spikes are suppressed unless they exceed
-the extreme-transient threshold and are marked as transient. Episode rows carry
-frequency path, median/peak strength, median frequency, slope, dominant axis,
-supporting window IDs, affected sensors, and explainable quality penalties for
-dropout gaps, broad drift, noisy feature flags, short duration, and transient
-extremes.
-
-`use_cases/diagnostics/post_run_dense_findings.py` fuses POSTRUN-06 episodes with
-POSTRUN-05 order bands. It compares each episode frequency path against the
-available wheel, driveshaft, and engine bands for the same `window_index`, ranks
-source hypotheses by match ratio, reference completeness, persistence, support
-density, and strength, then emits compact dense findings. Each finding carries
-the likely origin, alternative hypotheses, confidence score/label, evidence
-windows, supporting window count/duration, support density, and caveats for
-ambiguity, missing references, quality penalties, weak persistence, intermittent
-support, short/transient events, conflicting multi-sensor evidence, or strong
-unmatched resonance. The DTO can project back to the existing domain `Finding`
-shape for report/history compatibility without persisting dense spectra; that
-projection carries evidence counts so report facts can show support duration from
-the run feature interval.
 
 ## Related deep dives
 
@@ -157,14 +113,18 @@ RunRecorder.stop_recording()            # use_cases/run/logger.py
        └─ PostAnalysisWorker.schedule() # use_cases/run/post_analysis.py
             └─ _worker_loop()           # daemon thread, sequential queue
                  └─ _run_post_analysis(run_id)
-                      ├─ load metadata + samples (+ raw capture when present) via injected RunPersistence
+                      ├─ load metadata + persisted summary rows via injected RunPersistence
+                      ├─ load full RawRunCapture when a raw-capture manifest exists
                       ├─ build_post_analysis_input(...)
                       │    └─ raw_capture_replay.py rebuilds FFT-derived strength fields from raw windows when possible
+                      ├─ whole_run_* sidecar stages (spectra, context, orders, spatial coherence)
                       ├─ analysis_runner(...)
                       │    ← injected by RunRecorder
                       │      └─ RunAnalysis(metadata, samples, …).summarize()
-                      └─ history_db.store_analysis()
-                            ← persist results via injected RunPersistence
+                      ├─ append compact whole-run summaries/metadata to PersistedAnalysis
+                      ├─ history_db.astore_whole_run_artifacts()
+                      └─ history_db.astore_analysis()
+                            ← persist sidecars and report-facing summary via injected RunPersistence
 ```
 
 `PostAnalysisWorker` receives persistence access, the post-stop analysis
@@ -175,8 +135,10 @@ load/store boundary around the injected analysis dependency.
 ## Pipeline Steps
 
 `RunAnalysis.summarize()` in `run_analysis.py` delegates to
-`analysis_pipeline.py` and executes these steps
-in order. Each step runs exactly once per analysis invocation.
+`analysis_pipeline.py` for the compact summary/report-facing analysis over
+summary-style samples. `execute_post_analysis()` runs the whole-run sidecar
+stages before this compact summary is stored, then appends whole-run metadata and
+summaries to the persisted analysis.
 
 | # | Step | Key Function(s) | Module | Purpose |
 |---|------|-----------------|--------|---------|
@@ -215,13 +177,16 @@ in order. Each step runs exactly once per analysis invocation.
 | `_reference_resolution.py` | ~80 | Engine/tire/reference resolution helpers reused by order analysis |
 | `_sensor_locations.py` | ~80 | Stable sensor-location labels and connected-throughout-run detection |
 | `_run_loader.py` | ~20 | JSONL run loader used by analysis/report adapters |
-| `post_run_raw_windows.py` | ~300 | Manifest-aware streaming raw waveform reader and configurable overlapping-window iterator for dense post-run stages |
-| `post_run_stft.py` | ~350 | In-memory dense STFT engine over POSTRUN-01 raw-window DTOs |
-| `post_run_window_features.py` | ~300 | Window-level feature extraction over POSTRUN-02 STFT frames |
-| `post_run_vehicle_reference.py` | ~350 | Per-window vehicle speed/RPM/gear/final-drive reference normalization for dense order stages |
-| `post_run_order_bands.py` | ~400 | Per-window wheel/driveshaft/engine order-band generation over POSTRUN-04 vehicle references |
-| `post_run_vibration_episodes.py` | ~450 | Deterministic grouping of dense window peaks into persistent or intentional transient vibration episodes |
-| `post_run_dense_findings.py` | ~500 | Dense episode classification into likely origins, alternatives, confidence, caveats, evidence windows, and domain-finding compatibility |
+| `post_run_raw_windows.py` | ~300 | Compatibility/future-streaming manifest-aware raw waveform range reader and configurable overlapping-window iterator |
+| `post_run_stft.py` | ~350 | Support/prototype in-memory dense STFT engine over range-read raw-window DTOs |
+| `post_run_window_features.py` | ~300 | Support/prototype window-level feature extraction over dense STFT frames |
+| `post_run_vehicle_reference.py` | ~350 | Support/prototype per-window vehicle speed/RPM/gear/final-drive reference normalization |
+| `post_run_order_bands.py` | ~400 | Support/prototype per-window wheel/driveshaft/engine order-band generation |
+| `post_run_vibration_episodes.py` | ~450 | Support/prototype deterministic grouping of dense window peaks into episodes |
+| `post_run_dense_findings.py` | ~500 | Support/prototype dense episode classification and domain-finding projection |
+| `whole_run_spectra.py` | ~900 | Active sidecar spectral executor over loaded raw capture; emits dense spectra and compact spectral summaries |
+| `whole_run_context.py` | ~400 | Active sidecar context timeline and compact context intervals on the whole-run window grid |
+| `whole_run_spatial_coherence.py` | ~450 | Active candidate-level spatial evidence sidecars and compact spatial summaries |
 | `_counters.py` | ~20 | Shared `counter_delta()` helper used by diagnostics/runtime tests |
 | `_reference_findings.py` | ~100 | Reference-gap checks and engine/wheel/sample-rate sufficiency helpers |
 | `orders/pipeline.py` | ~250 | Order-finding orchestration: `OrderAnalysisSession`, `OrderAnalysisRequest`, multi-location split, and `_build_order_findings()` |
@@ -232,6 +197,9 @@ in order. Each step runs exactly once per analysis invocation.
 | `orders/statistics.py` | ~260 | Order evidence aggregation plus typed confidence calibration settings |
 | `orders/heuristics.py` | ~150 | Diffuse-excitation, localization-override, and engine-alias heuristics |
 | `orders/settings.py` | ~80 | Typed frozen tuning collections used by order scoring and heuristics |
+| `orders/whole_run_traces.py` | ~350 | Active dense order-trace sidecar generation from spectral summaries plus context labels |
+| `orders/whole_run_scoring.py` | ~600 | Active compact lock/stability scoring over dense order traces |
+| `orders/whole_run_family_summaries.py` | ~600 | Active family-level support intervals and phase summaries from scored order traces |
 | `peaks/findings.py` | ~200 | Persistent-peak support: `PeakFindingAnalyzer`, phase filtering, and duplicate suppression |
 | `peaks/accumulation.py` | ~100 | Raw peak-bin accumulation across samples |
 | `peaks/classification.py` | ~60 | Peak classification policy backed by typed settings |
@@ -253,13 +221,34 @@ in order. Each step runs exactly once per analysis invocation.
 
 ## Data Flow
 
+Whole-run sidecar flow:
+
 ```
-Input: raw samples (list[JsonObject]) + metadata (JsonObject)
+Input: persisted summary samples + metadata (+ optional raw-capture manifest/files)
+  │
+  ├─ post_analysis_loader.load_post_analysis_run()
+  │    ├─ loads persisted summary rows and caps compact-analysis input
+  │    └─ loads full RawRunCapture when raw capture is available
+  │
+  ├─ post_analysis_whole_run_builders.build_whole_run_artifacts()
+  │    ├─ whole_run_spectra.py → dense spectral sidecars + spectral summaries
+  │    ├─ whole_run_context.py → context-window-labels sidecar + compact intervals
+  │    ├─ orders/whole_run_traces.py → dense order-trace sidecar
+  │    ├─ orders/whole_run_scoring.py → compact trace summaries
+  │    ├─ orders/whole_run_family_summaries.py → compact family summaries
+  │    └─ whole_run_spatial_coherence.py → spatial sidecar + compact summaries
+  │
+  ├─ history_db.astore_whole_run_artifacts() → dense sidecar artifacts
+  │
+  └─ compact-analysis/report summary flow
+```
+
+Compact-analysis/report summary flow:
+
+```text
+Input: PostAnalysisRunInput + optional whole-run stage output
   │
   ├─ _context_decode.build_diagnostics_context() → typed diagnostics context
-  │    ├─ RunMetadataSnapshot
-  │    ├─ RunContextSnapshot
-  │    └─ diagnostics-local context conveniences / boundary metadata rehydration
   │
   ├─ _types.normalize_analysis_samples() → raw rows + typed AnalysisSample objects
   │
@@ -275,32 +264,37 @@ Input: raw samples (list[JsonObject]) + metadata (JsonObject)
   │    ├─ finalize_findings() → enriched domain Finding objects
   │    └─ select_top_causes() → ranked top causes
   │
-  ├─ _summary_result.build_analysis_result()
-  │    ├─ AnalysisResult
-  │    ├─ TestRun / DiagnosticCase
-  │    └─ rehydrated metadata dict for later boundary serialization
+  ├─ _summary_result.build_analysis_result() → AnalysisResult/TestRun/DiagnosticCase
   │
-  └─ _summary_result._plot_data() → diagnostics-local PlotDataResultData
-       └─ serialize_plot_data() → persisted chart payload + labeled peak table
+  ├─ _summary_result._plot_data() → diagnostics-local PlotDataResultData
+  │    └─ serialize_plot_data() → persisted chart payload + labeled peak table
   │
-Output: AnalysisResult (TestRun, DiagnosticCase, diagnostics-local artifacts)
+  ├─ post_analysis_executor.append_whole_run_*() → compact persisted summaries
+  │
+  └─ history_db.astore_analysis() → PersistedAnalysis/report-facing summary
 ```
 
 ## Persisted Outputs
 
-After `RunAnalysis.summarize()` returns, `PostAnalysisWorker`:
+During `execute_post_analysis()`, `PostAnalysisWorker`:
 
-1. Adds `analysis_metadata` (sample count, stride info, and whether raw-backed
-   replay was used).
-2. Adds language-neutral trust warnings when the captured run context
-   was incomplete for confident order analysis.
-3. Stores the summary via `history_db.store_analysis()` as a
-   versioned persistence envelope.
+1. Builds and stores dense whole-run sidecar artifacts when raw capture is
+   available and prerequisites pass.
+2. Runs the compact summary analysis path and adds `analysis_metadata` (sample
+   count, sampling method, profile info, raw/whole-run availability, artifact
+   manifest pointers, and stage/fallback details).
+3. Adds compact whole-run context/order/spatial/diagnosis summaries when those
+   stages produced them.
+4. Adds language-neutral trust warnings when the captured run context was
+   incomplete for confident order analysis.
+5. Stores the summary via `history_db.astore_analysis()` as a versioned
+   persistence envelope.
 
-History readers unwrap the envelope back to the summary shape. When a run has a
-raw capture bundle, the persisted analysis summary already reflects raw-backed
-strength/peak metrics from post-stop replay; report/history readers still stay
-persistence-only and never re-run diagnostics. The core
+History readers unwrap the envelope back to the summary shape. When a run has
+raw capture and whole-run sidecars, the persisted analysis summary already
+contains compact report-facing summaries plus sidecar manifest metadata;
+report/history readers still stay persistence-only and never re-run diagnostics.
+The core
 history/report projection is derived from persisted run data plus the persisted
 analysis summary only; any comparison against current mutable car settings is an
 explicit advisory overlay at the history delivery boundary, not a hidden input

--- a/docs/dataflows.md
+++ b/docs/dataflows.md
@@ -43,16 +43,28 @@ Deep dive: `docs/run_lifecycle.md`
 | Field | Value |
 |------|-------------|
 | Source | Optional per-run raw capture written alongside an active recording |
-| Main path | `use_cases/run/raw_capture_writer.py` -> raw capture manifest/store -> `use_cases/run/post_analysis_loader.py` -> `use_cases/run/post_analysis_input.py` + `raw_capture_replay.py` |
-| Boundary | Raw capture is loaded through `RunPersistence`; replay stays inside the post-analysis pipeline |
-| Final consumer | Offline post-stop analysis, especially whole-run/replay-backed analysis |
-| Data shape | Persisted and replayable |
+| Main path | `use_cases/run/raw_capture_writer.py` -> raw capture manifest/store -> `use_cases/run/post_analysis_loader.py` -> `use_cases/run/post_analysis_input.py` + `raw_capture_replay.py` + `post_analysis_whole_run_builders.py` |
+| Boundary | Raw capture is loaded through `RunPersistence`; compact replay and dense sidecar production stay inside the post-analysis pipeline |
+| Final consumer | Offline post-stop analysis: raw replay compatibility plus whole-run sidecar builders |
+| Data shape | Persisted and replayable raw artifacts, dense sidecar artifacts, and compact persisted summaries |
 
 Raw capture is not the report path and not the live UI path. Post-analysis may
 use raw replay when the manifest/store exists, or fall back to persisted summary
-rows when it does not. That degraded or missing raw state must propagate forward
-as lifecycle/artifact status and report context instead of triggering a second
-ad hoc recovery path in history or PDF code.
+rows when it does not. When raw capture is available, the current whole-run
+sidecar path builds spectra, context labels, order traces/summaries, family
+summaries, and spatial coherence through `post_analysis_whole_run_builders.py`
+and the `whole_run_*` diagnostics modules. Dense spectra/traces/matrices stay in
+`whole-run-artifacts/<run_id>/`; compact report-facing summaries and manifest
+metadata are appended to `analysis_json`.
+
+The compatibility/future-streaming raw window path is
+`use_cases/diagnostics/post_run_raw_windows.py`, which uses bounded raw range
+reads. The connected whole-run sidecar executor still receives a full
+`RawRunCapture` from `post_analysis_loader.py`, so future range-read work should
+replace that internal input without changing the history/report read side.
+Degraded or missing raw/whole-run state must propagate forward as
+lifecycle/artifact status and report context instead of triggering a second ad
+hoc recovery path in history or PDF code.
 
 Deep dives: `docs/run_lifecycle.md`, `docs/analysis_pipeline.md`
 

--- a/docs/design_language.md
+++ b/docs/design_language.md
@@ -78,9 +78,23 @@ Automatic on touch/coarse-pointer tablet-ish viewports (`pointer: coarse` + `max
 The generated PDF uses A4 portrait and starts with a **one-glance verdict page**:
 
 ### Page structure
-1. **Verdict page** (page 1) — compact date/car/run metadata, primary source, inspect-first target, short reason, a compact decision path, concise corner proof, ranked source-comparison bars, and the first action plus confirm/clean/parts-gate outcomes. Page 1 intentionally omits the run timeline and support-duration phrasing that can be confused with elapsed runtime. The action preview must not truncate the instruction, the lower layout should use the available vertical space for useful proof/inspection facts, and fallback wording should be operational (for example, "If the primary path is clean: inspect the fallback path") rather than vague caveat language.
-2. **Evidence & Diagnostics** (page 2) — left column: car hotspot heat-map diagram (42 % width, aspect-ratio preserved); right column: compact pattern evidence panel + diagnostic peaks table (system-relevance oriented).
-3. **Inspection path** — full action-card detail, alternatives, confirm/falsify guidance, and longer evidence/context that does not belong on the glanceable verdict page.
+1. **Verdict page** (page 1) — compact date/car/run metadata, primary source,
+   inspect-first target, short reason, a compact decision path, concise proof
+   rows, ranked source-comparison bars, and the first action plus
+   confirm/clean/parts-gate outcomes. Page 1 intentionally omits the run
+   timeline and support-duration phrasing that can be confused with elapsed
+   runtime. The action preview must not truncate the instruction, the lower
+   layout should use the available vertical space for useful proof/inspection
+   facts, and fallback wording should be operational (for example, "If the
+   primary path is clean: inspect the fallback path") rather than vague caveat
+   language.
+2. **Appendix / evidence pages** — Appendix-B style location proof and hotspot
+   diagrams, Appendix-C diagnosis proof packs, worksheet/action-matrix guidance,
+   and diagnostic peak/evidence tables are rendered from the canonical
+   `ReportDocument`, not by re-running diagnostics in the PDF adapter.
+3. **Inspection path** — full action-card detail, alternatives,
+   confirm/falsify guidance, and longer evidence/context that does not belong on
+   the glanceable verdict page.
 
 ### Primitives
 | Primitive | File | Purpose |
@@ -89,7 +103,7 @@ The generated PDF uses A4 portrait and starts with a **one-glance verdict page**
 | `strength_text(db_value, lang)` | `apps/server/vibesensor/shared/report_presentation.py` | Natural-language strength label with dB |
 | `ConfidenceAssessment.tier` | `apps/server/vibesensor/domain/confidence_assessment.py` | Report layout tier (A/B/C) for section visibility |
 
-### Card tone tokens (`report/pdf_style.py`)
+### Card tone tokens (`apps/server/vibesensor/adapters/pdf/pdf_style.py`)
 - `brand_surface_soft` — low-emphasis metadata strip background
 - `card_neutral_bg / _border` — informational
 - `card_success_bg / _border` — good / ok status
@@ -97,7 +111,11 @@ The generated PDF uses A4 portrait and starts with a **one-glance verdict page**
 - `card_error_bg / _border` — critical issue
 
 ### Heat-map gradient
-The car hotspot diagram uses a severity gradient defined in `report/pdf_style.py`.
+The car hotspot diagram uses a severity gradient defined in
+`apps/server/vibesensor/adapters/pdf/pdf_style.py` and is planned/rendered
+through the report-document and PDF adapter modules under
+`apps/server/vibesensor/use_cases/history/report_document/` and
+`apps/server/vibesensor/adapters/pdf/`.
 
 ### i18n
 All user-visible strings go through `tr(lang, KEY)` in `report_i18n.py`. Add new keys there instead of introducing new inline literals across the PDF renderer modules.

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -8,9 +8,10 @@
 > `docs/designs/whole-run-post-analysis-history.md` keeps old issue plans,
 > branch notes, and benchmark snapshots for reference only.
 
-This document records the current architecture, the target architecture, the
-shared contracts that must stay stable, and the recommended execution order. It
-does not track implementation status or old branch plans.
+This document records the implemented architecture, the remaining debt, and the
+shared contracts that must stay stable. Completed checklist items are kept only
+as historical context; current execution status lives in the code paths named
+below.
 
 ## Current state
 
@@ -29,17 +30,28 @@ does not track implementation status or old branch plans.
 ### Run persistence and post-stop analysis
 
 - `apps/server/vibesensor/use_cases/run/logger.py` finalizes a run and schedules
-  `PostAnalysisWorker`.
+   `PostAnalysisWorker`.
 - `apps/server/vibesensor/use_cases/run/post_analysis_loader.py` loads persisted
-  samples for a run, but caps analysis input at `_MAX_POST_ANALYSIS_SAMPLES =
-  12_000` and applies an upfront stride when the run is longer.
+   samples for a run, but caps analysis input at `_MAX_POST_ANALYSIS_SAMPLES =
+   12_000` and applies event-preserving sampling when the summary row set is
+   longer. When a raw-capture manifest exists, the loader also asks persistence
+   for the full `RawRunCapture` via `aload_raw_capture(...)`; the current
+   connected whole-run sidecar path is not yet a pure range-streaming executor.
 - `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` uses raw capture
-  only to rebuild FFT-derived metrics for those already-persisted summary rows.
+   only to rebuild FFT-derived metrics for those already-persisted summary rows.
+- `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` is the
+   canonical offline executor. It runs a structured stage pipeline:
+  `LoadRunStage`, `BuildPostAnalysisInputStage`,
+  `BuildWholeRunSpectraStage`, `BuildWholeRunContextStage`,
+  `BuildOrderTraceStage`, `BuildOrderTraceSummaryStage`,
+  `BuildOrderFamilySummaryStage`, `BuildSpatialSummaryStage`,
+  `PersistArtifactsStage`, `BuildReportFactsStage`, and
+  `PersistAnalysisSummaryStage`.
 - `apps/server/vibesensor/use_cases/diagnostics/run_analysis.py` and
-  `analysis_pipeline.py` still operate on summary-style `SensorFrame` samples,
-  not on a true full-run raw-window graph.
+  `analysis_pipeline.py` still provide the compact summary/report-facing
+  analysis path over summary-style `SensorFrame` samples.
 
-### Raw capture from #3065
+### Raw capture and dense sidecars
 
 - Raw artifacts are already stored separately from `samples_v2`.
 - The canonical storage contract is
@@ -49,52 +61,33 @@ does not track implementation status or old branch plans.
   - `RawCaptureChunkIndex`
   - `RawRunCapture`
 - Persistence uses `data/raw-runs/{run_id}/` with per-sensor
-  `.raw.i16le` and `.index.jsonl` files via
-  `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`.
-- Whole-run foundations now include indexed raw range reads via
-  `RunPersistence.aload_raw_capture_sensor_range(...)`, but there is still no
-  canonical offline executor that walks the full run as a deterministic window
-  graph.
-- POSTRUN-01 adds that diagnostics-layer access boundary in
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py`: it
-  validates raw manifests, derives configurable overlapping windows, filters
-  sensors, and streams each window through range reads with structured warnings.
-- POSTRUN-02 adds the first dense consumer in
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_stft.py`: an in-memory
-  STFT engine over those raw-window DTOs. Persistence of dense arrays remains
-  owned by POSTRUN-08.
-- POSTRUN-03 adds
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_window_features.py`:
-  a deterministic reduction from STFT frames to per-window/per-sensor diagnostic
-  features, including canonical dB strength, top peaks, axis dominance, RMS/P2P,
-  frequency masking, and propagated quality flags.
-- POSTRUN-04 adds
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py`:
-  a deterministic vehicle-reference timeline aligned to the dense window grid.
-  It normalizes speed, RPM, gear, and final-drive inputs, rejects ambiguous or
-  stale references, and derives wheel/driveshaft/engine Hz through
-  `OrderReferenceSpec`.
-- POSTRUN-05 adds
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py`:
-  a deterministic per-window order-band timeline for wheel, driveshaft, and
-  engine harmonics. It reuses shared tolerance math, clamps to the configured
-  dense spectrum range, and carries explicit unavailable reasons for missing
-  references.
-- POSTRUN-06 adds
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_vibration_episodes.py`:
-  deterministic grouping of POSTRUN-03 feature peaks into sustained vibration
-  episodes, with explicit transient-spike handling, dropout/drift/noise quality
-  penalties, and debug rows for inspection.
-- POSTRUN-07 adds
-  `apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py`:
-  deterministic classification of dense episodes against POSTRUN-05 order bands.
-  It ranks wheel, driveshaft, and engine hypotheses by per-window band matches,
-  reference completeness, persistence, and strength; preserves strong unmatched
-  episodes as unknown resonance; records caveats for ambiguity, missing
-  references, poor quality, short duration, transients, and conflicting
-  multi-sensor evidence; and maps compact
-  dense findings back into the existing domain `Finding` contract for
-  report/history compatibility.
+   `.raw.i16le` and `.index.jsonl` files via
+   `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`.
+- Indexed raw range reads exist through
+  `RunPersistence.aload_raw_capture_sensor_range(...)` and are used by the
+  compatibility/prototype diagnostics boundary in
+  `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py`.
+- The current connected dense sidecar path is owned by
+  `apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py` and
+  the `whole_run_*` diagnostics modules:
+  - `whole_run_spectra.py` builds deterministic whole-run spectral sidecars from
+    `RawRunCapture`, emitting spectral grids/matrices plus per-window compact
+    spectral summaries.
+  - `whole_run_context.py` labels the same window grid with speed/RPM/reference
+    context and persists compact context intervals in `analysis_json`.
+  - `orders/whole_run_traces.py` builds dense order trace points from
+    `spectral-summary:*` sidecars and context labels.
+  - `orders/whole_run_scoring.py` collapses dense traces into compact lock and
+    stability summaries.
+  - `orders/whole_run_family_summaries.py` rolls scored harmonic traces up to
+    family-level support intervals and phase summaries.
+  - `whole_run_spatial_coherence.py` builds candidate-level spatial evidence
+    windows and compact spatial summaries.
+- `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py`
+  persists dense sidecar artifacts under `data/whole-run-artifacts/{run_id}/`.
+- The older `post_run_*` modules remain useful support/prototype code for
+  bounded range-read experiments and legacy dense DTOs, but they are not the
+  currently connected sidecar pipeline in `execute_post_analysis()`.
 
 ### Persisted analysis and reporting
 
@@ -107,34 +100,38 @@ does not track implementation status or old branch plans.
 - `apps/server/vibesensor/use_cases/history/report_document/` composes the final
   `ReportDocument`, and `adapters/pdf` only renders it.
 
-## Why the current path is insufficient
+## Remaining debt
 
-The current architecture already has strong raw capture and a stable
-reporting boundary, but it still has four blocking limitations for whole-run
-offline analysis:
+The current architecture has raw capture, a canonical executor, dense sidecar
+persistence, whole-run spectra/context/order/spatial stages, and compact
+report-facing summaries. Remaining debt is narrower:
 
-1. **No full-run raw window engine.** Raw capture is only used to rehydrate the
-   FFT-derived fields of summary rows, not to analyze the full run as a
-   deterministic window graph.
-2. **Long runs are sample-capped.** `post_analysis_loader.py` strides the input
-   once a run exceeds 12k persisted rows, which is incompatible with
-   whole-run trace continuity.
-3. **Summary-shaped contracts dominate.** Orders, phases, and location proof are
-   still derived from per-sample peak summaries and matched points instead of
-   first-class whole-run artifacts.
-4. **Persisted analysis JSON is the wrong place for heavy artifacts.** The
-   report/history path should keep consuming compact summary objects, not
-   tens of thousands of per-window spectra or traces.
+1. **Future streaming/range-read refactor.** The compatibility
+   `post_run_raw_windows.py` path reads bounded raw ranges, but the connected
+   whole-run spectral stage currently receives a fully loaded `RawRunCapture`
+   from `post_analysis_loader.py`. Long-run memory pressure should be reduced by
+   wiring the sidecar executor to bounded range reads or an equivalent streaming
+   source.
+2. **Summary-era compatibility remains.** The compact `RunAnalysis` path over
+   summary rows still builds the report-facing baseline. Whole-run summaries are
+   projected into that persisted analysis, but legacy `Finding` narratives remain
+   a fallback when fused whole-run diagnosis summaries are absent.
+3. **Dense sidecars are write-mostly.** History/report consumers intentionally
+   read compact summaries and manifests. Sidecar readback is limited to explicit
+   internal needs; adding new report surfaces should still project compact
+   summaries first instead of loading dense matrices during render.
+4. **Fusion should stay compact.** Future diagnosis/fusion refinements must keep
+   `PersistedAnalysis` report-facing and store any dense evidence as sidecars.
 
-## Target architecture
+## Implemented architecture and current direction
 
-The target shape keeps the current one-time post-stop analysis model, but adds
-an internal whole-run artifact layer between raw capture and persisted
+The implemented shape keeps the one-time post-stop analysis model and adds an
+internal whole-run artifact layer between raw capture and persisted
 diagnosis/report summaries.
 
 ```text
 raw capture manifest/files (#3065)
-  -> indexed range/window reader
+  -> current RawRunCapture load (future streaming/range-read refactor)
   -> deterministic window planner
   -> raw-window spectral executor
   -> context timeline + segment labels
@@ -593,13 +590,16 @@ Add opt-in benchmarks for:
   (full/partial/missing plus speed/RPM gap counts) so history/report preparation
   can project caveats without loading dense sidecar labels during report render.
 
-## Recommended implementation order
+## Historical/completed implementation checklist
 
-1. Settle whole-run window contracts and sidecar artifact persistence.
-2. Add indexed raw range reads and the deterministic window planner.
-3. Build the raw-window spectral executor and benchmark it.
-4. Build the context timeline and segment labeling on the same window grid.
-5. Build order tracking and spatial/coherence in parallel on top of the shared
-   spectral/context artifacts.
-6. Build fusion, counterevidence, persisted diagnosis summaries, and report
-   wiring last.
+These items describe the completed implementation order and should not be read
+as current blockers:
+
+1. Whole-run window contracts and sidecar artifact persistence were added.
+2. Indexed raw range reads and deterministic window planning were added.
+3. The raw-window spectral executor and benchmarks were added.
+4. Context timelines and segment labels were added on the shared window grid.
+5. Whole-run order traces, order scoring, family summaries, and spatial
+   coherence were added on top of spectral/context artifacts.
+6. Compact whole-run summaries and report-facing fallback/fused-summary wiring
+   were added while keeping dense artifacts sidecar-only.

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -70,6 +70,9 @@ are rehydrated back into typed `SensorFrame.top_peaks` data on read.
 | `run_id` | TEXT FK | References `runs(run_id)` with `ON DELETE CASCADE` |
 | `timestamp_utc` | TEXT | ISO-8601 sample time |
 | `t_s` | REAL | Seconds since run start (monotonic) |
+| `analysis_window_start_us` | INTEGER | Optional raw-analysis window start timestamp in run-monotonic microseconds |
+| `analysis_window_end_us` | INTEGER | Optional raw-analysis window end timestamp in run-monotonic microseconds |
+| `analysis_window_synced` | INTEGER | Optional boolean flag (`0`/`1`) indicating whether the analysis window is synchronized to raw capture timing |
 | `client_id` | TEXT | Sensor MAC address (hex) |
 | `client_name` | TEXT | Human-readable sensor name |
 | `location` | TEXT | Mounting position (e.g. `front_left`) |
@@ -160,7 +163,11 @@ destructive deletion.
 | Batch insert size | 256 | Balances transaction overhead vs. memory usage |
 | Read batch size | 1000 (default) | Keyset pagination for streaming reads |
 
-## Storage comparison (approximate)
+## Historical storage comparison (approximate)
+
+This comparison records why the schema moved from older opaque sample JSON blobs
+to typed `samples_v2` columns. It is historical design context, not current
+guidance for choosing a storage version; current databases use schema v15.
 
 For a 30-minute run at 4 Hz × 4 sensors (~28,800 samples):
 

--- a/docs/intake_buffering.md
+++ b/docs/intake_buffering.md
@@ -99,9 +99,9 @@ handling and metric commits, while the pure DSP steps stay in shared helpers:
 2. `SignalMetricsComputer.compute()` detrends the captured windows by removing
    the per-axis mean before RMS/P2P and FFT computation.
 3. `apps/server/vibesensor/shared/fft_analysis.py` applies the SciPy-backed
-   Hann window, runs the planned pyFFTW RFFT backend, slices the configured
-   frequency range via SciPy FFT frequency bins, and produces both per-axis
-   spectra and a combined amplitude curve.
+   Hann window, runs the implemented thread-local pyFFTW RFFT backend, slices
+   the configured frequency range via SciPy FFT frequency bins, and produces
+   both per-axis spectra and a combined amplitude curve.
 4. `apps/server/vibesensor/vibration_strength.py` uses SciPy peak finding to
    select dominant candidate bins, estimates a P20/median noise floor, and
    converts the dominant peak band into the

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -82,11 +82,15 @@ Hysteresis and persistence logic is handled in `severity.severity_from_peak()`:
 - `PERSISTENCE_TICKS = 3` — ticks a new band must be seen before promotion
 - `DECAY_TICKS = 5` — ticks below threshold before demotion
 
-## JSONL Run Log Fields
+## Run persistence fields
 
-The field written to `.jsonl` run files is `vibration_strength_db` (dB).
+Current runtime history stores sample metrics in SQLite `samples_v2` typed
+columns; the legacy/CLI JSONL boundary uses the same `SensorFrame` field names.
+See `docs/history_db_schema.md` for the current DB schema and
+`docs/run_schema_v2.md` for the legacy JSONL boundary. This section lists only
+metric fields, not the full persistence schema.
 
-### Current fields (v2 schema)
+### Metric fields
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -94,6 +98,8 @@ The field written to `.jsonl` run files is `vibration_strength_db` (dB).
 | `strength_bucket` | str \| null | Severity band key (`l1`–`l5`) or `null` |
 | `top_peaks` | list | Up to 8 combined-spectrum peaks: `[{hz, amp, vibration_strength_db, strength_bucket}]` |
 | `dominant_freq_hz` | float | Frequency of dominant peak (Hz) |
+| `strength_peak_amp_g` | float | Peak amplitude used to compute dB strength |
+| `strength_floor_amp_g` | float | Noise-floor amplitude used to compute dB strength |
 
 ### Removed fields (previously present, now deleted)
 

--- a/docs/multithreading_performance.md
+++ b/docs/multithreading_performance.md
@@ -30,8 +30,11 @@ keeping the event loop unblocked during FFT. No change needed.
 
 ### 3. Post-analysis report generation — already threaded
 
-`MetricsLogger` already runs post-analysis in a background `Thread`.
-No change needed.
+`PostAnalysisWorker` in `apps/server/vibesensor/use_cases/run/post_analysis.py`
+owns a single daemon thread for completed-run post-analysis. `RunRecorder`
+creates it during run-lifecycle setup and schedules completed run IDs after
+finalization. No separate report-generation thread is created in the renderer;
+report requests read persisted analysis and render on demand.
 
 ### 4. UDP ingest path — kept lightweight (no threading added)
 
@@ -46,7 +49,7 @@ with explicit drop logging.
 |-----------|--------|
 | `worker_pool.py` | Bounded worker pool wrapper: caps running + queued tasks, applies caller backpressure, isolates task failures, exposes metrics, supports clean shutdown |
 | `processing/` | `compute_all()` dispatches per-client FFT adaptively; ingest/compute timing counters added |
-| `runtime/builders.py` | Creates shared `WorkerPool(max_workers=4)`, injects into `SignalProcessor`, runtime shuts it down on stop |
+| `app/container.py` | Creates shared `WorkerPool(max_workers=4, thread_name_prefix="vibesensor-fft")`, injects into `SignalProcessor`, runtime shuts it down on stop |
 | Tests | 14 new tests: pool correctness, parallel/sequential equivalence, concurrent ingest+compute safety |
 | Benchmark | `apps/server/tests/infra/workers/benchmark_compute_all.py` — canonical pytest-benchmark regression path |
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -5,7 +5,10 @@ Scope: shared order-reference math and the post-stop order-analysis flow.
 VibeSensor uses the same vehicle-order reference model in two places:
 
 - live telemetry, where the server precomputes order bands for spectrum views
-- post-stop diagnostics, where stored samples are matched against those orders
+- post-stop diagnostics, where the active whole-run sidecar pipeline scores
+  order traces against spectral summaries and context labels, and the legacy
+  compact path still matches stored sample peaks when whole-run summaries are
+  unavailable
 
 The shared physics lives in `apps/server/vibesensor/domain/order_reference.py`
 and `apps/server/vibesensor/shared/order_bands.py`. The post-stop finding flow
@@ -18,10 +21,11 @@ lives in `apps/server/vibesensor/use_cases/diagnostics/orders/`.
 | `OrderReferenceSpec` | `domain/order_reference.py` | Tire geometry, final-drive ratio, gear ratio, and uncertainty settings for order analysis. |
 | `vehicle_orders_hz()` | `shared/order_bands.py` | Resolve wheel / driveshaft / engine reference frequencies for one speed sample. |
 | `build_order_bands()` | `shared/order_bands.py` | Precompute live order-band payloads so the frontend does not duplicate tolerance math. |
-| `build_post_run_vehicle_reference_timeline()` | `use_cases/diagnostics/post_run_vehicle_reference.py` | Normalize speed/RPM/gear/final-drive references onto whole-run windows for dense post-run order stages. |
-| `build_post_run_order_band_timeline()` | `use_cases/diagnostics/post_run_order_bands.py` | Compute per-window wheel/driveshaft/engine order bands from the vehicle-reference timeline. |
+| `build_whole_run_order_trace_artifact_bundle()` | `use_cases/diagnostics/orders/whole_run_traces.py` | Build dense whole-run order trace points from spectral summaries plus context labels. |
+| `build_whole_run_order_trace_summary_artifact_bundle()` | `use_cases/diagnostics/orders/whole_run_scoring.py` | Collapse dense trace points into compact lock/stability summaries. |
+| `build_whole_run_order_family_summary_artifact_bundle()` | `use_cases/diagnostics/orders/whole_run_family_summaries.py` | Roll harmonic summaries up to family-level support intervals and phase summaries. |
 | `OrderHypothesis` | `use_cases/diagnostics/orders/physics.py` | One named order candidate such as `wheel_1x` or `engine_2x`. |
-| `OrderAnalysisSession` | `use_cases/diagnostics/orders/pipeline.py` | Run all eligible hypotheses across stored samples and return ranked findings. |
+| `OrderAnalysisSession` | `use_cases/diagnostics/orders/pipeline.py` | Legacy/compatibility compact sample-peak order pass used by the summary analysis path. |
 
 ## From speed to reference frequencies
 
@@ -43,10 +47,38 @@ The spec exposes capability checks before any of that math is used:
 If the required tire or driveline data is missing, VibeSensor omits the order
 reference instead of inventing one.
 
-## Per-window post-run references
+## Active whole-run order sidecar flow
 
-Dense post-run order work first maps vehicle context onto the deterministic
-window grid with
+The current connected dense order path is wired in
+`apps/server/vibesensor/use_cases/run/post_analysis_executor.py` after
+whole-run spectra and context sidecars are built:
+
+1. `whole_run_spectra.py` writes per-sensor `spectral-summary:*` sidecars with
+   compact per-window peaks, dB strength, and quality/coverage facts.
+2. `whole_run_context.py` writes `context-window-labels` and compact
+   `whole_run_context_intervals`, carrying speed/RPM/reference validity on the
+   same window grid.
+3. `orders/whole_run_traces.py` evaluates the fixed `OrderHypothesis` catalog
+   against each window, using the same predicted-Hz and peak-match tolerance
+   concepts as the compact sample path, and stores dense `order-trace-points`
+   sidecars.
+4. `orders/whole_run_scoring.py` scores those dense traces into compact
+   `OrderTraceSummary` rows with reference coverage, contiguous support,
+   drift/error, and lock score.
+5. `orders/whole_run_family_summaries.py` rolls harmonic summaries up into
+   source-family summaries with support intervals, phase support,
+   stable-frequency fields, and exemplar interval IDs.
+6. `post_analysis_executor.py` appends ranked
+   `whole_run_order_summaries` and related metadata into `analysis_json` while
+   keeping dense trace points sidecar-only.
+
+This split lets history/report consumers use compact report-facing summaries
+without loading dense sidecar artifacts during normal report generation.
+
+## Compatibility per-window post-run references
+
+The older `post_run_*` DTO path can still map vehicle context onto a
+deterministic window grid with
 `build_post_run_vehicle_reference_timeline()` in
 `use_cases/diagnostics/post_run_vehicle_reference.py`.
 
@@ -65,9 +97,9 @@ formulas. Missing RPM can still produce an engine reference only when speed,
 final drive, and gear ratio are available from aligned samples or settings, and
 the missing-RPM reason remains visible to downstream coverage scoring.
 
-## Per-window dense order bands
+## Compatibility per-window dense order bands
 
-`build_post_run_order_band_timeline()` consumes the POSTRUN-04
+`build_post_run_order_band_timeline()` consumes the compatibility
 `VehicleReferenceTimeline` and the run's `OrderReferenceSpec`. For each window it
 emits deterministic `OrderBand` rows for configured harmonics:
 
@@ -92,10 +124,10 @@ final-drive, gear, RPM, or whole order-reference settings also stay explicit on
 the affected rows. Engine bands can remain available from RPM even when
 speed-derived wheel/driveshaft bands are unavailable.
 
-## Dense episode classification
+## Compatibility dense episode classification
 
-`use_cases/diagnostics/post_run_dense_findings.py` consumes POSTRUN-06
-`VibrationEpisode` rows and the POSTRUN-05 `PostRunOrderBandTimeline`. For each
+`use_cases/diagnostics/post_run_dense_findings.py` consumes compatibility
+`VibrationEpisode` rows and the compatibility `PostRunOrderBandTimeline`. For each
 episode it checks the episode frequency at each supporting `window_index` against
 available order bands for wheel, driveshaft, and engine. A source hypothesis is
 scored from:
@@ -115,8 +147,9 @@ usable duration, transient-only evidence, and conflicting multi-sensor evidence
 are also carried as caveats.
 
 Dense findings keep compact evidence windows plus alternatives and can project
-to the existing domain `Finding` model, preserving report/history compatibility
-while leaving dense spectra and traces outside persisted summary JSON.
+to the existing domain `Finding` model. This remains support/prototype logic;
+the active sidecar path persists compact whole-run order summaries from
+`orders/whole_run_family_summaries.py`.
 
 ## Uncertainty and tolerance bands
 
@@ -177,7 +210,8 @@ Each `OrderHypothesis` carries:
 - `path_compliance`, which widens tolerance for softer transmission paths such
   as wheel/tire vibration traveling through suspension and bushings
 
-`OrderAnalysisSession.analyze()` coordinates the evidence flow:
+For the compact summary compatibility path, `OrderAnalysisSession.analyze()`
+coordinates the evidence flow:
 
 1. Skip hypotheses that do not have enough reference data (`_should_test()`).
 2. Use `match_samples_for_hypothesis()` to compare predicted order bands against
@@ -198,8 +232,11 @@ The same reference math serves both runtime and diagnostics:
 
 - live telemetry calls `vehicle_orders_hz()` and `build_order_bands()` so the
   UI can annotate the current spectrum without duplicating the formulas
-- post-stop diagnostics uses the same order references, then asks whether peaks
-  keep recurring in the predicted bands across the saved run
+- the active whole-run sidecar path uses the same order references and scores
+  whether peak support follows the expected wheel/driveshaft/engine trajectory
+  across the saved run
+- the compact compatibility path still asks whether stored summary peaks keep
+  recurring in the predicted bands
 
 The saved per-sample peak/floor inputs consumed by order matching come from the
 same canonical live-processing FFT/strength pipeline
@@ -217,9 +254,9 @@ That shared ownership is why `shared/order_bands.py` exists outside
 |------|----------------|
 | `apps/server/vibesensor/domain/order_reference.py` | Vehicle-physics reference model and frequency derivation helpers. |
 | `apps/server/vibesensor/shared/order_bands.py` | Shared uncertainty, tolerance-band, and live band-payload helpers. |
-| `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py` | Dense per-window vehicle reference normalization and debug fixtures. |
-| `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py` | Dense per-window order-band DTOs, clamping, unavailable reasons, and serializer rows. |
-| `apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py` | Classify dense vibration episodes against per-window order bands into compact findings with alternatives, caveats, and domain `Finding` projection. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_vehicle_reference.py` | Compatibility/prototype per-window vehicle reference normalization and debug fixtures. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_order_bands.py` | Compatibility/prototype per-window order-band DTOs, clamping, unavailable reasons, and serializer rows. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_dense_findings.py` | Compatibility/prototype dense vibration episode classification and domain `Finding` projection. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/physics.py` | Fixed hypothesis catalog and per-sample predicted-Hz helpers. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/matching.py` | Match predicted order bands against stored sample peaks. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -4,10 +4,11 @@
 
 The report generation pipeline has two distinct phases:
 
-1. **Post-stop analysis** (`vibesensor.use_cases.diagnostics`) — runs once when a recording
-   ends, producing an app-level `AnalysisResult`. The serialized summary dict is
-   then created at the boundary by `vibesensor.shared.boundaries.analysis_payloads`
-   / `vibesensor.adapters.analysis_summary`.
+1. **Post-stop analysis** (`vibesensor.use_cases.run.post_analysis_executor` +
+   `vibesensor.use_cases.diagnostics`) — runs once when a recording ends. It
+   builds dense whole-run sidecar artifacts when raw capture is available, builds
+   the compact diagnostics summary, appends compact whole-run report-facing
+   summaries, and persists the resulting `PersistedAnalysis`.
 2. **History request loading + reporting-boundary preparation + rendering**
       (`vibesensor.use_cases.history` →
       `vibesensor.shared.boundaries.reporting` →
@@ -17,21 +18,25 @@ The report generation pipeline has two distinct phases:
      plus precomputed semantic report facts, builds one canonical
      `ReportDocument`, and renders a PDF. This phase performs **zero
       analysis** — it only shapes persisted report data and formats pre-computed
-      results. If a run had raw capture available, that evidence was already
-      folded into the persisted analysis during post-stop replay.
+       results. If a run had raw capture available, raw-backed replay and any
+       whole-run sidecar summaries were already folded into the persisted
+       analysis during post-stop execution.
 
 ```text
 Recording stops
   → _run_post_analysis() [vibesensor.use_cases.run.post_analysis]
-    → build_post_analysis_summary() [vibesensor.use_cases.run.post_analysis]
-      → RunAnalysis(...).summarize() [vibesensor.use_cases.diagnostics.run_analysis]
-      → run_analysis.py + analysis_pipeline.py + run_data_preparation.py + _summary_steps.py + _summary_result.py (preparation, phases, suitability, domain/result assembly)
-      → analysis_result_to_summary() [vibesensor.shared.boundaries.analysis_payloads.summary]
-      → findings.py + _reference_findings.py + _context_decode.py/_context_projection.py + _sample_metrics.py + _analysis_models.py + orders/{pipeline,matching,scoring,finding_builder,statistics,heuristics,settings}.py + peaks/{findings,accumulation,classification,scoring,finding_builder,statistics,settings,table}.py + signal_aggregation.py + top_cause_selection.py + plots.py
-    → build_report_document() [vibesensor.use_cases.history.report_document]
-      → builder.py + document_context.py + composition.py + appendix_c.py +
-        timeline_graph.py + traceability.py + report_sections.py + peak_table.py
-    → store_analysis() [vibesensor.adapters.persistence.history_db]
+    → execute_post_analysis() [vibesensor.use_cases.run.post_analysis_executor]
+      → load_post_analysis_run() [vibesensor.use_cases.run.post_analysis_loader]
+      → build_whole_run_artifacts() [vibesensor.use_cases.run.post_analysis_whole_run_builders]
+        → whole_run_spectra.py + whole_run_context.py + whole_run_spatial_coherence.py
+        → orders/whole_run_traces.py + orders/whole_run_scoring.py + orders/whole_run_family_summaries.py
+      → astore_whole_run_artifacts() [vibesensor.adapters.persistence.history_db]
+      → build_post_analysis_summary() [vibesensor.use_cases.run.post_analysis_summary]
+        → RunAnalysis(...).summarize() [vibesensor.use_cases.diagnostics.run_analysis]
+        → run_analysis.py + analysis_pipeline.py + run_data_preparation.py + _summary_steps.py + _summary_result.py
+        → analysis_result_to_summary() [vibesensor.shared.boundaries.analysis_payloads.summary]
+      → append compact whole-run report-facing summaries
+      → astore_analysis() [vibesensor.adapters.persistence.history_db]
 
 GET /api/history/{run_id}/report.pdf [vibesensor.adapters.http.history]
   → HistoryReportService.build_pdf() [vibesensor.use_cases.history.reports]
@@ -86,11 +91,11 @@ normalization, and grouped semantic fact assembly:
 
 Canonical report-document assembly lives in
 `vibesensor.use_cases.history.report_document`, which maps `PreparedReportInput`
-into the renderer-facing `ReportDocument`. Pure report-domain interpretation
-that reads domain findings/test runs but does not perform i18n or PDF dataclass
-assembly still lives in `vibesensor.shared.boundaries.report_interpretation`,
-but it is consumed by the reporting boundary rather than imported directly by
-`adapters.pdf` modules.
+into the renderer-facing `ReportDocument`. Report-specific interpretation and
+fact preparation live under `vibesensor.shared.boundaries.reporting/` (for
+example `facts.py`, `evidence_facts.py`, `confidence_facts.py`, `findings.py`,
+`sensor_facts.py`, `decision_facts.py`, `projection.py`, and
+`preparation.py`) rather than in `adapters.pdf` modules.
 
 ### ReportDocument schema
 
@@ -135,7 +140,7 @@ needs:
    `vibesensor.shared.boundaries.reporting.document`.
 3. If the new section needs report-specific shaping, add it under
    `vibesensor.shared.boundaries.reporting` (`facts.py`, `sensor_facts.py`,
-   `decision_facts.py`, `projection.py`, `reconstruction.py`, or
+   `decision_facts.py`, `projection.py`, `findings.py`, `evidence_facts.py`, or
    `preparation.py` as appropriate), then populate the final renderer field in
    `build_report_document()` in
    `vibesensor.use_cases.history.report_document`.

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -13,10 +13,11 @@ one big state-machine class:
   artifact finalization for the active run.
 - `PostAnalysisWorker` owns the background queue and retry policy after a run
   stops.
-- `post_run_raw_windows.py` owns post-stop raw artifact window access for dense
-  diagnostics. It reads finalized raw sidecars by bounded ranges and emits
-  structured window warnings instead of reusing live buffers or loading full
-  runs into memory.
+- `post_run_raw_windows.py` owns the compatibility/future-streaming raw artifact
+  window access boundary. It reads finalized raw sidecars by bounded ranges and
+  emits structured window warnings, but the current connected whole-run sidecar
+  executor still receives a full `RawRunCapture` loaded by
+  `post_analysis_loader.py`.
 - `CaptureReadinessTracker` owns the backend pre-record readiness checklist for
   idle/live states.
 - `RunRecorder` coordinates those helpers without re-owning their internals.
@@ -32,7 +33,7 @@ one big state-machine class:
 | `CaptureReadinessTracker` | `use_cases/run/capture_readiness.py` | Evaluate live-sensor readiness, reference freshness, steady-speed dwell, and recent integrity quiet windows for the idle recording gate. |
 | `RunRecorder` | `use_cases/run/logger.py` | Start/stop entrypoint and coordinator for lifecycle, persistence, and post-analysis. |
 | `PostAnalysisWorker` | `use_cases/run/post_analysis.py` | Non-evicting queue and single daemon thread for completed runs. |
-| `execute_post_analysis()` | `use_cases/run/post_analysis_executor.py` | Load metadata/samples, build the persisted analysis, and store success or failure. |
+| `execute_post_analysis()` | `use_cases/run/post_analysis_executor.py` | Load metadata/samples/raw capture, build dense whole-run sidecars and compact persisted analysis, and store success or failure. |
 
 ## Lifecycle phases
 
@@ -158,12 +159,21 @@ because there is nothing persistent to close.
 - the queue is FIFO and processed by one daemon thread
 - `_run_post_analysis()` retries transient failures with
   `_RETRY_DELAYS_S = (0.5, 1.0, 2.0)`
-- `execute_post_analysis()` loads the stored run, calls the injected analysis
-  runner, and stores either analysis output or an analysis error record
-- the loaded post-stop input can now include both persisted summary rows and the
-  optional raw-capture bundle; the raw replay path rebuilds FFT-derived
-  strength/peak fields from raw windows when the bundle exists and falls back to
-  summary-only rows otherwise
+- `execute_post_analysis()` loads the stored run, builds whole-run sidecar
+  artifacts when raw capture is available, calls the injected compact analysis
+  runner, appends compact whole-run summaries/metadata, and stores either
+  analysis output or an analysis error record
+- the loaded post-stop input includes persisted summary rows and, when present,
+  a full raw-capture bundle loaded through `RunPersistence.aload_raw_capture()`;
+  the raw replay path rebuilds FFT-derived strength/peak fields for the compact
+  summary-row compatibility path and falls back to summary-only rows otherwise
+- the current whole-run sidecar stages are spectra, context labels, order trace
+  points, order trace summaries, order family summaries, spatial coherence, and
+  artifact persistence; dense artifacts stay under `whole-run-artifacts/`, while
+  `analysis_json` keeps compact report-facing summaries
+- future streaming/range-read refactor work should wire the connected whole-run
+  sidecar executor to bounded raw range reads instead of materializing the full
+  `RawRunCapture` for long runs
 
 The worker also exposes `PostAnalysisHealthSnapshot`, which is what the health
 surface uses for queue depth, active run ID, and the most recent completion
@@ -220,5 +230,10 @@ task/timeout helpers:
 | `apps/server/vibesensor/use_cases/run/raw_capture_writer.py` | Recorder-side raw chunk queue and raw manifest finalization. |
 | `apps/server/vibesensor/use_cases/run/logger.py` | Public recording start/stop entrypoint. |
 | `apps/server/vibesensor/use_cases/run/post_analysis.py` | Queue, worker-thread, retry, and health behavior. |
-| `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> analyze -> store execution path. |
+| `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> whole-run sidecars -> compact analysis -> store execution path. |
 | `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` | Raw-window replay for post-stop strength/peak rebuilding before diagnostics. |
+| `apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py` | Adapter between the executor and whole-run spectra/context/order/spatial sidecar builders. |
+| `apps/server/vibesensor/use_cases/diagnostics/post_run_raw_windows.py` | Compatibility/future-streaming raw range-read window boundary. |
+| `apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py` | Current whole-run spectral sidecar builder over loaded raw capture. |
+| `apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py` | Current whole-run context labels and compact intervals. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_*.py` | Current whole-run order trace, scoring, and family-summary sidecar/summarization stages. |

--- a/docs/run_schema_v2.md
+++ b/docs/run_schema_v2.md
@@ -1,8 +1,12 @@
-# Run Schema v2 (`.jsonl`)
+# Legacy Run Schema v2 (`.jsonl`)
 
-VibeSensor writes run logs as JSONL (`*.jsonl`).
+This document describes the legacy/CLI JSONL run boundary used by
+`shared/types/run_schema.py` constants and tools such as `vibesensor-report`.
+The current server runtime persists run history in SQLite (`history.db`) plus
+raw-capture and whole-run sidecar directories; see `docs/history_db_schema.md`
+and `docs/analysis_pipeline.md` for the active storage model.
 
-Each run file has:
+When a JSONL run file is read or written at this boundary, it has:
 
 1. `run_metadata` record (first line)
 2. many `sample` records (time series)
@@ -18,7 +22,13 @@ Required fields:
 - `start_time_utc`
 - `end_time_utc` (may be `null` while active)
 - `sensor_model`
+- `firmware_version` (optional)
+- `strength_algorithm_version` (optional)
+- `peak_detector_version` (optional)
+- `calibration_profile_id` (optional)
+- `vehicle_baseline_profile_id` (optional)
 - `raw_sample_rate_hz`
+- `configured_raw_sample_rate_hz` (optional)
 - `feature_interval_s` (used by time-aware order-evidence gating to convert logged match samples into durations)
 - `fft_window_size_samples`
 - `fft_window_type`
@@ -31,8 +41,14 @@ If key references are missing, set:
 
 Optional but recommended:
 
-- `tire_circumference_m` (required for wheel-order labeling)
-- `firmware_version` (ESP firmware version string captured from connected sensors)
+- `analysis_settings` (active run-attached analysis settings snapshot)
+- `car` (run-attached car identity and order-reference status)
+- `sensor_snapshots` (per-run sensor identity/location/orientation/sample-rate snapshots)
+- `raw_capture_finalize` (raw-capture finalize status when the runtime writes a DB-backed run)
+- `finalization_stages` (structured recorder finalization stage results)
+- `case_id`, `sensor_mac`, `symptom`, `report_date`, `language`
+- `wheel_circumference_m` (legacy wheel-reference fallback)
+- `recorded_utc_offset_seconds`
 
 ### `sample` (per timestamp)
 
@@ -40,15 +56,27 @@ Required columns (must exist per record):
 
 - `t_s` (monotonic seconds)
 - `speed_kmh` (required for speed/order analysis; can be `null`)
+- `gps_speed_kmh`
+- `speed_source`
+- `engine_rpm`
+- `engine_rpm_source`
+- `gear`
+- `final_drive_ratio`
 - `accel_x_g`
 - `accel_y_g`
 - `accel_z_g`
+- `analysis_window_start_us` (optional raw-analysis window start)
+- `analysis_window_end_us` (optional raw-analysis window end)
+- `analysis_window_synced` (optional raw-window sync flag)
 
 Recommended:
 
-- `engine_rpm`
-- `gear`
-- `gps_speed_kmh`
+- `client_id`
+- `client_name`
+- `location`
+- `sample_rate_hz`
+- `frames_dropped_total`
+- `queue_overflow_drops`
 
 Common derived fields:
 
@@ -68,15 +96,18 @@ Contains:
 
 The report pipeline does not infer orders without references.
 
-- Wheel order requires `speed_kmh` + `tire_circumference_m` (or wheel speed sensor).
-- Engine order requires `engine_rpm`.
+- Wheel order requires speed plus tire/order-reference settings.
+- Driveshaft order requires wheel reference plus final-drive data.
+- Engine order requires RPM or aligned speed/final-drive/gear reference data.
 
 When missing, report findings include explicit `reference missing` entries and
 order-specific claims are skipped.
 
-Order tracking uses per-sample predicted order frequencies and matches against
-`top_peaks` within tolerance, so wheel/driveline/engine findings remain valid
-when speed changes during the run.
+The current whole-run sidecar path scores order traces against the dense window
+grid and persists compact summaries. The legacy JSONL/summary path still uses
+per-sample predicted order frequencies and matches against `top_peaks` within
+tolerance, so wheel/driveline/engine findings can remain valid when speed
+changes during the run.
 
 ## Commands
 
@@ -86,7 +117,9 @@ Generate PDF from run file:
 vibesensor-report path/to/metrics_20260215_120000.jsonl
 ```
 
-Legacy CSV files are intentionally not supported in this lab setup.
+Legacy CSV files are intentionally not supported in this lab setup. For current
+runtime history, use the SQLite history DB and sidecar artifacts rather than
+treating JSONL files as the primary run store.
 
 ## Removed Fields (schema history)
 


### PR DESCRIPTION
## Summary

Remediates stale architecture documentation around post-stop analysis, dense whole-run sidecars, raw-capture loading, report generation, history schema fields, JSONL legacy boundaries, threading ownership, PDF layout references, metrics schema pointers, pyFFTW status, and updater package paths.

## Docs updated

| Doc | Update |
|---|---|
| `docs/designs/whole-run-post-analysis-program.md` | Reframed active blocker/checklist language as implemented current state, remaining debt, and historical completed checklist. |
| `docs/analysis_pipeline.md` | Rewrote the dense flow around the connected `whole_run_*` sidecar pipeline and marked `post_run_*` as support/prototype. |
| `docs/order_tracking.md` | Added active whole-run order sidecar flow and kept legacy sample/order math as compatibility. |
| `docs/run_lifecycle.md` | Documented current full `RawRunCapture` loading, raw replay compatibility, sidecar stages, and future range-read debt. |
| `docs/report_pipeline.md` | Fixed report generation order and replaced stale/nonexistent report package names. |
| `docs/dataflows.md` | Split raw replay compatibility from dense sidecar production and compact summary consumption. |
| `docs/history_db_schema.md` | Added current `samples_v2` analysis-window columns and marked v4/v5 comparison historical. |
| `docs/run_schema_v2.md` | Retitled as legacy/CLI JSONL boundary and clarified relationship to current DB plus sidecars. |
| `docs/multithreading_performance.md` | Updated post-analysis and worker-pool ownership names/paths. |
| `docs/design_language.md` | Updated report/PDF layout references to current document/appendix model and paths. |
| `docs/metrics.md` | Removed duplicated full schema framing and pointed to current schema docs/types. |
| `docs/intake_buffering.md` | Updated pyFFTW RFFT backend language from planned to implemented. |
| `apps/server/README.md` | Updated updater subsystem paths under `updates/firmware/`, `updates/wifi/`, and `updates/transport/`. |
| `docs/README.md` | Minimal link text update for the retitled legacy JSONL schema doc. |

## Verified against code

- `apps/server/vibesensor/use_cases/run/post_analysis_executor.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_loader.py`
- `apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py`
- `apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py`
- `apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py`
- `apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_scoring.py`
- `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_family_summaries.py`
- `apps/server/vibesensor/adapters/persistence/history_db/_schema.py`
- `apps/server/vibesensor/adapters/persistence/history_db/_engine.py`
- `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`
- `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py`
- `apps/server/vibesensor/shared/types/run_schema.py`
- `apps/server/vibesensor/shared/types/sensor_frame.py`
- `apps/server/vibesensor/shared/fft_analysis.py`
- `apps/server/vibesensor/use_cases/updates/firmware/`, `updates/wifi/`, and `updates/transport/`

## Remaining known documentation debt

- The docs now explicitly call out the future streaming/range-read refactor: `post_run_raw_windows.py` has bounded range reads, but the connected whole-run sidecar executor still receives a full `RawRunCapture` from `post_analysis_loader.py`.

## Tests/checks run

- `./.venv/bin/python tools/dev/docs_lint.py`
- `./.venv/bin/python tools/tests/run_ci_parallel.py --job docs-lint`
- `./.venv/bin/python tools/dev/verify_backend_static_guards.py`
- `./.venv/bin/python tools/tests/plan_validation.py`
- `git --no-pager diff --check`

`make docs-lint` and `make plan-validation` were attempted first, but this environment does not have `make`; the equivalent underlying repo scripts above were run directly.

Historical docs intentionally left historical: `docs/designs/whole-run-post-analysis-history.md` was not edited.